### PR TITLE
chore: copy client ci from virtool to virtool-ui

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "main"
+      - "alpha"
+      - "beta"
+  pull_request:
+    branches:
+      - "main"
+      - "alpha"
+      - "beta"
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4
+  client:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup NodeJS
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - name: Test
+        run: |
+          cd client
+          npm i
+          npx jest --coverage
+          npx webpack --config webpack.production.config.babel.js
+  release:
+    runs-on: ubuntu-20.04
+    needs: client
+    if: github.event_name == 'push'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup NodeJS
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Install semantic-release
+        run: npm i semantic-release@v18.0.0 conventional-changelog-conventionalcommits@4.6.1
+      - name: Run semantic-release
+        env:
+          GITHUB_USERNAME: ${{ secrets.GH_USERNAME }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: npx semantic-release


### PR DESCRIPTION
Copy of the github actions CI file with the server specific sections removed. Keeps the commitlint, client, and release jobs. (removes release dependency on server job as well)