### PR TITLE
chore: remove fonts.gstatic.com from CSP

### DIFF
--- a/run.js
+++ b/run.js
@@ -40,7 +40,7 @@ if (options.useProxy) {
     createProxyMiddleware(["/api", "/ws"], {
       target: options.apiUrl,
       ws: true,
-      pathRewrite: { "/api/": "/" },
+      pathRewrite: { "/api": "" },
     })
   );
 

--- a/server/csp.js
+++ b/server/csp.js
@@ -3,7 +3,7 @@ const crypto = require("crypto");
 const fontAwesomeURL = "https://use.fontawesome.com";
 const defaultSrc = "default-src 'self'";
 const imgSrc = "img-src 'self' data:";
-const fontSrc = `font-src 'self' https://fonts.gstatic.com ${fontAwesomeURL}`;
+const fontSrc = `font-src 'self' ${fontAwesomeURL}`;
 const connectSrc = "connect-src 'self' sentry.io";
 
 const generateCSPScriptSrc = (nonce) => {

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -67,7 +67,7 @@ module.exports = {
       "/api": {
         target: "http://localhost:9950",
         pathRewrite: {
-          "/api/": "/",
+          "/api": "",
         },
       },
       "/websocket": {


### PR DESCRIPTION
Changes:
 - removes fonts.gstatic.com from the CSP headers
 - fixes /api rewrite regex to allow the root of the `virtool` API to be called