### PR TITLE
feat: update reducers to use redux-toolkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3186,9 +3186,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -4661,9 +4661,9 @@
       },
       "dependencies": {
         "redux": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.0.tgz",
-          "integrity": "sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+          "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
           "requires": {
             "@babel/runtime": "^7.9.2"
           }
@@ -9971,9 +9971,9 @@
       "dev": true
     },
     "immer": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.5.tgz",
-      "integrity": "sha512-2WuIehr2y4lmYz9gaQzetPR2ECniCifk4ORaQbU3g5EalLt+0IVTosEPJ5BoYl/75ky2mivzdRzV8wWgQGOSYQ=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.7.tgz",
+      "integrity": "sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA=="
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -14826,9 +14826,9 @@
       }
     },
     "redux-thunk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
-      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
     },
     "reflect.ownkeys": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
-    "@babel/runtime": "^7.11.2",
+    "@babel/runtime": "^7.16.3",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
     "@testing-library/react-hooks": "^3.4.2",

--- a/src/js/account/reducer.js
+++ b/src/js/account/reducer.js
@@ -3,6 +3,7 @@
  *
  * @module account/reducer
  */
+import { createReducer } from "@reduxjs/toolkit";
 import {
     CLEAR_API_KEY,
     CREATE_API_KEY,
@@ -32,32 +33,32 @@ export const initialState = {
  * @param action {object}
  * @returns {object}
  */
-export default function accountReducer(state = initialState, action) {
-    switch (action.type) {
-        case GET_ACCOUNT.SUCCEEDED:
+export const accountReducer = createReducer(initialState, builder => {
+    builder
+        .addCase(GET_ACCOUNT.SUCCEEDED, (state, action) => {
             return { ...state, ...action.data, ready: true };
-        case UPDATE_ACCOUNT.SUCCEEDED:
+        })
+        .addCase(UPDATE_ACCOUNT.SUCCEEDED, (state, action) => {
             return { ...state, ...action.data };
-
-        case GET_API_KEYS.SUCCEEDED:
-            return { ...state, apiKeys: action.data };
-
-        case CREATE_API_KEY.REQUESTED:
-            return { ...state, key: null };
-
-        case CREATE_API_KEY.SUCCEEDED:
-            return { ...state, newKey: action.data.key };
-
-        case CLEAR_API_KEY:
-            return { ...state, newKey: null };
-
-        case UPDATE_ACCOUNT_SETTINGS.SUCCEEDED:
-            return { ...state, settings: action.data };
-
-        case LOGOUT.SUCCEEDED:
+        })
+        .addCase(GET_API_KEYS.SUCCEEDED, (state, action) => {
+            state.apiKeys = action.data;
+        })
+        .addCase(CREATE_API_KEY.REQUESTED, state => {
+            state.key = null;
+        })
+        .addCase(CREATE_API_KEY.SUCCEEDED, (state, action) => {
+            state.newKey = action.data.key;
+        })
+        .addCase(CLEAR_API_KEY, state => {
+            state.newKey = null;
+        })
+        .addCase(UPDATE_ACCOUNT_SETTINGS.SUCCEEDED, (state, action) => {
+            state.settings = action.data;
+        })
+        .addCase(LOGOUT.SUCCEEDED, () => {
             return { ...initialState };
+        });
+});
 
-        default:
-            return state;
-    }
-}
+export default accountReducer;

--- a/src/js/administration/reducer.js
+++ b/src/js/administration/reducer.js
@@ -1,21 +1,19 @@
+import { createReducer } from "@reduxjs/toolkit";
+import { assign } from "lodash-es";
 import { GET_SETTINGS, UPDATE_SETTINGS } from "../app/actionTypes";
 
 export const initialState = {
     data: null
 };
 
-export default function settingsReducer(state = initialState, action) {
-    switch (action.type) {
-        case GET_SETTINGS.SUCCEEDED:
-            return { ...state, data: action.data };
+export const settingsReducer = createReducer(initialState, builder => {
+    builder
+        .addCase(GET_SETTINGS.SUCCEEDED, (state, action) => {
+            state.data = action.data;
+        })
+        .addCase(UPDATE_SETTINGS.SUCCEEDED, (state, action) => {
+            assign(state.data, action.context.update);
+        });
+});
 
-        case UPDATE_SETTINGS.SUCCEEDED:
-            return {
-                ...state,
-                data: { ...state.data, ...action.context.update }
-            };
-
-        default:
-            return state;
-    }
-}
+export default settingsReducer;

--- a/src/js/analyses/reducer.js
+++ b/src/js/analyses/reducer.js
@@ -1,3 +1,4 @@
+import { createReducer } from "@reduxjs/toolkit";
 import { get, map } from "lodash-es";
 import {
     BLAST_NUVS,
@@ -106,98 +107,84 @@ export const updateIdLists = (state, action) => {
     };
 };
 
-export default function analysesReducer(state = initialState, action) {
-    switch (action.type) {
-        case SET_AODP_FILTER:
-            return { ...state, filterAODP: action.filterMin };
-
-        case WS_INSERT_ANALYSIS:
+export const analysesReducer = createReducer(initialState, builder => {
+    builder
+        .addCase(SET_AODP_FILTER, (state, action) => {
+            state.filterAODP = action.filterMin;
+        })
+        .addCase(WS_INSERT_ANALYSIS, (state, action) => {
             return insert(state, action, state.sortKey, state.sortDescending);
-
-        case WS_UPDATE_ANALYSIS:
+        })
+        .addCase(WS_UPDATE_ANALYSIS, (state, action) => {
             return update(state, action);
-
-        case WS_REMOVE_ANALYSIS:
+        })
+        .addCase(WS_REMOVE_ANALYSIS, (state, action) => {
             return remove(state, action);
-
-        case SET_ANALYSIS_ACTIVE_ID:
-            return { ...state, activeId: action.id };
-
-        case SET_SEARCH_IDS:
-            return { ...state, searchIds: action.ids };
-
-        case TOGGLE_FILTER_OTUS:
-            return { ...state, filterOTUs: !state.filterOTUs };
-
-        case TOGGLE_FILTER_ISOLATES:
-            return { ...state, filterIsolates: !state.filterIsolates };
-
-        case TOGGLE_FILTER_ORFS:
-            return { ...state, filterORFs: !state.filterORFs };
-
-        case TOGGLE_FILTER_SEQUENCES: {
-            return { ...state, filterSequences: !state.filterSequences };
-        }
-
-        case TOGGLE_SHOW_PATHOSCOPE_READS:
-            return { ...state, showPathoscopeReads: !state.showPathoscopeReads };
-
-        case SET_ANALYSIS_SORT_KEY:
-            return { ...state, sortKey: action.sortKey };
-
-        case TOGGLE_ANALYSIS_SORT_DESCENDING:
-            return { ...state, sortDescending: !state.sortDescending };
-
-        case LIST_READY_INDEXES.SUCCEEDED:
-            return { ...state, readyIndexes: action.data };
-
-        case FIND_ANALYSES.REQUESTED:
-            return { ...state, term: action.term };
-
-        case FIND_ANALYSES.SUCCEEDED:
+        })
+        .addCase(SET_ANALYSIS_ACTIVE_ID, (state, action) => {
+            state.activeId = action.id;
+        })
+        .addCase(SET_SEARCH_IDS, (state, action) => {
+            state.searchIds = action.ids;
+        })
+        .addCase(TOGGLE_FILTER_OTUS, state => {
+            state.filterOTUs = !state.filterOTUs;
+        })
+        .addCase(TOGGLE_FILTER_ISOLATES, state => {
+            state.filterIsolates = !state.filterIsolates;
+        })
+        .addCase(TOGGLE_FILTER_ORFS, state => {
+            state.filterORFs = !state.filterORFs;
+        })
+        .addCase(TOGGLE_FILTER_SEQUENCES, state => {
+            state.filterSequences = !state.filterSequences;
+        })
+        .addCase(TOGGLE_SHOW_PATHOSCOPE_READS, state => {
+            state.showPathoscopeReads = !state.showPathoscopeReads;
+        })
+        .addCase(SET_ANALYSIS_SORT_KEY, (state, action) => {
+            state.sortKey = action.sortKey;
+        })
+        .addCase(TOGGLE_ANALYSIS_SORT_DESCENDING, state => {
+            state.sortDescending = !state.sortDescending;
+        })
+        .addCase(LIST_READY_INDEXES.SUCCEEDED, (state, action) => {
+            state.readyIndexes = action.data;
+        })
+        .addCase(FIND_ANALYSES.REQUESTED, (state, action) => {
+            state.term = action.term;
+        })
+        .addCase(FIND_ANALYSES.SUCCEEDED, (state, action) => {
             return updateDocuments(state, action, "created_at", true);
-
-        case GET_ANALYSIS.REQUESTED:
+        })
+        .addCase(GET_ANALYSIS.REQUESTED, (state, action) => {
             if (get(state, "detail.id", null) !== action.analysisId) {
-                return {
-                    ...state,
-                    activeId: null,
-                    detail: null,
-                    filterIds: null,
-                    searchIds: null,
-                    sortKey: "length"
-                };
+                state.activeId = null;
+                state.detail = null;
+                state.filterIds = null;
+                state.searchIds = null;
+                state.sortKey = "length";
             }
-
-            return state;
-
-        case GET_ANALYSIS.SUCCEEDED: {
+        })
+        .addCase(GET_ANALYSIS.SUCCEEDED, (state, action) => {
             return updateIdLists(state, action);
-        }
-
-        case CLEAR_ANALYSES:
-            return {
-                ...state,
-                documents: null
-            };
-
-        case CLEAR_ANALYSIS:
-            return {
-                ...state,
-                detail: null,
-                searchIds: null
-            };
-
-        case BLAST_NUVS.REQUESTED:
+        })
+        .addCase(CLEAR_ANALYSES, state => {
+            state.documents = null;
+        })
+        .addCase(CLEAR_ANALYSIS, state => {
+            state.detail = null;
+            state.searchIds = null;
+        })
+        .addCase(BLAST_NUVS.REQUESTED, (state, action) => {
             return setNuvsBLAST(state, action.analysisId, action.sequenceIndex, {
                 ready: false
             });
-
-        case BLAST_NUVS.SUCCEEDED:
+        })
+        .addCase(BLAST_NUVS.SUCCEEDED, (state, action) => {
             const { analysisId, sequenceIndex } = action.context;
             return setNuvsBLAST(state, analysisId, sequenceIndex, action.data);
+        });
+});
 
-        default:
-            return state;
-    }
-}
+export default analysesReducer;

--- a/src/js/app/Main.js
+++ b/src/js/app/Main.js
@@ -81,9 +81,11 @@ export const Main = ({ ready, onLoad }) => {
     return <LoadingPlaceholder />;
 };
 
-export const mapStateToProps = state => ({
-    ready: state.account.ready && Boolean(state.settings.data)
-});
+export const mapStateToProps = state => {
+    return {
+        ready: state.account.ready && Boolean(state.settings.data)
+    };
+};
 
 export const mapDispatchToProps = dispatch => ({
     onLoad: () => {

--- a/src/js/app/reducer.js
+++ b/src/js/app/reducer.js
@@ -2,7 +2,7 @@ import { connectRouter, routerMiddleware } from "connected-react-router";
 import { applyMiddleware, combineReducers, createStore } from "redux";
 import createSagaMiddleware from "redux-saga";
 import accountReducer from "../account/reducer";
-import cachesReducer from "../caches/reducer";
+import cacheReducer from "../caches/reducer";
 import settingsReducer from "../administration/reducer";
 import analysesReducer from "../analyses/reducer";
 import errorsReducer from "../errors/reducer";
@@ -11,86 +11,59 @@ import groupsReducer from "../groups/reducer";
 import hmmsReducer from "../hmm/reducer";
 import indexesReducer from "../indexes/reducer";
 import jobsReducer from "../jobs/reducer";
-import otusReducer from "../otus/reducer";
-import referencesReducer from "../references/reducer";
+import OTUsReducer from "../otus/reducer";
+import referenceReducer from "../references/reducer";
 import samplesReducer from "../samples/reducer";
 import labelsReducer from "../labels/reducer";
-import subtractionReducer from "../subtraction/reducer";
+import subtractionsReducer from "../subtraction/reducer";
 import tasksReducer from "../tasks/reducer";
 import usersReducer from "../users/reducer";
 import { CREATE_FIRST_USER, LOGIN, LOGOUT, RESET_PASSWORD, SET_INITIAL_STATE } from "./actionTypes";
 import rootSaga from "./sagas";
+import { createReducer } from "@reduxjs/toolkit";
 
 const initialState = {
     login: false,
     reset: false
 };
-
-export const appReducer = (state = initialState, action) => {
-    switch (action.type) {
-        case LOGIN.SUCCEEDED:
+export const appReducer = createReducer(initialState, builder => {
+    builder
+        .addCase(LOGIN.SUCCEEDED, (state, action) => {
+            state.login = false;
             if (action.data.reset) {
-                return {
-                    ...state,
-                    login: false,
-                    reset: true,
-                    resetCode: action.data.reset_code
-                };
+                state.reset = true;
+                state.resetCode = action.data.reset_code;
+            } else {
+                state.reset = false;
             }
-
-            return {
-                ...state,
-                login: false,
-                reset: false
-            };
-
-        case LOGIN.FAILED:
-            return {
-                ...state,
-                login: true
-            };
-
-        case LOGOUT.SUCCEEDED:
-            return {
-                ...state,
-                login: true
-            };
-
-        case RESET_PASSWORD.SUCCEEDED:
-            return {
-                ...state,
-                login: false,
-                reset: false,
-                resetCode: null,
-                resetError: null
-            };
-
-        case RESET_PASSWORD.FAILED:
-            return {
-                ...state,
-                login: false,
-                reset: true,
-                resetCode: action.data.reset_code,
-                resetError: action.data.error
-            };
-
-        case CREATE_FIRST_USER.SUCCEEDED:
-            return {
-                ...state,
-                login: false,
-                first: false
-            };
-
-        case SET_INITIAL_STATE:
-            return {
-                ...state,
-                dev: action.dev,
-                first: action.first
-            };
-    }
-
-    return state;
-};
+        })
+        .addCase(LOGIN.FAILED, state => {
+            state.login = true;
+        })
+        .addCase(LOGOUT.SUCCEEDED, state => {
+            state.login = true;
+        })
+        .addCase(RESET_PASSWORD.SUCCEEDED, state => {
+            state.login = false;
+            state.reset = false;
+            state.resetCode = null;
+            state.resetError = null;
+        })
+        .addCase(RESET_PASSWORD.FAILED, (state, action) => {
+            state.login = false;
+            state.reset = true;
+            state.resetCode = action.data.reset_code;
+            state.resetError = action.data.error;
+        })
+        .addCase(CREATE_FIRST_USER.SUCCEEDED, state => {
+            state.login = false;
+            state.first = false;
+        })
+        .addCase(SET_INITIAL_STATE, (state, action) => {
+            state.dev = action.dev;
+            state.first = action.first;
+        });
+});
 
 export const createAppStore = history => {
     const sagaMiddleware = createSagaMiddleware();
@@ -100,7 +73,7 @@ export const createAppStore = history => {
             account: accountReducer,
             analyses: analysesReducer,
             app: appReducer,
-            caches: cachesReducer,
+            caches: cacheReducer,
             errors: errorsReducer,
             files: filesReducer,
             groups: groupsReducer,
@@ -108,12 +81,12 @@ export const createAppStore = history => {
             indexes: indexesReducer,
             jobs: jobsReducer,
             labels: labelsReducer,
-            otus: otusReducer,
-            references: referencesReducer,
+            otus: OTUsReducer,
+            references: referenceReducer,
             router: connectRouter(history),
             samples: samplesReducer,
             settings: settingsReducer,
-            subtraction: subtractionReducer,
+            subtraction: subtractionsReducer,
             tasks: tasksReducer,
             users: usersReducer
         }),

--- a/src/js/caches/reducer.js
+++ b/src/js/caches/reducer.js
@@ -1,21 +1,17 @@
+import { createReducer } from "@reduxjs/toolkit";
 import { GET_CACHE } from "../app/actionTypes";
 
 const initialState = {
     detail: null
 };
 
-export default function cacheReducer(state = initialState, action) {
-    switch (action.type) {
-        case GET_CACHE.REQUESTED:
-            return { ...state, detail: null };
-
-        case GET_CACHE.SUCCEEDED:
-            return {
-                ...state,
-                detail: action.data
-            };
-
-        default:
-            return state;
-    }
-}
+export const cacheReducer = createReducer(initialState, builder => {
+    builder
+        .addCase(GET_CACHE.REQUESTED, state => {
+            state.detail = null;
+        })
+        .addCase(GET_CACHE.SUCCEEDED, (state, action) => {
+            state.detail = action.data;
+        });
+});
+export default cacheReducer;

--- a/src/js/groups/reducer.js
+++ b/src/js/groups/reducer.js
@@ -1,4 +1,5 @@
-import { concat, get, some, sortBy, unionBy } from "lodash-es";
+import { createReducer } from "@reduxjs/toolkit";
+import { concat, get, hasIn, some, sortBy, unionBy } from "lodash-es";
 import {
     CHANGE_ACTIVE_GROUP,
     CREATE_GROUP,
@@ -28,55 +29,60 @@ export const initialState = {
     activeId: ""
 };
 
-export const updateGroup = (state, update) => ({
+export const updateGroup = (state, updateVal) => ({
     ...state,
     pending: false,
-    documents: sortBy(unionBy([update], state.documents, "id"), "id")
+    documents: sortBy(unionBy([updateVal], state.documents, "id"), "id")
 });
 
 export const insertGroup = (documents, entry) => sortBy(concat(documents, [entry]), "id");
 
-export default function groupsReducer(state = initialState, action) {
-    switch (action.type) {
-        case WS_INSERT_GROUP:
+export const groupsReducer = createReducer(initialState, builder => {
+    builder
+        .addCase(WS_INSERT_GROUP, (state, action) => {
             return insert(state, action, "id");
-
-        case WS_UPDATE_GROUP:
+        })
+        .addCase(WS_UPDATE_GROUP, (state, action) => {
             return update(state, action);
-
-        case WS_REMOVE_GROUP:
+        })
+        .addCase(WS_REMOVE_GROUP, (state, action) => {
             return updateActiveId(remove(state, action));
-
-        case CHANGE_ACTIVE_GROUP:
-            return {
-                ...state,
-                activeId: action.id
-            };
-
-        case LIST_GROUPS.SUCCEEDED:
+        })
+        .addCase(CHANGE_ACTIVE_GROUP, (state, action) => {
+            state.activeId = action.id;
+        })
+        .addCase(LIST_GROUPS.SUCCEEDED, (state, action) => {
             return updateActiveId({ ...state, documents: action.data });
-
-        case CREATE_GROUP.REQUESTED:
-        case REMOVE_GROUP.REQUESTED:
-        case SET_GROUP_PERMISSION.REQUESTED:
-            return { ...state, pending: true };
-
-        case CREATE_GROUP.SUCCEEDED:
-            return { ...state, pending: false, activeId: action.data.id };
-
-        case REMOVE_GROUP.SUCCEEDED:
+        })
+        .addCase(CREATE_GROUP.SUCCEEDED, (state, action) => {
+            state.pending = false;
+            state.activeId = action.data.id;
+        })
+        .addCase(REMOVE_GROUP.SUCCEEDED, state => {
             return updateActiveId({ ...state, pending: false });
-
-        case SET_GROUP_PERMISSION.SUCCEEDED:
-            return { ...state, pending: false };
-
-        case CREATE_GROUP.FAILED:
+        })
+        .addCase(SET_GROUP_PERMISSION.SUCCEEDED, state => {
+            state.pending = false;
+        })
+        .addCase(CREATE_GROUP.FAILED, (state, action) => {
             if (action.message === "Group already exists") {
-                return { ...state, createError: true, pending: false };
+                state.createError = true;
+                state.pending = false;
             }
-            return state;
+        })
+        .addMatcher(
+            action => {
+                const matches = {
+                    [CREATE_GROUP.REQUESTED]: true,
+                    [REMOVE_GROUP.REQUESTED]: true,
+                    [SET_GROUP_PERMISSION.REQUESTED]: true
+                };
+                return hasIn(matches, action.type);
+            },
+            state => {
+                state.pending = true;
+            }
+        );
+});
 
-        default:
-            return state;
-    }
-}
+export default groupsReducer;

--- a/src/js/hmm/reducer.js
+++ b/src/js/hmm/reducer.js
@@ -1,4 +1,6 @@
-import { WS_UPDATE_STATUS, FIND_HMMS, GET_HMM } from "../app/actionTypes";
+import { createReducer } from "@reduxjs/toolkit";
+import { set } from "lodash-es";
+import { FIND_HMMS, GET_HMM, WS_UPDATE_STATUS } from "../app/actionTypes";
 import { updateDocuments } from "../utils/reducers";
 
 export const initialState = {
@@ -9,38 +11,27 @@ export const initialState = {
     detail: null
 };
 
-export default function hmmsReducer(state = initialState, action) {
-    switch (action.type) {
-        case WS_UPDATE_STATUS:
+export const hmmsReducer = createReducer(initialState, builder => {
+    builder
+        .addCase(WS_UPDATE_STATUS, (state, action) => {
             if (action.data.id === "hmm") {
-                return {
-                    ...state,
-                    status: {
-                        ...state.status,
-                        installed: action.data.installed,
-                        task: action.data.task,
-                        release: action.data.release
-                    }
-                };
+                set(state, "status.installed", action.data.installed);
+                set(state, "status.task", action.data.task);
+                set(state, "status.release", action.data.release);
             }
-            return state;
-
-        case FIND_HMMS.REQUESTED:
-            return {
-                ...state,
-                term: action.term
-            };
-
-        case FIND_HMMS.SUCCEEDED:
+        })
+        .addCase(FIND_HMMS.REQUESTED, (state, action) => {
+            state.term = action.term;
+        })
+        .addCase(FIND_HMMS.SUCCEEDED, (state, action) => {
             return updateDocuments(state, action, "cluster");
+        })
+        .addCase(GET_HMM.REQUESTED, state => {
+            state.detail = null;
+        })
+        .addCase(GET_HMM.SUCCEEDED, (state, action) => {
+            state.detail = action.data;
+        });
+});
 
-        case GET_HMM.REQUESTED:
-            return { ...state, detail: null };
-
-        case GET_HMM.SUCCEEDED:
-            return { ...state, detail: action.data };
-
-        default:
-            return state;
-    }
-}
+export default hmmsReducer;

--- a/src/js/jobs/reducer.js
+++ b/src/js/jobs/reducer.js
@@ -1,3 +1,5 @@
+import { createReducer } from "@reduxjs/toolkit";
+import { assign } from "lodash-es";
 import { FIND_JOBS, GET_JOB, GET_LINKED_JOB, WS_INSERT_JOB, WS_REMOVE_JOB, WS_UPDATE_JOB } from "../app/actionTypes";
 import { insert, remove, update, updateDocuments } from "../utils/reducers";
 
@@ -12,36 +14,32 @@ export const initialState = {
     linkedJobs: {}
 };
 
-export default function jobsReducer(state = initialState, action) {
-    switch (action.type) {
-        case WS_INSERT_JOB:
+export const jobsReducer = createReducer(initialState, builder => {
+    builder
+        .addCase(WS_INSERT_JOB, (state, action) => {
             return insert(state, action, "created_at");
-
-        case WS_UPDATE_JOB:
+        })
+        .addCase(WS_UPDATE_JOB, (state, action) => {
             return update(state, action, "created_at");
-
-        case WS_REMOVE_JOB:
+        })
+        .addCase(WS_REMOVE_JOB, (state, action) => {
             return remove(state, action);
-
-        case GET_LINKED_JOB.SUCCEEDED:
-            return { ...state, linkedJobs: { ...state.linkedJobs, [action.data.id]: action.data } };
-
-        case FIND_JOBS.REQUESTED:
-            return {
-                ...state,
-                term: action.term
-            };
-
-        case FIND_JOBS.SUCCEEDED:
+        })
+        .addCase(GET_LINKED_JOB.SUCCEEDED, (state, action) => {
+            assign(state.linkedJobs, { [action.data.id]: action.data });
+        })
+        .addCase(FIND_JOBS.REQUESTED, (state, action) => {
+            state.term = action.term;
+        })
+        .addCase(FIND_JOBS.SUCCEEDED, (state, action) => {
             return updateDocuments(state, action, "created_at");
+        })
+        .addCase(GET_JOB.REQUESTED, state => {
+            state.detail = null;
+        })
+        .addCase(GET_JOB.SUCCEEDED, (state, action) => {
+            state.detail = action.data;
+        });
+});
 
-        case GET_JOB.REQUESTED:
-            return { ...state, detail: null };
-
-        case GET_JOB.SUCCEEDED:
-            return { ...state, detail: action.data };
-
-        default:
-            return state;
-    }
-}
+export default jobsReducer;

--- a/src/js/labels/reducer.js
+++ b/src/js/labels/reducer.js
@@ -1,3 +1,4 @@
+import { createReducer } from "@reduxjs/toolkit";
 import { CREATE_LABEL, LIST_LABELS, REMOVE_LABEL, UPDATE_LABEL } from "../app/actionTypes";
 import { insert, remove, update } from "../utils/reducers";
 
@@ -5,21 +6,20 @@ export const initialState = {
     documents: null
 };
 
-export default function labelsReducer(state = initialState, action) {
-    switch (action.type) {
-        case LIST_LABELS.SUCCEEDED:
+export const labelsReducer = createReducer(initialState, builder => {
+    builder
+        .addCase(LIST_LABELS.SUCCEEDED, (state, action) => {
             return { ...state, documents: action.data };
-
-        case CREATE_LABEL.SUCCEEDED:
+        })
+        .addCase(CREATE_LABEL.SUCCEEDED, (state, action) => {
             return insert(state, action);
-
-        case UPDATE_LABEL.SUCCEEDED:
+        })
+        .addCase(UPDATE_LABEL.SUCCEEDED, (state, action) => {
             return update(state, action);
-
-        case REMOVE_LABEL.SUCCEEDED:
+        })
+        .addCase(REMOVE_LABEL.SUCCEEDED, (state, action) => {
             return remove(state, action);
+        });
+});
 
-        default:
-            return state;
-    }
-}
+export default labelsReducer;

--- a/src/js/subtraction/reducer.js
+++ b/src/js/subtraction/reducer.js
@@ -1,8 +1,9 @@
+import { createReducer } from "@reduxjs/toolkit";
 import {
+    EDIT_SUBTRACTION,
     FIND_SUBTRACTIONS,
     GET_SUBTRACTION,
     SHORTLIST_SUBTRACTIONS,
-    EDIT_SUBTRACTION,
     WS_INSERT_SUBTRACTION,
     WS_REMOVE_SUBTRACTION,
     WS_UPDATE_SUBTRACTION
@@ -17,37 +18,35 @@ export const initialState = {
     total_count: 0
 };
 
-export default function subtractionsReducer(state = initialState, action) {
-    switch (action.type) {
-        case WS_INSERT_SUBTRACTION:
+export const subtractionsReducer = createReducer(initialState, builder => {
+    builder
+        .addCase(WS_INSERT_SUBTRACTION, (state, action) => {
             return insert(state, action, "id");
-
-        case WS_UPDATE_SUBTRACTION:
+        })
+        .addCase(WS_UPDATE_SUBTRACTION, (state, action) => {
             return update(state, action, "id");
-
-        case WS_REMOVE_SUBTRACTION:
+        })
+        .addCase(WS_REMOVE_SUBTRACTION, (state, action) => {
             return remove(state, action);
-
-        case FIND_SUBTRACTIONS.REQUESTED: {
-            return { ...state, term: action.term };
-        }
-
-        case FIND_SUBTRACTIONS.SUCCEEDED:
+        })
+        .addCase(FIND_SUBTRACTIONS.REQUESTED, (state, action) => {
+            state.term = action.term;
+        })
+        .addCase(FIND_SUBTRACTIONS.SUCCEEDED, (state, action) => {
             return updateDocuments(state, action, "id");
+        })
+        .addCase(SHORTLIST_SUBTRACTIONS.SUCCEEDED, (state, action) => {
+            state.shortlist = action.data;
+        })
+        .addCase(GET_SUBTRACTION.REQUESTED, state => {
+            state.detail = null;
+        })
+        .addCase(GET_SUBTRACTION.SUCCEEDED, (state, action) => {
+            state.detail = action.data;
+        })
+        .addCase(EDIT_SUBTRACTION.SUCCEEDED, (state, action) => {
+            state.detail = action.data;
+        });
+});
 
-        case SHORTLIST_SUBTRACTIONS.SUCCEEDED:
-            return { ...state, shortlist: action.data };
-
-        case GET_SUBTRACTION.REQUESTED:
-            return { ...state, detail: null };
-
-        case GET_SUBTRACTION.SUCCEEDED:
-            return { ...state, detail: action.data };
-
-        case EDIT_SUBTRACTION.SUCCEEDED:
-            return { ...state, detail: action.data };
-
-        default:
-            return state;
-    }
-}
+export default subtractionsReducer;

--- a/src/js/tasks/reducer.js
+++ b/src/js/tasks/reducer.js
@@ -1,3 +1,4 @@
+import { createReducer } from "@reduxjs/toolkit";
 import { GET_TASK, LIST_TASKS, WS_INSERT_TASK, WS_UPDATE_TASK } from "../app/actionTypes";
 import { insert, update } from "../utils/reducers";
 
@@ -6,27 +7,23 @@ export const initialState = {
     detail: null
 };
 
-export default function tasksReducer(state = initialState, action) {
-    switch (action.type) {
-        case WS_INSERT_TASK:
+export const tasksReducer = createReducer(initialState, builder => {
+    builder
+        .addCase(WS_INSERT_TASK, (state, action) => {
             return insert(state, action);
-
-        case WS_UPDATE_TASK:
+        })
+        .addCase(WS_UPDATE_TASK, (state, action) => {
             return update(state, action);
+        })
+        .addCase(LIST_TASKS.SUCCEEDED, (state, action) => {
+            state.documents = action.data;
+        })
+        .addCase(GET_TASK.REQUESTED, state => {
+            state.detail = null;
+        })
+        .addCase(GET_TASK.SUCCEEDED, (state, action) => {
+            state.detail = action.data;
+        });
+});
 
-        case LIST_TASKS.SUCCEEDED:
-            return {
-                ...state,
-                documents: action.data
-            };
-
-        case GET_TASK.REQUESTED:
-            return { ...state, detail: null };
-
-        case GET_TASK.SUCCEEDED:
-            return { ...state, detail: action.data };
-
-        default:
-            return state;
-    }
-}
+export default tasksReducer;

--- a/src/js/users/reducer.js
+++ b/src/js/users/reducer.js
@@ -1,13 +1,14 @@
+import { createReducer } from "@reduxjs/toolkit";
 import {
-    WS_INSERT_USER,
-    WS_UPDATE_USER,
-    WS_REMOVE_USER,
+    CREATE_USER,
+    EDIT_USER,
     FIND_USERS,
     GET_USER,
-    CREATE_USER,
-    EDIT_USER
+    WS_INSERT_USER,
+    WS_REMOVE_USER,
+    WS_UPDATE_USER
 } from "../app/actionTypes";
-import { updateDocuments, insert, update, remove } from "../utils/reducers";
+import { insert, remove, update, updateDocuments } from "../utils/reducers";
 
 export const initialState = {
     documents: null,
@@ -18,52 +19,47 @@ export const initialState = {
     passwordPending: false
 };
 
-const reducer = (state = initialState, action) => {
-    switch (action.type) {
-        case WS_INSERT_USER:
+const reducer = createReducer(initialState, builder => {
+    builder
+        .addCase(WS_INSERT_USER, (state, action) => {
             return insert(state, action, "id");
-
-        case WS_UPDATE_USER:
+        })
+        .addCase(WS_UPDATE_USER, (state, action) => {
             return update(state, action, "id");
-
-        case WS_REMOVE_USER:
+        })
+        .addCase(WS_REMOVE_USER, (state, action) => {
             return remove(state, action);
-
-        case FIND_USERS.REQUESTED:
-            return {
-                ...state,
-                term: action.term
-            };
-
-        case FIND_USERS.SUCCEEDED:
+        })
+        .addCase(FIND_USERS.REQUESTED, (state, action) => {
+            state.term = action.term;
+        })
+        .addCase(FIND_USERS.SUCCEEDED, (state, action) => {
             return updateDocuments(state, action, "id");
-
-        case GET_USER.REQUESTED:
-            return { ...state, detail: null };
-
-        case GET_USER.SUCCEEDED:
-            return { ...state, detail: action.data };
-
-        case CREATE_USER.REQUESTED:
-            return { ...state, createPending: true };
-
-        case CREATE_USER.SUCCEEDED:
-        case CREATE_USER.FAILED:
-            return { ...state, createPending: false };
-
-        case EDIT_USER.REQUESTED: {
+        })
+        .addCase(GET_USER.REQUESTED, state => {
+            state.detail = null;
+        })
+        .addCase(GET_USER.SUCCEEDED, (state, action) => {
+            state.detail = action.data;
+        })
+        .addCase(CREATE_USER.REQUESTED, state => {
+            state.createPending = true;
+        })
+        .addCase(CREATE_USER.SUCCEEDED, state => {
+            state.createPending = false;
+        })
+        .addCase(CREATE_USER.FAILED, state => {
+            state.createPending = false;
+        })
+        .addCase(EDIT_USER.REQUESTED, (state, action) => {
             if (action.update.password) {
                 return { ...state, passwordPending: true };
             }
             return state;
-        }
-
-        case EDIT_USER.SUCCEEDED:
+        })
+        .addCase(EDIT_USER.SUCCEEDED, (state, action) => {
             return { ...state, detail: action.data };
-
-        default:
-            return state;
-    }
-};
+        });
+});
 
 export default reducer;


### PR DESCRIPTION
All reducers are now created through `@redux-toolkits` `createReducer` function. Most cases were also rewritten to take advantage of the simpler state modification offered by immer.