### PR TITLE
remove placeholder version from home view

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -14,10 +14,6 @@
     <base href="/" />
     <script nonce="<#= nonce #>">
         window.__webpack_nonce__ = "<#= nonce #>";
-
-        window.virtool = {
-            version: "{{ version }}"
-        };
     </script>
     <link rel="shortcut icon" href="<%= htmlWebpackPlugin.files.favicon %>?v=2" type="images/x-icon"/>
 </head>

--- a/src/js/home/components/Welcome.js
+++ b/src/js/home/components/Welcome.js
@@ -26,7 +26,7 @@ export const Welcome = () => (
     <Container>
         <StyledWelcome>
             <Box>
-                <h1>Virtool {window.virtool.version}</h1>
+                <h1>Virtool</h1>
                 <p>Viral infection diagnostics using next-generation sequencing</p>
 
                 <strong>

--- a/src/js/home/components/__tests__/__snapshots__/Welcome.test.js.snap
+++ b/src/js/home/components/__tests__/__snapshots__/Welcome.test.js.snap
@@ -5,8 +5,7 @@ exports[`<Welcome /> should render 1`] = `
   <Welcome__StyledWelcome>
     <Box>
       <h1>
-        Virtool 
-        v1.2.3
+        Virtool
       </h1>
       <p>
         Viral infection diagnostics using next-generation sequencing

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -17,8 +17,7 @@ const sentryInit = res => {
     const dev = res.body.dev;
     if (!dev) {
         Sentry.init({
-            dsn: "https://d9ea493cb0f34ad4a141da5506e6b03b@sentry.io/220541",
-            version: window.virtool.version
+            dsn: "https://d9ea493cb0f34ad4a141da5506e6b03b@sentry.io/220541"
         });
 
         window.Sentry = Sentry;


### PR DESCRIPTION
Changes:
- prevents window.virtool.version from being declared in index.html
- remove references to window.virtool.version from home view
- removes usage of window.virtool.version from sentry init.