### PR TITLE
chore: Update node to stable (v16.13.1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/node:14-buster as build
+FROM library/node:16-buster as build
 WORKDIR /build
 COPY src /build/src
 COPY .eslintrc /build/
@@ -10,7 +10,7 @@ COPY webpack.production.config.babel.js /build/
 RUN npm i
 RUN npx webpack --config webpack.production.config.babel.js
 
-FROM library/node:14-buster
+FROM library/node:16-buster
 WORKDIR /ui
 COPY --from=build /build/dist dist
 RUN npm install commander express http-proxy-middleware

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       driver: none
 
   backend:
-    image: virtool/virtool:5.11.5
+    image: virtool/virtool:6.2.1
     expose:
       - "9950"
     ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "@babel/plugin-transform-runtime": "^7.11.5",
         "@babel/preset-env": "^7.11.5",
         "@babel/preset-react": "^7.10.4",
-        "@babel/runtime": "^7.11.2",
+        "@babel/runtime": "^7.16.3",
         "@testing-library/jest-dom": "^5.11.4",
         "@testing-library/react": "^11.0.4",
         "@testing-library/react-hooks": "^3.4.2",
@@ -3545,11 +3545,14 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -5802,15 +5805,6 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
-    "node_modules/@testing-library/user-event/node_modules/@babel/runtime": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
-      "dev": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "node_modules/@types/aria-query": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
@@ -6725,15 +6719,6 @@
       },
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/aria-query/node_modules/@babel/runtime": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
-      "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
-      "dev": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
       }
     },
     "node_modules/aria-query/node_modules/@babel/runtime-corejs3": {
@@ -26907,9 +26892,9 @@
       },
       "dependencies": {
         "redux": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
-          "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.0.tgz",
+          "integrity": "sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==",
           "requires": {
             "@babel/runtime": "^7.9.2"
           }
@@ -27237,17 +27222,6 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
       }
     },
     "@types/aria-query": {
@@ -28023,15 +27997,6 @@
         "@babel/runtime-corejs3": "^7.10.2"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
-          "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
         "@babel/runtime-corejs3": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.4.tgz",
@@ -32228,9 +32193,9 @@
       "dev": true
     },
     "immer": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.7.tgz",
-      "integrity": "sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA=="
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.5.tgz",
+      "integrity": "sha512-2WuIehr2y4lmYz9gaQzetPR2ECniCifk4ORaQbU3g5EalLt+0IVTosEPJ5BoYl/75ky2mivzdRzV8wWgQGOSYQ=="
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -37091,9 +37056,9 @@
       }
     },
     "redux-thunk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
     },
     "reflect.ownkeys": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "scripts": {
     "start": "webpack --config=webpack.config.babel.js --mode=production",
-    "poststart": "node runServer",
+    "poststart": "node run",
     "startDev": "webpack-dev-server",
     "pretest": "eslint --ignore-path .gitignore .",
     "test": "jest"

--- a/run.js
+++ b/run.js
@@ -22,7 +22,7 @@ program
     process.env.VT_UI_API_URL || "http://localhost:9950"
   )
   .option(
-    "-P, --use-proxy",
+    "-P, --use-proxy [bool]",
     "Use proxy to make API requests",
     process.env.VT_UI_USE_PROXY || false
   );
@@ -34,12 +34,12 @@ const options = program.opts();
 const app = express();
 
 app.disable("x-powered-by");
-
 if (options.useProxy) {
   app.use(
     createProxyMiddleware(["/api", "/ws"], {
       target: options.apiUrl,
       ws: true,
+      pathRewrite: { "/api/": "/" },
     })
   );
 

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -64,7 +64,12 @@ module.exports = {
   devServer: {
     hot: true,
     proxy: {
-      "/api": "http://localhost:9950",
+      "/api": {
+        target: "http://localhost:9950",
+        pathRewrite: {
+          "/api/": "/",
+        },
+      },
       "/websocket": {
         target: "ws://localhost:9950",
         ws: true,


### PR DESCRIPTION
Changes:
  - Updated dockerfile Node image to node:16-buster
  - Fixed npm start script to reflect new server file name
  - Fixed `VT_UI_USE_PROXY` env variable not being picked up 
  - Changed proxy to remove /api from backend requests