### PR TITLE
Show attribution for subtractions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - redis
       - postgres
     environment:
+      VT_DEV: "true"
       VT_DATA_PATH: /data
       VT_DB_CONNECTION_STRING: mongodb://mongo:27017
       VT_POSTGRES_CONNECTION_STRING: postgresql+asyncpg://virtool:virtool@postgres/virtool

--- a/src/js/base/Attribution.js
+++ b/src/js/base/Attribution.js
@@ -4,18 +4,16 @@ import styled from "styled-components";
 import { InitialIcon } from "./InitialIcon";
 import { RelativeTime } from "./RelativeTime";
 
-export const UnstyledAttribution = ({ className, time, user, verb = "created" }) => {
-    return (
-        <span className={className}>
-            {user ? <InitialIcon size="md" handle={user} /> : null}
-            <span>{user}</span>
-            <span>{user ? verb : capitalize(verb)}</span>
-            <RelativeTime time={time} />
-        </span>
-    );
-};
+export const Attribution = ({ className, time, user, verb = "created" }) => (
+    <StyledAttribution className={className}>
+        {user ? <InitialIcon size="md" handle={user} /> : null}
+        <span>{user}</span>
+        <span>{user ? verb : capitalize(verb)}</span>
+        <RelativeTime time={time} />
+    </StyledAttribution>
+);
 
-export const Attribution = styled(UnstyledAttribution)`
+export const StyledAttribution = styled.span`
     align-items: center;
     display: inline-flex;
     font-size: inherit;
@@ -25,5 +23,27 @@ export const Attribution = styled(UnstyledAttribution)`
     }
     .InitialIcon {
         margin-right: 5px;
+    }
+`;
+
+export const NameAttribution = ({ className, user, verb = "created" }) => (
+    <StyledNameAttribution className={className}>
+        <span>{capitalize(verb)} by </span>
+        {user ? <InitialIcon size="md" handle={user} /> : null}
+        <span>{user}</span>
+    </StyledNameAttribution>
+);
+
+export const StyledNameAttribution = styled.span`
+    align-items: center;
+    display: inline-flex;
+    font-size: inherit;
+
+    *:not(:first-child) {
+        margin-left: 3px;
+    }
+    .InitialIcon {
+        margin-right: 1px;
+        margin-left 7px;
     }
 `;

--- a/src/js/subtraction/components/Attribution.js
+++ b/src/js/subtraction/components/Attribution.js
@@ -1,0 +1,21 @@
+import { Attribution, NameAttribution } from "../../base";
+import React from "react";
+import { theme, getColor, getFontSize } from "../../app/theme";
+import styled from "styled-components";
+const StyledNoneFoundAttribution = styled.div`
+    color: ${getColor({ color: "grey", theme })};
+    font-size: ${getFontSize("sm")};
+    font-style: italic;
+    min-height: 20px;
+    top: 50%;
+`;
+
+export function SubtractionAttribution({ handle, time }) {
+    if (handle) {
+        if (time) {
+            return <Attribution user={handle} time={time} />;
+        }
+        return <NameAttribution user={handle} />;
+    }
+    return <StyledNoneFoundAttribution> Creator and timestamp unavailable</StyledNoneFoundAttribution>;
+}

--- a/src/js/subtraction/components/Detail/Detail.js
+++ b/src/js/subtraction/components/Detail/Detail.js
@@ -9,6 +9,7 @@ import { getSubtraction } from "../../actions";
 import EditSubtraction from "../Edit";
 import RemoveSubtraction from "../Remove";
 import SubtractionFiles from "./Files";
+import { SubtractionAttribution } from "../Attribution";
 
 const calculateGC = nucleotides => numbro(1 - nucleotides.a - nucleotides.t - nucleotides.n).format("0.000");
 
@@ -43,7 +44,6 @@ export class SubtractionDetail extends React.Component {
         if (!detail.ready) {
             return <LoadingPlaceholder message="Subtraction is still being imported" />;
         }
-
         return (
             <React.Fragment>
                 <ViewHeader title={detail.name}>
@@ -60,6 +60,9 @@ export class SubtractionDetail extends React.Component {
                             </ViewHeaderIcons>
                         )}
                     </ViewHeaderTitle>
+                    {detail.user ? (
+                        <SubtractionAttribution handle={detail.user.handle} time={detail.created_at} />
+                    ) : null}
                 </ViewHeader>
                 <Table>
                     <tbody>

--- a/src/js/subtraction/components/Item.js
+++ b/src/js/subtraction/components/Item.js
@@ -3,6 +3,7 @@ import { connect } from "react-redux";
 import styled from "styled-components";
 import { getFontSize, getFontWeight } from "../../app/theme";
 import { Icon, LinkBox, Loader } from "../../base";
+import { SubtractionAttribution } from "./Attribution";
 
 export const SubtractionItemIcon = ({ ready }) => {
     if (ready) {
@@ -12,7 +13,7 @@ export const SubtractionItemIcon = ({ ready }) => {
     return <Loader size="14px" color="primary" />;
 };
 
-const StyledSubtractionItem = styled(LinkBox)`
+const StyledSubtractionItemHeader = styled.div`
     align-items: center;
     display: flex;
     font-size: ${getFontSize("lg")};
@@ -23,19 +24,26 @@ const StyledSubtractionItem = styled(LinkBox)`
     }
 `;
 
-export const SubtractionItem = ({ id, name, ready }) => (
-    <StyledSubtractionItem key={id} to={`/subtraction/${id}`}>
-        <span>{name}</span>
-        <span>
-            <SubtractionItemIcon ready={ready} /> <span>{ready ? "Ready" : "Creating"}</span>
-        </span>
-    </StyledSubtractionItem>
-);
+export const SubtractionItem = ({ id, user, name, ready, created_at }) => {
+    return (
+        <LinkBox key={id} to={`/subtraction/${id}`}>
+            <StyledSubtractionItemHeader>
+                <span>{name}</span>
+                <span>
+                    <SubtractionItemIcon ready={ready} /> {ready ? "Ready" : "Creating"}
+                </span>
+            </StyledSubtractionItemHeader>
+            <SubtractionAttribution handle={user.handle} time={created_at} />
+        </LinkBox>
+    );
+};
 
 export const mapStateToProps = (state, props) => {
-    const { id, name, ready } = state.subtraction.documents[props.index];
+    const { id, user, name, ready, created_at } = state.subtraction.documents[props.index];
     return {
         id,
+        user,
+        created_at,
         name,
         ready
     };

--- a/src/js/subtraction/components/__tests__/Item.test.js
+++ b/src/js/subtraction/components/__tests__/Item.test.js
@@ -14,6 +14,7 @@ describe("<SubtractionItem />", () => {
         props = {
             id: "foo",
             name: "Foo",
+            user: { handle: "bar" },
             ready: true
         };
     });

--- a/src/js/subtraction/components/__tests__/__snapshots__/Item.test.js.snap
+++ b/src/js/subtraction/components/__tests__/__snapshots__/Item.test.js.snap
@@ -1,43 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<SubtractionItem /> should render when [ready=false] 1`] = `
-<Item__StyledSubtractionItem
+<Box__LinkBox
   key="foo"
   to="/subtraction/foo"
 >
-  <span>
-    Foo
-  </span>
-  <span>
-    <SubtractionItemIcon
-      ready={false}
-    />
-     
+  <Item__StyledSubtractionItemHeader>
     <span>
+      Foo
+    </span>
+    <span>
+      <SubtractionItemIcon
+        ready={false}
+      />
+       
       Creating
     </span>
-  </span>
-</Item__StyledSubtractionItem>
+  </Item__StyledSubtractionItemHeader>
+  <SubtractionAttribution
+    handle="bar"
+  />
+</Box__LinkBox>
 `;
 
 exports[`<SubtractionItem /> should render when [ready=true] 1`] = `
-<Item__StyledSubtractionItem
+<Box__LinkBox
   key="foo"
   to="/subtraction/foo"
 >
-  <span>
-    Foo
-  </span>
-  <span>
-    <SubtractionItemIcon
-      ready={true}
-    />
-     
+  <Item__StyledSubtractionItemHeader>
     <span>
+      Foo
+    </span>
+    <span>
+      <SubtractionItemIcon
+        ready={true}
+      />
+       
       Ready
     </span>
-  </span>
-</Item__StyledSubtractionItem>
+  </Item__StyledSubtractionItemHeader>
+  <SubtractionAttribution
+    handle="bar"
+  />
+</Box__LinkBox>
 `;
 
 exports[`<SubtractionItemIcon /> should render when [ready=false] 1`] = `


### PR DESCRIPTION
Note: Created as draft PR since created_at object name is not yet guaranteed 

Changes:

- Created new SubtractionAttributions component for handling the logic needed to accommodate various levels of available user information. May be worth moving into attribution, but given that only subtraction components need this logic right now it has been kept separate to reduce load on long list renders.
- Added NameAttribution as a new attribution type for handling cases where we can't or don't want to present time information
- Updated Subtraction list to render different attribution styles depending on what information is present. Displays a message if both user and time are missing.
-  Updated detail to render different attribution styles depending on what information is present. Shows no attribution if both user and time are missing. 