### PR TITLE
Use createAction for all actions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       driver: none
 
   backend:
-    image: virtool/virtool:6.2.1
+    image: virtool/virtool:6.3.0
     expose:
       - "9950"
     ports:

--- a/src/js/account/__tests__/reducer.test.js
+++ b/src/js/account/__tests__/reducer.test.js
@@ -30,7 +30,7 @@ describe("Account Reducer", () => {
     it("should handle GET_ACCOUNT_SUCCEEDED", () => {
         const action = {
             type: GET_ACCOUNT.SUCCEEDED,
-            data: {
+            payload: {
                 foo: "bar"
             }
         };
@@ -47,7 +47,7 @@ describe("Account Reducer", () => {
         };
         const action = {
             type: UPDATE_ACCOUNT.SUCCEEDED,
-            data: {
+            payload: {
                 foo: "bar"
             }
         };
@@ -59,7 +59,7 @@ describe("Account Reducer", () => {
         const keys = [{ id: "foo" }, { id: "bar" }];
         const action = {
             type: GET_API_KEYS.SUCCEEDED,
-            data: keys
+            payload: keys
         };
         const result = reducer({}, action);
         expect(result).toEqual({ apiKeys: keys });
@@ -81,7 +81,7 @@ describe("Account Reducer", () => {
     it("should handle CREATE_API_KEY_SUCCEEDED", () => {
         const action = {
             type: CREATE_API_KEY.SUCCEEDED,
-            data: {
+            payload: {
                 key: {
                     id: "foo"
                 }
@@ -106,13 +106,13 @@ describe("Account Reducer", () => {
     it("should handle UPDATE_ACCOUNT_SETTINGS_SUCCEEDED", () => {
         const action = {
             type: UPDATE_ACCOUNT_SETTINGS.SUCCEEDED,
-            data: {
+            payload: {
                 foo: "bar"
             }
         };
         const result = reducer({}, action);
         expect(result).toEqual({
-            settings: action.data
+            settings: action.payload
         });
     });
 });

--- a/src/js/account/components/API/__tests__/Create.test.js
+++ b/src/js/account/components/API/__tests__/Create.test.js
@@ -180,8 +180,10 @@ describe("mapDispatchToProps()", () => {
         props.onHide();
         expect(dispatch).toHaveBeenCalledWith({
             type: PUSH_STATE,
-            state: {
-                createAPIKey: false
+            payload: {
+                state: {
+                    createAPIKey: false
+                }
             }
         });
         expect(dispatch).toHaveBeenCalledWith({

--- a/src/js/account/components/__tests__/Password.test.js
+++ b/src/js/account/components/__tests__/Password.test.js
@@ -168,7 +168,7 @@ describe("mapDispatchToProps()", () => {
         props.onClearError();
         expect(dispatch).toHaveBeenCalledWith({
             type: CLEAR_ERROR,
-            error: "CHANGE_ACCOUNT_PASSWORD_ERROR"
+            payload: { error: "CHANGE_ACCOUNT_PASSWORD_ERROR" }
         });
     });
 });

--- a/src/js/account/reducer.js
+++ b/src/js/account/reducer.js
@@ -36,25 +36,25 @@ export const initialState = {
 export const accountReducer = createReducer(initialState, builder => {
     builder
         .addCase(GET_ACCOUNT.SUCCEEDED, (state, action) => {
-            return { ...state, ...action.data, ready: true };
+            return { ...state, ...action.payload, ready: true };
         })
         .addCase(UPDATE_ACCOUNT.SUCCEEDED, (state, action) => {
-            return { ...state, ...action.data };
+            return { ...state, ...action.payload };
         })
         .addCase(GET_API_KEYS.SUCCEEDED, (state, action) => {
-            state.apiKeys = action.data;
+            state.apiKeys = action.payload;
         })
         .addCase(CREATE_API_KEY.REQUESTED, state => {
             state.key = null;
         })
         .addCase(CREATE_API_KEY.SUCCEEDED, (state, action) => {
-            state.newKey = action.data.key;
+            state.newKey = action.payload.key;
         })
         .addCase(CLEAR_API_KEY, state => {
             state.newKey = null;
         })
         .addCase(UPDATE_ACCOUNT_SETTINGS.SUCCEEDED, (state, action) => {
-            state.settings = action.data;
+            state.settings = action.payload;
         })
         .addCase(LOGOUT.SUCCEEDED, () => {
             return { ...initialState };

--- a/src/js/account/sagas.js
+++ b/src/js/account/sagas.js
@@ -1,4 +1,4 @@
-import { put, takeEvery, takeLatest } from "redux-saga/effects";
+import { takeEvery, takeLatest } from "redux-saga/effects";
 import {
     CHANGE_ACCOUNT_PASSWORD,
     CREATE_API_KEY,
@@ -49,7 +49,7 @@ export function* updateAccountSettings(action) {
 
 export function* changeAccountPassword(action) {
     yield apiCall(accountAPI.changePassword, action.payload, CHANGE_ACCOUNT_PASSWORD);
-    yield put({ type: GET_ACCOUNT.REQUESTED });
+    yield getAccount();
 }
 
 export function* getAPIKeys() {
@@ -63,12 +63,12 @@ export function* createAPIKey(action) {
 
 export function* updateAPIKey(action) {
     yield apiCall(accountAPI.updateAPIKey, action.payload, UPDATE_API_KEY);
-    yield put({ type: GET_API_KEYS.REQUESTED });
+    yield getAPIKeys();
 }
 
 export function* removeAPIKey(action) {
     yield apiCall(accountAPI.removeAPIKey, action.payload, REMOVE_API_KEY);
-    yield put({ type: GET_API_KEYS.REQUESTED });
+    yield getAPIKeys();
 }
 
 export function* login(action) {

--- a/src/js/administration/__tests__/actions.test.js
+++ b/src/js/administration/__tests__/actions.test.js
@@ -13,7 +13,7 @@ describe("updateSetting()", () => {
         const result = updateSetting("foo", "bar");
         expect(result).toEqual({
             type: UPDATE_SETTINGS.REQUESTED,
-            update: { foo: "bar" }
+            payload: { update: { foo: "bar" } }
         });
     });
 });
@@ -24,7 +24,7 @@ describe("updateSettings()", () => {
         const result = updateSettings(update);
         expect(result).toEqual({
             type: UPDATE_SETTINGS.REQUESTED,
-            update
+            payload: { update }
         });
     });
 });

--- a/src/js/administration/__tests__/reducer.test.js
+++ b/src/js/administration/__tests__/reducer.test.js
@@ -19,7 +19,7 @@ describe("Settings Reducer", () => {
     it("should handle GET_SETTINGS_SUCCEEDED", () => {
         const action = {
             type: GET_SETTINGS.SUCCEEDED,
-            data: { foo: "bar" }
+            payload: { foo: "bar" }
         };
         const result = reducer({}, action);
         expect(result).toEqual({

--- a/src/js/administration/actions.js
+++ b/src/js/administration/actions.js
@@ -1,5 +1,5 @@
-import { simpleActionCreator } from "../utils/utils";
 import { GET_SETTINGS, UPDATE_SETTINGS } from "../app/actionTypes";
+import { createAction } from "@reduxjs/toolkit";
 
 /**
  * Returns action that can trigger an API call for retrieving settings.
@@ -7,7 +7,7 @@ import { GET_SETTINGS, UPDATE_SETTINGS } from "../app/actionTypes";
  * @func
  * @returns {object}
  */
-export const getSettings = simpleActionCreator(GET_SETTINGS.REQUESTED);
+export const getSettings = createAction(GET_SETTINGS.REQUESTED);
 
 /**
  * Returns action that can trigger an API call to update a specific setting.
@@ -30,7 +30,6 @@ export const updateSetting = (key, value) => {
  * @param update {object} update data of key-value pairs
  * @returns {object}
  */
-export const updateSettings = update => ({
-    type: UPDATE_SETTINGS.REQUESTED,
-    update
-});
+export const updateSettings = createAction(UPDATE_SETTINGS.REQUESTED, update => ({
+    payload: { update }
+}));

--- a/src/js/administration/components/__tests__/API.test.js
+++ b/src/js/administration/components/__tests__/API.test.js
@@ -50,8 +50,10 @@ describe("mapDispatchToProps", () => {
         const props = mapDispatchToProps(dispatch);
         props.onToggle(value);
         expect(dispatch).toHaveBeenCalledWith({
-            update: {
-                enable_api: "foo"
+            payload: {
+                update: {
+                    enable_api: "foo"
+                }
             },
             type: UPDATE_SETTINGS.REQUESTED
         });

--- a/src/js/administration/components/__tests__/SampleRights.test.js
+++ b/src/js/administration/components/__tests__/SampleRights.test.js
@@ -107,7 +107,7 @@ describe("mapDispatchToProps()", () => {
         props.onChangeSampleGroup("force_choice");
         expect(dispatch).toHaveBeenCalledWith({
             type: UPDATE_SETTINGS.REQUESTED,
-            update: { sample_group: "force_choice" }
+            payload: { update: { sample_group: "force_choice" } }
         });
     });
 
@@ -124,9 +124,11 @@ describe("mapDispatchToProps()", () => {
         props.onChangeRights(scope, str);
         expect(dispatch).toHaveBeenCalledWith({
             type: UPDATE_SETTINGS.REQUESTED,
-            update: {
-                [`sample_${scope}_read`]: read,
-                [`sample_${scope}_write`]: write
+            payload: {
+                update: {
+                    [`sample_${scope}_read`]: read,
+                    [`sample_${scope}_write`]: write
+                }
             }
         });
     });

--- a/src/js/administration/components/__tests__/Sentry.test.js
+++ b/src/js/administration/components/__tests__/Sentry.test.js
@@ -45,8 +45,10 @@ describe("mapDispatchToProps", () => {
 
         expect(dispatch).toHaveBeenCalledWith({
             type: UPDATE_SETTINGS.REQUESTED,
-            update: {
-                enable_sentry: enabled
+            payload: {
+                update: {
+                    enable_sentry: enabled
+                }
             }
         });
     });

--- a/src/js/administration/components/__tests__/UniqueNames.test.js
+++ b/src/js/administration/components/__tests__/UniqueNames.test.js
@@ -35,7 +35,7 @@ describe("mapDispatchToProps()", () => {
 
         expect(dispatch).toHaveBeenCalledWith({
             type: UPDATE_SETTINGS.REQUESTED,
-            update: { sample_unique_names: enabled }
+            payload: { update: { sample_unique_names: enabled } }
         });
     });
 });

--- a/src/js/administration/reducer.js
+++ b/src/js/administration/reducer.js
@@ -9,7 +9,7 @@ export const initialState = {
 export const settingsReducer = createReducer(initialState, builder => {
     builder
         .addCase(GET_SETTINGS.SUCCEEDED, (state, action) => {
-            state.data = action.data;
+            state.data = action.payload;
         })
         .addCase(UPDATE_SETTINGS.SUCCEEDED, (state, action) => {
             assign(state.data, action.context.update);

--- a/src/js/administration/sagas.js
+++ b/src/js/administration/sagas.js
@@ -13,7 +13,7 @@ function* getSettings(action) {
 }
 
 function* updateSettings(action) {
-    yield apiCall(settingsAPI.update, action, UPDATE_SETTINGS, {
-        update: action.update
+    yield apiCall(settingsAPI.update, action.payload, UPDATE_SETTINGS, {
+        update: action.payload.update
     });
 }

--- a/src/js/analyses/__tests__/actions.test.js
+++ b/src/js/analyses/__tests__/actions.test.js
@@ -35,7 +35,7 @@ it("wsInsertAnalysis should return action to insert analysis via websocket", () 
     const data = { id: "foo" };
     expect(wsInsertAnalysis(data)).toEqual({
         type: WS_INSERT_ANALYSIS,
-        data
+        payload: data
     });
 });
 
@@ -44,7 +44,7 @@ it("wsUpdateAnalysis() should return action to update analysis via websocket", (
     const result = wsUpdateAnalysis(data);
     expect(result).toEqual({
         type: WS_UPDATE_ANALYSIS,
-        data
+        payload: data
     });
 });
 
@@ -53,7 +53,7 @@ it("wsRemoveAnalysis() should return action to remove analysis via websocket", (
     const result = wsRemoveAnalysis(data);
     expect(result).toEqual({
         type: WS_REMOVE_ANALYSIS,
-        data
+        payload: data
     });
 });
 
@@ -61,7 +61,7 @@ it("setAnalysisSortKey() should return action to set sort key", () => {
     const sortKey = "foo";
     expect(setAnalysisSortKey(sortKey)).toEqual({
         type: SET_ANALYSIS_SORT_KEY,
-        sortKey
+        payload: { sortKey }
     });
 });
 
@@ -88,9 +88,7 @@ it("findAnalyses() should return action to find analyses", () => {
     const result = findAnalyses(sampleId, term, page);
     expect(result).toEqual({
         type: FIND_ANALYSES.REQUESTED,
-        sampleId,
-        term,
-        page
+        payload: { sampleId, term, page }
     });
 });
 
@@ -99,7 +97,7 @@ it("get() should return action to get a specific analysis", () => {
     const result = getAnalysis(analysisId);
     expect(result).toEqual({
         type: GET_ANALYSIS.REQUESTED,
-        analysisId
+        payload: { analysisId }
     });
 });
 
@@ -121,11 +119,7 @@ it("analyze() should return action to analyze sample", () => {
 
     expect(result).toEqual({
         type: ANALYZE.REQUESTED,
-        userId,
-        refId,
-        sampleId,
-        subtractionIds,
-        workflow
+        payload: { userId, refId, sampleId, subtractionIds, workflow }
     });
 
     global.Date = originalDate;
@@ -137,8 +131,7 @@ it("blastNuvs() should return action to start BLAST analysis", () => {
     const result = blastNuvs(analysisId, sequenceIndex);
     expect(result).toEqual({
         type: BLAST_NUVS.REQUESTED,
-        analysisId,
-        sequenceIndex
+        payload: { analysisId, sequenceIndex }
     });
 });
 
@@ -147,6 +140,6 @@ it("removeAnalysis() should return action to remove analysis", () => {
     const result = removeAnalysis(analysisId);
     expect(result).toEqual({
         type: REMOVE_ANALYSIS.REQUESTED,
-        analysisId
+        payload: { analysisId }
     });
 });

--- a/src/js/analyses/__tests__/reducer.test.js
+++ b/src/js/analyses/__tests__/reducer.test.js
@@ -64,7 +64,7 @@ describe("Analyses Reducer", () => {
         };
         const action = {
             type: WS_INSERT_ANALYSIS,
-            data: {
+            payload: {
                 id: "foo",
                 created_at: "2018-01-01T00:00:00.000000Z",
                 sample: {
@@ -74,7 +74,7 @@ describe("Analyses Reducer", () => {
         };
         const result = reducer(state, action);
         expect(result).toEqual({
-            documents: [action.data]
+            documents: [action.payload]
         });
     });
 
@@ -85,7 +85,7 @@ describe("Analyses Reducer", () => {
 
         const action = {
             type: WS_UPDATE_ANALYSIS,
-            data: {
+            payload: {
                 id: "foo",
                 created_at: "2018-01-01T00:00:00.000000Z",
                 sample: {
@@ -95,7 +95,7 @@ describe("Analyses Reducer", () => {
         };
         const result = reducer(state, action);
         expect(result).toEqual({
-            documents: [action.data]
+            documents: [action.payload]
         });
     });
 
@@ -105,7 +105,7 @@ describe("Analyses Reducer", () => {
         };
         const action = {
             type: WS_REMOVE_ANALYSIS,
-            data: ["foo"]
+            payload: ["foo"]
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -167,21 +167,21 @@ describe("Analyses Reducer", () => {
 
     it("should handle SET_ANALYSIS_SORT_KEY", () => {
         const state = { sortKey: "e-value" };
-        const action = { type: SET_ANALYSIS_SORT_KEY, sortKey: "coverage" };
+        const action = { type: SET_ANALYSIS_SORT_KEY, payload: { sortKey: "coverage" } };
         const result = reducer(state, action);
         expect(result).toEqual({ sortKey: "coverage" });
     });
 
     it("should handle LIST_READY_INDEXES_SUCCEEDED", () => {
         const state = { foo: "bar" };
-        const action = { type: LIST_READY_INDEXES.SUCCEEDED, data: ["foo"] };
+        const action = { type: LIST_READY_INDEXES.SUCCEEDED, payload: ["foo"] };
         const result = reducer(state, action);
         expect(result).toEqual({ foo: "bar", readyIndexes: ["foo"] });
     });
 
     it("should handle FIND_ANALYSES_REQUESTED", () => {
         const state = { term: "" };
-        const action = { type: FIND_ANALYSES.REQUESTED, term: "foo" };
+        const action = { type: FIND_ANALYSES.REQUESTED, payload: { term: "foo" } };
         const result = reducer(state, action);
         expect(result).toEqual({ ...state, term: "foo" });
     });
@@ -190,7 +190,7 @@ describe("Analyses Reducer", () => {
         const initialState = { documents: null };
         const action = {
             type: FIND_ANALYSES.SUCCEEDED,
-            data: { documents: ["foo"] }
+            payload: { documents: ["foo"] }
         };
         const result = reducer(initialState, action);
         expect(result).toEqual({ ...initialState, documents: ["foo"] });
@@ -198,7 +198,8 @@ describe("Analyses Reducer", () => {
 
     it("should handle GET_ANALYSIS_REQUESTED", () => {
         const action = {
-            type: GET_ANALYSIS.REQUESTED
+            type: GET_ANALYSIS.REQUESTED,
+            payload: {}
         };
         const result = reducer({}, action);
         expect(result).toEqual({
@@ -221,7 +222,7 @@ describe("Analyses Reducer", () => {
         };
         const action = {
             type: "GET_ANALYSIS_SUCCEEDED",
-            data: {
+            payload: {
                 workflow,
                 ready,
                 results: []
@@ -247,7 +248,7 @@ describe("Analyses Reducer", () => {
         const state = {};
         const action = {
             type: "GET_ANALYSIS_SUCCEEDED",
-            data: {
+            payload: {
                 workflow,
                 ready,
                 results: []
@@ -284,8 +285,7 @@ describe("Analyses Reducer", () => {
         };
         const action = {
             type: BLAST_NUVS.REQUESTED,
-            analysisId: "testid",
-            sequenceIndex: 3
+            payload: { analysisId: "testid", sequenceIndex: 3 }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -307,11 +307,12 @@ describe("Analyses Reducer", () => {
         };
         const action = {
             type: BLAST_NUVS.SUCCEEDED,
+
             context: {
                 analysisId: "testid",
                 sequenceIndex: 3
             },
-            data: {}
+            payload: {}
         };
         const result = reducer(state, action);
         expect(result).toEqual({

--- a/src/js/analyses/actions.js
+++ b/src/js/analyses/actions.js
@@ -20,12 +20,17 @@ import {
     WS_REMOVE_ANALYSIS,
     WS_UPDATE_ANALYSIS
 } from "../app/actionTypes";
-import { simpleActionCreator } from "../utils/utils";
+import { createAction } from "@reduxjs/toolkit";
 
-export const wsInsertAnalysis = data => ({
-    type: WS_INSERT_ANALYSIS,
-    data
-});
+/**
+ * Returns an action that should be dispatched when a analysis document is inserted via websocket.
+ *
+ * @func
+ * @param data {object} update data passed in the websocket message
+ * @returns {object}
+ */
+
+export const wsInsertAnalysis = createAction(WS_INSERT_ANALYSIS);
 
 /**
  * Returns an action that should be dispatched when a analysis document is updated via websocket.
@@ -34,10 +39,7 @@ export const wsInsertAnalysis = data => ({
  * @param data {object} update data passed in the websocket message
  * @returns {object}
  */
-export const wsUpdateAnalysis = data => ({
-    type: WS_UPDATE_ANALYSIS,
-    data
-});
+export const wsUpdateAnalysis = createAction(WS_UPDATE_ANALYSIS);
 
 /**
  * Returns an action that should be dispatched when a analysis document is removed via websocket.
@@ -46,46 +48,34 @@ export const wsUpdateAnalysis = data => ({
  * @param data {string} the id for the specific analysis
  * @returns {object}
  */
-export const wsRemoveAnalysis = data => ({
-    type: WS_REMOVE_ANALYSIS,
-    data
-});
+export const wsRemoveAnalysis = createAction(WS_REMOVE_ANALYSIS);
 
-export const setActiveHitId = id => ({
-    type: SET_ANALYSIS_ACTIVE_ID,
-    id
-});
+export const setActiveHitId = createAction(SET_ANALYSIS_ACTIVE_ID, id => ({
+    payload: { id }
+}));
 
-export const setSearchIds = ids => ({
-    type: SET_SEARCH_IDS,
-    ids
-});
+export const setSearchIds = createAction(SET_SEARCH_IDS, ids => ({
+    payload: { ids }
+}));
 
-export const setAODPFilter = filterMin => {
-    return {
-        type: SET_AODP_FILTER,
-        filterMin
-    };
-};
+export const setAODPFilter = createAction(SET_AODP_FILTER, filterMin => ({
+    payload: { filterMin }
+}));
 
-export const setAnalysisSortKey = sortKey => ({
-    type: SET_ANALYSIS_SORT_KEY,
-    sortKey
-});
+export const setAnalysisSortKey = createAction(SET_ANALYSIS_SORT_KEY, sortKey => ({
+    payload: { sortKey }
+}));
 
-export const toggleFilterOTUs = simpleActionCreator(TOGGLE_FILTER_OTUS);
-export const toggleFilterIsolates = simpleActionCreator(TOGGLE_FILTER_ISOLATES);
-export const toggleFilterORFs = simpleActionCreator(TOGGLE_FILTER_ORFS);
-export const toggleFilterSequences = simpleActionCreator(TOGGLE_FILTER_SEQUENCES);
-export const toggleAnalysisSortDescending = simpleActionCreator(TOGGLE_ANALYSIS_SORT_DESCENDING);
-export const toggleShowPathoscopeReads = simpleActionCreator(TOGGLE_SHOW_PATHOSCOPE_READS);
+export const toggleFilterOTUs = createAction(TOGGLE_FILTER_OTUS);
+export const toggleFilterIsolates = createAction(TOGGLE_FILTER_ISOLATES);
+export const toggleFilterORFs = createAction(TOGGLE_FILTER_ORFS);
+export const toggleFilterSequences = createAction(TOGGLE_FILTER_SEQUENCES);
+export const toggleAnalysisSortDescending = createAction(TOGGLE_ANALYSIS_SORT_DESCENDING);
+export const toggleShowPathoscopeReads = createAction(TOGGLE_SHOW_PATHOSCOPE_READS);
 
-export const findAnalyses = (sampleId, term, page) => ({
-    type: FIND_ANALYSES.REQUESTED,
-    sampleId,
-    term,
-    page
-});
+export const findAnalyses = createAction(FIND_ANALYSES.REQUESTED, (sampleId, term, page) => ({
+    payload: { sampleId, term, page }
+}));
 
 /**
  * Returns action that can trigger an API call for retrieving a specific analysis.
@@ -94,13 +84,12 @@ export const findAnalyses = (sampleId, term, page) => ({
  * @param analysisId {string} unique analysis id
  * @returns {object}
  */
-export const getAnalysis = analysisId => ({
-    type: GET_ANALYSIS.REQUESTED,
-    analysisId
-});
+export const getAnalysis = createAction(GET_ANALYSIS.REQUESTED, analysisId => ({
+    payload: { analysisId }
+}));
 
-export const clearAnalyses = simpleActionCreator(CLEAR_ANALYSES);
-export const clearAnalysis = simpleActionCreator(CLEAR_ANALYSIS);
+export const clearAnalyses = createAction(CLEAR_ANALYSES);
+export const clearAnalysis = createAction(CLEAR_ANALYSIS);
 
 /**
  * Returns action that can trigger an API call for sample analysis.
@@ -113,14 +102,15 @@ export const clearAnalysis = simpleActionCreator(CLEAR_ANALYSIS);
  * @param userId {string} the id of the requesting user
  * @returns {object}
  */
-export const analyze = (sampleId, refId, subtractionIds, userId, workflow) => ({
-    type: ANALYZE.REQUESTED,
-    refId,
-    sampleId,
-    subtractionIds,
-    userId,
-    workflow
-});
+export const analyze = createAction(ANALYZE.REQUESTED, (sampleId, refId, subtractionIds, userId, workflow) => ({
+    payload: {
+        refId,
+        sampleId,
+        subtractionIds,
+        userId,
+        workflow
+    }
+}));
 
 /**
  * Returns action that can trigger an API call for BLASTing NuV analysis contigs.
@@ -130,11 +120,9 @@ export const analyze = (sampleId, refId, subtractionIds, userId, workflow) => ({
  * @param sequenceIndex {number} index of the sequence
  * @returns {object}
  */
-export const blastNuvs = (analysisId, sequenceIndex) => ({
-    type: BLAST_NUVS.REQUESTED,
-    analysisId,
-    sequenceIndex
-});
+export const blastNuvs = createAction(BLAST_NUVS.REQUESTED, (analysisId, sequenceIndex) => ({
+    payload: { analysisId, sequenceIndex }
+}));
 
 /**
  * Returns action that can trigger an API call for removing an analysis.
@@ -143,7 +131,6 @@ export const blastNuvs = (analysisId, sequenceIndex) => ({
  * @param analysisId {string} unique analysis id
  * @returns {object}
  */
-export const removeAnalysis = analysisId => ({
-    type: REMOVE_ANALYSIS.REQUESTED,
-    analysisId
-});
+export const removeAnalysis = createAction(REMOVE_ANALYSIS.REQUESTED, analysisId => ({
+    payload: { analysisId }
+}));

--- a/src/js/analyses/components/Create/__tests__/Create.test.js
+++ b/src/js/analyses/components/Create/__tests__/Create.test.js
@@ -145,19 +145,20 @@ describe("mapDispatchToProps()", () => {
 
         props.onAnalyze(sampleId, references, subtractionIds, userId, workflows);
         expect(dispatch).toHaveBeenCalledWith({
-            type: "ANALYZE.REQUESTED",
-            refId: references[0],
-            sampleId,
-            subtractionIds,
             type: "ANALYZE_REQUESTED",
-            userId,
-            workflow: workflows[0]
+            payload: {
+                refId: references[0],
+                sampleId,
+                subtractionIds,
+                userId,
+                workflow: workflows[0]
+            }
         });
     });
 
     it("should return onHide() in props", () => {
         props.onHide();
-        expect(dispatch).toHaveBeenCalledWith({ state: {}, type: "PUSH_STATE" });
+        expect(dispatch).toHaveBeenCalledWith({ payload: { state: {} }, type: "PUSH_STATE" });
     });
 
     it("should return onShortlistSubtractions() in props", () => {

--- a/src/js/analyses/components/Pathoscope/__tests__/Toolbar.test.js
+++ b/src/js/analyses/components/Pathoscope/__tests__/Toolbar.test.js
@@ -156,7 +156,7 @@ describe("mapDispatchToProps()", () => {
         props.onSetSortKey("foo");
         expect(dispatch).toHaveBeenCalledWith({
             type: SET_ANALYSIS_SORT_KEY,
-            sortKey: "foo"
+            payload: { sortKey: "foo" }
         });
     });
 

--- a/src/js/analyses/components/__tests__/Item.test.js
+++ b/src/js/analyses/components/__tests__/Item.test.js
@@ -85,7 +85,7 @@ describe("mapDispatchToProps", () => {
         props.onRemove();
         expect(dispatch).toHaveBeenCalledWith({
             type: REMOVE_ANALYSIS.REQUESTED,
-            analysisId: id
+            payload: { analysisId: id }
         });
     });
 });

--- a/src/js/analyses/components/__tests__/Toolbar.test.js
+++ b/src/js/analyses/components/__tests__/Toolbar.test.js
@@ -103,8 +103,10 @@ describe("mapDispatchToProps", () => {
         props.onShowCreate("foobar");
         expect(dispatch).toHaveBeenCalledWith({
             type: PUSH_STATE,
-            state: {
-                createAnalysis: "foobar"
+            payload: {
+                state: {
+                    createAnalysis: "foobar"
+                }
             }
         });
     });
@@ -118,9 +120,7 @@ describe("mapDispatchToProps", () => {
         props.onFind(sampleId, term, page);
         expect(dispatch).toHaveBeenCalledWith({
             type: FIND_ANALYSES.REQUESTED,
-            sampleId,
-            term,
-            page
+            payload: { sampleId, term, page }
         });
     });
 });

--- a/src/js/analyses/reducer.js
+++ b/src/js/analyses/reducer.js
@@ -52,7 +52,7 @@ export const initialState = {
 };
 
 export const getInitialSortKey = action => {
-    switch (action.data.workflow) {
+    switch (action.payload.workflow) {
         case "nuvs":
             return "length";
 
@@ -88,9 +88,9 @@ export const setNuvsBLAST = (state, analysisId, sequenceIndex, data = "ip") => {
 
 export const updateIdLists = (state, action) => {
     const analysisDetailId = get(state, "detail.id", null);
-    const detail = formatData(action.data);
+    const detail = formatData(action.payload);
 
-    if (analysisDetailId === action.data.id) {
+    if (analysisDetailId === action.payload.id) {
         return {
             ...state,
             detail
@@ -110,22 +110,22 @@ export const updateIdLists = (state, action) => {
 export const analysesReducer = createReducer(initialState, builder => {
     builder
         .addCase(SET_AODP_FILTER, (state, action) => {
-            state.filterAODP = action.filterMin;
+            state.filterAODP = action.payload.filterMin;
         })
         .addCase(WS_INSERT_ANALYSIS, (state, action) => {
-            return insert(state, action, state.sortKey, state.sortDescending);
+            return insert(state, action.payload, state.sortKey, state.sortDescending);
         })
         .addCase(WS_UPDATE_ANALYSIS, (state, action) => {
-            return update(state, action);
+            return update(state, action.payload);
         })
         .addCase(WS_REMOVE_ANALYSIS, (state, action) => {
-            return remove(state, action);
+            return remove(state, action.payload);
         })
         .addCase(SET_ANALYSIS_ACTIVE_ID, (state, action) => {
-            state.activeId = action.id;
+            state.activeId = action.payload.id;
         })
         .addCase(SET_SEARCH_IDS, (state, action) => {
-            state.searchIds = action.ids;
+            state.searchIds = action.payload.ids;
         })
         .addCase(TOGGLE_FILTER_OTUS, state => {
             state.filterOTUs = !state.filterOTUs;
@@ -143,22 +143,22 @@ export const analysesReducer = createReducer(initialState, builder => {
             state.showPathoscopeReads = !state.showPathoscopeReads;
         })
         .addCase(SET_ANALYSIS_SORT_KEY, (state, action) => {
-            state.sortKey = action.sortKey;
+            state.sortKey = action.payload.sortKey;
         })
         .addCase(TOGGLE_ANALYSIS_SORT_DESCENDING, state => {
             state.sortDescending = !state.sortDescending;
         })
         .addCase(LIST_READY_INDEXES.SUCCEEDED, (state, action) => {
-            state.readyIndexes = action.data;
+            state.readyIndexes = action.payload;
         })
         .addCase(FIND_ANALYSES.REQUESTED, (state, action) => {
-            state.term = action.term;
+            state.term = action.payload.term;
         })
         .addCase(FIND_ANALYSES.SUCCEEDED, (state, action) => {
-            return updateDocuments(state, action, "created_at", true);
+            return updateDocuments(state, action.payload, "created_at", true);
         })
         .addCase(GET_ANALYSIS.REQUESTED, (state, action) => {
-            if (get(state, "detail.id", null) !== action.analysisId) {
+            if (get(state, "detail.id", null) !== action.payload.analysisId) {
                 state.activeId = null;
                 state.detail = null;
                 state.filterIds = null;
@@ -177,13 +177,13 @@ export const analysesReducer = createReducer(initialState, builder => {
             state.searchIds = null;
         })
         .addCase(BLAST_NUVS.REQUESTED, (state, action) => {
-            return setNuvsBLAST(state, action.analysisId, action.sequenceIndex, {
+            return setNuvsBLAST(state, action.payload.analysisId, action.payload.sequenceIndex, {
                 ready: false
             });
         })
         .addCase(BLAST_NUVS.SUCCEEDED, (state, action) => {
             const { analysisId, sequenceIndex } = action.context;
-            return setNuvsBLAST(state, analysisId, sequenceIndex, action.data);
+            return setNuvsBLAST(state, analysisId, sequenceIndex, action.payload);
         });
 });
 

--- a/src/js/analyses/sagas.js
+++ b/src/js/analyses/sagas.js
@@ -23,31 +23,31 @@ export function* watchAnalyses() {
 export function* wsUpdateAnalysis(action) {
     const analysisId = yield select(getAnalysisDetailId);
 
-    if (analysisId === action.data.id) {
+    if (analysisId === action.payload.data.id) {
         yield apiCall(analysesAPI.get, { analysisId }, GET_ANALYSIS);
     }
 }
 
 export function* findAnalyses(action) {
-    yield apiCall(analysesAPI.find, action, FIND_ANALYSES);
-    yield pushFindTerm(action.term);
+    yield apiCall(analysesAPI.find, action.payload, FIND_ANALYSES);
+    yield pushFindTerm(action.payload.term);
 }
 
 export function* getAnalysis(action) {
-    yield apiCall(analysesAPI.get, action, GET_ANALYSIS);
+    yield apiCall(analysesAPI.get, action.payload, GET_ANALYSIS);
 }
 
 export function* analyze(action) {
-    yield apiCall(analysesAPI.analyze, action, ANALYZE);
+    yield apiCall(analysesAPI.analyze, action.payload, ANALYZE);
 }
 
 export function* blastNuvs(action) {
-    yield apiCall(analysesAPI.blastNuvs, action, BLAST_NUVS, {
-        analysisId: action.analysisId,
-        sequenceIndex: action.sequenceIndex
+    yield apiCall(analysesAPI.blastNuvs, action.payload, BLAST_NUVS, {
+        analysisId: action.payload.analysisId,
+        sequenceIndex: action.payload.sequenceIndex
     });
 }
 
 export function* removeAnalysis(action) {
-    yield apiCall(analysesAPI.remove, action, REMOVE_ANALYSIS);
+    yield apiCall(analysesAPI.remove, action.payload, REMOVE_ANALYSIS);
 }

--- a/src/js/app/__tests__/appReducer.test.js
+++ b/src/js/app/__tests__/appReducer.test.js
@@ -24,7 +24,7 @@ describe("App Reducer", () => {
 
     it.each([
         [
-            { type: LOGIN.SUCCEEDED, data: { reset: true, reset_code: false } },
+            { type: LOGIN.SUCCEEDED, payload: { reset: true, reset_code: false } },
             { dev: "foo", first: "bar", login: false, reset: true, resetCode: false }
         ],
         [{ type: LOGIN.FAILED }, { dev: "foo", first: "bar", reset: false, resetCode: true, login: true }]
@@ -73,7 +73,7 @@ describe("App Reducer", () => {
             type,
             resetCode: false,
             resetError: false,
-            data: { reset_code: true, error: true }
+            payload: { reset_code: true, error: true }
         };
         const result = appReducer(state, action);
 

--- a/src/js/app/actions.js
+++ b/src/js/app/actions.js
@@ -1,12 +1,10 @@
 import { PUSH_STATE, SET_INITIAL_STATE } from "./actionTypes";
+import { createAction } from "@reduxjs/toolkit";
 
-export const pushState = state => ({
-    type: PUSH_STATE,
-    state
-});
+export const pushState = createAction(PUSH_STATE, state => ({
+    payload: { state }
+}));
 
-export const setInitialState = ({ dev, first_user }) => ({
-    type: SET_INITIAL_STATE,
-    dev,
-    first: first_user
-});
+export const setInitialState = createAction(SET_INITIAL_STATE, ({ dev, first_user }) => ({
+    payload: { dev, first: first_user }
+}));

--- a/src/js/app/reducer.js
+++ b/src/js/app/reducer.js
@@ -30,9 +30,9 @@ export const appReducer = createReducer(initialState, builder => {
     builder
         .addCase(LOGIN.SUCCEEDED, (state, action) => {
             state.login = false;
-            if (action.data.reset) {
+            if (action.payload.reset) {
                 state.reset = true;
-                state.resetCode = action.data.reset_code;
+                state.resetCode = action.payload.reset_code;
             } else {
                 state.reset = false;
             }
@@ -52,16 +52,16 @@ export const appReducer = createReducer(initialState, builder => {
         .addCase(RESET_PASSWORD.FAILED, (state, action) => {
             state.login = false;
             state.reset = true;
-            state.resetCode = action.data.reset_code;
-            state.resetError = action.data.error;
+            state.resetCode = action.payload.reset_code;
+            state.resetError = action.payload.error;
         })
         .addCase(CREATE_FIRST_USER.SUCCEEDED, state => {
             state.login = false;
             state.first = false;
         })
         .addCase(SET_INITIAL_STATE, (state, action) => {
-            state.dev = action.dev;
-            state.first = action.first;
+            state.dev = action.payload.dev;
+            state.first = action.payload.first;
         });
 });
 

--- a/src/js/app/sagas.js
+++ b/src/js/app/sagas.js
@@ -21,7 +21,7 @@ import { PUSH_STATE } from "./actionTypes";
 
 function* pushState(action) {
     const routerLocation = yield select(getLocation);
-    yield put(push({ ...routerLocation, state: action.state }));
+    yield put(push({ ...routerLocation, state: action.payload.state }));
 }
 
 export function* watchRouter() {

--- a/src/js/caches/__tests__/reducer.test.js
+++ b/src/js/caches/__tests__/reducer.test.js
@@ -22,7 +22,7 @@ describe("<cacheReducer />", () => {
     it("should return detail action.data", () => {
         const action = {
             type: GET_CACHE.SUCCEEDED,
-            data: "foo"
+            payload: "foo"
         };
         const result = cacheReducer(state, action);
         expect(result).toEqual({ ...state, detail: "foo" });

--- a/src/js/caches/actions.js
+++ b/src/js/caches/actions.js
@@ -1,6 +1,5 @@
 import { GET_CACHE } from "../app/actionTypes";
-
-export const getCache = cacheId => ({
-    type: GET_CACHE.REQUESTED,
-    cacheId
-});
+import { createAction } from "@reduxjs/toolkit";
+export const getCache = createAction(GET_CACHE.REQUESTED, cacheId => ({
+    payload: { cacheId }
+}));

--- a/src/js/caches/components/__tests__/Detail.test.js
+++ b/src/js/caches/components/__tests__/Detail.test.js
@@ -66,7 +66,7 @@ describe("mapDispatchToProps", () => {
         props.onGet("foo");
         expect(dispatch).toHaveBeenCalledWith({
             type: GET_CACHE.REQUESTED,
-            cacheId: "foo"
+            payload: { cacheId: "foo" }
         });
     });
 });

--- a/src/js/caches/reducer.js
+++ b/src/js/caches/reducer.js
@@ -11,7 +11,7 @@ export const cacheReducer = createReducer(initialState, builder => {
             state.detail = null;
         })
         .addCase(GET_CACHE.SUCCEEDED, (state, action) => {
-            state.detail = action.data;
+            state.detail = action.payload;
         });
 });
 export default cacheReducer;

--- a/src/js/caches/sagas.js
+++ b/src/js/caches/sagas.js
@@ -8,5 +8,5 @@ export function* watchCaches() {
 }
 
 export function* getCache(action) {
-    yield apiCall(cachesAPI.get, action, GET_CACHE);
+    yield apiCall(cachesAPI.get, action.payload, GET_CACHE);
 }

--- a/src/js/dev/actions.js
+++ b/src/js/dev/actions.js
@@ -1,3 +1,4 @@
 import { POST_DEV_COMMAND } from "../app/actionTypes";
+import { createAction } from "@reduxjs/toolkit";
 
-export const postDevCommand = command => ({ type: POST_DEV_COMMAND.REQUESTED, command });
+export const postDevCommand = createAction(POST_DEV_COMMAND.REQUESTED, command => ({ payload: { command } }));

--- a/src/js/dev/sagas.js
+++ b/src/js/dev/sagas.js
@@ -9,7 +9,7 @@ export function* watchDev() {
 }
 
 export function* postDevCommand(action) {
-    yield apiCall(devApi.post, action, POST_DEV_COMMAND);
+    yield apiCall(devApi.post, action.payload, POST_DEV_COMMAND);
 
     if (action.command === "clear_users") {
         yield put(pushState({}));

--- a/src/js/errors/__tests__/actions.test.js
+++ b/src/js/errors/__tests__/actions.test.js
@@ -7,7 +7,7 @@ describe("Errors Action Creators:", () => {
         const result = clearError(error);
         const expected = {
             type: CLEAR_ERROR,
-            error
+            payload: { error }
         };
 
         expect(result).toEqual(expected);

--- a/src/js/errors/__tests__/reducer.test.js
+++ b/src/js/errors/__tests__/reducer.test.js
@@ -39,8 +39,7 @@ describe("reducer()", () => {
         const state = {};
         const action = {
             type: `${actionTypePrefix}_FAILED`,
-            status: 409,
-            message: "There was an error"
+            payload: { status: 409, message: "There was an error" }
         };
         const result = reducer(state, action);
 
@@ -58,8 +57,7 @@ describe("reducer()", () => {
         const state = {};
         const action = {
             type: "TEST_FAILED",
-            status: 400,
-            message: "test action failed"
+            payload: { status: 400, message: "test action failed" }
         };
         const result = reducer(state, action);
 
@@ -76,8 +74,7 @@ describe("reducer()", () => {
         };
         const action = {
             type: "CREATE_SAMPLE_REQUESTED",
-            status: 200,
-            message: "requesting same action again"
+            payload: { status: 200, message: "requesting same action again" }
         };
         const result = reducer(state, action);
 
@@ -96,7 +93,7 @@ describe("reducer()", () => {
         };
         const action = {
             type: "CLEAR_ERROR",
-            error: "CREATE_SAMPLE_ERROR"
+            payload: { error: "CREATE_SAMPLE_ERROR" }
         };
         const result = reducer(state, action);
         const expected = {

--- a/src/js/errors/actions.js
+++ b/src/js/errors/actions.js
@@ -4,6 +4,7 @@
  * @module error/actions
  */
 import { CLEAR_ERROR } from "../app/actionTypes";
+import { createAction } from "@reduxjs/toolkit";
 
 /**
  * Returns action that clears specific error in the store.
@@ -11,7 +12,6 @@ import { CLEAR_ERROR } from "../app/actionTypes";
  * @func
  * @returns {object}
  */
-export const clearError = error => ({
-    type: CLEAR_ERROR,
-    error
-});
+export const clearError = createAction(CLEAR_ERROR, error => ({
+    payload: { error }
+}));

--- a/src/js/errors/reducer.js
+++ b/src/js/errors/reducer.js
@@ -84,7 +84,7 @@ export const errorsReducer = createReducer({}, builder => {
     builder
         .addCase(CLEAR_ERROR, (state, action) => {
             // Clear specific error explicitly
-            state[action.error] = null;
+            state[action.payload.error] = null;
         })
         .addMatcher(
             action => checkActionFailed(action),
@@ -92,10 +92,9 @@ export const errorsReducer = createReducer({}, builder => {
                 const errorName = getErrorName(action);
 
                 const errorPayload = {
-                    status: action.status,
-                    message: action.message
+                    status: action.payload.status,
+                    message: action.payload.message
                 };
-
                 switch (action.type) {
                     case CREATE_SAMPLE.FAILED:
                     case UPDATE_SAMPLE.FAILED:
@@ -127,7 +126,7 @@ export const errorsReducer = createReducer({}, builder => {
                         state[errorName] = errorPayload;
                         break;
                     case CREATE_FIRST_USER.FAILED:
-                        state[errorName] = action.error.response.body;
+                        state[errorName] = action.payload.error.response.body;
                         break;
 
                     default:

--- a/src/js/files/__tests__/actions.test.js
+++ b/src/js/files/__tests__/actions.test.js
@@ -19,7 +19,7 @@ describe("Files Action Creators", () => {
 
         expect(result).toEqual({
             type: WS_INSERT_FILE,
-            data
+            payload: { ...data }
         });
     });
 
@@ -32,7 +32,7 @@ describe("Files Action Creators", () => {
 
         expect(result).toEqual({
             type: WS_UPDATE_FILE,
-            data
+            payload: { ...data }
         });
     });
 
@@ -42,7 +42,7 @@ describe("Files Action Creators", () => {
 
         expect(result).toEqual({
             type: WS_REMOVE_FILE,
-            data
+            payload: { ...data }
         });
     });
 
@@ -53,9 +53,7 @@ describe("Files Action Creators", () => {
         const result = findFiles(fileType, "foo", page);
         expect(result).toEqual({
             type: FIND_FILES.REQUESTED,
-            fileType,
-            term,
-            page
+            payload: { fileType, term, page }
         });
     });
 
@@ -68,10 +66,7 @@ describe("Files Action Creators", () => {
         const result = upload(localId, file, fileType);
         expect(result).toEqual({
             type: UPLOAD.REQUESTED,
-            context: {},
-            localId,
-            file,
-            fileType
+            payload: { context: {}, localId, file, fileType }
         });
     });
 
@@ -80,7 +75,7 @@ describe("Files Action Creators", () => {
         const result = removeFile(fileId);
         expect(result).toEqual({
             type: REMOVE_FILE.REQUESTED,
-            fileId
+            payload: { fileId }
         });
     });
 
@@ -90,8 +85,7 @@ describe("Files Action Creators", () => {
         const result = uploadProgress(localId, progress);
         expect(result).toEqual({
             type: UPLOAD_PROGRESS,
-            localId,
-            progress
+            payload: { localId, progress }
         });
     });
 });

--- a/src/js/files/__tests__/reducer.test.js
+++ b/src/js/files/__tests__/reducer.test.js
@@ -19,7 +19,7 @@ describe("filesReducer()", () => {
             const state = { fileType: "reads" };
             const action = {
                 type: WS_INSERT_FILE,
-                data: { type: "subtraction" }
+                payload: { type: "subtraction" }
             };
             const result = reducer(state, action);
             expect(result).toEqual(state);
@@ -36,10 +36,10 @@ describe("filesReducer()", () => {
             };
             const action = {
                 type: WS_INSERT_FILE,
-                data: { type: "reads", id: "test" }
+                payload: { type: "reads", id: "test" }
             };
             const result = reducer(state, action);
-            expect(result).toEqual({ ...state, documents: [action.data], total_count: 0 });
+            expect(result).toEqual({ ...state, documents: [action.payload], total_count: 0 });
         });
     });
 
@@ -49,10 +49,10 @@ describe("filesReducer()", () => {
         };
         const action = {
             type: WS_UPDATE_FILE,
-            data: { id: "test", foo: "not-bar" }
+            payload: { id: "test", foo: "not-bar" }
         };
         const result = reducer(state, action);
-        expect(result).toEqual({ ...state, documents: [action.data] });
+        expect(result).toEqual({ ...state, documents: [action.payload] });
     });
 
     it("should handle WS_REMOVE_FILE", () => {
@@ -62,7 +62,7 @@ describe("filesReducer()", () => {
         };
         const action = {
             type: WS_REMOVE_FILE,
-            data: ["test"]
+            payload: ["test"]
         };
         const result = reducer(state, action);
         expect(result).toEqual({ documents: [], total_count: 1 });
@@ -72,8 +72,7 @@ describe("filesReducer()", () => {
         const state = {};
         const action = {
             type: FIND_FILES.REQUESTED,
-            term: "foo",
-            page: 5
+            payload: { term: "foo", page: 5 }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -86,13 +85,13 @@ describe("filesReducer()", () => {
         const state = { documents: [], page: 1 };
         const action = {
             type: FIND_FILES.SUCCEEDED,
-            data: { documents: [] },
+            payload: { documents: [] },
             context: { fileType: "test" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
             ...state,
-            ...action.data,
+            ...action.payload,
             fileType: "test"
         });
     });
@@ -112,12 +111,14 @@ describe("filesReducer()", () => {
 
         const action = {
             type: UPLOAD.REQUESTED,
-            localId,
-            context,
-            fileType: type,
-            file: {
-                name,
-                size
+            payload: {
+                localId,
+                context,
+                fileType: type,
+                file: {
+                    name,
+                    size
+                }
             }
         };
 
@@ -145,8 +146,7 @@ describe("filesReducer()", () => {
             state.uploads = [];
             const action = {
                 type: UPLOAD_PROGRESS,
-                localId: "foo",
-                progress: 5
+                payload: { localId: "foo", progress: 5 }
             };
             expect(reducer(state, action)).toEqual({
                 uploads: []
@@ -156,8 +156,7 @@ describe("filesReducer()", () => {
         it("when a zero-progress upload is updated", () => {
             const action = {
                 type: UPLOAD_PROGRESS,
-                localId: "bar",
-                progress: 22
+                payload: { localId: "bar", progress: 22 }
             };
             const result = reducer(state, action);
             expect(result).toEqual({
@@ -171,8 +170,7 @@ describe("filesReducer()", () => {
         it("when a partial upload is updated", () => {
             const action = {
                 type: UPLOAD_PROGRESS,
-                localId: "foo",
-                progress: 65
+                payload: { localId: "foo", progress: 65 }
             };
             const result = reducer(state, action);
             expect(result).toEqual({
@@ -186,8 +184,7 @@ describe("filesReducer()", () => {
         it("when an update that brings a progress value to 100", () => {
             const action = {
                 type: UPLOAD_PROGRESS,
-                localId: "foo",
-                progress: 100
+                payload: { localId: "foo", progress: 100 }
             };
             const result = reducer(state, action);
             expect(result).toEqual({

--- a/src/js/files/actions.js
+++ b/src/js/files/actions.js
@@ -13,11 +13,11 @@ import {
     UPLOAD,
     UPLOAD_PROGRESS
 } from "../app/actionTypes";
+import { createAction } from "@reduxjs/toolkit";
 
-export const wsInsertFile = data => ({
-    type: WS_INSERT_FILE,
-    data
-});
+export const wsInsertFile = createAction(WS_INSERT_FILE, data => ({
+    payload: { ...data }
+}));
 
 /**
  * Returns an action that should be dispatched when a file document is updated via websocket.
@@ -26,10 +26,9 @@ export const wsInsertFile = data => ({
  * @param data {object} the data passed in the websocket message
  * @returns {object}
  */
-export const wsUpdateFile = data => ({
-    type: WS_UPDATE_FILE,
-    data
-});
+export const wsUpdateFile = createAction(WS_UPDATE_FILE, data => ({
+    payload: { ...data }
+}));
 
 /**
  * Returns an action that should be dispatched when a file document is removed via websocket.
@@ -38,10 +37,9 @@ export const wsUpdateFile = data => ({
  * @param data {object} the data passed in the websocket message
  * @returns {object}
  */
-export const wsRemoveFile = data => ({
-    type: WS_REMOVE_FILE,
-    data
-});
+export const wsRemoveFile = createAction(WS_REMOVE_FILE, data => ({
+    payload: { ...data }
+}));
 
 /**
  * Returns an action that can trigger an API call that finds file documents.
@@ -51,12 +49,13 @@ export const wsRemoveFile = data => ({
  * @param page {number} which page of results to return
  * @returns {object}
  */
-export const findFiles = (fileType, term, page) => ({
-    type: FIND_FILES.REQUESTED,
-    fileType,
-    term,
-    page
-});
+export const findFiles = createAction(FIND_FILES.REQUESTED, (fileType, term, page) => ({
+    payload: {
+        fileType,
+        term,
+        page
+    }
+}));
 
 /**
  * Returns an action that can trigger the upload of a file to the server.
@@ -68,13 +67,14 @@ export const findFiles = (fileType, term, page) => ({
  * @param context {object} extra information to attach to the upload object
  * @returns {object}
  */
-export const upload = (localId, file, fileType, context = {}) => ({
-    type: UPLOAD.REQUESTED,
-    localId,
-    file,
-    fileType,
-    context
-});
+export const upload = createAction(UPLOAD.REQUESTED, (localId, file, fileType, context = {}) => ({
+    payload: {
+        localId,
+        file,
+        fileType,
+        context
+    }
+}));
 
 /**
  * Returns an action that can trigger an API call that removes a file by its fileId.
@@ -83,10 +83,9 @@ export const upload = (localId, file, fileType, context = {}) => ({
  * @param fileId {string} the unique id for the file
  * @returns {object}
  */
-export const removeFile = fileId => ({
-    type: REMOVE_FILE.REQUESTED,
-    fileId
-});
+export const removeFile = createAction(REMOVE_FILE.REQUESTED, fileId => ({
+    payload: { fileId }
+}));
 
 /**
  * Returns and action that updates the progress of an ongoing upload.
@@ -96,8 +95,6 @@ export const removeFile = fileId => ({
  * @param progress {number} the new progress value
  * @returns {object}
  */
-export const uploadProgress = (localId, progress) => ({
-    type: UPLOAD_PROGRESS,
-    localId,
-    progress
-});
+export const uploadProgress = createAction(UPLOAD_PROGRESS, (localId, progress) => ({
+    payload: { localId, progress }
+}));

--- a/src/js/files/components/__tests__/File.test.js
+++ b/src/js/files/components/__tests__/File.test.js
@@ -107,7 +107,7 @@ describe("mapDispatchToProps", () => {
         props.onRemove("foo");
         expect(dispatch).toHaveBeenCalledWith({
             type: REMOVE_FILE.REQUESTED,
-            fileId: "foo"
+            payload: { fileId: "foo" }
         });
     });
 });

--- a/src/js/files/reducer.js
+++ b/src/js/files/reducer.js
@@ -81,36 +81,36 @@ export const updateProgress = (state, action) => {
 export const filesReducer = createReducer(initialState, builder => {
     builder
         .addCase(WS_INSERT_FILE, (state, action) => {
-            if (action.data.type === state.fileType) {
-                return insert(state, action, "uploaded_at", true);
+            if (action.payload.type === state.fileType) {
+                return insert(state, action.payload, "uploaded_at", true);
             }
             return state;
         })
         .addCase(WS_UPDATE_FILE, (state, action) => {
-            return update(state, action, "uploaded_at", true);
+            return update(state, action.payload, "uploaded_at", true);
         })
         .addCase(WS_REMOVE_FILE, (state, action) => {
-            return remove(state, action);
+            return remove(state, action.payload);
         })
         .addCase(FIND_FILES.REQUESTED, (state, action) => {
-            state.term = action.term;
-            state.documents = state.fileType === action.fileType ? state.documents : null;
+            state.term = action.payload.term;
+            state.documents = state.fileType === action.payload.fileType ? state.documents : null;
             state.fileType = "";
         })
         .addCase(FIND_FILES.SUCCEEDED, (state, action) => {
             return {
-                ...updateDocuments(state, action, "uploaded_at", true),
+                ...updateDocuments(state, action.payload, "uploaded_at", true),
                 fileType: action.context.fileType
             };
         })
         .addCase(UPLOAD.REQUESTED, (state, action) => {
-            return cleanUploads(appendUpload(state, action));
+            return cleanUploads(appendUpload(state, action.payload));
         })
         .addCase(UPLOAD_SAMPLE_FILE.REQUESTED, (state, action) => {
-            return cleanUploads(appendUpload(state, action));
+            return cleanUploads(appendUpload(state, action.payload));
         })
         .addCase(UPLOAD_PROGRESS, (state, action) => {
-            return cleanUploads(updateProgress(state, action));
+            return cleanUploads(updateProgress(state, action.payload));
         });
 });
 

--- a/src/js/files/sagas.js
+++ b/src/js/files/sagas.js
@@ -13,18 +13,18 @@ export function* watchFiles() {
 }
 
 export function* findFiles(action) {
-    yield apiCall(filesAPI.list, action, FIND_FILES, {
-        fileType: action.fileType
+    yield apiCall(filesAPI.list, action.payload, FIND_FILES, {
+        fileType: action.payload.fileType
     });
 }
 
 export function* removeFile(action) {
-    yield apiCall(filesAPI.remove, action, REMOVE_FILE);
+    yield apiCall(filesAPI.remove, action.payload, REMOVE_FILE);
 }
 
 export function* upload(action) {
-    const { localId } = action;
-    const channel = yield call(createUploadChannel, action, filesAPI.upload);
+    const { localId } = action.payload;
+    const channel = yield call(createUploadChannel, action.payload, filesAPI.upload);
     yield watchUploadChannel(channel, UPLOAD, localId);
 }
 
@@ -63,11 +63,10 @@ export function* watchUploadChannel(channel, actionType, localId) {
         if (err) {
             return yield putGenericError(actionType, err);
         }
-
         if (response) {
             return yield put({
                 type: actionType.SUCCEEDED,
-                data: {
+                payload: {
                     ...response.body,
                     localId
                 }

--- a/src/js/groups/__tests__/actions.test.js
+++ b/src/js/groups/__tests__/actions.test.js
@@ -23,7 +23,7 @@ describe("Groups Action Creators:", () => {
         const result = wsInsertGroup(data);
         expect(result).toEqual({
             type: WS_INSERT_GROUP,
-            data
+            payload: { ...data }
         });
     });
 
@@ -32,7 +32,7 @@ describe("Groups Action Creators:", () => {
         const result = wsUpdateGroup(data);
         expect(result).toEqual({
             type: WS_UPDATE_GROUP,
-            data
+            payload: { ...data }
         });
     });
 
@@ -41,7 +41,7 @@ describe("Groups Action Creators:", () => {
         const result = wsRemoveGroup(data);
         expect(result).toEqual({
             type: WS_REMOVE_GROUP,
-            data
+            payload: data
         });
     });
 
@@ -57,7 +57,7 @@ describe("Groups Action Creators:", () => {
         const result = createGroup(groupId);
         expect(result).toEqual({
             type: CREATE_GROUP.REQUESTED,
-            groupId
+            payload: { groupId }
         });
     });
 
@@ -68,9 +68,7 @@ describe("Groups Action Creators:", () => {
         const result = setGroupPermission(groupId, permission, value);
         expect(result).toEqual({
             type: SET_GROUP_PERMISSION.REQUESTED,
-            groupId,
-            permission,
-            value
+            payload: { groupId, permission, value }
         });
     });
 
@@ -79,7 +77,7 @@ describe("Groups Action Creators:", () => {
         const result = removeGroup(groupId);
         expect(result).toEqual({
             type: REMOVE_GROUP.REQUESTED,
-            groupId
+            payload: { groupId }
         });
     });
 });

--- a/src/js/groups/__tests__/reducer.test.js
+++ b/src/js/groups/__tests__/reducer.test.js
@@ -26,7 +26,7 @@ describe("Groups Reducer", () => {
     describe("should handle WS_INSERT_GROUP", () => {
         it("if documents are not yet fetched, return state", () => {
             const state = { documents: null };
-            const action = { type: WS_INSERT_GROUP, data: { id: "foo" } };
+            const action = { type: WS_INSERT_GROUP, payload: { id: "foo" } };
             const result = reducer(state, action);
             expect(result).toEqual({
                 documents: [{ id: "foo" }]
@@ -37,7 +37,7 @@ describe("Groups Reducer", () => {
             const state = { documents: [] };
             const action = {
                 type: WS_INSERT_GROUP,
-                data: { id: "test" }
+                payload: { id: "test" }
             };
             const result = reducer(state, action);
             expect(result).toEqual({ documents: [{ id: "test" }] });
@@ -48,7 +48,7 @@ describe("Groups Reducer", () => {
         const state = { documents: [{ id: "test", foo: "bar" }] };
         const action = {
             type: WS_UPDATE_GROUP,
-            data: { id: "test", foo: "baz" }
+            payload: { id: "test", foo: "baz" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({ ...state, documents: [{ id: "test", foo: "baz" }] });
@@ -56,22 +56,22 @@ describe("Groups Reducer", () => {
 
     it("should handle WS_REMOVE_GROUP", () => {
         const state = { documents: [{ id: "foo" }, { id: "bar" }], activeId: "bar" };
-        const action = { type: WS_REMOVE_GROUP, data: ["bar"] };
+        const action = { type: WS_REMOVE_GROUP, payload: ["bar"] };
         const result = reducer(state, action);
         expect(result).toEqual({ ...state, documents: [{ id: "foo" }], activeId: "foo" });
     });
 
     it("should handle LIST_GROUPS_SUCCEEDED", () => {
         const state = { documents: null };
-        const data = [{ id: "foo" }, { id: "bar" }];
+        const payload = [{ id: "foo" }, { id: "bar" }];
         const action = {
             type: LIST_GROUPS.SUCCEEDED,
-            data
+            payload
         };
         const result = reducer(state, action);
         expect(result).toEqual({
             ...state,
-            documents: data,
+            documents: payload,
             activeId: "foo"
         });
     });
@@ -103,7 +103,7 @@ describe("Groups Reducer", () => {
 
     it("should handle CREATE_GROUP_SUCCEEDED", () => {
         const id = "foo";
-        const action = { type: CREATE_GROUP.SUCCEEDED, data: { id } };
+        const action = { type: CREATE_GROUP.SUCCEEDED, payload: { id } };
         const result = reducer({}, action);
         expect(result).toEqual({ pending: false, activeId: id });
     });

--- a/src/js/groups/actions.js
+++ b/src/js/groups/actions.js
@@ -1,4 +1,3 @@
-import { simpleActionCreator } from "../utils/utils";
 import {
     WS_INSERT_GROUP,
     WS_UPDATE_GROUP,
@@ -9,33 +8,22 @@ import {
     REMOVE_GROUP,
     CHANGE_ACTIVE_GROUP
 } from "../app/actionTypes";
+import { createAction } from "@reduxjs/toolkit";
 
-export const wsInsertGroup = data => ({
-    type: WS_INSERT_GROUP,
-    data
-});
+export const wsInsertGroup = createAction(WS_INSERT_GROUP);
 
-export const wsUpdateGroup = data => ({
-    type: WS_UPDATE_GROUP,
-    data
-});
+export const wsUpdateGroup = createAction(WS_UPDATE_GROUP);
 
-export const wsRemoveGroup = data => ({
-    type: WS_REMOVE_GROUP,
-    data
-});
+export const wsRemoveGroup = createAction(WS_REMOVE_GROUP);
 
-export const changeActiveGroup = id => ({
-    type: CHANGE_ACTIVE_GROUP,
-    id
-});
+export const changeActiveGroup = createAction(CHANGE_ACTIVE_GROUP, id => ({ payload: { id } }));
 
 /**
  * Returns an action that triggers a request for all groups from the API.
  *
  * @func
  */
-export const listGroups = simpleActionCreator(LIST_GROUPS.REQUESTED);
+export const listGroups = createAction(LIST_GROUPS.REQUESTED);
 
 /**
  * Returns an action that triggers a API request to create a group with the given `groupId`.
@@ -44,10 +32,7 @@ export const listGroups = simpleActionCreator(LIST_GROUPS.REQUESTED);
  * @param groupId {string} the id for the new group
  * @returns {object}
  */
-export const createGroup = groupId => ({
-    type: CREATE_GROUP.REQUESTED,
-    groupId
-});
+export const createGroup = createAction(CREATE_GROUP.REQUESTED, groupId => ({ payload: { groupId } }));
 
 /**
  * Returns action that can trigger an API request for modifying group permissions.
@@ -57,12 +42,9 @@ export const createGroup = groupId => ({
  * @param value {boolean} is checked or not
  * @returns {object}
  */
-export const setGroupPermission = (groupId, permission, value) => ({
-    type: SET_GROUP_PERMISSION.REQUESTED,
-    groupId,
-    permission,
-    value
-});
+export const setGroupPermission = createAction(SET_GROUP_PERMISSION.REQUESTED, (groupId, permission, value) => ({
+    payload: { groupId, permission, value }
+}));
 
 /**
  * Returns an action that triggers a API request to remove a group with the given `groupId`.
@@ -71,7 +53,4 @@ export const setGroupPermission = (groupId, permission, value) => ({
  * @param groupId {string} the id for the new group
  * @returns {object}
  */
-export const removeGroup = groupId => ({
-    type: REMOVE_GROUP.REQUESTED,
-    groupId
-});
+export const removeGroup = createAction(REMOVE_GROUP.REQUESTED, groupId => ({ payload: { groupId } }));

--- a/src/js/groups/components/__tests__/Group.test.js
+++ b/src/js/groups/components/__tests__/Group.test.js
@@ -60,7 +60,7 @@ describe("mapDispatchToProps", () => {
 
         expect(dispatch).toHaveBeenCalledWith({
             type: CHANGE_ACTIVE_GROUP,
-            id: "foo"
+            payload: { id: "foo" }
         });
     });
 });

--- a/src/js/groups/reducer.js
+++ b/src/js/groups/reducer.js
@@ -40,23 +40,23 @@ export const insertGroup = (documents, entry) => sortBy(concat(documents, [entry
 export const groupsReducer = createReducer(initialState, builder => {
     builder
         .addCase(WS_INSERT_GROUP, (state, action) => {
-            return insert(state, action, "id");
+            return insert(state, action.payload, "id");
         })
         .addCase(WS_UPDATE_GROUP, (state, action) => {
-            return update(state, action);
+            return update(state, action.payload);
         })
         .addCase(WS_REMOVE_GROUP, (state, action) => {
-            return updateActiveId(remove(state, action));
+            return updateActiveId(remove(state, action.payload));
         })
         .addCase(CHANGE_ACTIVE_GROUP, (state, action) => {
-            state.activeId = action.id;
+            state.activeId = action.payload.id;
         })
         .addCase(LIST_GROUPS.SUCCEEDED, (state, action) => {
-            return updateActiveId({ ...state, documents: action.data });
+            return updateActiveId({ ...state, documents: action.payload });
         })
         .addCase(CREATE_GROUP.SUCCEEDED, (state, action) => {
             state.pending = false;
-            state.activeId = action.data.id;
+            state.activeId = action.payload.id;
         })
         .addCase(REMOVE_GROUP.SUCCEEDED, state => {
             return updateActiveId({ ...state, pending: false });

--- a/src/js/groups/sagas.js
+++ b/src/js/groups/sagas.js
@@ -15,13 +15,13 @@ function* listGroups(action) {
 }
 
 function* createGroup(action) {
-    yield apiCall(groupsAPI.create, action, CREATE_GROUP);
+    yield apiCall(groupsAPI.create, action.payload, CREATE_GROUP);
 }
 
 function* setGroupPermission(action) {
-    yield apiCall(groupsAPI.setPermission, action, SET_GROUP_PERMISSION);
+    yield apiCall(groupsAPI.setPermission, action.payload, SET_GROUP_PERMISSION);
 }
 
 function* removeGroup(action) {
-    yield apiCall(groupsAPI.remove, action, REMOVE_GROUP);
+    yield apiCall(groupsAPI.remove, action.payload, REMOVE_GROUP);
 }

--- a/src/js/hmm/__tests__/actions.test.js
+++ b/src/js/hmm/__tests__/actions.test.js
@@ -8,8 +8,7 @@ describe("HMM Action Creators:", () => {
         const result = findHmms(term, page);
         expect(result).toEqual({
             type: FIND_HMMS.REQUESTED,
-            term,
-            page
+            payload: { term, page }
         });
     });
 
@@ -18,7 +17,7 @@ describe("HMM Action Creators:", () => {
         const result = getHmm(hmmId);
         expect(result).toEqual({
             type: GET_HMM.REQUESTED,
-            hmmId
+            payload: { hmmId }
         });
     });
 
@@ -27,7 +26,7 @@ describe("HMM Action Creators:", () => {
         const result = installHMMs(releaseId);
         expect(result).toEqual({
             type: INSTALL_HMMS.REQUESTED,
-            release_id: releaseId
+            payload: { release_id: releaseId }
         });
     });
 

--- a/src/js/hmm/__tests__/reducer.test.js
+++ b/src/js/hmm/__tests__/reducer.test.js
@@ -20,7 +20,7 @@ describe("HMM Reducer", () => {
             const state = {};
             const action = {
                 type: WS_UPDATE_STATUS,
-                data: {
+                payload: {
                     id: "hmm",
                     installed: {},
                     task: {},
@@ -41,7 +41,7 @@ describe("HMM Reducer", () => {
             const state = {};
             const action = {
                 type: WS_UPDATE_STATUS,
-                data: { id: "not_hmm" }
+                payload: { id: "not_hmm" }
             };
             const result = reducer(state, action);
             expect(result).toEqual(state);
@@ -50,7 +50,7 @@ describe("HMM Reducer", () => {
 
     it("should handle FIND_HMMS_REQUESTED", () => {
         const term = "foo";
-        const action = { type: FIND_HMMS.REQUESTED, term, page: 5 };
+        const action = { type: FIND_HMMS.REQUESTED, payload: { term, page: 5 } };
         const result = reducer({}, action);
         expect(result).toEqual({
             term
@@ -61,7 +61,7 @@ describe("HMM Reducer", () => {
         const state = { documents: null, page: 0 };
         const action = {
             type: FIND_HMMS.SUCCEEDED,
-            data: { documents: [{ id: "foo" }], page: 1 }
+            payload: { documents: [{ id: "foo" }], page: 1 }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -84,11 +84,11 @@ describe("HMM Reducer", () => {
     it("should handle GET_HMM_SUCCEEDED", () => {
         const action = {
             type: GET_HMM.SUCCEEDED,
-            data: {}
+            payload: {}
         };
         const result = reducer({}, action);
         expect(result).toEqual({
-            detail: action.data
+            detail: action.payload
         });
     });
 });

--- a/src/js/hmm/actions.js
+++ b/src/js/hmm/actions.js
@@ -1,11 +1,9 @@
-import { simpleActionCreator } from "../utils/utils";
 import { GET_HMM, INSTALL_HMMS, FIND_HMMS, PURGE_HMMS } from "../app/actionTypes";
+import { createAction } from "@reduxjs/toolkit";
 
-export const findHmms = (term, page) => ({
-    type: FIND_HMMS.REQUESTED,
-    term,
-    page
-});
+export const findHmms = createAction(FIND_HMMS.REQUESTED, (term, page) => ({
+    payload: { term, page }
+}));
 
 /**
  * Returns action that can trigger an API call for getting specific hmm documents from database.
@@ -14,10 +12,7 @@ export const findHmms = (term, page) => ({
  * @param hmmId {string} unique id for specific hmm document
  * @returns {object}
  */
-export const getHmm = hmmId => ({
-    type: GET_HMM.REQUESTED,
-    hmmId
-});
+export const getHmm = createAction(GET_HMM.REQUESTED, hmmId => ({ payload: { hmmId } }));
 
 /**
  * Returns action that can trigger an API call for installing HMMs from virtool repository.
@@ -25,10 +20,7 @@ export const getHmm = hmmId => ({
  * @func
  * @returns {object}
  */
-export const installHMMs = releaseId => ({
-    type: INSTALL_HMMS.REQUESTED,
-    release_id: releaseId
-});
+export const installHMMs = createAction(INSTALL_HMMS.REQUESTED, releaseId => ({ payload: { release_id: releaseId } }));
 
 /**
  * Returns action that can trigger an API call for purging all HMMs. In other words, removing unreferenced HMM profiles
@@ -37,4 +29,4 @@ export const installHMMs = releaseId => ({
  * @func
  * @returns {object}
  */
-export const purgeHMMs = simpleActionCreator(PURGE_HMMS.REQUESTED);
+export const purgeHMMs = createAction(PURGE_HMMS.REQUESTED);

--- a/src/js/hmm/components/__tests__/Detail.test.js
+++ b/src/js/hmm/components/__tests__/Detail.test.js
@@ -66,6 +66,6 @@ describe("mapDispatchToProps()", () => {
     it("should return onGet() in props", () => {
         const props = mapDispatchToProps(dispatch);
         props.onGet("foo");
-        expect(dispatch).toHaveBeenCalledWith({ hmmId: "foo", type: "GET_HMM_REQUESTED" });
+        expect(dispatch).toHaveBeenCalledWith({ payload: { hmmId: "foo" }, type: "GET_HMM_REQUESTED" });
     });
 });

--- a/src/js/hmm/components/__tests__/InstallOption.test.js
+++ b/src/js/hmm/components/__tests__/InstallOption.test.js
@@ -54,7 +54,7 @@ describe("mapDispatchToProps", () => {
         const props = mapDispatchToProps(dispatch);
         props.onInstall(releaseId);
         expect(dispatch).toHaveBeenCalledWith({
-            release_id: "foo",
+            payload: { release_id: "foo" },
             type: "INSTALL_HMMS_REQUESTED"
         });
     });

--- a/src/js/hmm/components/__tests__/Installer.test.js
+++ b/src/js/hmm/components/__tests__/Installer.test.js
@@ -71,6 +71,6 @@ describe("mapDispatchToProps", () => {
         const dispatch = jest.fn();
         const props = mapDispatchToProps(dispatch);
         props.onInstall("foo");
-        expect(dispatch).toHaveBeenCalledWith({ release_id: "foo", type: "INSTALL_HMMS_REQUESTED" });
+        expect(dispatch).toHaveBeenCalledWith({ payload: { release_id: "foo" }, type: "INSTALL_HMMS_REQUESTED" });
     });
 });

--- a/src/js/hmm/reducer.js
+++ b/src/js/hmm/reducer.js
@@ -14,23 +14,23 @@ export const initialState = {
 export const hmmsReducer = createReducer(initialState, builder => {
     builder
         .addCase(WS_UPDATE_STATUS, (state, action) => {
-            if (action.data.id === "hmm") {
-                set(state, "status.installed", action.data.installed);
-                set(state, "status.task", action.data.task);
-                set(state, "status.release", action.data.release);
+            if (action.payload.id === "hmm") {
+                set(state, "status.installed", action.payload.installed);
+                set(state, "status.task", action.payload.task);
+                set(state, "status.release", action.payload.release);
             }
         })
         .addCase(FIND_HMMS.REQUESTED, (state, action) => {
-            state.term = action.term;
+            state.term = action.payload.term;
         })
         .addCase(FIND_HMMS.SUCCEEDED, (state, action) => {
-            return updateDocuments(state, action, "cluster");
+            return updateDocuments(state, action.payload, "cluster");
         })
         .addCase(GET_HMM.REQUESTED, state => {
             state.detail = null;
         })
         .addCase(GET_HMM.SUCCEEDED, (state, action) => {
-            state.detail = action.data;
+            state.detail = action.payload;
         });
 });
 

--- a/src/js/hmm/sagas.js
+++ b/src/js/hmm/sagas.js
@@ -12,7 +12,7 @@ export function* watchHmms() {
 }
 
 export function* findHmms(action) {
-    yield apiCall(hmmsAPI.find, action, FIND_HMMS);
+    yield apiCall(hmmsAPI.find, action.payload, FIND_HMMS);
 
     const routerLocation = yield select(getLocation);
 
@@ -26,7 +26,7 @@ export function* installHmms(action) {
 }
 
 export function* getHmm(action) {
-    yield apiCall(hmmsAPI.get, action, GET_HMM);
+    yield apiCall(hmmsAPI.get, action.payload, GET_HMM);
 }
 
 export function* purgeHmms(action) {

--- a/src/js/indexes/__tests__/actions.test.js
+++ b/src/js/indexes/__tests__/actions.test.js
@@ -27,7 +27,7 @@ describe("Index Action Creators", () => {
         const result = wsInsertHistory(data);
         expect(result).toEqual({
             type: WS_INSERT_HISTORY,
-            data
+            payload: { ...data }
         });
     });
 
@@ -36,7 +36,7 @@ describe("Index Action Creators", () => {
         const result = wsInsertIndex(data);
         expect(result).toEqual({
             type: WS_INSERT_INDEX,
-            data
+            payload: { ...data }
         });
     });
 
@@ -45,7 +45,7 @@ describe("Index Action Creators", () => {
         const result = wsUpdateIndex(data);
         expect(result).toEqual({
             type: WS_UPDATE_INDEX,
-            data
+            payload: { ...data }
         });
     });
 
@@ -56,9 +56,7 @@ describe("Index Action Creators", () => {
         const result = findIndexes(refId, term, page);
         expect(result).toEqual({
             type: FIND_INDEXES.REQUESTED,
-            refId,
-            term,
-            page
+            payload: { refId, term, page }
         });
     });
 
@@ -72,7 +70,7 @@ describe("Index Action Creators", () => {
         const result = getIndex(indexId);
         expect(result).toEqual({
             type: GET_INDEX.REQUESTED,
-            indexId
+            payload: { indexId }
         });
     });
 
@@ -81,7 +79,7 @@ describe("Index Action Creators", () => {
         const result = getUnbuilt(refId);
         expect(result).toEqual({
             type: GET_UNBUILT.REQUESTED,
-            refId
+            payload: { refId }
         });
     });
 
@@ -90,7 +88,7 @@ describe("Index Action Creators", () => {
         const result = createIndex(refId);
         expect(result).toEqual({
             type: CREATE_INDEX.REQUESTED,
-            refId
+            payload: { refId }
         });
     });
 
@@ -100,8 +98,7 @@ describe("Index Action Creators", () => {
         const result = getIndexHistory(indexId, page);
         expect(result).toEqual({
             type: GET_INDEX_HISTORY.REQUESTED,
-            indexId,
-            page
+            payload: { indexId, page }
         });
     });
 });

--- a/src/js/indexes/__tests__/reducer.test.js
+++ b/src/js/indexes/__tests__/reducer.test.js
@@ -28,7 +28,7 @@ describe("Indexes Reducer", () => {
             const state = { refId: "foo", modified_otu_count: 3 };
             const action = {
                 type: WS_INSERT_HISTORY,
-                data: { reference: { id: "foo" } }
+                payload: { reference: { id: "foo" } }
             };
             const result = reducer(state, action);
             expect(result).toEqual({ ...state, modified_otu_count: 4 });
@@ -38,7 +38,7 @@ describe("Indexes Reducer", () => {
             const state = { refId: "foo" };
             const action = {
                 type: WS_INSERT_HISTORY,
-                data: { reference: { id: "bar" } }
+                payload: { reference: { id: "bar" } }
             };
             const result = reducer(state, action);
             expect(result).toEqual(state);
@@ -50,7 +50,7 @@ describe("Indexes Reducer", () => {
             const state = { refId: "foo" };
             const action = {
                 type: WS_INSERT_INDEX,
-                data: {
+                payload: {
                     reference: { id: "bar" }
                 }
             };
@@ -66,7 +66,7 @@ describe("Indexes Reducer", () => {
             };
             const action = {
                 type: WS_INSERT_INDEX,
-                data: {
+                payload: {
                     reference: { id: "foo" },
                     version: 0
                 }
@@ -74,7 +74,7 @@ describe("Indexes Reducer", () => {
             const result = reducer(state, action);
             expect(result).toEqual({
                 ...state,
-                documents: [{ ...action.data }]
+                documents: [{ ...action.payload }]
             });
         });
     });
@@ -84,7 +84,7 @@ describe("Indexes Reducer", () => {
             const state = { refId: "foo" };
             const action = {
                 type: WS_UPDATE_INDEX,
-                data: { reference: { id: "bar" } }
+                payload: { reference: { id: "bar" } }
             };
             const result = reducer(state, action);
             expect(result).toEqual(state);
@@ -97,7 +97,7 @@ describe("Indexes Reducer", () => {
             };
             const action = {
                 type: WS_UPDATE_INDEX,
-                data: {
+                payload: {
                     id: "test",
                     reference: { id: "foo" },
                     version: 1
@@ -117,9 +117,7 @@ describe("Indexes Reducer", () => {
         const refId = "foo";
         const action = {
             type: FIND_INDEXES.REQUESTED,
-            refId,
-            term,
-            page: 4
+            payload: { refId, term, page: 4 }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -135,7 +133,7 @@ describe("Indexes Reducer", () => {
         };
         const action = {
             type: FIND_INDEXES.SUCCEEDED,
-            data: {
+            payload: {
                 documents: [{ id: "1" }],
                 page: 2
             }
@@ -149,7 +147,7 @@ describe("Indexes Reducer", () => {
 
     it("should handle GET_INDEX_REQUESTED", () => {
         const state = {};
-        const action = { type: GET_INDEX.REQUESTED };
+        const action = { type: GET_INDEX.REQUESTED, payload: {} };
         const result = reducer(state, action);
         expect(result).toEqual({ detail: null });
     });
@@ -158,12 +156,12 @@ describe("Indexes Reducer", () => {
         const state = { detail: null };
         const action = {
             type: GET_INDEX.SUCCEEDED,
-            data: { id: "foo", version: 3 }
+            payload: { id: "foo", version: 3 }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
             ...state,
-            detail: action.data
+            detail: action.payload
         });
     });
 
@@ -171,11 +169,11 @@ describe("Indexes Reducer", () => {
         const state = {};
         const action = {
             type: GET_UNBUILT.SUCCEEDED,
-            data: {}
+            payload: {}
         };
         const result = reducer(state, action);
         expect(result).toEqual({
-            unbuilt: action.data
+            unbuilt: action.payload
         });
     });
 
@@ -183,13 +181,13 @@ describe("Indexes Reducer", () => {
         const state = { history: { documents: null } };
         const action = {
             type: GET_INDEX_HISTORY.SUCCEEDED,
-            data: { documents: [{ foo: "bar" }], page: 1, per_page: 3 }
+            payload: { documents: [{ foo: "bar" }], page: 1, per_page: 3 }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
             ...state,
             history: {
-                ...action.data
+                ...action.payload
             }
         });
     });

--- a/src/js/indexes/actions.js
+++ b/src/js/indexes/actions.js
@@ -9,16 +9,25 @@ import {
     LIST_READY_INDEXES,
     WS_INSERT_HISTORY
 } from "../app/actionTypes";
+import { createAction } from "@reduxjs/toolkit";
 
-export const wsInsertHistory = data => ({
-    type: WS_INSERT_HISTORY,
-    data
-});
+/**
+ * Returns an action that should be dispatched when a history document is inserted via websocket.
+ *
+ * @func
+ * @param data {object} the data passed in the websocket message
+ * @returns {object}
+ */
+export const wsInsertHistory = createAction(WS_INSERT_HISTORY);
 
-export const wsInsertIndex = data => ({
-    type: WS_INSERT_INDEX,
-    data
-});
+/**
+ * Returns an action that should be dispatched when an index document is inserted via websocket.
+ *
+ * @func
+ * @param data {object} the data passed in the websocket message
+ * @returns {object}
+ */
+export const wsInsertIndex = createAction(WS_INSERT_INDEX);
 
 /**
  * Returns an action that should be dispatched when an index document is updated via websocket.
@@ -27,10 +36,7 @@ export const wsInsertIndex = data => ({
  * @param data {object} the data passed in the websocket message
  * @returns {object}
  */
-export const wsUpdateIndex = data => ({
-    type: WS_UPDATE_INDEX,
-    data
-});
+export const wsUpdateIndex = createAction(WS_UPDATE_INDEX);
 
 /**
  * Returns action that can trigger an API call for getting available OTU indexes.
@@ -38,12 +44,9 @@ export const wsUpdateIndex = data => ({
  * @func
  * @returns {object}
  */
-export const findIndexes = (refId, term, page) => ({
-    type: FIND_INDEXES.REQUESTED,
-    refId,
-    term,
-    page
-});
+export const findIndexes = createAction(FIND_INDEXES.REQUESTED, (refId, term, page) => ({
+    payload: { refId, term, page }
+}));
 
 /**
  * Returns action that can trigger an API call for getting all ready OTU indexes.
@@ -51,9 +54,7 @@ export const findIndexes = (refId, term, page) => ({
  * @func
  * @returns {object}
  */
-export const listReadyIndexes = () => ({
-    type: LIST_READY_INDEXES.REQUESTED
-});
+export const listReadyIndexes = createAction(LIST_READY_INDEXES.REQUESTED);
 
 /**
  * Returns action that can trigger an API call for getting specific OTU index.
@@ -62,10 +63,7 @@ export const listReadyIndexes = () => ({
  * @param indexId {string} the unique index id.
  * @returns {object}
  */
-export const getIndex = indexId => ({
-    type: GET_INDEX.REQUESTED,
-    indexId
-});
+export const getIndex = createAction(GET_INDEX.REQUESTED, indexId => ({ payload: { indexId } }));
 
 /**
  * Returns action that can trigger an API call for getting unbuilt data.
@@ -73,10 +71,7 @@ export const getIndex = indexId => ({
  * @func
  * @returns {object}
  */
-export const getUnbuilt = refId => ({
-    type: GET_UNBUILT.REQUESTED,
-    refId
-});
+export const getUnbuilt = createAction(GET_UNBUILT.REQUESTED, refId => ({ payload: { refId } }));
 
 /**
  * Returns action that can trigger an API call for creating a new OTU index.
@@ -84,10 +79,7 @@ export const getUnbuilt = refId => ({
  * @func
  * @returns {object}
  */
-export const createIndex = refId => ({
-    type: CREATE_INDEX.REQUESTED,
-    refId
-});
+export const createIndex = createAction(CREATE_INDEX.REQUESTED, refId => ({ payload: { refId } }));
 
 /**
  * Returns action that can trigger an API call for getting a specific page in the index version history.
@@ -97,8 +89,6 @@ export const createIndex = refId => ({
  * @param page {number} the page to retrieve from the list of changes.
  * @returns {object}
  */
-export const getIndexHistory = (indexId, page) => ({
-    type: GET_INDEX_HISTORY.REQUESTED,
-    indexId,
-    page
-});
+export const getIndexHistory = createAction(GET_INDEX_HISTORY.REQUESTED, (indexId, page) => ({
+    payload: { indexId, page }
+}));

--- a/src/js/indexes/components/__tests__/Detail.test.js
+++ b/src/js/indexes/components/__tests__/Detail.test.js
@@ -112,7 +112,7 @@ describe("mapDispatchToProps()", () => {
         result.onGetIndex(indexId);
         expect(dispatch).toHaveBeenCalledWith({
             type: GET_INDEX.REQUESTED,
-            indexId
+            payload: { indexId }
         });
     });
 
@@ -122,8 +122,7 @@ describe("mapDispatchToProps()", () => {
         result.onGetChanges(indexId, 3);
         expect(dispatch).toHaveBeenCalledWith({
             type: GET_INDEX_HISTORY.REQUESTED,
-            indexId,
-            page: 3
+            payload: { indexId, page: 3 }
         });
     });
 });

--- a/src/js/indexes/reducer.js
+++ b/src/js/indexes/reducer.js
@@ -24,45 +24,45 @@ export const initialState = {
 export const indexesReducer = createReducer(initialState, builder => {
     builder
         .addCase(WS_INSERT_HISTORY, (state, action) => {
-            if (action.data.reference.id === state.refId) {
+            if (action.payload.reference.id === state.refId) {
                 state.modified_otu_count++;
             }
             return state;
         })
         .addCase(WS_INSERT_INDEX, (state, action) => {
-            if (action.data.reference.id === state.refId) {
-                return insert(state, action, "version", true);
+            if (action.payload.reference.id === state.refId) {
+                return insert(state, action.payload, "version", true);
             }
             return state;
         })
         .addCase(WS_UPDATE_INDEX, (state, action) => {
-            if (action.data.reference.id === state.refId) {
-                return update(state, action, "version", true);
+            if (action.payload.reference.id === state.refId) {
+                return update(state, action.payload, "version", true);
             }
             return state;
         })
         .addCase(FIND_INDEXES.REQUESTED, (state, action) => {
-            state.term = action.term;
-            state.refId = action.refId;
+            state.term = action.payload.term;
+            state.refId = action.payload.refId;
         })
         .addCase(FIND_INDEXES.SUCCEEDED, (state, action) => {
-            return updateDocuments(state, action, "version", true);
+            return updateDocuments(state, action.payload, "version", true);
         })
         .addCase(GET_INDEX.REQUESTED, (state, action) => {
-            state.refId = action.refId;
+            state.refId = action.payload.refId;
             state.detail = null;
         })
         .addCase(GET_INDEX.SUCCEEDED, (state, action) => {
-            state.detail = action.data;
+            state.detail = action.payload;
         })
         .addCase(GET_UNBUILT.SUCCEEDED, (state, action) => {
-            state.unbuilt = action.data;
+            state.unbuilt = action.payload;
         })
         .addCase(GET_INDEX_HISTORY.SUCCEEDED, (state, action) => {
             return {
                 ...state,
                 history: {
-                    ...updateDocuments(state.history, action, "otu.name")
+                    ...updateDocuments(state.history, action.payload, "otu.name")
                 }
             };
         });

--- a/src/js/indexes/sagas.js
+++ b/src/js/indexes/sagas.js
@@ -32,8 +32,8 @@ export function* watchIndexes() {
 }
 
 export function* wsChangeIndexes(action) {
-    // The id of the ref accosicated with the WS update.
-    const indexDetailId = action.data.reference.id;
+    // The id of the ref associated with the WS update.
+    const indexDetailId = action.payload.reference.id;
 
     // The id of the current detailed ref.
     const refId = yield select(state => get(state, "references.detail.id"));
@@ -49,24 +49,24 @@ export function* wsChangeIndexes(action) {
 }
 
 export function* findIndexes(action) {
-    yield apiCall(indexesAPI.find, action, FIND_INDEXES);
+    yield apiCall(indexesAPI.find, action.payload, FIND_INDEXES);
 }
 
 export function* getIndex(action) {
     yield select();
-    yield apiCall(indexesAPI.get, action, GET_INDEX);
+    yield apiCall(indexesAPI.get, action.payload, GET_INDEX);
 }
 
 export function* getUnbuilt(action) {
-    yield apiCall(indexesAPI.getUnbuilt, action, GET_UNBUILT);
+    yield apiCall(indexesAPI.getUnbuilt, action.payload, GET_UNBUILT);
 }
 
 export function* listReadyIndexes(action) {
-    yield apiCall(indexesAPI.listReady, action, LIST_READY_INDEXES);
+    yield apiCall(indexesAPI.listReady, action.payload, LIST_READY_INDEXES);
 }
 
 export function* createIndex(action) {
-    const response = yield apiCall(indexesAPI.create, action, CREATE_INDEX);
+    const response = yield apiCall(indexesAPI.create, action.payload, CREATE_INDEX);
 
     if (response.ok) {
         yield put(pushState({ rebuild: false }));
@@ -74,5 +74,5 @@ export function* createIndex(action) {
 }
 
 export function* getIndexHistory(action) {
-    yield apiCall(indexesAPI.getHistory, action, GET_INDEX_HISTORY);
+    yield apiCall(indexesAPI.getHistory, action.payload, GET_INDEX_HISTORY);
 }

--- a/src/js/jobs/__tests__/actions.test.js
+++ b/src/js/jobs/__tests__/actions.test.js
@@ -16,7 +16,7 @@ describe("Jobs Action Creators:", () => {
         const result = wsInsertJob(data);
         expect(result).toEqual({
             type: WS_INSERT_JOB,
-            data
+            payload: { ...data }
         });
     });
 
@@ -25,7 +25,7 @@ describe("Jobs Action Creators:", () => {
         const result = wsUpdateJob(data);
         expect(result).toEqual({
             type: WS_UPDATE_JOB,
-            data
+            payload: { ...data }
         });
     });
 
@@ -34,7 +34,7 @@ describe("Jobs Action Creators:", () => {
         const result = wsRemoveJob(data);
         expect(result).toEqual({
             type: WS_REMOVE_JOB,
-            data
+            payload: data
         });
     });
 
@@ -44,8 +44,7 @@ describe("Jobs Action Creators:", () => {
         const result = findJobs(term, page);
         expect(result).toEqual({
             type: FIND_JOBS.REQUESTED,
-            term,
-            page
+            payload: { term, page }
         });
     });
 
@@ -54,7 +53,7 @@ describe("Jobs Action Creators:", () => {
         const result = getJob(jobId);
         expect(result).toEqual({
             type: GET_JOB.REQUESTED,
-            jobId
+            payload: { jobId }
         });
     });
 
@@ -63,7 +62,7 @@ describe("Jobs Action Creators:", () => {
         const result = cancelJob(jobId);
         expect(result).toEqual({
             type: CANCEL_JOB.REQUESTED,
-            jobId
+            payload: { jobId }
         });
     });
 
@@ -72,7 +71,7 @@ describe("Jobs Action Creators:", () => {
         const result = removeJob(jobId);
         expect(result).toEqual({
             type: REMOVE_JOB.REQUESTED,
-            jobId
+            payload: { jobId }
         });
     });
 
@@ -81,7 +80,7 @@ describe("Jobs Action Creators:", () => {
         const result = clearJobs(scope);
         expect(result).toEqual({
             type: CLEAR_JOBS.REQUESTED,
-            scope
+            payload: { scope }
         });
     });
 });

--- a/src/js/jobs/__tests__/reducer.test.js
+++ b/src/js/jobs/__tests__/reducer.test.js
@@ -18,7 +18,7 @@ describe("Job Reducer", () => {
     describe("should handle WS_INSERT_JOB", () => {
         it("when documents are not yet fetched, returns state", () => {
             const document = { id: "foo" };
-            const action = { type: WS_INSERT_JOB, data: document };
+            const action = { type: WS_INSERT_JOB, payload: document };
             const result = reducer({}, action);
             expect(result).toEqual({
                 documents: [document]
@@ -30,7 +30,7 @@ describe("Job Reducer", () => {
                 documents: null,
                 page: 1
             };
-            const action = { type: WS_INSERT_JOB, data: { id: "test" } };
+            const action = { type: WS_INSERT_JOB, payload: { id: "test" } };
             const result = reducer(state, action);
             expect(result).toEqual({
                 ...state,
@@ -54,7 +54,7 @@ describe("Job Reducer", () => {
         };
         const action = {
             type: WS_UPDATE_JOB,
-            data: {
+            payload: {
                 id: "bar",
                 workflow: "finish_job"
             }
@@ -81,7 +81,7 @@ describe("Job Reducer", () => {
         };
         const action = {
             type: WS_REMOVE_JOB,
-            data: ["test2"]
+            payload: ["test2"]
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -91,7 +91,7 @@ describe("Job Reducer", () => {
     });
 
     it("should handle FIND_JOBS_REQUESTED", () => {
-        const action = { type: FIND_JOBS.REQUESTED, term: "foo" };
+        const action = { type: FIND_JOBS.REQUESTED, payload: { term: "foo" } };
         const result = reducer({}, action);
         expect(result).toEqual({ term: "foo" });
     });
@@ -101,7 +101,7 @@ describe("Job Reducer", () => {
         const documents = [{ id: "foo" }];
         const action = {
             type: FIND_JOBS.SUCCEEDED,
-            data: { documents, page: 2 }
+            payload: { documents, page: 2 }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -123,12 +123,12 @@ describe("Job Reducer", () => {
         const state = {};
         const action = {
             type: GET_JOB.SUCCEEDED,
-            data: { id: "foo" }
+            payload: { id: "foo" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
             ...state,
-            detail: action.data
+            detail: action.payload
         });
     });
 });

--- a/src/js/jobs/actions.js
+++ b/src/js/jobs/actions.js
@@ -9,11 +9,15 @@ import {
     WS_REMOVE_JOB,
     WS_UPDATE_JOB
 } from "../app/actionTypes";
-
-export const wsInsertJob = data => ({
-    type: WS_INSERT_JOB,
-    data
-});
+import { createAction } from "@reduxjs/toolkit";
+/**
+ * Returns an action that should be dispatched when a job document is inserted via websocket.
+ *
+ * @func
+ * @param data {object} the data passed in the websocket message
+ * @returns {object}
+ */
+export const wsInsertJob = createAction(WS_INSERT_JOB);
 
 /**
  * Returns an action that should be dispatched when a job document is updated via websocket.
@@ -22,10 +26,7 @@ export const wsInsertJob = data => ({
  * @param data {object} the data passed in the websocket message
  * @returns {object}
  */
-export const wsUpdateJob = data => ({
-    type: WS_UPDATE_JOB,
-    data
-});
+export const wsUpdateJob = createAction(WS_UPDATE_JOB);
 
 /**
  * Returns an action that should be dispatched when a job document is removed via websocket.
@@ -34,10 +35,7 @@ export const wsUpdateJob = data => ({
  * @param jobId {string} the id for the specific job
  * @returns {object}
  */
-export const wsRemoveJob = data => ({
-    type: WS_REMOVE_JOB,
-    data
-});
+export const wsRemoveJob = createAction(WS_REMOVE_JOB);
 
 /**
  * Returns action that can trigger an API call for getting all available jobs.
@@ -46,11 +44,9 @@ export const wsRemoveJob = data => ({
  * @returns {object}
  */
 
-export const findJobs = (term, page) => ({
-    type: FIND_JOBS.REQUESTED,
-    term,
-    page
-});
+export const findJobs = createAction(FIND_JOBS.REQUESTED, (term, page) => ({
+    payload: { term, page }
+}));
 
 /**
  * Returns action that can trigger an API call for getting a specific job document.
@@ -59,15 +55,9 @@ export const findJobs = (term, page) => ({
  * @param jobId {string} the id for the specific job
  * @returns {object}
  */
-export const getJob = jobId => ({
-    type: GET_JOB.REQUESTED,
-    jobId
-});
+export const getJob = createAction(GET_JOB.REQUESTED, jobId => ({ payload: { jobId } }));
 
-export const getLinkedJob = jobId => ({
-    type: GET_LINKED_JOB.REQUESTED,
-    jobId
-});
+export const getLinkedJob = createAction(GET_LINKED_JOB.REQUESTED, jobId => ({ payload: { jobId } }));
 
 /**
  * Returns action that can trigger an API call for cancelling a currently running job.
@@ -76,10 +66,7 @@ export const getLinkedJob = jobId => ({
  * @param jobId {string} the id for the specific job
  * @returns {object}
  */
-export const cancelJob = jobId => ({
-    type: CANCEL_JOB.REQUESTED,
-    jobId
-});
+export const cancelJob = createAction(CANCEL_JOB.REQUESTED, jobId => ({ payload: { jobId } }));
 
 /**
  * Returns action that can trigger an API call for removing a specific job.
@@ -88,10 +75,7 @@ export const cancelJob = jobId => ({
  * @param jobId {string} the id for the specific job
  * @returns {object}
  */
-export const removeJob = jobId => ({
-    type: REMOVE_JOB.REQUESTED,
-    jobId
-});
+export const removeJob = createAction(REMOVE_JOB.REQUESTED, jobId => ({ payload: { jobId } }));
 
 /**
  * Returns action that can trigger an API call for clearing a subset of listed jobs.
@@ -100,7 +84,4 @@ export const removeJob = jobId => ({
  * @param scope {string} keyword for a category of jobs
  * @returns {object}
  */
-export const clearJobs = scope => ({
-    type: CLEAR_JOBS.REQUESTED,
-    scope
-});
+export const clearJobs = createAction(CLEAR_JOBS.REQUESTED, scope => ({ payload: { scope } }));

--- a/src/js/jobs/components/Item/__tests__/Item.test.js
+++ b/src/js/jobs/components/Item/__tests__/Item.test.js
@@ -51,7 +51,7 @@ describe("mapDispatchToProps", () => {
 
         expect(dispatch).toHaveBeenCalledWith({
             type: "CANCEL_JOB_REQUESTED",
-            jobId: "foo"
+            payload: { jobId: "foo" }
         });
     });
     it("should return onRemove() in props", () => {
@@ -61,7 +61,7 @@ describe("mapDispatchToProps", () => {
         props.onRemove("foo");
 
         expect(dispatch).toHaveBeenCalledWith({
-            jobId: "foo",
+            payload: { jobId: "foo" },
             type: "REMOVE_JOB_REQUESTED"
         });
     });

--- a/src/js/jobs/components/__tests__/List.test.js
+++ b/src/js/jobs/components/__tests__/List.test.js
@@ -104,6 +104,6 @@ describe("mapDispatchToProps", () => {
         const props = mapDispatchToProps(dispatch);
 
         props.onLoadNextPage("foo", "bar");
-        expect(dispatch).toHaveBeenCalledWith({ term: "foo", page: "bar", type: "FIND_JOBS_REQUESTED" });
+        expect(dispatch).toHaveBeenCalledWith({ payload: { term: "foo", page: "bar" }, type: "FIND_JOBS_REQUESTED" });
     });
 });

--- a/src/js/jobs/components/__tests__/Toolbar.test.js
+++ b/src/js/jobs/components/__tests__/Toolbar.test.js
@@ -62,8 +62,7 @@ describe("mapDispatchToProps", () => {
         props.onFind(e, "foo", "bar");
         expect(dispatch).toHaveBeenCalledWith({
             type: FIND_JOBS.REQUESTED,
-            term: "Foo",
-            page: 1
+            payload: { term: "Foo", page: 1 }
         });
     });
 
@@ -74,7 +73,7 @@ describe("mapDispatchToProps", () => {
         props.onClear("Foo");
         expect(dispatch).toHaveBeenCalledWith({
             type: CLEAR_JOBS.REQUESTED,
-            scope: "Foo"
+            payload: { scope: "Foo" }
         });
     });
 });

--- a/src/js/jobs/reducer.js
+++ b/src/js/jobs/reducer.js
@@ -17,28 +17,28 @@ export const initialState = {
 export const jobsReducer = createReducer(initialState, builder => {
     builder
         .addCase(WS_INSERT_JOB, (state, action) => {
-            return insert(state, action, "created_at");
+            return insert(state, action.payload, "created_at");
         })
         .addCase(WS_UPDATE_JOB, (state, action) => {
-            return update(state, action, "created_at");
+            return update(state, action.payload, "created_at");
         })
         .addCase(WS_REMOVE_JOB, (state, action) => {
-            return remove(state, action);
+            return remove(state, action.payload);
         })
         .addCase(GET_LINKED_JOB.SUCCEEDED, (state, action) => {
-            assign(state.linkedJobs, { [action.data.id]: action.data });
+            assign(state.linkedJobs, { [action.payload.id]: action.payload });
         })
         .addCase(FIND_JOBS.REQUESTED, (state, action) => {
-            state.term = action.term;
+            state.term = action.payload.term;
         })
         .addCase(FIND_JOBS.SUCCEEDED, (state, action) => {
-            return updateDocuments(state, action, "created_at");
+            return updateDocuments(state, action.payload, "created_at");
         })
         .addCase(GET_JOB.REQUESTED, state => {
             state.detail = null;
         })
         .addCase(GET_JOB.SUCCEEDED, (state, action) => {
-            state.detail = action.data;
+            state.detail = action.payload;
         });
 });
 

--- a/src/js/jobs/sagas.js
+++ b/src/js/jobs/sagas.js
@@ -23,7 +23,7 @@ export function* watchJobs() {
 }
 
 export function* wsUpdateJob(action) {
-    const jobId = action.data.id;
+    const jobId = action.payload.id;
     const jobDetailId = yield select(getJobDetailId);
 
     if (jobId === jobDetailId) {
@@ -43,21 +43,21 @@ export function* findJobs(action) {
 }
 
 export function* getJob(action) {
-    yield apiCall(jobsAPI.get, action, GET_JOB);
+    yield apiCall(jobsAPI.get, action.payload, GET_JOB);
 }
 
 export function* getLinkedJob(action) {
-    yield apiCall(jobsAPI.get, action, GET_LINKED_JOB);
+    yield apiCall(jobsAPI.get, action.payload, GET_LINKED_JOB);
 }
 
 export function* cancelJob(action) {
-    yield apiCall(jobsAPI.cancel, action, CANCEL_JOB);
+    yield apiCall(jobsAPI.cancel, action.payload, CANCEL_JOB);
 }
 
 export function* removeJob(action) {
-    yield apiCall(jobsAPI.remove, action, REMOVE_JOB);
+    yield apiCall(jobsAPI.remove, action.payload, REMOVE_JOB);
 }
 
 export function* clearJobs(action) {
-    yield apiCall(jobsAPI.clear, action, REMOVE_JOB);
+    yield apiCall(jobsAPI.clear, action.payload, REMOVE_JOB);
 }

--- a/src/js/labels/actions.js
+++ b/src/js/labels/actions.js
@@ -1,4 +1,5 @@
 import { LIST_LABELS, CREATE_LABEL, REMOVE_LABEL, UPDATE_LABEL } from "../app/actionTypes";
+import { createAction } from "@reduxjs/toolkit";
 
 /**
  * Returns action that can trigger an API call to get sample labels.
@@ -6,9 +7,16 @@ import { LIST_LABELS, CREATE_LABEL, REMOVE_LABEL, UPDATE_LABEL } from "../app/ac
  * @func
  * @returns {object}
  */
-export const listLabels = () => ({
-    type: LIST_LABELS.REQUESTED
-});
+export const listLabels = createAction(LIST_LABELS.REQUESTED);
+
+/**
+ * Returns action that can trigger an API call to get sample labels.
+ *
+ * @func
+ * @param payload {onject} label list object response from the server
+ * @returns {object}
+ */
+export const listLabelsSuccess = createAction(LIST_LABELS.SUCCEEDED);
 
 /**
  * Returns action that can trigger an API call for removing a label.
@@ -17,10 +25,7 @@ export const listLabels = () => ({
  * @param labelId {string} unique label id
  * @returns {object}
  */
-export const removeLabel = labelId => ({
-    type: REMOVE_LABEL.REQUESTED,
-    labelId
-});
+export const removeLabel = createAction(REMOVE_LABEL.REQUESTED, labelId => ({ payload: { labelId } }));
 
 /**
  * Returns action that can trigger an API call for creating a new label.
@@ -31,12 +36,9 @@ export const removeLabel = labelId => ({
  * @param color  {string} color name or hex value of label
  * @return {object}
  */
-export const createLabel = (name, description, color) => ({
-    type: CREATE_LABEL.REQUESTED,
-    name,
-    description,
-    color
-});
+export const createLabel = createAction(CREATE_LABEL.REQUESTED, (name, description, color) => ({
+    payload: { name, description, color }
+}));
 
 /**
  * Returns action that can trigger an API call for updating a label
@@ -48,10 +50,11 @@ export const createLabel = (name, description, color) => ({
  * @param color
  * @return {object}
  */
-export const updateLabel = (labelId, name, description, color) => ({
-    type: UPDATE_LABEL.REQUESTED,
-    labelId,
-    name,
-    description,
-    color
-});
+export const updateLabel = createAction(UPDATE_LABEL.REQUESTED, (labelId, name, description, color) => ({
+    payload: {
+        labelId,
+        name,
+        description,
+        color
+    }
+}));

--- a/src/js/labels/components/__tests__/Create.test.js
+++ b/src/js/labels/components/__tests__/Create.test.js
@@ -75,9 +75,7 @@ describe("mapDispatchToProps()", () => {
         props.onSubmit(name, description, color);
         expect(dispatch).toHaveBeenCalledWith({
             type: "CREATE_LABEL_REQUESTED",
-            name,
-            description,
-            color
+            payload: { name, description, color }
         });
     });
 
@@ -85,8 +83,10 @@ describe("mapDispatchToProps()", () => {
         props.onHide();
         expect(dispatch).toHaveBeenCalledWith({
             type: PUSH_STATE,
-            state: {
-                createLabel: false
+            payload: {
+                state: {
+                    createLabel: false
+                }
             }
         });
     });

--- a/src/js/labels/components/__tests__/Edit.test.js
+++ b/src/js/labels/components/__tests__/Edit.test.js
@@ -94,10 +94,7 @@ describe("mapDispatchToProps()", () => {
         props.onSubmit(labelId, name, description, color);
         expect(dispatch).toHaveBeenCalledWith({
             type: "UPDATE_LABEL_REQUESTED",
-            labelId,
-            name,
-            description,
-            color
+            payload: { labelId, name, description, color }
         });
     });
 
@@ -105,8 +102,10 @@ describe("mapDispatchToProps()", () => {
         props.onHide();
         expect(dispatch).toHaveBeenCalledWith({
             type: PUSH_STATE,
-            state: {
-                editLabel: false
+            payload: {
+                state: {
+                    editLabel: false
+                }
             }
         });
     });

--- a/src/js/labels/components/__tests__/Labels.test.js
+++ b/src/js/labels/components/__tests__/Labels.test.js
@@ -16,6 +16,6 @@ describe("mapDispatchToProps()", () => {
 
     it("should return onHide() in props", () => {
         props.onHide();
-        expect(dispatch).toHaveBeenCalledWith({ type: "PUSH_STATE", state: { removeLabel: false } });
+        expect(dispatch).toHaveBeenCalledWith({ type: "PUSH_STATE", payload: { state: { removeLabel: false } } });
     });
 });

--- a/src/js/labels/reducer.js
+++ b/src/js/labels/reducer.js
@@ -9,16 +9,16 @@ export const initialState = {
 export const labelsReducer = createReducer(initialState, builder => {
     builder
         .addCase(LIST_LABELS.SUCCEEDED, (state, action) => {
-            return { ...state, documents: action.data };
+            return { ...state, documents: action.payload };
         })
         .addCase(CREATE_LABEL.SUCCEEDED, (state, action) => {
-            return insert(state, action);
+            return insert(state, action.payload);
         })
         .addCase(UPDATE_LABEL.SUCCEEDED, (state, action) => {
-            return update(state, action);
+            return update(state, action.payload);
         })
         .addCase(REMOVE_LABEL.SUCCEEDED, (state, action) => {
-            return remove(state, action);
+            return remove(state, action.payload);
         });
 });
 

--- a/src/js/labels/sagas.js
+++ b/src/js/labels/sagas.js
@@ -3,7 +3,7 @@ import { pushState } from "../app/actions";
 import { CREATE_LABEL, LIST_LABELS, REMOVE_LABEL, UPDATE_LABEL } from "../app/actionTypes";
 import { apiCall } from "../utils/sagas";
 import * as labelsAPI from "./api";
-import { listLabels as listLabelsAction } from "./actions";
+import { listLabels as listLabelsAction, listLabelsSuccess } from "./actions";
 
 export function* watchLabels() {
     yield takeLatest(LIST_LABELS.REQUESTED, listLabels);
@@ -14,11 +14,11 @@ export function* watchLabels() {
 
 export function* listLabels(action) {
     const response = yield labelsAPI.listLabels(action);
-    yield put({ type: LIST_LABELS.SUCCEEDED, data: response.body });
+    yield put(listLabelsSuccess(response.body));
 }
 
 export function* createLabel(action) {
-    const { ok } = yield apiCall(labelsAPI.create, action, CREATE_LABEL);
+    const { ok } = yield apiCall(labelsAPI.create, action.payload, CREATE_LABEL);
 
     if (ok) {
         yield put(pushState({ createLabel: false }));
@@ -26,7 +26,7 @@ export function* createLabel(action) {
 }
 
 export function* removeLabel(action) {
-    const { ok } = yield apiCall(labelsAPI.remove, action, REMOVE_LABEL);
+    const { ok } = yield apiCall(labelsAPI.remove, action.payload, REMOVE_LABEL);
 
     if (ok) {
         yield put(pushState({ removeLabel: false }));
@@ -35,7 +35,7 @@ export function* removeLabel(action) {
 }
 
 export function* updateLabel(action) {
-    const { ok } = yield apiCall(labelsAPI.update, action, UPDATE_LABEL);
+    const { ok } = yield apiCall(labelsAPI.update, action.payload, UPDATE_LABEL);
 
     if (ok) {
         yield put(pushState({ updateLabel: false }));

--- a/src/js/otus/__tests__/actions.test.js
+++ b/src/js/otus/__tests__/actions.test.js
@@ -69,19 +69,19 @@ describe("OTUs Action Creators", () => {
     it("wsInsertOTU: returns action to insert OTU entry via websocket", () => {
         const data = { id: "test" };
         const result = wsInsertOTU(data);
-        expect(result).toEqual({ type: WS_INSERT_OTU, data });
+        expect(result).toEqual({ type: WS_INSERT_OTU, payload: { ...data } });
     });
 
     it("wsUpdateOTU: returns action to update OTU entry via websocket", () => {
         const data = { id: "test", foo: "bar" };
         const result = wsUpdateOTU(data);
-        expect(result).toEqual({ type: WS_UPDATE_OTU, data });
+        expect(result).toEqual({ type: WS_UPDATE_OTU, payload: { ...data } });
     });
 
     it("wsRemoveOTU: returns action to remove OTU entry via websocket", () => {
         const data = ["test"];
         const result = wsRemoveOTU(data);
-        expect(result).toEqual({ type: WS_REMOVE_OTU, data });
+        expect(result).toEqual({ type: WS_REMOVE_OTU, payload: data });
     });
 
     it("findOTUs: returns action to list specific page of otu documents", () => {
@@ -90,17 +90,17 @@ describe("OTUs Action Creators", () => {
         const verified = true;
         const page = 2;
         const result = findOTUs(refId, term, verified, page);
-        expect(result).toEqual({ type: FIND_OTUS.REQUESTED, refId, term, verified, page });
+        expect(result).toEqual({ type: FIND_OTUS.REQUESTED, payload: { refId, term, verified, page } });
     });
 
     it("getOTU: returns action to retrieve a specific otu", () => {
         const result = getOTU(otuId);
-        expect(result).toEqual({ type: GET_OTU.REQUESTED, otuId });
+        expect(result).toEqual({ type: GET_OTU.REQUESTED, payload: { otuId } });
     });
 
     it("getOTUHistory: returns action to retrieve change history of specific otu", () => {
         const result = getOTUHistory(otuId);
-        expect(result).toEqual({ type: GET_OTU_HISTORY.REQUESTED, otuId });
+        expect(result).toEqual({ type: GET_OTU_HISTORY.REQUESTED, payload: { otuId } });
     });
 
     it("createOTU: returns action to create a new otu", () => {
@@ -108,7 +108,7 @@ describe("OTUs Action Creators", () => {
         const name = "new otu";
         const abbreviation = "NEW";
         const result = createOTU(refId, name, abbreviation);
-        expect(result).toEqual({ type: CREATE_OTU.REQUESTED, refId, name, abbreviation });
+        expect(result).toEqual({ type: CREATE_OTU.REQUESTED, payload: { refId, name, abbreviation } });
     });
 
     it("editOTU: return action to edit a specific otu", () => {
@@ -116,34 +116,31 @@ describe("OTUs Action Creators", () => {
         const abbreviation = "OLD";
         const schema = [];
         const result = editOTU(otuId, name, abbreviation, schema);
-        expect(result).toEqual({ type: EDIT_OTU.REQUESTED, otuId, name, abbreviation, schema });
+        expect(result).toEqual({ type: EDIT_OTU.REQUESTED, payload: { otuId, name, abbreviation, schema } });
     });
 
     it("removeOTU: returns action to delete specific otu", () => {
         const refId = "123abc";
         const history = {};
         const result = removeOTU(refId, otuId, history);
-        expect(result).toEqual({ type: REMOVE_OTU.REQUESTED, refId, otuId, history });
+        expect(result).toEqual({ type: REMOVE_OTU.REQUESTED, payload: { refId, otuId, history } });
     });
 
     it("addIsolate: returns action to add an isolate to an otu", () => {
         const result = addIsolate(otuId, sourceType, sourceName);
-        expect(result).toEqual({ type: ADD_ISOLATE.REQUESTED, otuId, sourceType, sourceName });
+        expect(result).toEqual({ type: ADD_ISOLATE.REQUESTED, payload: { otuId, sourceType, sourceName } });
     });
 
     it("setIsolateAsDefault: returns action to set specific isolate as default", () => {
         const result = setIsolateAsDefault(otuId, isolateId);
-        expect(result).toEqual({ type: SET_ISOLATE_AS_DEFAULT.REQUESTED, otuId, isolateId });
+        expect(result).toEqual({ type: SET_ISOLATE_AS_DEFAULT.REQUESTED, payload: { otuId, isolateId } });
     });
 
     it("editIsolate: returns action to edit a specific isolate", () => {
         const result = editIsolate(otuId, isolateId, sourceType, sourceName);
         expect(result).toEqual({
             type: EDIT_ISOLATE.REQUESTED,
-            otuId,
-            isolateId,
-            sourceType,
-            sourceName
+            payload: { otuId, isolateId, sourceType, sourceName }
         });
     });
 
@@ -152,9 +149,7 @@ describe("OTUs Action Creators", () => {
         const result = removeIsolate(otuId, isolateId, nextIsolateId);
         expect(result).toEqual({
             type: REMOVE_ISOLATE.REQUESTED,
-            otuId,
-            isolateId,
-            nextIsolateId
+            payload: { otuId, isolateId, nextIsolateId }
         });
     });
 
@@ -162,14 +157,7 @@ describe("OTUs Action Creators", () => {
         const result = addSequence({ otuId, isolateId, accession, definition, host, sequence, segment, target });
         expect(result).toEqual({
             type: ADD_SEQUENCE.REQUESTED,
-            otuId,
-            isolateId,
-            accession,
-            definition,
-            host,
-            sequence,
-            segment,
-            target
+            payload: { otuId, isolateId, accession, definition, host, sequence, segment, target }
         });
     });
 
@@ -187,15 +175,7 @@ describe("OTUs Action Creators", () => {
         });
         expect(result).toEqual({
             type: EDIT_SEQUENCE.REQUESTED,
-            otuId,
-            isolateId,
-            sequenceId,
-            accession,
-            definition,
-            host,
-            sequence,
-            segment,
-            target
+            payload: { otuId, isolateId, sequenceId, accession, definition, host, sequence, segment, target }
         });
     });
 
@@ -203,9 +183,7 @@ describe("OTUs Action Creators", () => {
         const result = removeSequence(otuId, isolateId, sequenceId);
         expect(result).toEqual({
             type: REMOVE_SEQUENCE.REQUESTED,
-            otuId,
-            isolateId,
-            sequenceId
+            payload: { otuId, isolateId, sequenceId }
         });
     });
 
@@ -213,12 +191,12 @@ describe("OTUs Action Creators", () => {
         const changeId = "123abc";
         const otuVersion = 3;
         const result = revert(otuId, otuVersion, changeId);
-        expect(result).toEqual({ type: REVERT.REQUESTED, otuId, otuVersion, change_id: changeId });
+        expect(result).toEqual({ type: REVERT.REQUESTED, payload: { otuId, otuVersion, change_id: changeId } });
     });
 
     it("selectIsolate: returns action to select isolate to expand", () => {
         const result = selectIsolate(isolateId);
-        expect(result).toEqual({ type: SELECT_ISOLATE, isolateId });
+        expect(result).toEqual({ type: SELECT_ISOLATE, payload: { isolateId } });
     });
 
     it("showEditOTU: returns action to display edit otu modal", () => {
@@ -237,10 +215,7 @@ describe("OTUs Action Creators", () => {
         const result = showEditIsolate(otuId, isolateId, sourceType, sourceName);
         expect(result).toEqual({
             type: SHOW_EDIT_ISOLATE,
-            otuId,
-            isolateId,
-            sourceType,
-            sourceName
+            payload: { otuId, isolateId, sourceType, sourceName }
         });
     });
 
@@ -250,7 +225,7 @@ describe("OTUs Action Creators", () => {
 
     it("showRemoveSequence: returns action to display remove sequence modal", () => {
         const result = showRemoveSequence(sequenceId);
-        expect(result).toEqual({ type: SHOW_REMOVE_SEQUENCE, sequenceId });
+        expect(result).toEqual({ type: SHOW_REMOVE_SEQUENCE, payload: { sequenceId } });
     });
 
     it("hideOTUModal: returns action to hide otu modal", () => {

--- a/src/js/otus/__tests__/reducer.test.js
+++ b/src/js/otus/__tests__/reducer.test.js
@@ -44,14 +44,14 @@ describe("OTUs Reducer:", () => {
 
     describe("should handle WS_UPDATE_STATUS", () => {
         it("if status id is 'OTU_import', return importData", () => {
-            const action = { type: WS_UPDATE_STATUS, data: { id: "OTU_import" } };
+            const action = { type: WS_UPDATE_STATUS, payload: { id: "OTU_import" } };
             const result = reducer({}, action);
             expect(result).toEqual({ importData: { id: "OTU_import", inProgress: true } });
         });
 
         it("otherwise return state", () => {
             const state = {};
-            const action = { type: WS_UPDATE_STATUS, data: { id: "test" } };
+            const action = { type: WS_UPDATE_STATUS, payload: { id: "test" } };
             const result = reducer(state, action);
             expect(result).toEqual(state);
         });
@@ -62,7 +62,7 @@ describe("OTUs Reducer:", () => {
             const state = { refId: "foo" };
             const action = {
                 type: WS_INSERT_OTU,
-                data: { id: "test", reference: { id: "bar" } }
+                payload: { id: "test", reference: { id: "bar" } }
             };
             const result = reducer(state, action);
             expect(result).toEqual(state);
@@ -78,10 +78,10 @@ describe("OTUs Reducer:", () => {
             };
             const action = {
                 type: WS_INSERT_OTU,
-                data: { id: "test", reference: { id: "123abc" } }
+                payload: { id: "test", reference: { id: "123abc" } }
             };
             const result = reducer(state, action);
-            expect(result).toEqual({ ...state, documents: [action.data] });
+            expect(result).toEqual({ ...state, documents: [action.payload] });
         });
     });
 
@@ -90,7 +90,7 @@ describe("OTUs Reducer:", () => {
             const state = { refId: "foo" };
             const action = {
                 type: WS_UPDATE_OTU,
-                data: { id: "test", reference: { id: "bar" } }
+                payload: { id: "test", reference: { id: "bar" } }
             };
             const result = reducer(state, action);
             expect(result).toEqual(state);
@@ -104,7 +104,7 @@ describe("OTUs Reducer:", () => {
             };
             const action = {
                 type: WS_UPDATE_OTU,
-                data: { id: "test-otu", foo: "baz", reference: { id: refId } }
+                payload: { id: "test-otu", foo: "baz", reference: { id: refId } }
             };
             const result = reducer(state, action);
             expect(result).toEqual({
@@ -133,7 +133,7 @@ describe("OTUs Reducer:", () => {
             };
             const action = {
                 type: WS_REMOVE_OTU,
-                data: ["foo"]
+                payload: ["foo"]
             };
             const result = reducer(state, action);
             expect(result).toEqual({ documents: [] });
@@ -143,7 +143,7 @@ describe("OTUs Reducer:", () => {
     it("should handle FIND_OTUS_REQUESTED", () => {
         const refId = "baz";
         const term = "foo";
-        const action = { type: FIND_OTUS.REQUESTED, refId, term, page: 3 };
+        const action = { type: FIND_OTUS.REQUESTED, payload: { refId, term, page: 3 } };
         const result = reducer({}, action);
         expect(result).toEqual({ term, refId });
     });
@@ -152,17 +152,17 @@ describe("OTUs Reducer:", () => {
         const state = { documents: [], page: 1 };
         const action = {
             type: FIND_OTUS.SUCCEEDED,
-            data: { documents: [{ id: "test" }], page: 2 }
+            payload: { documents: [{ id: "test" }], page: 2 }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
-            ...action.data
+            ...action.payload
         });
     });
 
     it("should handle FIND_OTUS.SUCCEEDED", () => {
         const state = { documents: null };
-        const action = { type: FIND_OTUS.SUCCEEDED, data: { documents: [] } };
+        const action = { type: FIND_OTUS.SUCCEEDED, payload: { documents: [] } };
         const result = reducer(state, action);
         expect(result).toEqual({ documents: [] });
     });
@@ -206,11 +206,11 @@ describe("OTUs Reducer:", () => {
             it(`should handle ${actionType}`, () => {
                 const action = {
                     type: actionType,
-                    data: { id: "test-otu", isolates: [] }
+                    payload: { id: "test-otu", isolates: [] }
                 };
                 const result = reducer({}, action);
                 expect(result).toEqual({
-                    detail: action.data,
+                    detail: action.payload,
                     ...hideOTUModal({}),
                     activeIsolate: null,
                     activeIsolateId: null
@@ -228,7 +228,7 @@ describe("OTUs Reducer:", () => {
     it("should handle GET_OTU_HISTORY_SUCCEEDED", () => {
         const action = {
             type: GET_OTU_HISTORY.SUCCEEDED,
-            data: { foo: "bar" }
+            payload: { foo: "bar" }
         };
         const result = reducer({}, action);
         expect(result).toEqual({ detailHistory: { foo: "bar" } });
@@ -237,8 +237,7 @@ describe("OTUs Reducer:", () => {
     it("should handle REVERT_SUCCEEDED", () => {
         const action = {
             type: REVERT.SUCCEEDED,
-            data: { isolates: [] },
-            history: {}
+            payload: { otu: { isolates: [] }, history: {} }
         };
         const result = reducer({}, action);
         expect(result).toEqual({
@@ -252,7 +251,7 @@ describe("OTUs Reducer:", () => {
     it("should handle UPLOAD_IMPORT.SUCCEEDED", () => {
         const action = {
             type: UPLOAD_IMPORT.SUCCEEDED,
-            data: { foo: "bar" }
+            payload: { foo: "bar" }
         };
         const result = reducer({}, action);
         expect(result).toEqual({ importData: { foo: "bar", inProgress: false } });
@@ -262,7 +261,7 @@ describe("OTUs Reducer:", () => {
         const state = { detail: { isolates: [{ id: "test-isolate" }] } };
         const action = {
             type: SELECT_ISOLATE,
-            isolateId: "test-isolate"
+            payload: { isolateId: "test-isolate" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -303,7 +302,7 @@ describe("OTUs Reducer:", () => {
     });
 
     it("should handle SHOW_REMOVE_SEQUENCE", () => {
-        const action = { type: SHOW_REMOVE_SEQUENCE, sequenceId: "test-sequence" };
+        const action = { type: SHOW_REMOVE_SEQUENCE, payload: { sequenceId: "test-sequence" } };
         const result = reducer({}, action);
         expect(result).toEqual({ removeSequence: "test-sequence" });
     });
@@ -355,9 +354,7 @@ describe("Helper functions:", () => {
 
     it("receiveOTU(): replace state.detail with action data and reformat isolates", () => {
         const action = {
-            data: {
-                isolates: [{ id: "123abc", sourceType: "isolate", sourceName: "tester" }]
-            }
+            isolates: [{ id: "123abc", sourceType: "isolate", sourceName: "tester" }]
         };
         const result = receiveOTU({}, action);
         expect(result).toEqual({
@@ -369,7 +366,7 @@ describe("Helper functions:", () => {
             },
             activeIsolateId: "123abc",
             detail: {
-                isolates: [{ ...action.data.isolates[0], name: "Isolate tester" }]
+                isolates: [{ ...action.isolates[0], name: "Isolate tester" }]
             }
         });
     });

--- a/src/js/otus/actions.js
+++ b/src/js/otus/actions.js
@@ -25,30 +25,44 @@ import {
     WS_REMOVE_OTU,
     WS_UPDATE_OTU
 } from "../app/actionTypes";
-import { simpleActionCreator } from "../utils/utils";
 
-export const wsInsertOTU = data => ({
-    type: WS_INSERT_OTU,
-    data
-});
+import { createAction } from "@reduxjs/toolkit";
 
-export const wsUpdateOTU = data => ({
-    type: WS_UPDATE_OTU,
-    data
-});
+/**
+ * Returns an action that should be dispatched when an OTU is inserted via websocket.
+ *
+ * @func
+ * @param data {object} the data passed in the websocket message
+ * @returns {object}
+ */
+export const wsInsertOTU = createAction(WS_INSERT_OTU);
 
-export const wsRemoveOTU = data => ({
-    type: WS_REMOVE_OTU,
-    data
-});
+/**
+ * Returns an action that should be dispatched when an OTU is updated via websocket.
+ *
+ * @func
+ * @param data {object} the data passed in the websocket message
+ * @returns {object}
+ */
+export const wsUpdateOTU = createAction(WS_UPDATE_OTU);
 
-export const findOTUs = (refId, term, verified, page) => ({
-    type: FIND_OTUS.REQUESTED,
-    refId,
-    term,
-    verified,
-    page
-});
+/**
+ * Returns an action that should be dispatched when an OTU is removed via websocket.
+ *
+ * @func
+ * @param data {object} the data passed in the websocket message
+ * @returns {object}
+ */
+export const wsRemoveOTU = createAction(WS_REMOVE_OTU);
+
+export const findOTUs = createAction(FIND_OTUS.REQUESTED, (refId, term, verified, page) => ({
+    payload: {
+        refId,
+        term,
+        verified,
+        page
+    }
+}));
 
 /**
  * Returns action that can trigger an API call for retrieving a specific OTU.
@@ -57,10 +71,7 @@ export const findOTUs = (refId, term, verified, page) => ({
  * @param otuId {string} unique OTU id
  * @returns {object}
  */
-export const getOTU = otuId => ({
-    type: GET_OTU.REQUESTED,
-    otuId
-});
+export const getOTU = createAction(GET_OTU.REQUESTED, otuId => ({ payload: { otuId } }));
 
 /**
  * Returns action that can trigger an API call for getting a OTU's history.
@@ -69,10 +80,7 @@ export const getOTU = otuId => ({
  * @param otuId {string} unique OTU id
  * @returns {object}
  */
-export const getOTUHistory = otuId => ({
-    type: GET_OTU_HISTORY.REQUESTED,
-    otuId
-});
+export const getOTUHistory = createAction(GET_OTU_HISTORY.REQUESTED, otuId => ({ payload: { otuId } }));
 
 /**
  * Returns action that can trigger an API call for creating a new OTU.
@@ -82,12 +90,9 @@ export const getOTUHistory = otuId => ({
  * @param abbreviation {string} unique abbreviation for OTU name
  * @returns {object}
  */
-export const createOTU = (refId, name, abbreviation) => ({
-    type: CREATE_OTU.REQUESTED,
-    refId,
-    name,
-    abbreviation
-});
+export const createOTU = createAction(CREATE_OTU.REQUESTED, (refId, name, abbreviation) => ({
+    payload: { refId, name, abbreviation }
+}));
 
 /**
  * Returns action that can trigger an API call for modifying a OTU.
@@ -99,13 +104,14 @@ export const createOTU = (refId, name, abbreviation) => ({
  * @param schema {array} array of sequences in custom order
  * @returns {object}
  */
-export const editOTU = (otuId, name, abbreviation, schema) => ({
-    type: EDIT_OTU.REQUESTED,
-    otuId,
-    name,
-    abbreviation,
-    schema
-});
+export const editOTU = createAction(EDIT_OTU.REQUESTED, (otuId, name, abbreviation, schema) => ({
+    payload: {
+        otuId,
+        name,
+        abbreviation,
+        schema
+    }
+}));
 
 /**
  * Returns action that can trigger an API call for removing a OTU.
@@ -115,12 +121,9 @@ export const editOTU = (otuId, name, abbreviation, schema) => ({
  * @param history {object} list of all changes made to the OTU
  * @returns {object}
  */
-export const removeOTU = (refId, otuId, history) => ({
-    type: REMOVE_OTU.REQUESTED,
-    refId,
-    otuId,
-    history
-});
+export const removeOTU = createAction(REMOVE_OTU.REQUESTED, (refId, otuId, history) => ({
+    payload: { refId, otuId, history }
+}));
 
 /**
  * Returns action that can trigger an API call for adding an isolate to a OTU.
@@ -131,12 +134,9 @@ export const removeOTU = (refId, otuId, history) => ({
  * @param sourceName {string} the name of the isolate source
  * @returns {object}
  */
-export const addIsolate = (otuId, sourceType, sourceName) => ({
-    type: ADD_ISOLATE.REQUESTED,
-    otuId,
-    sourceType,
-    sourceName
-});
+export const addIsolate = createAction(ADD_ISOLATE.REQUESTED, (otuId, sourceType, sourceName) => ({
+    payload: { otuId, sourceType, sourceName }
+}));
 
 /**
  * Returns action that can trigger an API call for modifying which isolate is made default.
@@ -146,11 +146,9 @@ export const addIsolate = (otuId, sourceType, sourceName) => ({
  * @param isolateId {string} unique isolate id
  * @returns {object}
  */
-export const setIsolateAsDefault = (otuId, isolateId) => ({
-    type: SET_ISOLATE_AS_DEFAULT.REQUESTED,
-    otuId,
-    isolateId
-});
+export const setIsolateAsDefault = createAction(SET_ISOLATE_AS_DEFAULT.REQUESTED, (otuId, isolateId) => ({
+    payload: { otuId, isolateId }
+}));
 
 /**
  * Returns action that can trigger an API call for modifying an isolate.
@@ -162,13 +160,14 @@ export const setIsolateAsDefault = (otuId, isolateId) => ({
  * @param sourceName {string} the name of the isolate source
  * @returns {object}
  */
-export const editIsolate = (otuId, isolateId, sourceType, sourceName) => ({
-    type: EDIT_ISOLATE.REQUESTED,
-    otuId,
-    isolateId,
-    sourceType,
-    sourceName
-});
+export const editIsolate = createAction(EDIT_ISOLATE.REQUESTED, (otuId, isolateId, sourceType, sourceName) => ({
+    payload: {
+        otuId,
+        isolateId,
+        sourceType,
+        sourceName
+    }
+}));
 
 /**
  * Returns action that can trigger an API call for removing an isolate from a OTU.
@@ -180,12 +179,9 @@ export const editIsolate = (otuId, isolateId, sourceType, sourceName) => ({
  * first in resulting list (i.e. the next isolate) becomes default
  * @returns {object}
  */
-export const removeIsolate = (otuId, isolateId, nextIsolateId) => ({
-    type: REMOVE_ISOLATE.REQUESTED,
-    otuId,
-    isolateId,
-    nextIsolateId
-});
+export const removeIsolate = createAction(REMOVE_ISOLATE.REQUESTED, (otuId, isolateId, nextIsolateId) => ({
+    payload: { otuId, isolateId, nextIsolateId }
+}));
 
 /**
  * Returns action that can trigger an API call for adding a sequence to an isolate.
@@ -201,17 +197,21 @@ export const removeIsolate = (otuId, isolateId, nextIsolateId) => ({
  * @param target {string} the reference target associated with the sequence
  * @returns {object}
  */
-export const addSequence = ({ otuId, isolateId, accession, definition, host, sequence, segment, target }) => ({
-    type: ADD_SEQUENCE.REQUESTED,
-    accession,
-    definition,
-    host,
-    isolateId,
-    otuId,
-    segment,
-    sequence,
-    target
-});
+export const addSequence = createAction(
+    ADD_SEQUENCE.REQUESTED,
+    ({ otuId, isolateId, accession, definition, host, sequence, segment, target }) => ({
+        payload: {
+            accession,
+            definition,
+            host,
+            isolateId,
+            otuId,
+            segment,
+            sequence,
+            target
+        }
+    })
+);
 
 /**
  * Returns action that can trigger an API call for modifying a sequence.
@@ -228,28 +228,22 @@ export const addSequence = ({ otuId, isolateId, accession, definition, host, seq
  * @param target {string} the barcode target associated with the OTU
  * @returns {object}
  */
-export const editSequence = ({
-    otuId,
-    isolateId,
-    sequenceId,
-    accession,
-    definition,
-    host,
-    sequence,
-    segment,
-    target
-}) => ({
-    type: EDIT_SEQUENCE.REQUESTED,
-    otuId,
-    isolateId,
-    sequenceId,
-    accession,
-    definition,
-    host,
-    sequence,
-    segment,
-    target
-});
+export const editSequence = createAction(
+    EDIT_SEQUENCE.REQUESTED,
+    ({ otuId, isolateId, sequenceId, accession, definition, host, sequence, segment, target }) => ({
+        payload: {
+            otuId,
+            isolateId,
+            sequenceId,
+            accession,
+            definition,
+            host,
+            sequence,
+            segment,
+            target
+        }
+    })
+);
 
 /**
  * Returns action that can trigger an API call for removing a sequence from an isolate.
@@ -260,12 +254,9 @@ export const editSequence = ({
  * @param sequenceId {string} unique sequence id
  * @returns {object}
  */
-export const removeSequence = (otuId, isolateId, sequenceId) => ({
-    type: REMOVE_SEQUENCE.REQUESTED,
-    otuId,
-    isolateId,
-    sequenceId
-});
+export const removeSequence = createAction(REMOVE_SEQUENCE.REQUESTED, (otuId, isolateId, sequenceId) => ({
+    payload: { otuId, isolateId, sequenceId }
+}));
 
 /**
  * Returns action that can trigger an API call for deleting unbuilt changes of a OTU.
@@ -275,12 +266,34 @@ export const removeSequence = (otuId, isolateId, sequenceId) => ({
  * @param version {string} OTU index version
  * @returns {object}
  */
-export const revert = (otuId, otuVersion, changeId) => ({
-    type: REVERT.REQUESTED,
-    otuId,
-    otuVersion,
-    change_id: changeId
-});
+export const revert = createAction(REVERT.REQUESTED, (otuId, otuVersion, changeId) => ({
+    payload: {
+        otuId,
+        otuVersion,
+        change_id: changeId
+    }
+}));
+
+/**
+ * Returns action that can trigger an API call for deleting unbuilt changes of a OTU.
+ *
+ * @func
+ * @param error {onject} error object
+ * @returns {object}
+ */
+export const revertFailed = createAction(REVERT.FAILED, error => ({ payload: { error } }));
+
+/**
+ * Returns action that can trigger an API call for deleting unbuilt changes of a OTU.
+ *
+ * @func
+ * @param otu {object} OTU object
+ * @param history {object} OTU history object
+ * @returns {object}
+ */
+export const revertSucceeded = createAction(REVERT.SUCCEEDED, (otu, history) => ({
+    payload: { otu, history }
+}));
 
 /**
  * Returns action for selecting an isolate to view.
@@ -289,10 +302,7 @@ export const revert = (otuId, otuVersion, changeId) => ({
  * @param isolateId {string} unique isolate id
  * @returns {object}
  */
-export const selectIsolate = isolateId => ({
-    type: SELECT_ISOLATE,
-    isolateId
-});
+export const selectIsolate = createAction(SELECT_ISOLATE, isolateId => ({ payload: { isolateId } }));
 
 /**
  * Returns action for displaying the edit OTU modal.
@@ -300,7 +310,7 @@ export const selectIsolate = isolateId => ({
  * @func
  * @returns {object}
  */
-export const showEditOTU = simpleActionCreator(SHOW_EDIT_OTU);
+export const showEditOTU = createAction(SHOW_EDIT_OTU);
 
 /**
  * Returns action for displaying the remove OTU modal.
@@ -308,7 +318,7 @@ export const showEditOTU = simpleActionCreator(SHOW_EDIT_OTU);
  * @func
  * @returns {object}
  */
-export const showRemoveOTU = simpleActionCreator(SHOW_REMOVE_OTU);
+export const showRemoveOTU = createAction(SHOW_REMOVE_OTU);
 
 /**
  * Returns action for displaying the add isolate modal.
@@ -316,7 +326,7 @@ export const showRemoveOTU = simpleActionCreator(SHOW_REMOVE_OTU);
  * @func
  * @returns {object}
  */
-export const showAddIsolate = simpleActionCreator(SHOW_ADD_ISOLATE);
+export const showAddIsolate = createAction(SHOW_ADD_ISOLATE);
 
 /**
  * Returns action for displaying the edit isolate modal.
@@ -328,13 +338,14 @@ export const showAddIsolate = simpleActionCreator(SHOW_ADD_ISOLATE);
  * @param sourceName {string} the name for the isolate source
  * @returns {object}
  */
-export const showEditIsolate = (otuId, isolateId, sourceType, sourceName) => ({
-    type: SHOW_EDIT_ISOLATE,
-    otuId,
-    isolateId,
-    sourceType,
-    sourceName
-});
+export const showEditIsolate = createAction(SHOW_EDIT_ISOLATE, (otuId, isolateId, sourceType, sourceName) => ({
+    payload: {
+        otuId,
+        isolateId,
+        sourceType,
+        sourceName
+    }
+}));
 
 /**
  * Returns action for displaying the remove isolate modal.
@@ -342,7 +353,7 @@ export const showEditIsolate = (otuId, isolateId, sourceType, sourceName) => ({
  * @func
  * @returns {object}
  */
-export const showRemoveIsolate = simpleActionCreator(SHOW_REMOVE_ISOLATE);
+export const showRemoveIsolate = createAction(SHOW_REMOVE_ISOLATE);
 
 /**
  * Returns action for displaying the remove sequence modal.
@@ -351,10 +362,7 @@ export const showRemoveIsolate = simpleActionCreator(SHOW_REMOVE_ISOLATE);
  * @param sequenceId {string} unique sequence id
  * @returns {object}
  */
-export const showRemoveSequence = sequenceId => ({
-    type: SHOW_REMOVE_SEQUENCE,
-    sequenceId
-});
+export const showRemoveSequence = createAction(SHOW_REMOVE_SEQUENCE, sequenceId => ({ payload: { sequenceId } }));
 
 /**
  * Returns action for hiding the OTU modal.
@@ -362,4 +370,4 @@ export const showRemoveSequence = sequenceId => ({
  * @func
  * @returns {object}
  */
-export const hideOTUModal = simpleActionCreator(HIDE_OTU_MODAL);
+export const hideOTUModal = createAction(HIDE_OTU_MODAL);

--- a/src/js/otus/components/Detail/Isolates/__tests__/Remove.test.js
+++ b/src/js/otus/components/Detail/Isolates/__tests__/Remove.test.js
@@ -100,9 +100,7 @@ describe("mapDispatchToProps", () => {
         props.onConfirm("foo", "bar", "baz");
         expect(dispatch).toHaveBeenCalledWith({
             type: REMOVE_ISOLATE.REQUESTED,
-            otuId: "foo",
-            isolateId: "bar",
-            nextIsolateId: "baz"
+            payload: { otuId: "foo", isolateId: "bar", nextIsolateId: "baz" }
         });
     });
 });

--- a/src/js/otus/components/Detail/__tests__/Remove.test.js
+++ b/src/js/otus/components/Detail/__tests__/Remove.test.js
@@ -84,9 +84,7 @@ describe("mapDispatchToProps()", () => {
         props.onConfirm(refId, otuId, history);
         expect(dispatch).toHaveBeenCalledWith({
             type: REMOVE_OTU.REQUESTED,
-            history,
-            otuId,
-            refId
+            payload: { history, otuId, refId }
         });
     });
 

--- a/src/js/otus/components/__tests__/List.test.js
+++ b/src/js/otus/components/__tests__/List.test.js
@@ -68,8 +68,10 @@ describe("mapDispatchToProps()", () => {
         props.onHide();
         expect(dispatch).toHaveBeenCalledWith({
             type: PUSH_STATE,
-            state: {
-                createOTU: false
+            payload: {
+                state: {
+                    createOTU: false
+                }
             }
         });
     });
@@ -77,10 +79,7 @@ describe("mapDispatchToProps()", () => {
     it("should return onLoadNextPage() in props", () => {
         props.onLoadNextPage("foo", "bar", true, 1);
         expect(dispatch).toHaveBeenCalledWith({
-            refId: "foo",
-            term: "bar",
-            verified: true,
-            page: 1,
+            payload: { refId: "foo", term: "bar", verified: true, page: 1 },
             type: "FIND_OTUS_REQUESTED"
         });
     });

--- a/src/js/otus/reducer.js
+++ b/src/js/otus/reducer.js
@@ -82,8 +82,8 @@ export const getActiveIsolate = state => {
 
 export const receiveOTU = (state, action) => {
     const detail = {
-        ...action.data,
-        isolates: map(action.data.isolates, isolate => ({
+        ...action,
+        isolates: map(action.isolates, isolate => ({
             ...isolate,
             name: formatIsolateName(isolate)
         }))
@@ -95,35 +95,36 @@ export const receiveOTU = (state, action) => {
 export const OTUsReducer = createReducer(initialState, builder => {
     builder
         .addCase(WS_UPDATE_STATUS, (state, action) => {
-            if (action.data.id === "OTU_import") {
-                state.importData = { ...action.data, inProgress: true };
+            if (action.payload.id === "OTU_import") {
+                state.importData = { ...action.payload, inProgress: true };
             }
         })
         .addCase(WS_INSERT_OTU, (state, action) => {
-            if (action.data.reference.id === state.refId) {
-                return insert(state, action, "name");
+            if (action.payload.reference.id === state.refId) {
+                return insert(state, action.payload, "name");
             }
+
             return state;
         })
         .addCase(WS_UPDATE_OTU, (state, action) => {
-            if (action.data.reference.id === state.refId) {
-                return update(state, action, "name");
+            if (action.payload.reference.id === state.refId) {
+                return update(state, action.payload, "name");
             }
             return state;
         })
         .addCase(WS_REMOVE_OTU, (state, action) => {
-            return remove(state, action);
+            return remove(state, action.payload);
         })
         .addCase(FIND_OTUS.REQUESTED, (state, action) => {
-            state.term = action.term;
-            state.verified = action.verified;
-            state.refId = action.refId;
+            state.term = action.payload.term;
+            state.verified = action.payload.verified;
+            state.refId = action.payload.refId;
         })
         .addCase(FIND_OTUS.SUCCEEDED, (state, action) => {
-            return updateDocuments(state, action, "name");
+            return updateDocuments(state, action.payload, "name");
         })
         .addCase(REFRESH_OTUS.SUCCEEDED, (state, action) => {
-            return updateDocuments(state, action, "name");
+            return updateDocuments(state, action.payload, "name");
         })
         .addCase(GET_OTU.REQUESTED, state => {
             return hideOTUModal({ ...state, detail: null, activeIsolateId: null });
@@ -135,17 +136,17 @@ export const OTUsReducer = createReducer(initialState, builder => {
             state.detailHistory = null;
         })
         .addCase(GET_OTU_HISTORY.SUCCEEDED, (state, action) => {
-            state.detailHistory = action.data;
+            state.detailHistory = action.payload;
         })
         .addCase(REVERT.SUCCEEDED, (state, action) => {
-            return { ...receiveOTU(state, action), detailHistory: action.history };
+            return { ...receiveOTU(state, action.payload.otu), detailHistory: action.payload.history };
         })
         .addCase(UPLOAD_IMPORT.SUCCEEDED, (state, action) => {
-            state.importData = { ...action.data, inProgress: false };
+            state.importData = { ...action.payload, inProgress: false };
         })
         .addCase(SELECT_ISOLATE, (state, action) => {
-            state.activeIsolate = find(state.detail.isolates, { id: action.isolateId });
-            state.activeIsolateId = action.isolateId;
+            state.activeIsolate = find(state.detail.isolates, { id: action.payload.isolateId });
+            state.activeIsolateId = action.payload.isolateId;
         })
         .addCase(SHOW_EDIT_OTU, state => {
             state.edit = true;
@@ -163,7 +164,7 @@ export const OTUsReducer = createReducer(initialState, builder => {
             state.removeIsolate = true;
         })
         .addCase(SHOW_REMOVE_SEQUENCE, (state, action) => {
-            state.removeSequence = action.sequenceId;
+            state.removeSequence = action.payload.sequenceId;
         })
         .addCase(HIDE_OTU_MODAL, state => {
             state.edit = false;
@@ -189,7 +190,7 @@ export const OTUsReducer = createReducer(initialState, builder => {
                 return hasIn(matches, action.type);
             },
             (state, action) => {
-                return hideOTUModal(receiveOTU(state, action));
+                return hideOTUModal(receiveOTU(state, action.payload));
             }
         );
 });

--- a/src/js/references/__tests__/actions.test.js
+++ b/src/js/references/__tests__/actions.test.js
@@ -41,29 +41,29 @@ import {
 
 describe("References Action Creators:", () => {
     it("wsInsertReference", () => {
-        const data = { id: "test" };
-        const result = wsInsertReference(data);
+        const payload = { id: "test" };
+        const result = wsInsertReference(payload);
         expect(result).toEqual({
             type: WS_INSERT_REFERENCE,
-            data
+            payload
         });
     });
 
     it("wsUpdateReference", () => {
-        const data = { id: "test" };
-        const result = wsUpdateReference(data);
+        const payload = { id: "test" };
+        const result = wsUpdateReference(payload);
         expect(result).toEqual({
             type: WS_UPDATE_REFERENCE,
-            data
+            payload
         });
     });
 
     it("wsRemoveReference", () => {
-        const data = { id: "test" };
-        const result = wsRemoveReference(data);
+        const payload = { id: "test" };
+        const result = wsRemoveReference(payload);
         expect(result).toEqual({
             type: WS_REMOVE_REFERENCE,
-            data
+            payload
         });
     });
 
@@ -73,8 +73,7 @@ describe("References Action Creators:", () => {
         const result = findReferences(term, page);
         expect(result).toEqual({
             type: FIND_REFERENCES.REQUESTED,
-            term,
-            page
+            payload: { term, page }
         });
     });
 
@@ -86,10 +85,7 @@ describe("References Action Creators:", () => {
         const result = emptyReference(name, description, dataType, organism);
         expect(result).toEqual({
             type: EMPTY_REFERENCE.REQUESTED,
-            name,
-            description,
-            dataType,
-            organism
+            payload: { name, description, dataType, organism }
         });
     });
 
@@ -99,8 +95,7 @@ describe("References Action Creators:", () => {
         const result = editReference(refId, update);
         expect(result).toEqual({
             type: EDIT_REFERENCE.REQUESTED,
-            refId,
-            update
+            payload: { refId, update }
         });
     });
 
@@ -113,11 +108,7 @@ describe("References Action Creators:", () => {
         const result = importReference(name, description, dataType, organism, fileId);
         expect(result).toEqual({
             type: IMPORT_REFERENCE.REQUESTED,
-            name,
-            description,
-            dataType,
-            organism,
-            fileId
+            payload: { name, description, dataType, organism, fileId }
         });
     });
 
@@ -130,11 +121,7 @@ describe("References Action Creators:", () => {
         const result = cloneReference(name, description, dataType, organism, refId);
         expect(result).toEqual({
             type: CLONE_REFERENCE.REQUESTED,
-            name,
-            description,
-            dataType,
-            organism,
-            refId
+            payload: { name, description, dataType, organism, refId }
         });
     });
 
@@ -147,7 +134,7 @@ describe("References Action Creators:", () => {
         const result = removeReference(refId);
         expect(result).toEqual({
             type: REMOVE_REFERENCE.REQUESTED,
-            refId
+            payload: { refId }
         });
     });
 
@@ -157,8 +144,7 @@ describe("References Action Creators:", () => {
         const result = addReferenceUser(refId, user);
         expect(result).toEqual({
             type: ADD_REFERENCE_USER.REQUESTED,
-            refId,
-            user
+            payload: { refId, user }
         });
     });
 
@@ -169,9 +155,7 @@ describe("References Action Creators:", () => {
         const result = editReferenceUser(refId, userId, update);
         expect(result).toEqual({
             type: EDIT_REFERENCE_USER.REQUESTED,
-            refId,
-            userId,
-            update
+            payload: { refId, userId, update }
         });
     });
 
@@ -181,8 +165,7 @@ describe("References Action Creators:", () => {
         const result = removeReferenceUser(refId, userId);
         expect(result).toEqual({
             type: REMOVE_REFERENCE_USER.REQUESTED,
-            refId,
-            userId
+            payload: { refId, userId }
         });
     });
 
@@ -192,8 +175,7 @@ describe("References Action Creators:", () => {
         const result = addReferenceGroup(refId, group);
         expect(result).toEqual({
             type: ADD_REFERENCE_GROUP.REQUESTED,
-            refId,
-            group
+            payload: { refId, group }
         });
     });
 
@@ -204,9 +186,7 @@ describe("References Action Creators:", () => {
         const result = editReferenceGroup(refId, groupId, update);
         expect(result).toEqual({
             type: EDIT_REFERENCE_GROUP.REQUESTED,
-            refId,
-            groupId,
-            update
+            payload: { refId, groupId, update }
         });
     });
 
@@ -216,8 +196,7 @@ describe("References Action Creators:", () => {
         const result = removeReferenceGroup(refId, groupId);
         expect(result).toEqual({
             type: REMOVE_REFERENCE_GROUP.REQUESTED,
-            refId,
-            groupId
+            payload: { refId, groupId }
         });
     });
 
@@ -226,7 +205,7 @@ describe("References Action Creators:", () => {
         const result = checkUpdates(refId);
         expect(result).toEqual({
             type: CHECK_REMOTE_UPDATES.REQUESTED,
-            refId
+            payload: { refId }
         });
     });
 
@@ -235,7 +214,7 @@ describe("References Action Creators:", () => {
         const result = updateRemoteReference(refId);
         expect(result).toEqual({
             type: UPDATE_REMOTE_REFERENCE.REQUESTED,
-            refId
+            payload: { refId }
         });
     });
 });

--- a/src/js/references/__tests__/reducer.test.js
+++ b/src/js/references/__tests__/reducer.test.js
@@ -34,7 +34,7 @@ describe("References Reducer", () => {
     describe("should handle WS_INSERT_REFERENCE", () => {
         it("returns state if documents not yet fetched", () => {
             const state = { documents: null };
-            const action = { type: WS_INSERT_REFERENCE, data: { id: "foo" } };
+            const action = { type: WS_INSERT_REFERENCE, payload: { id: "foo" } };
             const result = reducer(state, action);
             expect(result).toEqual({ documents: [{ id: "foo" }] });
         });
@@ -48,12 +48,12 @@ describe("References Reducer", () => {
             };
             const action = {
                 type: WS_INSERT_REFERENCE,
-                data: { id: "123abc", name: "testReference" }
+                payload: { id: "123abc", name: "testReference" }
             };
             const result = reducer(state, action);
             expect(result).toEqual({
                 ...state,
-                documents: [{ ...action.data }]
+                documents: [{ ...action.payload }]
             });
         });
     });
@@ -62,7 +62,7 @@ describe("References Reducer", () => {
         const state = { documents: [{ id: "123abc", name: "testReference" }] };
         const action = {
             type: WS_UPDATE_REFERENCE,
-            data: { id: "123abc", name: "testReference-edited" }
+            payload: { id: "123abc", name: "testReference-edited" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -77,7 +77,7 @@ describe("References Reducer", () => {
         };
         const action = {
             type: WS_REMOVE_REFERENCE,
-            data: ["123abc"]
+            payload: { "123abc": "123abc" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -89,7 +89,7 @@ describe("References Reducer", () => {
         const term = "foo";
         const action = {
             type: FIND_REFERENCES.REQUESTED,
-            term: "foo"
+            payload: { term: "foo" }
         };
         const result = reducer({}, action);
         expect(result).toEqual({ term });
@@ -99,11 +99,11 @@ describe("References Reducer", () => {
         const state = { documents: null };
         const action = {
             type: FIND_REFERENCES.SUCCEEDED,
-            data: { documents: [], page: 3, page_count: 5 }
+            payload: { documents: [], page: 3, page_count: 5 }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
-            ...action.data
+            ...action.payload
         });
     });
 
@@ -114,7 +114,7 @@ describe("References Reducer", () => {
     });
 
     it("should handle GET_REFERENCE_SUCCEEDED", () => {
-        const action = { type: GET_REFERENCE.SUCCEEDED, data: { foo: "bar" } };
+        const action = { type: GET_REFERENCE.SUCCEEDED, payload: { foo: "bar" } };
         const result = reducer({}, action);
         expect(result).toEqual({ detail: { foo: "bar" } });
     });
@@ -123,14 +123,14 @@ describe("References Reducer", () => {
         const state = { detail: { foo: "bar" } };
         const action = {
             type: EDIT_REFERENCE.SUCCEEDED,
-            data: { foo: "baz" }
+            payload: { foo: "baz" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({ detail: { foo: "baz" } });
     });
 
     it("should handle UPLOAD_SUCCEEDED", () => {
-        const action = { type: UPLOAD.SUCCEEDED, data: { foo: "bar" } };
+        const action = { type: UPLOAD.SUCCEEDED, payload: { foo: "bar" } };
         const result = reducer({}, action);
         expect(result).toEqual({
             importFile: {
@@ -158,7 +158,7 @@ describe("References Reducer", () => {
         const state = { checking: true };
         const action = {
             type: CHECK_REMOTE_UPDATES.SUCCEEDED,
-            data: { foo: "bar" }
+            payload: { foo: "bar" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -173,7 +173,7 @@ describe("References Reducer", () => {
         const state = { detail: {} };
         const action = {
             type: UPDATE_REMOTE_REFERENCE.SUCCEEDED,
-            data: { foo: "bar" }
+            payload: { foo: "bar" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({ detail: { release: { foo: "bar" } } });
@@ -183,7 +183,7 @@ describe("References Reducer", () => {
         const state = { detail: { users: [] } };
         const action = {
             type: ADD_REFERENCE_USER.SUCCEEDED,
-            data: { id: "test-user" }
+            payload: { id: "test-user" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({ detail: { users: [{ id: "test-user" }] } });
@@ -193,7 +193,7 @@ describe("References Reducer", () => {
         const state = { detail: { users: [{ id: "test-user", foo: "bar" }] } };
         const action = {
             type: EDIT_REFERENCE_USER.SUCCEEDED,
-            data: { id: "test-user", foo: "baz" }
+            payload: { id: "test-user", foo: "baz" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -206,8 +206,7 @@ describe("References Reducer", () => {
             const state = { detail: { id: "foo" }, pendingRemoveUsers: ["fred"] };
             const action = {
                 type: REMOVE_REFERENCE_USER.REQUESTED,
-                refId: "foo",
-                userId: "bob"
+                payload: { refId: "foo", userId: "bob" }
             };
             const result = reducer(state, action);
             expect(result).toEqual({
@@ -220,8 +219,7 @@ describe("References Reducer", () => {
             const state = { detail: { id: "foo" }, pendingRemoveUsers: ["fred"] };
             const action = {
                 type: REMOVE_REFERENCE_USER.REQUESTED,
-                refId: "bar",
-                userId: "bob"
+                payload: { refId: "bar", userId: "bob" }
             };
             const result = reducer(state, action);
             expect(result).toEqual(state);
@@ -235,9 +233,11 @@ describe("References Reducer", () => {
         beforeEach(() => {
             action = {
                 type: REMOVE_REFERENCE_USER.SUCCEEDED,
-                context: {
-                    refId: "foo",
-                    userId: "bar"
+                payload: {
+                    context: {
+                        refId: "foo",
+                        userId: "bar"
+                    }
                 }
             };
             state = {
@@ -258,7 +258,7 @@ describe("References Reducer", () => {
         });
 
         it("when store and action ref ids don't match", () => {
-            action.context.refId = "boo";
+            action.payload.context.refId = "boo";
             const result = reducer(state, action);
             expect(result).toEqual(state);
         });
@@ -268,7 +268,7 @@ describe("References Reducer", () => {
         const state = { detail: { groups: [] } };
         const action = {
             type: ADD_REFERENCE_GROUP.SUCCEEDED,
-            data: { id: "test-group" }
+            payload: { id: "test-group" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -284,7 +284,7 @@ describe("References Reducer", () => {
         };
         const action = {
             type: EDIT_REFERENCE_GROUP.SUCCEEDED,
-            data: { id: "foo", foo: "baz" }
+            payload: { id: "foo", foo: "baz" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -301,8 +301,7 @@ describe("References Reducer", () => {
         beforeEach(() => {
             action = {
                 type: REMOVE_REFERENCE_GROUP.REQUESTED,
-                refId: "foo",
-                groupId: "baz"
+                payload: { refId: "foo", groupId: "baz" }
             };
             state = {
                 detail: { id: "foo" },
@@ -319,7 +318,7 @@ describe("References Reducer", () => {
         });
 
         it("when store and action ref ids don't match", () => {
-            action.refId = "bar";
+            action.payload.refId = "bar";
             const result = reducer(state, action);
             expect(result).toEqual(state);
         });
@@ -332,9 +331,11 @@ describe("References Reducer", () => {
         beforeEach(() => {
             action = {
                 type: REMOVE_REFERENCE_GROUP.SUCCEEDED,
-                context: {
-                    refId: "foobar",
-                    groupId: "bar"
+                payload: {
+                    context: {
+                        refId: "foobar",
+                        groupId: "bar"
+                    }
                 }
             };
 
@@ -359,7 +360,7 @@ describe("References Reducer", () => {
         });
 
         it("when store and action ref ids don't match", () => {
-            action.context.refId = "bid";
+            action.payload.context.refId = "bid";
             const result = reducer(state, action);
             expect(result).toEqual(state);
         });

--- a/src/js/references/actions.js
+++ b/src/js/references/actions.js
@@ -19,118 +19,105 @@ import {
     CHECK_REMOTE_UPDATES,
     UPDATE_REMOTE_REFERENCE
 } from "../app/actionTypes";
+import { createAction } from "@reduxjs/toolkit";
+/**
+ * Returns an action that should be dispatched when a reference is inserted via websocket.
+ *
+ * @func
+ * @param data {object} the data passed in the websocket message
+ * @returns {object}
+ */
+export const wsInsertReference = createAction(WS_INSERT_REFERENCE);
+/**
+ * Returns an action that should be dispatched when a reference is updated via websocket.
+ *
+ * @func
+ * @param data {object} the data passed in the websocket message
+ * @returns {object}
+ */
+export const wsUpdateReference = createAction(WS_UPDATE_REFERENCE);
+/**
+ * Returns an action that should be dispatched when a reference is removed via websocket.
+ *
+ * @func
+ * @param data {object} the data passed in the websocket message
+ * @returns {object}
+ */
+export const wsRemoveReference = createAction(WS_REMOVE_REFERENCE);
 
-export const wsInsertReference = data => ({
-    type: WS_INSERT_REFERENCE,
-    data
-});
+export const findReferences = createAction(FIND_REFERENCES.REQUESTED, (term, page = 1) => ({
+    payload: { term, page }
+}));
 
-export const wsUpdateReference = data => ({
-    type: WS_UPDATE_REFERENCE,
-    data
-});
+export const getReference = createAction(GET_REFERENCE.REQUESTED, refId => ({ payload: { refId } }));
 
-export const wsRemoveReference = data => ({
-    type: WS_REMOVE_REFERENCE,
-    data
-});
+export const emptyReference = createAction(EMPTY_REFERENCE.REQUESTED, (name, description, dataType, organism) => ({
+    payload: {
+        name,
+        description,
+        dataType,
+        organism
+    }
+}));
 
-export const findReferences = (term, page = 1) => ({
-    type: FIND_REFERENCES.REQUESTED,
-    term,
-    page
-});
+export const editReference = createAction(EDIT_REFERENCE.REQUESTED, (refId, update) => ({
+    payload: { refId, update }
+}));
 
-export const getReference = refId => ({
-    type: GET_REFERENCE.REQUESTED,
-    refId
-});
+export const importReference = createAction(
+    IMPORT_REFERENCE.REQUESTED,
+    (name, description, dataType, organism, fileId) => ({
+        payload: {
+            name,
+            description,
+            dataType,
+            organism,
+            fileId
+        }
+    })
+);
 
-export const emptyReference = (name, description, dataType, organism) => ({
-    type: EMPTY_REFERENCE.REQUESTED,
-    name,
-    description,
-    dataType,
-    organism
-});
+export const cloneReference = createAction(
+    CLONE_REFERENCE.REQUESTED,
+    (name, description, dataType, organism, refId) => ({
+        payload: {
+            name,
+            description,
+            dataType,
+            organism,
+            refId
+        }
+    })
+);
 
-export const editReference = (refId, update) => ({
-    type: EDIT_REFERENCE.REQUESTED,
-    refId,
-    update
-});
+export const remoteReference = createAction(REMOTE_REFERENCE.REQUESTED);
 
-export const importReference = (name, description, dataType, organism, fileId) => ({
-    type: IMPORT_REFERENCE.REQUESTED,
-    name,
-    description,
-    dataType,
-    organism,
-    fileId
-});
+export const removeReference = createAction(REMOVE_REFERENCE.REQUESTED, refId => ({ payload: { refId } }));
 
-export const cloneReference = (name, description, dataType, organism, refId) => ({
-    type: CLONE_REFERENCE.REQUESTED,
-    name,
-    description,
-    dataType,
-    organism,
-    refId
-});
+export const addReferenceUser = createAction(ADD_REFERENCE_USER.REQUESTED, (refId, user) => ({
+    payload: { refId, user }
+}));
 
-export const remoteReference = () => ({
-    type: REMOTE_REFERENCE.REQUESTED
-});
+export const editReferenceUser = createAction(EDIT_REFERENCE_USER.REQUESTED, (refId, userId, update) => ({
+    payload: { refId, userId, update }
+}));
 
-export const removeReference = refId => ({
-    type: REMOVE_REFERENCE.REQUESTED,
-    refId
-});
+export const removeReferenceUser = createAction(REMOVE_REFERENCE_USER.REQUESTED, (refId, userId) => ({
+    payload: { refId, userId }
+}));
 
-export const addReferenceUser = (refId, user) => ({
-    type: ADD_REFERENCE_USER.REQUESTED,
-    refId,
-    user
-});
+export const addReferenceGroup = createAction(ADD_REFERENCE_GROUP.REQUESTED, (refId, group) => ({
+    payload: { refId, group }
+}));
 
-export const editReferenceUser = (refId, userId, update) => ({
-    type: EDIT_REFERENCE_USER.REQUESTED,
-    refId,
-    userId,
-    update
-});
+export const editReferenceGroup = createAction(EDIT_REFERENCE_GROUP.REQUESTED, (refId, groupId, update) => ({
+    payload: { refId, groupId, update }
+}));
 
-export const removeReferenceUser = (refId, userId) => ({
-    type: REMOVE_REFERENCE_USER.REQUESTED,
-    refId,
-    userId
-});
+export const removeReferenceGroup = createAction(REMOVE_REFERENCE_GROUP.REQUESTED, (refId, groupId) => ({
+    payload: { refId, groupId }
+}));
 
-export const addReferenceGroup = (refId, group) => ({
-    type: ADD_REFERENCE_GROUP.REQUESTED,
-    refId,
-    group
-});
+export const checkUpdates = createAction(CHECK_REMOTE_UPDATES.REQUESTED, refId => ({ payload: { refId } }));
 
-export const editReferenceGroup = (refId, groupId, update) => ({
-    type: EDIT_REFERENCE_GROUP.REQUESTED,
-    refId,
-    groupId,
-    update
-});
-
-export const removeReferenceGroup = (refId, groupId) => ({
-    type: REMOVE_REFERENCE_GROUP.REQUESTED,
-    refId,
-    groupId
-});
-
-export const checkUpdates = refId => ({
-    type: CHECK_REMOTE_UPDATES.REQUESTED,
-    refId
-});
-
-export const updateRemoteReference = refId => ({
-    type: UPDATE_REMOTE_REFERENCE.REQUESTED,
-    refId
-});
+export const updateRemoteReference = createAction(UPDATE_REMOTE_REFERENCE.REQUESTED, refId => ({ payload: { refId } }));

--- a/src/js/references/components/Detail/Targets/__tests__/Add.test.js
+++ b/src/js/references/components/Detail/Targets/__tests__/Add.test.js
@@ -119,6 +119,9 @@ describe("mapDispatchToProps()", () => {
         const dispatch = jest.fn();
         const props = mapDispatchToProps(dispatch);
         props.onSubmit("foo", "bar");
-        expect(dispatch).toHaveBeenCalledWith({ refId: "foo", update: "bar", type: "EDIT_REFERENCE_REQUESTED" });
+        expect(dispatch).toHaveBeenCalledWith({
+            payload: { refId: "foo", update: "bar" },
+            type: "EDIT_REFERENCE_REQUESTED"
+        });
     });
 });

--- a/src/js/references/components/Detail/Targets/__tests__/Edit.test.js
+++ b/src/js/references/components/Detail/Targets/__tests__/Edit.test.js
@@ -175,8 +175,7 @@ describe("mapDispatchToProps()", () => {
         const props = mapDispatchToProps(dispatch);
         props.onSubmit("foo", "bar");
         expect(dispatch).toHaveBeenCalledWith({
-            refId: "foo",
-            update: "bar",
+            payload: { refId: "foo", update: "bar" },
             type: "EDIT_REFERENCE_REQUESTED"
         });
     });

--- a/src/js/references/components/Detail/Targets/__tests__/Targets.test.js
+++ b/src/js/references/components/Detail/Targets/__tests__/Targets.test.js
@@ -120,6 +120,9 @@ describe("mapDispatchToProps()", () => {
         const dispatch = jest.fn();
         const props = mapDispatchToProps(dispatch);
         props.onRemove("foo", "bar");
-        expect(dispatch).toHaveBeenCalledWith({ refId: "foo", update: "bar", type: "EDIT_REFERENCE_REQUESTED" });
+        expect(dispatch).toHaveBeenCalledWith({
+            payload: { refId: "foo", update: "bar" },
+            type: "EDIT_REFERENCE_REQUESTED"
+        });
     });
 });

--- a/src/js/references/components/Detail/__tests__/Header.test.js
+++ b/src/js/references/components/Detail/__tests__/Header.test.js
@@ -111,6 +111,6 @@ describe("mapDispatchToProps", () => {
         const dispatch = jest.fn();
         const result = mapDispatchToProps(dispatch);
         result.onEdit();
-        expect(dispatch).toHaveBeenCalledWith({ state: { editReference: true }, type: "PUSH_STATE" });
+        expect(dispatch).toHaveBeenCalledWith({ payload: { state: { editReference: true } }, type: "PUSH_STATE" });
     });
 });

--- a/src/js/references/components/Detail/__tests__/Manage.test.js
+++ b/src/js/references/components/Detail/__tests__/Manage.test.js
@@ -65,13 +65,17 @@ describe("mapDispatchToProps()", () => {
     it("should return checkUpdates() in props", () => {
         const props = mapDispatchToProps(dispatch);
         props.onCheckUpdates("foo");
-        expect(dispatch).toHaveBeenCalledWith({ refId: "foo", type: "CHECK_REMOTE_UPDATES_REQUESTED" });
+        expect(dispatch).toHaveBeenCalledWith({ payload: { refId: "foo" }, type: "CHECK_REMOTE_UPDATES_REQUESTED" });
     });
 
     it("should return updateRemoteReference() in props", () => {
         const props = mapDispatchToProps(dispatch);
         props.onUpdate("bar");
-        expect(dispatch).toHaveBeenCalledWith((1, { refId: "foo", type: "CHECK_REMOTE_UPDATES_REQUESTED" }));
-        expect(dispatch).toHaveBeenCalledWith((2, { refId: "bar", type: "UPDATE_REMOTE_REFERENCE_REQUESTED" }));
+        expect(dispatch).toHaveBeenCalledWith(
+            (1, { payload: { refId: "foo" }, type: "CHECK_REMOTE_UPDATES_REQUESTED" })
+        );
+        expect(dispatch).toHaveBeenCalledWith(
+            (2, { payload: { refId: "bar" }, type: "UPDATE_REMOTE_REFERENCE_REQUESTED" })
+        );
     });
 });

--- a/src/js/references/components/Detail/__tests__/Remove.test.js
+++ b/src/js/references/components/Detail/__tests__/Remove.test.js
@@ -64,7 +64,7 @@ describe("mapDispatchToProps", () => {
 
         expect(dispatch).toHaveBeenCalledWith({
             type: REMOVE_REFERENCE.REQUESTED,
-            refId: "foo"
+            payload: { refId: "foo" }
         });
     });
 });

--- a/src/js/references/components/__tests__/Clone.test.js
+++ b/src/js/references/components/__tests__/Clone.test.js
@@ -164,16 +164,12 @@ describe("mapDispatchToProps()", () => {
     it("should return onSubmit in props", () => {
         props.onSubmit("foo", "bar", "fee", "baz", "boo");
         expect(dispatch).toHaveBeenCalledWith({
-            name: "foo",
-            description: "bar",
-            dataType: "fee",
-            organism: "baz",
-            refId: "boo",
+            payload: { name: "foo", description: "bar", dataType: "fee", organism: "baz", refId: "boo" },
             type: "CLONE_REFERENCE_REQUESTED"
         });
     });
     it("should return onClearError in props", () => {
         props.onClearError(true);
-        expect(dispatch).toHaveBeenCalledWith({ error: true, type: "CLEAR_ERROR" });
+        expect(dispatch).toHaveBeenCalledWith({ payload: { error: true }, type: "CLEAR_ERROR" });
     });
 });

--- a/src/js/references/components/__tests__/Create.test.js
+++ b/src/js/references/components/__tests__/Create.test.js
@@ -86,17 +86,14 @@ describe("mapDispatchToProps()", () => {
     it("should return onSubmit in props", () => {
         props.onSubmit("foo", "bar", "fee", "baz");
         expect(dispatch).toHaveBeenCalledWith({
-            name: "foo",
-            description: "bar",
-            dataType: "fee",
-            organism: "baz",
+            payload: { name: "foo", description: "bar", dataType: "fee", organism: "baz" },
             type: "EMPTY_REFERENCE_REQUESTED"
         });
     });
     it("should return onClearError in props", () => {
         props.onClearError("foo");
         expect(dispatch).toHaveBeenCalledWith({
-            error: "foo",
+            payload: { error: "foo" },
             type: "CLEAR_ERROR"
         });
     });

--- a/src/js/references/components/__tests__/SourceTypes.test.js
+++ b/src/js/references/components/__tests__/SourceTypes.test.js
@@ -135,8 +135,10 @@ describe("mapDispatchToProps", () => {
         props.onUpdate(["genotype"], true, "foo");
         expect(dispatch).toHaveBeenCalledWith({
             type: UPDATE_SETTINGS.REQUESTED,
-            update: {
-                default_source_types: ["genotype"]
+            payload: {
+                update: {
+                    default_source_types: ["genotype"]
+                }
             }
         });
     });
@@ -145,9 +147,11 @@ describe("mapDispatchToProps", () => {
         props.onUpdate(["genotype"], false, "foo");
         expect(dispatch).toHaveBeenCalledWith({
             type: EDIT_REFERENCE.REQUESTED,
-            refId: "foo",
-            update: {
-                source_types: ["genotype"]
+            payload: {
+                refId: "foo",
+                update: {
+                    source_types: ["genotype"]
+                }
             }
         });
     });
@@ -156,9 +160,11 @@ describe("mapDispatchToProps", () => {
         props.onToggle("foo", false);
         expect(dispatch).toHaveBeenCalledWith({
             type: EDIT_REFERENCE.REQUESTED,
-            refId: "foo",
-            update: {
-                restrict_source_types: false
+            payload: {
+                refId: "foo",
+                update: {
+                    restrict_source_types: false
+                }
             }
         });
     });
@@ -167,9 +173,11 @@ describe("mapDispatchToProps", () => {
         props.onToggle("foo", true);
         expect(dispatch).toHaveBeenCalledWith({
             type: EDIT_REFERENCE.REQUESTED,
-            refId: "foo",
-            update: {
-                restrict_source_types: true
+            payload: {
+                refId: "foo",
+                update: {
+                    restrict_source_types: true
+                }
             }
         });
     });

--- a/src/js/references/reducer.js
+++ b/src/js/references/reducer.js
@@ -39,66 +39,66 @@ export const initialState = {
 export const referenceReducer = createReducer(initialState, builder => {
     builder
         .addCase(WS_INSERT_REFERENCE, (state, action) => {
-            const updated = insert(state, action, "name");
+            const updated = insert(state, action.payload, "name");
             return {
                 ...updated
             };
         })
         .addCase(WS_UPDATE_REFERENCE, (state, action) => {
-            const updated = update(state, action, "name");
+            const updated = update(state, action.payload, "name");
 
-            if (state.detail && state.detail.id === action.data.id) {
-                state.detail = { ...state.detail, ...action.data };
+            if (state.detail && state.detail.id === action.payload.id) {
+                state.detail = { ...state.detail, ...action.payload };
             } else {
                 assign(state, updated);
             }
         })
         .addCase(WS_REMOVE_REFERENCE, (state, action) => {
-            return remove(state, action);
+            return remove(state, action.payload);
         })
         .addCase(FIND_REFERENCES.REQUESTED, (state, action) => {
-            state.term = action.term;
+            state.term = action.payload.term;
         })
         .addCase(FIND_REFERENCES.SUCCEEDED, (state, action) => {
-            return updateDocuments(state, action, "name");
+            return updateDocuments(state, action.payload, "name");
         })
         .addCase(GET_REFERENCE.REQUESTED, state => {
             state.detail = null;
         })
         .addCase(GET_REFERENCE.SUCCEEDED, (state, action) => {
-            state.detail = action.data;
+            state.detail = action.payload;
         })
         .addCase(EDIT_REFERENCE.SUCCEEDED, (state, action) => {
-            state.detail = action.data;
+            state.detail = action.payload;
         })
         .addCase(UPLOAD.REQUESTED, (state, action) => {
-            if (action.fileType === "reference") {
+            if (action.payload.fileType === "reference") {
                 state.importFile = null;
-                state.importUploadId = action.localId;
-                state.importUploadName = action.name;
+                state.importUploadId = action.payload.localId;
+                state.importUploadName = action.payload.name;
                 state.importUploadProgress = 0;
             }
 
             return state;
         })
         .addCase(UPLOAD.SUCCEEDED, (state, action) => {
-            if (state.importUploadId === action.data.localId) {
-                state.importFile = action.data;
+            if (state.importUploadId === action.payload.localId) {
+                state.importFile = action.payload;
                 state.importUploadId = null;
                 state.importUploadName = null;
                 state.importUploadProgress = 0;
             }
         })
         .addCase(UPLOAD.FAILED, (state, action) => {
-            if (action.fileType === "reference") {
+            if (action.payload.fileType === "reference") {
                 state.importFile = null;
                 state.importUploadId = null;
                 state.importUploadProgress = 0;
             }
         })
         .addCase(UPLOAD_PROGRESS, (state, action) => {
-            if (state.importUploadId === action.localId) {
-                state.importUploadProgress = action.progress;
+            if (state.importUploadId === action.payload.localId) {
+                state.importUploadProgress = action.payload.progress;
             }
         })
         .addCase(CHECK_REMOTE_UPDATES.REQUESTED, state => {
@@ -109,43 +109,43 @@ export const referenceReducer = createReducer(initialState, builder => {
         })
         .addCase(CHECK_REMOTE_UPDATES.SUCCEEDED, (state, action) => {
             state.checking = false;
-            set(state, "detail.release", action.data);
+            set(state, "detail.release", action.payload);
         })
         .addCase(UPDATE_REMOTE_REFERENCE.SUCCEEDED, (state, action) => {
-            set(state, "detail.release", action.data);
+            set(state, "detail.release", action.payload);
         })
         .addCase(ADD_REFERENCE_USER.SUCCEEDED, (state, action) => {
-            state.detail.users = concat(state.detail.users, [action.data]);
+            state.detail.users = concat(state.detail.users, [action.payload]);
         })
         .addCase(EDIT_REFERENCE_USER.SUCCEEDED, (state, action) => {
-            state.detail.users = updateMember(state.detail.users, action);
+            state.detail.users = updateMember(state.detail.users, action.payload);
         })
         .addCase(REMOVE_REFERENCE_USER.REQUESTED, (state, action) => {
-            if (action.refId === state.detail.id) {
-                state.pendingRemoveUsers = union(state.pendingRemoveUsers, [action.userId]);
+            if (action.payload.refId === state.detail.id) {
+                state.pendingRemoveUsers = union(state.pendingRemoveUsers, [action.payload.userId]);
             }
         })
         .addCase(REMOVE_REFERENCE_USER.SUCCEEDED, (state, action) => {
-            if (action.context.refId === state.detail.id) {
-                const userId = action.context.userId;
+            if (action.payload.context.refId === state.detail.id) {
+                const userId = action.payload.context.userId;
                 state.pendingRemoveUsers = without(state.pendingRemoveUsers, userId);
                 state.detail.users = reject(state.detail.users, { id: userId });
             }
         })
         .addCase(ADD_REFERENCE_GROUP.SUCCEEDED, (state, action) => {
-            state.detail.groups = concat(state.detail.groups, [action.data]);
+            state.detail.groups = concat(state.detail.groups, [action.payload]);
         })
         .addCase(EDIT_REFERENCE_GROUP.SUCCEEDED, (state, action) => {
-            state.detail.groups = updateMember(state.detail.groups, action);
+            state.detail.groups = updateMember(state.detail.groups, action.payload);
         })
         .addCase(REMOVE_REFERENCE_GROUP.REQUESTED, (state, action) => {
-            if (action.refId === state.detail.id) {
-                state.pendingRemoveGroups = union(state.pendingRemoveGroups, [action.groupId]);
+            if (action.payload.refId === state.detail.id) {
+                state.pendingRemoveGroups = union(state.pendingRemoveGroups, [action.payload.groupId]);
             }
         })
         .addCase(REMOVE_REFERENCE_GROUP.SUCCEEDED, (state, action) => {
-            if (action.context.refId === state.detail.id) {
-                const groupId = action.context.groupId;
+            if (action.payload.context.refId === state.detail.id) {
+                const groupId = action.payload.context.groupId;
                 state.pendingRemoveGroups = without(state.pendingRemoveGroups, groupId);
                 state.detail.groups = reject(state.detail.groups, { id: groupId });
             }

--- a/src/js/references/sagas.js
+++ b/src/js/references/sagas.js
@@ -35,16 +35,16 @@ export function* afterReferenceCreation() {
 }
 
 export function* findReferences(action) {
-    yield apiCall(referenceAPI.find, action, FIND_REFERENCES);
-    yield pushFindTerm(action.term);
+    yield apiCall(referenceAPI.find, action.payload, FIND_REFERENCES);
+    yield pushFindTerm(action.payload.term);
 }
 
 export function* getReference(action) {
-    yield apiCall(referenceAPI.get, action, GET_REFERENCE);
+    yield apiCall(referenceAPI.get, action.payload, GET_REFERENCE);
 }
 
 export function* emptyReference(action) {
-    const resp = yield apiCall(referenceAPI.create, action, EMPTY_REFERENCE);
+    const resp = yield apiCall(referenceAPI.create, action.payload, EMPTY_REFERENCE);
 
     if (resp.ok) {
         yield afterReferenceCreation();
@@ -52,11 +52,11 @@ export function* emptyReference(action) {
 }
 
 export function* editReference(action) {
-    yield apiCall(referenceAPI.edit, action, EDIT_REFERENCE);
+    yield apiCall(referenceAPI.edit, action.payload, EDIT_REFERENCE);
 }
 
 export function* removeReference(action) {
-    const resp = yield apiCall(referenceAPI.remove, action, REMOVE_REFERENCE);
+    const resp = yield apiCall(referenceAPI.remove, action.payload, REMOVE_REFERENCE);
 
     if (resp.ok) {
         yield put(push("/refs"));
@@ -64,7 +64,7 @@ export function* removeReference(action) {
 }
 
 export function* importReference(action) {
-    const resp = yield apiCall(referenceAPI.importReference, action, IMPORT_REFERENCE);
+    const resp = yield apiCall(referenceAPI.importReference, action.payload, IMPORT_REFERENCE);
 
     if (resp.ok) {
         yield afterReferenceCreation();
@@ -72,7 +72,7 @@ export function* importReference(action) {
 }
 
 export function* cloneReference(action) {
-    const resp = yield apiCall(referenceAPI.cloneReference, action, CLONE_REFERENCE);
+    const resp = yield apiCall(referenceAPI.cloneReference, action.payload, CLONE_REFERENCE);
 
     if (resp.ok) {
         yield afterReferenceCreation();
@@ -92,17 +92,17 @@ export function* remoteReference() {
 }
 
 export function* addRefUser(action) {
-    yield apiCall(referenceAPI.addUser, action, ADD_REFERENCE_USER);
+    yield apiCall(referenceAPI.addUser, action.payload, ADD_REFERENCE_USER);
 }
 
 export function* editRefUser(action) {
-    yield apiCall(referenceAPI.editUser, action, EDIT_REFERENCE_USER);
+    yield apiCall(referenceAPI.editUser, action.payload, EDIT_REFERENCE_USER);
 }
 
 export function* removeRefUser(action) {
-    yield apiCall(referenceAPI.removeUser, action, REMOVE_REFERENCE_USER, {
-        userId: action.userId,
-        refId: action.refId
+    yield apiCall(referenceAPI.removeUser, action.payload, REMOVE_REFERENCE_USER, {
+        userId: action.payload.userId,
+        refId: action.payload.refId
     });
 }
 
@@ -116,17 +116,17 @@ export function* editRefGroup(action) {
 
 export function* removeRefGroup(action) {
     yield apiCall(referenceAPI.removeGroup, action, REMOVE_REFERENCE_GROUP, {
-        groupId: action.groupId,
-        refId: action.refId
+        groupId: action.payload.groupId,
+        refId: action.payload.refId
     });
 }
 
 export function* checkRemoteUpdates(action) {
-    yield apiCall(referenceAPI.checkUpdates, action, CHECK_REMOTE_UPDATES);
+    yield apiCall(referenceAPI.checkUpdates, action.payload, CHECK_REMOTE_UPDATES);
 }
 
 export function* updateRemoteReference(action) {
-    yield apiCall(referenceAPI.updateRemote, action, UPDATE_REMOTE_REFERENCE);
+    yield apiCall(referenceAPI.updateRemote, action.payload, UPDATE_REMOTE_REFERENCE);
 }
 
 export function* watchReferences() {

--- a/src/js/samples/__tests__/actions.test.js
+++ b/src/js/samples/__tests__/actions.test.js
@@ -38,7 +38,7 @@ describe("Sample Action Creators:", () => {
         const result = wsInsertSample(data);
         expect(result).toEqual({
             type: WS_INSERT_SAMPLE,
-            data
+            payload: { ...data }
         });
     });
 
@@ -50,7 +50,7 @@ describe("Sample Action Creators:", () => {
         const result = wsUpdateSample(data);
         expect(result).toEqual({
             type: WS_UPDATE_SAMPLE,
-            data
+            payload: { ...data }
         });
     });
 
@@ -59,7 +59,7 @@ describe("Sample Action Creators:", () => {
         const result = wsRemoveSample(data);
         expect(result).toEqual({
             type: WS_REMOVE_SAMPLE,
-            data
+            payload: data
         });
     });
 
@@ -73,10 +73,7 @@ describe("Sample Action Creators:", () => {
 
         expect(result).toEqual({
             type: FIND_SAMPLES.REQUESTED,
-            labels,
-            term,
-            page,
-            workflows
+            payload: { labels, term, page, workflows }
         });
     });
 
@@ -90,7 +87,7 @@ describe("Sample Action Creators:", () => {
         const result = getSample(sampleId);
         expect(result).toEqual({
             type: GET_SAMPLE.REQUESTED,
-            sampleId
+            payload: { sampleId }
         });
     });
 
@@ -105,13 +102,7 @@ describe("Sample Action Creators:", () => {
         const result = createSample(name, isolate, host, locale, libraryType, subtractions, files);
         expect(result).toEqual({
             type: CREATE_SAMPLE.REQUESTED,
-            name,
-            isolate,
-            host,
-            locale,
-            libraryType,
-            subtractions,
-            files
+            payload: { name, isolate, host, locale, libraryType, subtractions, files }
         });
     });
 
@@ -120,8 +111,7 @@ describe("Sample Action Creators:", () => {
         const result = editSample(sampleId, update);
         expect(result).toEqual({
             type: UPDATE_SAMPLE.REQUESTED,
-            sampleId,
-            update
+            payload: { sampleId, update }
         });
     });
 
@@ -130,8 +120,7 @@ describe("Sample Action Creators:", () => {
         const result = updateSampleRights(sampleId, update);
         expect(result).toEqual({
             type: UPDATE_SAMPLE_RIGHTS.REQUESTED,
-            sampleId,
-            update
+            payload: { sampleId, update }
         });
     });
 
@@ -139,7 +128,7 @@ describe("Sample Action Creators:", () => {
         const result = removeSample(sampleId);
         expect(result).toEqual({
             type: REMOVE_SAMPLE.REQUESTED,
-            sampleId
+            payload: { sampleId }
         });
     });
 

--- a/src/js/samples/__tests__/reducer.test.js
+++ b/src/js/samples/__tests__/reducer.test.js
@@ -28,7 +28,7 @@ describe("Samples Reducer", () => {
     it.each([null, []])("should handle WS_INSERT_SAMPLE and when when [documents=%p]", existing => {
         const action = {
             type: WS_INSERT_SAMPLE,
-            data: {
+            payload: {
                 id: "foo",
                 name: "Foo"
             }
@@ -36,7 +36,7 @@ describe("Samples Reducer", () => {
         const state = { documents: existing };
         const result = reducer(state, action);
         expect(result).toEqual({
-            documents: [action.data]
+            documents: [action.payload]
         });
     });
 
@@ -47,7 +47,7 @@ describe("Samples Reducer", () => {
         };
         const action = {
             type: WS_UPDATE_SAMPLE,
-            data: {
+            payload: {
                 id: "foo",
                 name: "New"
             }
@@ -66,7 +66,7 @@ describe("Samples Reducer", () => {
         };
         const action = {
             type: WS_REMOVE_SAMPLE,
-            data: ["foo"]
+            payload: ["foo"]
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -79,8 +79,7 @@ describe("Samples Reducer", () => {
         const term = "foo";
         const action = {
             type: FIND_SAMPLES.REQUESTED,
-            term,
-            page: 5
+            payload: { term, page: 5 }
         };
         const result = reducer({}, action);
         expect(result).toEqual({
@@ -91,7 +90,7 @@ describe("Samples Reducer", () => {
     it("should handle FIND_SAMPLES_SUCCEEDED", () => {
         const action = {
             type: FIND_SAMPLES.SUCCEEDED,
-            data: { documents: [], page: 5 }
+            payload: { documents: [], page: 5 }
         };
         const result = reducer({}, action);
         expect(result).toEqual({
@@ -103,7 +102,7 @@ describe("Samples Reducer", () => {
     it("should handle FIND_READ_FILES_SUCCEEDED", () => {
         const action = {
             type: FIND_READ_FILES.SUCCEEDED,
-            data: {
+            payload: {
                 documents: [],
                 found_count: 0,
                 page: 1,
@@ -115,7 +114,7 @@ describe("Samples Reducer", () => {
         const result = reducer(initialState, action);
         expect(result).toEqual({
             ...initialState,
-            readFiles: action.data.documents
+            readFiles: action.payload.documents
         });
     });
 
@@ -134,7 +133,7 @@ describe("Samples Reducer", () => {
     it("should handle GET_SAMPLE_SUCCEEDED", () => {
         const action = {
             type: GET_SAMPLE.SUCCEEDED,
-            data: {
+            payload: {
                 id: "123abc",
                 name: "test"
             }
@@ -142,14 +141,14 @@ describe("Samples Reducer", () => {
         const result = reducer(initialState, action);
         expect(result).toEqual({
             ...initialState,
-            detail: action.data
+            detail: action.payload
         });
     });
 
     it("should handle UPDATE_SAMPLE_SUCCEEDED", () => {
         const action = {
             type: UPDATE_SAMPLE.SUCCEEDED,
-            data: {
+            payload: {
                 id: "123abc",
                 name: "test"
             }
@@ -157,7 +156,7 @@ describe("Samples Reducer", () => {
         const result = reducer(initialState, action);
         expect(result).toEqual({
             ...initialState,
-            detail: action.data
+            detail: action.payload
         });
     });
 
@@ -165,12 +164,12 @@ describe("Samples Reducer", () => {
         const state = {};
         const action = {
             type: UPDATE_SAMPLE_RIGHTS.SUCCEEDED,
-            data: { foo: "bar" }
+            payload: { foo: "bar" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
             ...state,
-            detail: action.data
+            detail: action.payload
         });
     });
 
@@ -185,7 +184,7 @@ describe("Samples Reducer", () => {
     });
 
     it("should handle SELECT_SAMPLE", () => {
-        const action = { type: SELECT_SAMPLE, sampleId: "foo" };
+        const action = { type: SELECT_SAMPLE, payload: { sampleId: "foo" } };
         const state = { selected: ["bar", "baz"] };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -194,7 +193,7 @@ describe("Samples Reducer", () => {
     });
 
     it("should handle SELECT_SAMPLE when sample already selected", () => {
-        const action = { type: SELECT_SAMPLE, sampleId: "foo" };
+        const action = { type: SELECT_SAMPLE, payload: { sampleId: "foo" } };
         const state = { selected: ["bar", "foo", "baz"] };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -203,7 +202,7 @@ describe("Samples Reducer", () => {
     });
 
     it("should handle DESELECT_SAMPLES", () => {
-        const action = { type: DESELECT_SAMPLES, sampleIds: ["foo", "bad"] };
+        const action = { type: DESELECT_SAMPLES, payload: { sampleIds: ["foo", "bad"] } };
         const state = { selected: ["foo", "bar", "bad", "baz"] };
         const result = reducer(state, action);
         expect(result).toEqual({

--- a/src/js/samples/actions.js
+++ b/src/js/samples/actions.js
@@ -16,12 +16,17 @@ import {
     WS_REMOVE_SAMPLE,
     WS_UPDATE_SAMPLE
 } from "../app/actionTypes";
-import { simpleActionCreator } from "../utils/utils";
+import { createAction } from "@reduxjs/toolkit";
 
-export const wsInsertSample = data => ({
-    type: WS_INSERT_SAMPLE,
-    data
-});
+/**
+ * Returns an action that should be dispatched when a sample document is inserted via websocket.
+ *
+ * @func
+ * @param data {object} update data passed in the websocket message
+ * @returns {object} an action object
+ */
+
+export const wsInsertSample = createAction(WS_INSERT_SAMPLE);
 
 /**
  * Returns an action that should be dispatched when a sample document is updated via websocket.
@@ -30,10 +35,7 @@ export const wsInsertSample = data => ({
  * @param data {object} update data passed in the websocket message
  * @returns {object} an action object
  */
-export const wsUpdateSample = data => ({
-    type: WS_UPDATE_SAMPLE,
-    data
-});
+export const wsUpdateSample = createAction(WS_UPDATE_SAMPLE);
 
 /**
  * Returns an action that should be dispatched when a sample document is removed via websocket.
@@ -42,25 +44,20 @@ export const wsUpdateSample = data => ({
  * @param data {string} the id for the specific sample
  * @returns {object}
  */
-export const wsRemoveSample = data => ({
-    type: WS_REMOVE_SAMPLE,
-    data
-});
+export const wsRemoveSample = createAction(WS_REMOVE_SAMPLE);
 
-export const updateSearch = parameters => ({
-    type: UPDATE_SEARCH,
-    parameters
-});
+export const updateSearch = createAction(UPDATE_SEARCH, parameters => ({ payload: { parameters } }));
 
-export const findSamples = ({ labels, page, term, workflows }) => ({
-    type: FIND_SAMPLES.REQUESTED,
-    labels,
-    term,
-    page,
-    workflows
-});
+export const findSamples = createAction(FIND_SAMPLES.REQUESTED, ({ labels, page, term, workflows }) => ({
+    payload: {
+        labels,
+        term,
+        page,
+        workflows
+    }
+}));
 
-export const findReadFiles = simpleActionCreator(FIND_READ_FILES.REQUESTED);
+export const findReadFiles = createAction(FIND_READ_FILES.REQUESTED);
 
 /**
  * Returns action that can trigger an API call for getting a specific sample.
@@ -69,10 +66,26 @@ export const findReadFiles = simpleActionCreator(FIND_READ_FILES.REQUESTED);
  * @param sampleId {string} the id for the specific sample
  * @returns {object}
  */
-export const getSample = sampleId => ({
-    type: GET_SAMPLE.REQUESTED,
-    sampleId
-});
+export const getSample = createAction(GET_SAMPLE.REQUESTED, sampleId => ({
+    payload: {
+        sampleId
+    }
+}));
+
+/**
+ * Returns action that updates state with returned sample object
+ *
+ * @func
+ * @param sample {onject} object containing sample details
+ * @param canModify {boolean} boolean indicating if the user can modify the sample
+ * @returns {object}
+ */
+export const getSampleSucceeded = createAction(GET_SAMPLE.SUCCEEDED, (sample, canModify) => ({
+    payload: {
+        ...sample,
+        canModify
+    }
+}));
 
 /**
  * Returns action that can trigger an API call for creating a new sample.
@@ -90,18 +103,22 @@ export const getSample = sampleId => ({
  * @param label {Array} Array of ids(int) of the labels selected
  * @returns {object}
  */
-export const createSample = (name, isolate, host, locale, libraryType, subtractions, files, labels, group) => ({
-    type: CREATE_SAMPLE.REQUESTED,
-    name,
-    isolate,
-    host,
-    locale,
-    libraryType,
-    subtractions,
-    files,
-    labels,
-    group
-});
+export const createSample = createAction(
+    CREATE_SAMPLE.REQUESTED,
+    (name, isolate, host, locale, libraryType, subtractions, files, labels, group) => ({
+        payload: {
+            name,
+            isolate,
+            host,
+            locale,
+            libraryType,
+            subtractions,
+            files,
+            labels,
+            group
+        }
+    })
+);
 
 /**
  * Returns action that can trigger an API call for modifying a sample.
@@ -111,11 +128,9 @@ export const createSample = (name, isolate, host, locale, libraryType, subtracti
  * @param update {object} update data
  * @returns {object}
  */
-export const editSample = (sampleId, update) => ({
-    type: UPDATE_SAMPLE.REQUESTED,
-    sampleId,
-    update
-});
+export const editSample = createAction(UPDATE_SAMPLE.REQUESTED, (sampleId, update) => ({
+    payload: { sampleId, update }
+}));
 
 /**
  * Returns action that can trigger an API call for modifying sample rights.
@@ -125,11 +140,9 @@ export const editSample = (sampleId, update) => ({
  * @param update {object} update data
  * @returns {object}
  */
-export const updateSampleRights = (sampleId, update) => ({
-    type: UPDATE_SAMPLE_RIGHTS.REQUESTED,
-    sampleId,
-    update
-});
+export const updateSampleRights = createAction(UPDATE_SAMPLE_RIGHTS.REQUESTED, (sampleId, update) => ({
+    payload: { sampleId, update }
+}));
 
 /**
  * Returns action that can trigger an API call for removing a sample.
@@ -138,10 +151,7 @@ export const updateSampleRights = (sampleId, update) => ({
  * @param sampleId {string} unique sample id
  * @returns {object}
  */
-export const removeSample = sampleId => ({
-    type: REMOVE_SAMPLE.REQUESTED,
-    sampleId
-});
+export const removeSample = createAction(REMOVE_SAMPLE.REQUESTED, sampleId => ({ payload: { sampleId } }));
 
 /**
  * Returns action for displaying the remove sample modal.
@@ -149,7 +159,7 @@ export const removeSample = sampleId => ({
  * @func
  * @returns {object}
  */
-export const showRemoveSample = simpleActionCreator(SHOW_REMOVE_SAMPLE);
+export const showRemoveSample = createAction(SHOW_REMOVE_SAMPLE);
 
 /**
  * Returns action for hiding the sample modal.
@@ -157,16 +167,10 @@ export const showRemoveSample = simpleActionCreator(SHOW_REMOVE_SAMPLE);
  * @func
  * @returns {object}
  */
-export const hideSampleModal = simpleActionCreator(HIDE_SAMPLE_MODAL);
+export const hideSampleModal = createAction(HIDE_SAMPLE_MODAL);
 
-export const selectSample = sampleId => ({
-    type: SELECT_SAMPLE,
-    sampleId
-});
+export const selectSample = createAction(SELECT_SAMPLE, sampleId => ({ payload: { sampleId } }));
 
-export const deselectSamples = sampleIds => ({
-    type: DESELECT_SAMPLES,
-    sampleIds
-});
+export const deselectSamples = createAction(DESELECT_SAMPLES, sampleIds => ({ payload: { sampleIds } }));
 
-export const clearSampleSelection = simpleActionCreator(CLEAR_SAMPLE_SELECTION);
+export const clearSampleSelection = createAction(CLEAR_SAMPLE_SELECTION);

--- a/src/js/samples/components/Create/__tests__/Create.test.js
+++ b/src/js/samples/components/Create/__tests__/Create.test.js
@@ -270,20 +270,22 @@ describe("mapDispatchToProps()", () => {
     it("should return createSample() in props", () => {
         props.onCreate("name", "isolate", "host", "locale", "libraryType", ["subtractions"], "files");
         expect(dispatch).toHaveBeenCalledWith({
-            name: "name",
-            isolate: "isolate",
-            host: "host",
-            locale: "locale",
-            libraryType: "libraryType",
-            subtractions: ["subtractions"],
-            files: "files",
-            type: "CREATE_SAMPLE_REQUESTED"
+            type: "CREATE_SAMPLE_REQUESTED",
+            payload: {
+                name: "name",
+                isolate: "isolate",
+                host: "host",
+                locale: "locale",
+                libraryType: "libraryType",
+                subtractions: ["subtractions"],
+                files: "files"
+            }
         });
     });
 
     it("should return onClearError() in props", () => {
         props.onClearError();
-        expect(dispatch).toHaveBeenCalledWith({ error: "CREATE_SAMPLE_ERROR", type: "CLEAR_ERROR" });
+        expect(dispatch).toHaveBeenCalledWith({ payload: { error: "CREATE_SAMPLE_ERROR" }, type: "CLEAR_ERROR" });
     });
 
     it("should return onListLabels() in props", () => {

--- a/src/js/samples/components/Detail/__tests__/Rights.test.js
+++ b/src/js/samples/components/Detail/__tests__/Rights.test.js
@@ -133,8 +133,7 @@ describe("mapDispatchToProps()", () => {
         props.onChangeGroup("foo", "bar");
         expect(dispatch).toHaveBeenNthCalledWith(1, { type: "LIST_GROUPS_REQUESTED" });
         expect(dispatch).toHaveBeenNthCalledWith(2, {
-            sampleId: "foo",
-            update: { group: "bar" },
+            payload: { sampleId: "foo", update: { group: "bar" } },
             type: "UPDATE_SAMPLE_RIGHTS_REQUESTED"
         });
     });
@@ -144,16 +143,17 @@ describe("mapDispatchToProps()", () => {
         props.onChangeRights("foo", "group", "read");
         expect(dispatch).toHaveBeenNthCalledWith(1, { type: "LIST_GROUPS_REQUESTED" });
         expect(dispatch).toHaveBeenNthCalledWith(2, {
-            sampleId: "foo",
-            type: "UPDATE_SAMPLE_RIGHTS_REQUESTED",
-            update: { group: "bar" }
+            payload: { sampleId: "foo", update: { group: "bar" } },
+            type: "UPDATE_SAMPLE_RIGHTS_REQUESTED"
         });
         expect(dispatch).toHaveBeenNthCalledWith(3, {
-            sampleId: "foo",
             type: "UPDATE_SAMPLE_RIGHTS_REQUESTED",
-            update: {
-                group_read: true,
-                group_write: false
+            payload: {
+                sampleId: "foo",
+                update: {
+                    group_read: true,
+                    group_write: false
+                }
             }
         });
     });

--- a/src/js/samples/reducer.js
+++ b/src/js/samples/reducer.js
@@ -30,46 +30,46 @@ export const initialState = {
 export const samplesReducer = createReducer(initialState, builder => {
     builder
         .addCase(WS_INSERT_SAMPLE, (state, action) => {
-            return insert(state, action, "created_at", true);
+            return insert(state, action.payload, "created_at", true);
         })
         .addCase(WS_UPDATE_SAMPLE, (state, action) => {
-            return update(state, action, "created_at", true);
+            return update(state, action.payload, "created_at", true);
         })
         .addCase(WS_REMOVE_SAMPLE, (state, action) => {
-            return remove(state, action);
+            return remove(state, action.payload);
         })
         .addCase(FIND_SAMPLES.REQUESTED, (state, action) => {
-            const { term, pathoscope, nuvs } = action;
+            const { term, pathoscope, nuvs } = action.payload;
             state.term = term;
             state.pathoscopeCondition = pathoscope;
             state.nuvsCondition = nuvs;
         })
         .addCase(FIND_SAMPLES.SUCCEEDED, (state, action) => {
-            return updateDocuments(state, action, "created_at", true);
+            return updateDocuments(state, action.payload, "created_at", true);
         })
         .addCase(FIND_READ_FILES.SUCCEEDED, (state, action) => {
-            state.readFiles = action.data.documents;
+            state.readFiles = action.payload.documents;
         })
         .addCase(GET_SAMPLE.REQUESTED, state => {
             state.detail = null;
         })
         .addCase(GET_SAMPLE.SUCCEEDED, (state, action) => {
-            state.detail = action.data;
+            state.detail = action.payload;
         })
         .addCase(UPDATE_SAMPLE.SUCCEEDED, (state, action) => {
-            set(state, "detail", action.data);
+            set(state, "detail", action.payload);
         })
         .addCase(UPDATE_SAMPLE_RIGHTS.SUCCEEDED, (state, action) => {
-            set(state, "detail", action.data);
+            set(state, "detail", action.payload);
         })
         .addCase(REMOVE_SAMPLE.SUCCEEDED, state => {
             state.detail = null;
         })
         .addCase(SELECT_SAMPLE, (state, action) => {
-            state.selected = xor(state.selected, [action.sampleId]);
+            state.selected = xor(state.selected, [action.payload.sampleId]);
         })
         .addCase(DESELECT_SAMPLES, (state, action) => {
-            state.selected = xor(state.selected, action.sampleIds);
+            state.selected = xor(state.selected, action.payload.sampleIds);
         })
         .addCase(CLEAR_SAMPLE_SELECTION, state => {
             state.selected = [];

--- a/src/js/status/__tests__/actions.test.js
+++ b/src/js/status/__tests__/actions.test.js
@@ -7,7 +7,7 @@ describe("Status Action Creators:", () => {
         const result = wsUpdateStatus(data);
         const expected = {
             type: WS_UPDATE_STATUS,
-            data
+            payload: { ...data }
         };
 
         expect(result).toEqual(expected);

--- a/src/js/status/actions.js
+++ b/src/js/status/actions.js
@@ -1,4 +1,5 @@
 import { WS_UPDATE_STATUS } from "../app/actionTypes";
+import { createAction } from "@reduxjs/toolkit";
 
 /**
  * Returns an action that should be dispatched when the status is updated via websocket.
@@ -7,7 +8,4 @@ import { WS_UPDATE_STATUS } from "../app/actionTypes";
  * @param data {object} the data passed in the websocket message
  * @returns {object}
  */
-export const wsUpdateStatus = data => ({
-    type: WS_UPDATE_STATUS,
-    data
-});
+export const wsUpdateStatus = createAction(WS_UPDATE_STATUS);

--- a/src/js/subtraction/__tests__/actions.test.js
+++ b/src/js/subtraction/__tests__/actions.test.js
@@ -35,7 +35,7 @@ describe("Subtraction Action Creators:", () => {
         const result = wsInsertSubtraction(data);
         expect(result).toEqual({
             type: WS_INSERT_SUBTRACTION,
-            data
+            payload: { ...data }
         });
     });
 
@@ -52,7 +52,7 @@ describe("Subtraction Action Creators:", () => {
         const result = wsUpdateSubtraction(data);
         expect(result).toEqual({
             type: WS_UPDATE_SUBTRACTION,
-            data
+            payload: { ...data }
         });
     });
 
@@ -61,7 +61,7 @@ describe("Subtraction Action Creators:", () => {
         const result = wsRemoveSubtraction(data);
         expect(result).toEqual({
             type: WS_REMOVE_SUBTRACTION,
-            data
+            payload: data
         });
     });
 
@@ -71,8 +71,7 @@ describe("Subtraction Action Creators:", () => {
         const result = findSubtractions(term, page);
         expect(result).toEqual({
             type: FIND_SUBTRACTIONS.REQUESTED,
-            term,
-            page
+            payload: { term, page }
         });
     });
 
@@ -80,7 +79,7 @@ describe("Subtraction Action Creators:", () => {
         const result = getSubtraction(subtractionId);
         expect(result).toEqual({
             type: GET_SUBTRACTION.REQUESTED,
-            subtractionId
+            payload: { subtractionId }
         });
     });
 
@@ -92,9 +91,7 @@ describe("Subtraction Action Creators:", () => {
 
         expect(result).toEqual({
             type: CREATE_SUBTRACTION.REQUESTED,
-            uploadId,
-            name,
-            nickname
+            payload: { uploadId, name, nickname }
         });
     });
 
@@ -104,9 +101,7 @@ describe("Subtraction Action Creators:", () => {
         const result = editSubtraction(subtractionId, name, nickname);
         expect(result).toEqual({
             type: EDIT_SUBTRACTION.REQUESTED,
-            subtractionId,
-            name,
-            nickname
+            payload: { subtractionId, name, nickname }
         });
     });
 
@@ -114,7 +109,7 @@ describe("Subtraction Action Creators:", () => {
         const result = removeSubtraction(subtractionId);
         expect(result).toEqual({
             type: REMOVE_SUBTRACTION.REQUESTED,
-            subtractionId
+            payload: { subtractionId }
         });
     });
 });

--- a/src/js/subtraction/__tests__/reducer.test.js
+++ b/src/js/subtraction/__tests__/reducer.test.js
@@ -25,7 +25,7 @@ describe("Subtraction Reducer", () => {
     describe("should handle WS_INSERT_SUBTRACTION", () => {
         const action = {
             type: WS_INSERT_SUBTRACTION,
-            data: {
+            payload: {
                 id: "foo"
             }
         };
@@ -60,13 +60,13 @@ describe("Subtraction Reducer", () => {
         };
         const action = {
             type: WS_UPDATE_SUBTRACTION,
-            data: {
+            payload: {
                 id: "foo",
                 ready: true
             }
         };
         const result = reducer(state, action);
-        expect(result).toEqual({ documents: [{ ...action.data }] });
+        expect(result).toEqual({ documents: [{ ...action.payload }] });
     });
 
     it("should handle WS_REMOVE_SUBTRACTION", () => {
@@ -79,7 +79,7 @@ describe("Subtraction Reducer", () => {
         };
         const action = {
             type: WS_REMOVE_SUBTRACTION,
-            data: ["foo"]
+            payload: ["foo"]
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -90,19 +90,18 @@ describe("Subtraction Reducer", () => {
     it("should handle FIND_SUBTRACTIONS_REQUESTED", () => {
         const action = {
             type: FIND_SUBTRACTIONS.REQUESTED,
-            term: "foo",
-            page: 5
+            payload: { term: "foo", page: 5 }
         };
         const result = reducer({}, action);
         expect(result).toEqual({
-            term: action.term
+            term: action.payload.term
         });
     });
 
     it("should handle FIND_SUBTRACTIONS_SUCCEEDED", () => {
         const action = {
             type: FIND_SUBTRACTIONS.SUCCEEDED,
-            data: {
+            payload: {
                 documents: [],
                 page: 1,
                 page_count: 1
@@ -119,7 +118,7 @@ describe("Subtraction Reducer", () => {
     it("should handle GET_SUBTRACTION_REQUESTED", () => {
         const action = {
             type: GET_SUBTRACTION.REQUESTED,
-            subtractionId: "foo"
+            payload: { subtractionId: "foo" }
         };
         const result = reducer({}, action);
         expect(result).toEqual({
@@ -130,7 +129,7 @@ describe("Subtraction Reducer", () => {
     it("should handle GET_SUBTRACTION_SUCCEEDED", () => {
         const action = {
             type: GET_SUBTRACTION.SUCCEEDED,
-            data: {
+            payload: {
                 id: "foo"
             }
         };
@@ -145,9 +144,9 @@ describe("Subtraction Reducer", () => {
     it("should handle UPDATE_SUBTRACTION_SUCCEEDED", () => {
         const action = {
             type: EDIT_SUBTRACTION.SUCCEEDED,
-            data: { foo: "bar" }
+            payload: { foo: "bar" }
         };
         const result = reducer({}, action);
-        expect(result).toEqual({ detail: action.data });
+        expect(result).toEqual({ detail: action.payload });
     });
 });

--- a/src/js/subtraction/actions.js
+++ b/src/js/subtraction/actions.js
@@ -10,30 +10,38 @@ import {
     SHORTLIST_SUBTRACTIONS
 } from "../app/actionTypes";
 
-import { simpleActionCreator } from "../utils/utils";
+import { createAction } from "@reduxjs/toolkit";
+/**
+ * Returns an action that should be dispatched when a subtraction document is inserted via websocket.
+ *
+ * @func
+ * @param data {object} update data passed in the websocket message
+ * @returns {object} an action object
+ */
+export const wsInsertSubtraction = createAction(WS_INSERT_SUBTRACTION);
+/**
+ * Returns an action that should be dispatched when a subtraction document is updated via websocket.
+ *
+ * @func
+ * @param data {object} update data passed in the websocket message
+ * @returns {object} an action object
+ */
+export const wsUpdateSubtraction = createAction(WS_UPDATE_SUBTRACTION);
 
-export const wsInsertSubtraction = data => ({
-    type: WS_INSERT_SUBTRACTION,
-    data
-});
+/**
+ * Returns an action that should be dispatched when a subtraction document is removed via websocket.
+ *
+ * @func
+ * @param data {object} update data passed in the websocket message
+ * @returns {object} an action object
+ */
+export const wsRemoveSubtraction = createAction(WS_REMOVE_SUBTRACTION);
 
-export const wsUpdateSubtraction = data => ({
-    type: WS_UPDATE_SUBTRACTION,
-    data
-});
+export const findSubtractions = createAction(FIND_SUBTRACTIONS.REQUESTED, (term, page) => ({
+    payload: { term, page }
+}));
 
-export const wsRemoveSubtraction = data => ({
-    type: WS_REMOVE_SUBTRACTION,
-    data
-});
-
-export const findSubtractions = (term, page) => ({
-    type: FIND_SUBTRACTIONS.REQUESTED,
-    term,
-    page
-});
-
-export const shortlistSubtractions = simpleActionCreator(SHORTLIST_SUBTRACTIONS.REQUESTED);
+export const shortlistSubtractions = createAction(SHORTLIST_SUBTRACTIONS.REQUESTED);
 
 /**
  * Returns action that can trigger an API call to retrieve a subtraction.
@@ -42,10 +50,9 @@ export const shortlistSubtractions = simpleActionCreator(SHORTLIST_SUBTRACTIONS.
  * @param subtractionId {string} unique subtraction id
  * @returns {object}
  */
-export const getSubtraction = subtractionId => ({
-    type: GET_SUBTRACTION.REQUESTED,
-    subtractionId
-});
+export const getSubtraction = createAction(GET_SUBTRACTION.REQUESTED, subtractionId => ({
+    payload: { subtractionId }
+}));
 
 /**
  * Returns action that can trigger an API call to create a new subtraction.
@@ -56,12 +63,9 @@ export const getSubtraction = subtractionId => ({
  * @param nickname {string} common or nickname for the subtraction host
  * @returns {object}
  */
-export const createSubtraction = (uploadId, name, nickname) => ({
-    type: CREATE_SUBTRACTION.REQUESTED,
-    name,
-    nickname,
-    uploadId
-});
+export const createSubtraction = createAction(CREATE_SUBTRACTION.REQUESTED, (uploadId, name, nickname) => ({
+    payload: { name, nickname, uploadId }
+}));
 
 /**
  * Returns action that can trigger an API call to modify a subtraction.
@@ -72,12 +76,9 @@ export const createSubtraction = (uploadId, name, nickname) => ({
  * @param nickname {string} common or nickname for the subtraction host
  * @returns {object}
  */
-export const editSubtraction = (subtractionId, name, nickname) => ({
-    type: EDIT_SUBTRACTION.REQUESTED,
-    subtractionId,
-    name,
-    nickname
-});
+export const editSubtraction = createAction(EDIT_SUBTRACTION.REQUESTED, (subtractionId, name, nickname) => ({
+    payload: { subtractionId, name, nickname }
+}));
 
 /**
  * Returns action that can trigger an API call to remove a subtraction.
@@ -86,7 +87,6 @@ export const editSubtraction = (subtractionId, name, nickname) => ({
  * @param subtractionId {string} unique subtraction id
  * @returns {object}
  */
-export const removeSubtraction = subtractionId => ({
-    type: REMOVE_SUBTRACTION.REQUESTED,
-    subtractionId
-});
+export const removeSubtraction = createAction(REMOVE_SUBTRACTION.REQUESTED, subtractionId => ({
+    payload: { subtractionId }
+}));

--- a/src/js/subtraction/components/__tests__/Edit.test.js
+++ b/src/js/subtraction/components/__tests__/Edit.test.js
@@ -69,9 +69,7 @@ describe("mapDispatchToProps()", () => {
         const props = mapDispatchToProps(dispatch);
         props.onUpdate("foo", "Foo", "Bar");
         expect(dispatch).toHaveBeenCalledWith({
-            subtractionId: "foo",
-            name: "Foo",
-            nickname: "Bar",
+            payload: { subtractionId: "foo", name: "Foo", nickname: "Bar" },
             type: "UPDATE_SUBTRACTION_REQUESTED"
         });
     });

--- a/src/js/subtraction/components/__tests__/Remove.test.js
+++ b/src/js/subtraction/components/__tests__/Remove.test.js
@@ -64,7 +64,7 @@ describe("mapDispatchToProps", () => {
         props.onHide();
         expect(dispatch).toHaveBeenCalledWith({
             type: PUSH_STATE,
-            state: { removeSubtraction: false }
+            payload: { state: { removeSubtraction: false } }
         });
     });
 
@@ -72,7 +72,7 @@ describe("mapDispatchToProps", () => {
         props.onConfirm("foo");
         expect(dispatch).toHaveBeenCalledWith({
             type: REMOVE_SUBTRACTION.REQUESTED,
-            subtractionId: "foo"
+            payload: { subtractionId: "foo" }
         });
     });
 });

--- a/src/js/subtraction/components/__tests__/Toolbar.test.js
+++ b/src/js/subtraction/components/__tests__/Toolbar.test.js
@@ -81,8 +81,7 @@ describe("mapDispatchToProps()", () => {
 
         expect(dispatch).toHaveBeenCalledWith({
             type: FIND_SUBTRACTIONS.REQUESTED,
-            term: value === "Foo" ? "Foo" : null,
-            page: 1
+            payload: { term: value === "Foo" ? "Foo" : null, page: 1 }
         });
     });
 });

--- a/src/js/subtraction/reducer.js
+++ b/src/js/subtraction/reducer.js
@@ -21,31 +21,31 @@ export const initialState = {
 export const subtractionsReducer = createReducer(initialState, builder => {
     builder
         .addCase(WS_INSERT_SUBTRACTION, (state, action) => {
-            return insert(state, action, "id");
+            return insert(state, action.payload, "id");
         })
         .addCase(WS_UPDATE_SUBTRACTION, (state, action) => {
-            return update(state, action, "id");
+            return update(state, action.payload, "id");
         })
         .addCase(WS_REMOVE_SUBTRACTION, (state, action) => {
-            return remove(state, action);
+            return remove(state, action.payload);
         })
         .addCase(FIND_SUBTRACTIONS.REQUESTED, (state, action) => {
-            state.term = action.term;
+            state.term = action.payload.term;
         })
         .addCase(FIND_SUBTRACTIONS.SUCCEEDED, (state, action) => {
-            return updateDocuments(state, action, "id");
+            return updateDocuments(state, action.payload, "id");
         })
         .addCase(SHORTLIST_SUBTRACTIONS.SUCCEEDED, (state, action) => {
-            state.shortlist = action.data;
+            state.shortlist = action.payload;
         })
         .addCase(GET_SUBTRACTION.REQUESTED, state => {
             state.detail = null;
         })
         .addCase(GET_SUBTRACTION.SUCCEEDED, (state, action) => {
-            state.detail = action.data;
+            state.detail = action.payload;
         })
         .addCase(EDIT_SUBTRACTION.SUCCEEDED, (state, action) => {
-            state.detail = action.data;
+            state.detail = action.payload;
         });
 });
 

--- a/src/js/subtraction/sagas.js
+++ b/src/js/subtraction/sagas.js
@@ -13,16 +13,16 @@ import { apiCall, pushFindTerm } from "../utils/sagas";
 import * as subtractionAPI from "./api";
 
 export function* findSubtractions(action) {
-    yield apiCall(subtractionAPI.find, action, FIND_SUBTRACTIONS);
-    yield pushFindTerm(action.term);
+    yield apiCall(subtractionAPI.find, action.payload, FIND_SUBTRACTIONS);
+    yield pushFindTerm(action.payload.term);
 }
 
 export function* getSubtraction(action) {
-    yield apiCall(subtractionAPI.get, action, GET_SUBTRACTION);
+    yield apiCall(subtractionAPI.get, action.payload, GET_SUBTRACTION);
 }
 
 export function* createSubtraction(action) {
-    const resp = yield apiCall(subtractionAPI.create, action, CREATE_SUBTRACTION);
+    const resp = yield apiCall(subtractionAPI.create, action.payload, CREATE_SUBTRACTION);
 
     if (resp.ok) {
         yield put(push("/subtraction"));
@@ -30,11 +30,11 @@ export function* createSubtraction(action) {
 }
 
 export function* shortlistSubtractions(action) {
-    yield apiCall(subtractionAPI.shortlist, action, SHORTLIST_SUBTRACTIONS);
+    yield apiCall(subtractionAPI.shortlist, action.payload, SHORTLIST_SUBTRACTIONS);
 }
 
 export function* editSubtraction(action) {
-    const resp = yield apiCall(subtractionAPI.edit, action, EDIT_SUBTRACTION);
+    const resp = yield apiCall(subtractionAPI.edit, action.payload, EDIT_SUBTRACTION);
 
     if (resp.ok) {
         yield put(pushState({ editSubtraction: false }));
@@ -42,7 +42,7 @@ export function* editSubtraction(action) {
 }
 
 export function* removeSubtraction(action) {
-    const resp = yield apiCall(subtractionAPI.remove, action, REMOVE_SUBTRACTION);
+    const resp = yield apiCall(subtractionAPI.remove, action.payload, REMOVE_SUBTRACTION);
 
     if (resp.ok) {
         yield put(push("/subtraction"));

--- a/src/js/tasks/__tests__/actions.test.js
+++ b/src/js/tasks/__tests__/actions.test.js
@@ -5,7 +5,7 @@ describe("wsInsertTask()", () => {
     it("should return action to insert new task", () => {
         const data = { id: "123abc" };
         const result = wsInsertTask(data);
-        expect(result).toEqual({ type: WS_INSERT_TASK, data });
+        expect(result).toEqual({ type: WS_INSERT_TASK, payload: { ...data } });
     });
 });
 
@@ -13,7 +13,7 @@ describe("wsUpdateTask()", () => {
     it("should return action to update existing task", () => {
         const data = { id: "123abc", foo: "bar" };
         const result = wsUpdateTask(data);
-        expect(result).toEqual({ type: WS_UPDATE_TASK, data });
+        expect(result).toEqual({ type: WS_UPDATE_TASK, payload: { ...data } });
     });
 });
 
@@ -27,6 +27,6 @@ describe("getTask()", () => {
     it("should return action to retrieve specific task", () => {
         const taskId = "123abc";
         const result = getTask(taskId);
-        expect(result).toEqual({ type: GET_TASK, taskId });
+        expect(result).toEqual({ type: GET_TASK, payload: { taskId } });
     });
 });

--- a/src/js/tasks/__tests__/reducer.test.js
+++ b/src/js/tasks/__tests__/reducer.test.js
@@ -16,14 +16,14 @@ describe("tasksReducer()", () => {
 
     it("should handle WS_INSERT_TASK", () => {
         const state = { documents: [] };
-        const action = { type: WS_INSERT_TASK, data: { id: "test" } };
+        const action = { type: WS_INSERT_TASK, payload: { id: "test" } };
         const result = tasksReducer(state, action);
         expect(result).toEqual({ documents: [{ id: "test" }] });
     });
 
     it("should handle WS_UPDATE_TASK", () => {
         const state = { documents: [{ id: "test", foo: "bar" }] };
-        const action = { type: WS_UPDATE_TASK, data: { id: "test", foo: "baz" } };
+        const action = { type: WS_UPDATE_TASK, payload: { id: "test", foo: "baz" } };
         const result = tasksReducer(state, action);
         expect(result).toEqual({ documents: [{ id: "test", foo: "baz" }] });
     });
@@ -32,10 +32,10 @@ describe("tasksReducer()", () => {
         const state = { documents: [] };
         const action = {
             type: LIST_TASKS.SUCCEEDED,
-            data: [{ id: "test1" }, { id: "test2" }, { id: "test3" }]
+            payload: [{ id: "test1" }, { id: "test2" }, { id: "test3" }]
         };
         const result = tasksReducer(state, action);
-        expect(result).toEqual({ documents: [...action.data] });
+        expect(result).toEqual({ documents: [...action.payload] });
     });
 
     it("should handle GET_TASK_REQUESTED", () => {
@@ -47,7 +47,7 @@ describe("tasksReducer()", () => {
 
     it("should handle GET_TASK_SUCCEEDED", () => {
         const state = { detail: null };
-        const action = { type: GET_TASK.SUCCEEDED, data: { foo: "bar" } };
+        const action = { type: GET_TASK.SUCCEEDED, payload: { foo: "bar" } };
         const result = tasksReducer(state, action);
         expect(result).toEqual({ detail: { foo: "bar" } });
     });

--- a/src/js/tasks/actions.js
+++ b/src/js/tasks/actions.js
@@ -1,19 +1,24 @@
 import { GET_TASK, LIST_TASKS, WS_INSERT_TASK, WS_UPDATE_TASK } from "../app/actionTypes";
-import { simpleActionCreator } from "../utils/utils";
+import { createAction } from "@reduxjs/toolkit";
 
-export const wsInsertTask = data => ({
-    type: WS_INSERT_TASK,
-    data
-});
+/**
+ * Returns an action that should be dispatched when a task document is inserted via websocket.
+ *
+ * @func
+ * @param data {object} update data passed in the websocket message
+ * @returns {object} an action object
+ */
+export const wsInsertTask = createAction(WS_INSERT_TASK);
 
-export const wsUpdateTask = data => ({
-    type: WS_UPDATE_TASK,
-    data
-});
+/**
+ * Returns an action that should be dispatched when a task document is updated via websocket.
+ *
+ * @func
+ * @param data {object} update data passed in the websocket message
+ * @returns {object} an action object
+ */
+export const wsUpdateTask = createAction(WS_UPDATE_TASK);
 
-export const listTasks = simpleActionCreator(LIST_TASKS.REQUESTED);
+export const listTasks = createAction(LIST_TASKS.REQUESTED);
 
-export const getTask = taskId => ({
-    type: GET_TASK,
-    taskId
-});
+export const getTask = createAction(GET_TASK, taskId => ({ payload: { taskId } }));

--- a/src/js/tasks/reducer.js
+++ b/src/js/tasks/reducer.js
@@ -10,19 +10,19 @@ export const initialState = {
 export const tasksReducer = createReducer(initialState, builder => {
     builder
         .addCase(WS_INSERT_TASK, (state, action) => {
-            return insert(state, action);
+            return insert(state, action.payload);
         })
         .addCase(WS_UPDATE_TASK, (state, action) => {
-            return update(state, action);
+            return update(state, action.payload);
         })
         .addCase(LIST_TASKS.SUCCEEDED, (state, action) => {
-            state.documents = action.data;
+            state.documents = action.payload;
         })
         .addCase(GET_TASK.REQUESTED, state => {
             state.detail = null;
         })
         .addCase(GET_TASK.SUCCEEDED, (state, action) => {
-            state.detail = action.data;
+            state.detail = action.payload;
         });
 });
 

--- a/src/js/tasks/sagas.js
+++ b/src/js/tasks/sagas.js
@@ -8,7 +8,7 @@ export function* listTasks(action) {
 }
 
 export function* getTask(action) {
-    yield apiCall(tasksAPI.get, action, GET_TASK);
+    yield apiCall(tasksAPI.get, action.payload, GET_TASK);
 }
 
 export function* watchTasks() {

--- a/src/js/users/__tests__/actions.test.js
+++ b/src/js/users/__tests__/actions.test.js
@@ -23,29 +23,29 @@ describe("Users Action Creators", () => {
     const userId = "bill";
 
     it("wsInsertUser", () => {
-        const data = {};
-        const result = wsInsertUser(data);
+        const payload = {};
+        const result = wsInsertUser(payload);
         expect(result).toEqual({
             type: WS_INSERT_USER,
-            data
+            payload
         });
     });
 
     it("wsUpdateUser", () => {
-        const data = {};
-        const result = wsUpdateUser(data);
+        const payload = {};
+        const result = wsUpdateUser(payload);
         expect(result).toEqual({
             type: WS_UPDATE_USER,
-            data
+            payload
         });
     });
 
     it("wsRemoveUser", () => {
-        const data = [];
-        const result = wsRemoveUser(data);
+        const payload = {};
+        const result = wsRemoveUser(payload);
         expect(result).toEqual({
             type: WS_REMOVE_USER,
-            data
+            payload
         });
     });
 
@@ -55,8 +55,7 @@ describe("Users Action Creators", () => {
         const result = findUsers(term, page);
         expect(result).toEqual({
             type: FIND_USERS.REQUESTED,
-            term,
-            page
+            payload: { term, page }
         });
     });
 
@@ -64,15 +63,16 @@ describe("Users Action Creators", () => {
         const result = getUser(userId);
         expect(result).toEqual({
             type: GET_USER.REQUESTED,
-            userId
+            payload: { userId }
         });
     });
 
     it("createUser", () => {
-        const data = {};
-        const result = createUser(data);
+        const payload = {};
+        const result = createUser(payload);
         expect(result).toEqual({
-            type: CREATE_USER.REQUESTED
+            type: CREATE_USER.REQUESTED,
+            payload
         });
     });
 
@@ -81,8 +81,7 @@ describe("Users Action Creators", () => {
         const result = editUser(userId, update);
         expect(result).toEqual({
             type: EDIT_USER.REQUESTED,
-            userId,
-            update
+            payload: { userId, update }
         });
     });
 
@@ -90,7 +89,7 @@ describe("Users Action Creators", () => {
         const result = removeUser(userId);
         expect(result).toEqual({
             type: REMOVE_USER.REQUESTED,
-            userId
+            payload: { userId }
         });
     });
 });

--- a/src/js/users/__tests__/reducer.test.js
+++ b/src/js/users/__tests__/reducer.test.js
@@ -29,13 +29,13 @@ describe("Users Reducer", () => {
         };
         const action = {
             type: WS_INSERT_USER,
-            data: {
+            payload: {
                 id: "bill"
             }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
-            documents: [action.data]
+            documents: [action.payload]
         });
     });
     it("should handle WS_UPDATE_USER", () => {
@@ -47,7 +47,7 @@ describe("Users Reducer", () => {
         };
         const action = {
             type: WS_UPDATE_USER,
-            data: {
+            payload: {
                 id: "fred",
                 administrator: true
             }
@@ -67,7 +67,7 @@ describe("Users Reducer", () => {
         };
         const action = {
             type: WS_REMOVE_USER,
-            data: ["bob"]
+            payload: ["bob"]
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -79,8 +79,7 @@ describe("Users Reducer", () => {
         const term = "foo";
         const action = {
             type: FIND_USERS.REQUESTED,
-            term,
-            page: 3
+            payload: { term, page: 3 }
         };
         const result = reducer({}, action);
         expect(result).toEqual({
@@ -91,12 +90,12 @@ describe("Users Reducer", () => {
     it("should handle FIND_USERS_SUCCEEDED", () => {
         const action = {
             type: FIND_USERS.SUCCEEDED,
-            data: {
+            payload: {
                 documents: [{ id: "foo" }]
             }
         };
         const result = reducer({}, action);
-        expect(result).toEqual(action.data);
+        expect(result).toEqual(action.payload);
     });
 
     it("should handle GET_USER_REQUESTED", () => {
@@ -107,7 +106,7 @@ describe("Users Reducer", () => {
         };
         const action = {
             type: GET_USER.REQUESTED,
-            userId: "bob"
+            payload: { userId: "bob" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
@@ -118,7 +117,7 @@ describe("Users Reducer", () => {
     it("should handle GET_USER_SUCCEEDED", () => {
         const action = {
             type: GET_USER.SUCCEEDED,
-            data: {
+            payload: {
                 administrator: true,
                 force_reset: false,
                 groups: [],
@@ -130,7 +129,7 @@ describe("Users Reducer", () => {
         };
         const result = reducer({}, action);
         expect(result).toEqual({
-            detail: action.data
+            detail: action.payload
         });
     });
 
@@ -170,9 +169,11 @@ describe("Users Reducer", () => {
         it("when handling password update, return [passwordPending=true]", () => {
             const action = {
                 type: EDIT_USER.REQUESTED,
-                userId: "bob",
-                update: {
-                    password: "new_password"
+                payload: {
+                    userId: "bob",
+                    update: {
+                        password: "new_password"
+                    }
                 }
             };
             const result = reducer({}, action);
@@ -184,8 +185,10 @@ describe("Users Reducer", () => {
         it("otherwise return state", () => {
             const action = {
                 type: EDIT_USER.REQUESTED,
-                update: {
-                    other: "not_password"
+                payload: {
+                    update: {
+                        other: "not_password"
+                    }
                 }
             };
             const result = reducer(initialState, action);
@@ -203,7 +206,7 @@ describe("Users Reducer", () => {
         };
         const action = {
             type: EDIT_USER.SUCCEEDED,
-            data: {
+            payload: {
                 id: "user",
                 permissions: { testing: true }
             }
@@ -211,7 +214,7 @@ describe("Users Reducer", () => {
         const result = reducer(state, action);
         expect(result).toEqual({
             ...state,
-            detail: action.data
+            detail: action.payload
         });
     });
 });

--- a/src/js/users/actions.js
+++ b/src/js/users/actions.js
@@ -15,21 +15,34 @@ import {
     REMOVE_USER,
     CREATE_FIRST_USER
 } from "../app/actionTypes";
+import { createAction } from "@reduxjs/toolkit";
 
-export const wsInsertUser = data => ({
-    type: WS_INSERT_USER,
-    data
-});
+/**
+ * Returns an action that should be dispatched when a user document is inserted via websocket.
+ *
+ * @func
+ * @param data {object} update data passed in the websocket message
+ * @returns {object} an action object
+ */
+export const wsInsertUser = createAction(WS_INSERT_USER);
 
-export const wsUpdateUser = data => ({
-    type: WS_UPDATE_USER,
-    data
-});
+/**
+ * Returns an action that should be dispatched when a user document is updated via websocket.
+ *
+ * @func
+ * @param data {object} update data passed in the websocket message
+ * @returns {object} an action object
+ */
+export const wsUpdateUser = createAction(WS_UPDATE_USER);
 
-export const wsRemoveUser = data => ({
-    type: WS_REMOVE_USER,
-    data
-});
+/**
+ * Returns an action that should be dispatched when a user document is removed via websocket.
+ *
+ * @func
+ * @param data {object} update data passed in the websocket message
+ * @returns {object} an action object
+ */
+export const wsRemoveUser = createAction(WS_REMOVE_USER);
 
 /**
  * Returns an action that can trigger an API call for finding users.
@@ -37,16 +50,11 @@ export const wsRemoveUser = data => ({
  * @func
  * @returns {object}
  */
-export const findUsers = (term, page) => ({
-    type: FIND_USERS.REQUESTED,
-    term,
-    page
-});
+export const findUsers = createAction(FIND_USERS.REQUESTED, (term, page) => ({
+    payload: { term, page }
+}));
 
-export const getUser = userId => ({
-    type: GET_USER.REQUESTED,
-    userId
-});
+export const getUser = createAction(GET_USER.REQUESTED, userId => ({ payload: { userId } }));
 
 /**
  * Returns action that can trigger an API call for creating a new user.
@@ -55,16 +63,11 @@ export const getUser = userId => ({
  * @param data {object} data used to create a new user
  * @returns {object}
  */
-export const createUser = data => ({
-    type: CREATE_USER.REQUESTED,
-    ...data
-});
+export const createUser = createAction(CREATE_USER.REQUESTED);
 
-export const createFirstUser = (handle, password) => ({
-    type: CREATE_FIRST_USER.REQUESTED,
-    handle,
-    password
-});
+export const createFirstUser = createAction(CREATE_FIRST_USER.REQUESTED, (handle, password) => ({
+    payload: { handle, password }
+}));
 
 /**
  * Returns action that can trigger an API call for modifying an existing user.
@@ -74,13 +77,8 @@ export const createFirstUser = (handle, password) => ({
  * @param update {object} key-value pairs of new user properties
  * @returns {object}
  */
-export const editUser = (userId, update) => ({
-    type: EDIT_USER.REQUESTED,
-    userId,
-    update
-});
+export const editUser = createAction(EDIT_USER.REQUESTED, (userId, update) => ({
+    payload: { userId, update }
+}));
 
-export const removeUser = userId => ({
-    type: REMOVE_USER.REQUESTED,
-    userId
-});
+export const removeUser = createAction(REMOVE_USER.REQUESTED, userId => ({ payload: { userId } }));

--- a/src/js/users/components/__tests__/Create.test.js
+++ b/src/js/users/components/__tests__/Create.test.js
@@ -142,21 +142,19 @@ describe("mapDispatchToProps", () => {
 
         result.onCreate(data);
         expect(dispatch).toHaveBeenCalledWith({
-            0: "f",
-            1: "o",
-            2: "o",
+            payload: "foo",
             type: "CREATE_USER_REQUESTED"
         });
     });
     it("should return onHide() in props", () => {
         result.onHide();
-        expect(dispatch).toHaveBeenCalledWith({ type: PUSH_STATE, state: { createUser: false } });
+        expect(dispatch).toHaveBeenCalledWith({ type: PUSH_STATE, payload: { state: { createUser: false } } });
     });
 
     it("should return onClearError() in props", () => {
         result.onClearError();
         expect(dispatch).toHaveBeenCalledWith({
-            error: "CREATE_USER_ERROR",
+            payload: { error: "CREATE_USER_ERROR" },
             type: "CLEAR_ERROR"
         });
     });

--- a/src/js/users/components/__tests__/Detail.test.js
+++ b/src/js/users/components/__tests__/Detail.test.js
@@ -100,7 +100,7 @@ describe("mapDispatchToProps", () => {
         result.onGetUser(userId);
         expect(dispatch).toHaveBeenCalledWith({
             type: "GET_USER_REQUESTED",
-            userId
+            payload: { userId }
         });
     });
 
@@ -116,7 +116,7 @@ describe("mapDispatchToProps", () => {
         result.onRemoveUser(userId);
         expect(dispatch).toHaveBeenCalledWith({
             type: "REMOVE_USER_REQUESTED",
-            userId
+            payload: { userId }
         });
     });
 });

--- a/src/js/users/components/__tests__/List.test.js
+++ b/src/js/users/components/__tests__/List.test.js
@@ -83,8 +83,7 @@ describe("mapDispatchToProps()", () => {
 
         expect(dispatch).toHaveBeenCalledWith({
             type: FIND_USERS.REQUESTED,
-            term,
-            page
+            payload: { term, page }
         });
     });
 });

--- a/src/js/users/components/__tests__/PrimaryGroup.test.js
+++ b/src/js/users/components/__tests__/PrimaryGroup.test.js
@@ -47,10 +47,12 @@ describe("mapDispatchToProps", () => {
 
         expect(dispatch).toHaveBeenCalledWith({
             type: "EDIT_USER_REQUESTED",
-            update: {
-                primary_group: "bar"
-            },
-            userId: "foo"
+            payload: {
+                update: {
+                    primary_group: "bar"
+                },
+                userId: "foo"
+            }
         });
     });
 });

--- a/src/js/users/components/__tests__/Users.test.js
+++ b/src/js/users/components/__tests__/Users.test.js
@@ -78,8 +78,7 @@ describe("mapDispatchToProps", () => {
         };
         result.onFind(e);
         expect(dispatch).toHaveBeenCalledWith({
-            page: 1,
-            term: "foo",
+            payload: { page: 1, term: "foo" },
             type: "FIND_USERS_REQUESTED"
         });
     });
@@ -88,7 +87,7 @@ describe("mapDispatchToProps", () => {
         const error = "foo";
         result.onClearError(error);
         expect(dispatch).toHaveBeenCalledWith({
-            error: "foo",
+            payload: { error: "foo" },
             type: "CLEAR_ERROR"
         });
     });

--- a/src/js/users/reducer.js
+++ b/src/js/users/reducer.js
@@ -22,25 +22,25 @@ export const initialState = {
 const reducer = createReducer(initialState, builder => {
     builder
         .addCase(WS_INSERT_USER, (state, action) => {
-            return insert(state, action, "id");
+            return insert(state, action.payload, "id");
         })
         .addCase(WS_UPDATE_USER, (state, action) => {
-            return update(state, action, "id");
+            return update(state, action.payload, "id");
         })
         .addCase(WS_REMOVE_USER, (state, action) => {
-            return remove(state, action);
+            return remove(state, action.payload);
         })
         .addCase(FIND_USERS.REQUESTED, (state, action) => {
-            state.term = action.term;
+            state.term = action.payload.term;
         })
         .addCase(FIND_USERS.SUCCEEDED, (state, action) => {
-            return updateDocuments(state, action, "id");
+            return updateDocuments(state, action.payload, "id");
         })
         .addCase(GET_USER.REQUESTED, state => {
             state.detail = null;
         })
         .addCase(GET_USER.SUCCEEDED, (state, action) => {
-            state.detail = action.data;
+            state.detail = action.payload;
         })
         .addCase(CREATE_USER.REQUESTED, state => {
             state.createPending = true;
@@ -52,13 +52,13 @@ const reducer = createReducer(initialState, builder => {
             state.createPending = false;
         })
         .addCase(EDIT_USER.REQUESTED, (state, action) => {
-            if (action.update.password) {
+            if (action.payload.update.password) {
                 return { ...state, passwordPending: true };
             }
             return state;
         })
         .addCase(EDIT_USER.SUCCEEDED, (state, action) => {
-            return { ...state, detail: action.data };
+            return { ...state, detail: action.payload };
         });
 });
 

--- a/src/js/users/sagas.js
+++ b/src/js/users/sagas.js
@@ -6,32 +6,31 @@ import { apiCall, pushFindTerm } from "../utils/sagas";
 import * as usersAPI from "./api";
 
 function* findUsers(action) {
-    yield apiCall(usersAPI.find, action, FIND_USERS);
-    yield pushFindTerm(action.term);
+    yield apiCall(usersAPI.find, action.payload, FIND_USERS);
+    yield pushFindTerm(action.payload.term);
 }
 
 function* getUser(action) {
-    yield apiCall(usersAPI.get, action, GET_USER);
+    yield apiCall(usersAPI.get, action.payload, GET_USER);
 }
 
 function* createUser(action) {
-    const resp = yield apiCall(usersAPI.create, action, CREATE_USER);
-
+    const resp = yield apiCall(usersAPI.create, action.payload, CREATE_USER);
     if (resp.ok) {
         yield put(pushState({ createUser: false }));
     }
 }
 
 function* createFirstUser(action) {
-    yield apiCall(usersAPI.createFirst, action, CREATE_FIRST_USER);
+    yield apiCall(usersAPI.createFirst, action.payload, CREATE_FIRST_USER);
 }
 
 function* editUser(action) {
-    yield apiCall(usersAPI.edit, action, EDIT_USER);
+    yield apiCall(usersAPI.edit, action.payload, EDIT_USER);
 }
 
 function* removeUser(action) {
-    const resp = yield apiCall(usersAPI.remove, action, REMOVE_USER);
+    const resp = yield apiCall(usersAPI.remove, action.payload, REMOVE_USER);
 
     if (resp.ok) {
         yield put(push("/administration/users"));

--- a/src/js/utils/__tests__/reducers.test.js
+++ b/src/js/utils/__tests__/reducers.test.js
@@ -11,19 +11,19 @@ describe("Reducer utility functions", () => {
         ];
     });
 
-    describe("updateDocuments: updates documents with action data", () => {
+    describe("updateDocuments: updates documents with action payload", () => {
         it("should insert all if [documents=null]", () => {
             const state = {
                 documents: null
             };
             const action = {
                 type: "UPDATE_DOCUMENTS",
-                data: {
+                payload: {
                     documents,
                     page: 1
                 }
             };
-            const result = updateDocuments(state, action);
+            const result = updateDocuments(state, action.payload);
             expect(result).toEqual({
                 documents,
                 page: 1
@@ -36,12 +36,12 @@ describe("Reducer utility functions", () => {
             };
             const action = {
                 type: "UPDATE_DOCUMENTS",
-                data: {
+                payload: {
                     documents,
                     page: 1
                 }
             };
-            const result = updateDocuments(state, action);
+            const result = updateDocuments(state, action.payload);
             expect(result).toEqual({
                 documents,
                 page: 1
@@ -58,12 +58,12 @@ describe("Reducer utility functions", () => {
             ];
             const action = {
                 type: "UPDATE_DOCUMENTS",
-                data: {
+                payload: {
                     documents: updated,
                     page: 2
                 }
             };
-            const result = updateDocuments(state, action);
+            const result = updateDocuments(state, action.payload);
             expect(result).toEqual({
                 documents: [updated[0], { id: "test", meta: "chi" }, documents[1], documents[2]],
                 page: 2
@@ -80,12 +80,12 @@ describe("Reducer utility functions", () => {
             ];
             const action = {
                 type: "UPDATE_DOCUMENTS",
-                data: {
+                payload: {
                     documents: updated,
                     page: 2
                 }
             };
-            const result = updateDocuments(state, action, "meta");
+            const result = updateDocuments(state, action.payload, "meta");
             expect(result).toEqual({
                 documents: [documents[2], { id: "test", meta: "chi" }, documents[1], updated[0]],
                 page: 2
@@ -102,12 +102,12 @@ describe("Reducer utility functions", () => {
             ];
             const action = {
                 type: "UPDATE_DOCUMENTS",
-                data: {
+                payload: {
                     documents: updated,
                     page: 2
                 }
             };
-            const result = updateDocuments(state, action, "meta", true);
+            const result = updateDocuments(state, action.payload, "meta", true);
             expect(result).toEqual({
                 documents: [updated[0], documents[1], { id: "test", meta: "chi" }, documents[2]],
                 page: 2
@@ -122,10 +122,10 @@ describe("Reducer utility functions", () => {
             };
             const action = {
                 type: "WS_INSERT_ENTRY",
-                data: { id: "test", meta: "chi" }
+                payload: { id: "test", meta: "chi" }
             };
-            const result = insert(state, action);
-            expect(result).toEqual({ documents: [...documents, action.data] });
+            const result = insert(state, action.payload);
+            expect(result).toEqual({ documents: [...documents, action.payload] });
         });
 
         it("inserts and sorts by key", () => {
@@ -134,10 +134,10 @@ describe("Reducer utility functions", () => {
             };
             const action = {
                 type: "WS_INSERT_ENTRY",
-                data: { id: "test", meta: "theta" }
+                payload: { id: "test", meta: "theta" }
             };
-            const result = insert(state, action, "meta");
-            expect(result).toEqual({ documents: [documents[0], documents[2], documents[1], action.data] });
+            const result = insert(state, action.payload, "meta");
+            expect(result).toEqual({ documents: [documents[0], documents[2], documents[1], action.payload] });
         });
 
         it("inserts and sorts by key in reverse", () => {
@@ -146,10 +146,10 @@ describe("Reducer utility functions", () => {
             };
             const action = {
                 type: "WS_INSERT_ENTRY",
-                data: { id: "test", meta: "theta" }
+                payload: { id: "test", meta: "theta" }
             };
-            const result = insert(state, action, "meta", true);
-            expect(result).toEqual({ documents: [action.data, documents[1], documents[2], documents[0]] });
+            const result = insert(state, action.payload, "meta", true);
+            expect(result).toEqual({ documents: [action.payload, documents[1], documents[2], documents[0]] });
         });
 
         it("handles [documents=[]]", () => {
@@ -158,9 +158,9 @@ describe("Reducer utility functions", () => {
             };
             const action = {
                 type: "WS_INSERT",
-                data: { id: "test" }
+                payload: { id: "test" }
             };
-            const result = insert(state, action);
+            const result = insert(state, action.payload);
             expect(result).toEqual({ documents: [{ id: "test" }] });
         });
 
@@ -170,9 +170,9 @@ describe("Reducer utility functions", () => {
             };
             const action = {
                 type: "WS_INSERT_ENTRY",
-                data: { id: "test" }
+                payload: { id: "test" }
             };
-            const result = insert(state, action);
+            const result = insert(state, action.payload);
             expect(result).toEqual({ documents: [{ id: "test" }] });
         });
     });
@@ -183,9 +183,9 @@ describe("Reducer utility functions", () => {
             const state = { documents };
             const action = {
                 type: "WS_UPDATE",
-                data: { id: "foo", meta: "chi" }
+                payload: { id: "foo", meta: "chi" }
             };
-            const result = update(state, action);
+            const result = update(state, action.payload);
             expect(result).toEqual({
                 documents: [documents[0], documents[1], { ...documents[2], meta: "chi" }]
             });
@@ -196,7 +196,7 @@ describe("Reducer utility functions", () => {
             const state = { documents };
             const action = {
                 type: "WS_UPDATE",
-                data: { id: "test", meta: "chi" }
+                payload: { id: "test", meta: "chi" }
             };
             const result = update(state, action);
             expect(result).toEqual(state);
@@ -208,9 +208,9 @@ describe("Reducer utility functions", () => {
             };
             const action = {
                 type: "WS_UPDATE",
-                data: { id: "bar", meta: "chi" }
+                payload: { id: "bar", meta: "chi" }
             };
-            const result = update(state, action, "meta");
+            const result = update(state, action.payload, "meta");
             expect(result).toEqual({ documents: [documents[2], { ...documents[0], meta: "chi" }, documents[1]] });
         });
 
@@ -220,9 +220,9 @@ describe("Reducer utility functions", () => {
             };
             const action = {
                 type: "WS_UPDATE",
-                data: { id: "bar", meta: "chi" }
+                payload: { id: "bar", meta: "chi" }
             };
-            const result = update(state, action, "meta", true);
+            const result = update(state, action.payload, "meta", true);
             expect(result).toEqual({ documents: [documents[1], { ...documents[0], meta: "chi" }, documents[2]] });
         });
 
@@ -232,9 +232,9 @@ describe("Reducer utility functions", () => {
             };
             const action = {
                 type: "WS_UPDATE",
-                data: { id: "test", meta: "chi" }
+                payload: { id: "test", meta: "chi" }
             };
-            const result = update(state, action);
+            const result = update(state, action.payload);
             expect(result).toEqual(state);
         });
 
@@ -244,9 +244,9 @@ describe("Reducer utility functions", () => {
             };
             const action = {
                 type: "WS_UPDATE",
-                data: { id: "test", meta: "chi" }
+                payload: { id: "test", meta: "chi" }
             };
-            const result = update(state, action);
+            const result = update(state, action.payload);
             expect(result).toEqual(state);
         });
     });
@@ -257,9 +257,9 @@ describe("Reducer utility functions", () => {
             const state = { documents };
             const action = {
                 type: "WS_REMOVE",
-                data: ["foo"]
+                payload: ["foo"]
             };
-            const result = remove(state, action);
+            const result = remove(state, action.payload);
             expect(result).toEqual({ documents: [documents[0], documents[1]] });
         });
 
@@ -269,9 +269,9 @@ describe("Reducer utility functions", () => {
             };
             const action = {
                 type: "WS_REMOVE",
-                data: ["foo", "bar"]
+                payload: ["foo", "bar"]
             };
-            const result = remove(state, action);
+            const result = remove(state, action.payload);
             expect(result).toEqual({
                 documents: [documents[1]]
             });
@@ -282,9 +282,9 @@ describe("Reducer utility functions", () => {
             const state = { documents };
             const action = {
                 type: "WS_REMOVE",
-                data: ["test"]
+                payload: ["test"]
             };
-            const result = remove(state, action);
+            const result = remove(state, action.payload);
             expect(result).toEqual(state);
         });
 
@@ -294,9 +294,9 @@ describe("Reducer utility functions", () => {
             };
             const action = {
                 type: "WS_REMOVE",
-                data: ["foo"]
+                payload: ["foo"]
             };
-            const result = remove(state, action);
+            const result = remove(state, action.payload);
             expect(result).toEqual(state);
         });
 
@@ -306,9 +306,9 @@ describe("Reducer utility functions", () => {
             };
             const action = {
                 type: "WS_REMOVE",
-                data: ["foo", "bar"]
+                payload: ["foo", "bar"]
             };
-            const result = remove(state, action);
+            const result = remove(state, action.payload);
             expect(result).toEqual(state);
         });
     });

--- a/src/js/utils/reducers.js
+++ b/src/js/utils/reducers.js
@@ -1,23 +1,9 @@
 import { reject, map, includes, sortBy, unionBy } from "lodash-es";
 
-export const updateDocuments = (state, action, sortKey, sortReverse) => {
-    const existing = action.data.page === 1 ? [] : state.documents || [];
+export const updateDocuments = (state, payload, sortKey, sortReverse) => {
+    const existing = payload.page === 1 ? [] : state.documents || [];
 
-    const documents = sortBy(unionBy(action.data.documents, existing, "id"), sortKey);
-
-    if (sortReverse) {
-        documents.reverse();
-    }
-
-    return {
-        ...state,
-        ...action.data,
-        documents
-    };
-};
-
-export const insert = (state, action, sortKey, sortReverse = false) => {
-    const documents = sortBy(unionBy(state.documents || [], [action.data], "id"), sortKey);
+    const documents = sortBy(unionBy(payload.documents, existing, "id"), sortKey);
 
     if (sortReverse) {
         documents.reverse();
@@ -25,16 +11,29 @@ export const insert = (state, action, sortKey, sortReverse = false) => {
 
     return {
         ...state,
+        ...payload,
         documents
     };
 };
 
-export const update = (state, action, sortKey, sortReverse = false) => {
+export const insert = (state, payload, sortKey, sortReverse = false) => {
+    const documents = sortBy(unionBy(state.documents || [], [payload], "id"), sortKey);
+    if (sortReverse) {
+        documents.reverse();
+    }
+
+    return {
+        ...state,
+        documents
+    };
+};
+
+export const update = (state, payload, sortKey, sortReverse = false) => {
     if (!state.documents) {
         return state;
     }
 
-    const documents = sortBy(updateMember(state.documents, action), sortKey);
+    const documents = sortBy(updateMember(state.documents, payload), sortKey);
 
     if (sortReverse) {
         documents.reverse();
@@ -46,24 +45,24 @@ export const update = (state, action, sortKey, sortReverse = false) => {
     };
 };
 
-export const remove = (state, action) => {
+export const remove = (state, payload) => {
     if (!state.documents) {
         return state;
     }
 
     return {
         ...state,
-        documents: reject(state.documents, ({ id }) => includes(action.data, id))
+        documents: reject(state.documents, ({ id }) => includes(payload, id))
     };
 };
 
-export const updateMember = (list, action) => {
+export const updateMember = (list, payload) => {
     if (!list) {
         return list;
     }
     return map(list, item => {
-        if (item.id === action.data.id) {
-            return action.data;
+        if (item.id === payload.id) {
+            return payload;
         }
         return item;
     });

--- a/src/js/utils/sagas.js
+++ b/src/js/utils/sagas.js
@@ -25,7 +25,7 @@ import { createFindURL } from "./utils";
 export function* apiCall(apiMethod, action, actionType, context = {}) {
     try {
         const response = yield apiMethod(action);
-        yield put({ type: actionType.SUCCEEDED, data: response.body, context });
+        yield put({ type: actionType.SUCCEEDED, payload: response.body, context });
         return response;
     } catch (error) {
         const statusCode = get(error, "response.statusCode");
@@ -67,8 +67,6 @@ export function* putGenericError(actionType, error) {
 
     yield put({
         type: actionType.FAILED,
-        message: body.message,
-        error,
-        status
+        payload: { message: body.message, error, status }
     });
 }

--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -131,23 +131,11 @@ export const formatIsolateName = isolate => {
  */
 export const getWorkflowDisplayName = workflow => get(workflowDisplayNames, workflow, startCase(workflow));
 
-export const reportAPIError = action => window.captureException(action.error);
+export const reportAPIError = action => window.captureException(action.payload.error);
 
 export const routerLocationHasState = (state, key, value) =>
     !!state.router.location.state &&
     (value ? state.router.location.state[key] === value : !!state.router.location.state[key]);
-
-/**
- * Returns an action creator that returns an action with ``type`` as the only property.
- *
- * @func
- * @param type {string} the value to use for the type property
- * @returns {function}
- */
-export const simpleActionCreator = type =>
-    function actionCreator() {
-        return { type };
-    };
 
 export const getTargetChange = target => ({
     name: target.name,

--- a/src/js/wall/__tests__/FirstUser.test.js
+++ b/src/js/wall/__tests__/FirstUser.test.js
@@ -64,8 +64,7 @@ describe("mapDispatchToProps", () => {
         props.onSubmit("foo", "bar");
 
         expect(dispatch).toHaveBeenCalledWith({
-            handle: "foo",
-            password: "bar",
+            payload: { handle: "foo", password: "bar" },
             type: "CREATE_FIRST_USER_REQUESTED"
         });
     });


### PR DESCRIPTION
Fairly large refactor of the client state management that changes all actions over to use createAction from redux toolkit. 