### PR TITLE
Add test patterns to .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,5 +1,9 @@
 version = 1
 
+test_patterns = [
+  "*.test.js"
+]
+
 [[analyzers]]
 name = "javascript"
 enabled = true


### PR DESCRIPTION
Makes DeepSource aware of what our test files are.