### PR TITLE
chore: convert attribution to styled component

### DIFF
--- a/src/js/base/Attribution.js
+++ b/src/js/base/Attribution.js
@@ -4,16 +4,16 @@ import styled from "styled-components";
 import { InitialIcon } from "./InitialIcon";
 import { RelativeTime } from "./RelativeTime";
 
-export const Attribution = ({ className, time, user, verb = "created" }) => (
-    <StyledAttribution className={className}>
+export const UnstyledAttribution = ({ className, time, user, verb = "created" }) => (
+    <span className={className}>
         {user ? <InitialIcon size="md" handle={user} /> : null}
         <span>{user}</span>
         <span>{user ? verb : capitalize(verb)}</span>
         <RelativeTime time={time} />
-    </StyledAttribution>
+    </span>
 );
 
-export const StyledAttribution = styled.span`
+export const Attribution = styled(UnstyledAttribution)`
     align-items: center;
     display: inline-flex;
     font-size: inherit;
@@ -26,15 +26,15 @@ export const StyledAttribution = styled.span`
     }
 `;
 
-export const NameAttribution = ({ className, user, verb = "created" }) => (
-    <StyledNameAttribution className={className}>
+export const UnstyledNameAttribution = ({ className, user, verb = "created" }) => (
+    <span className={className}>
         <span>{capitalize(verb)} by </span>
         {user ? <InitialIcon size="md" handle={user} /> : null}
         <span>{user}</span>
-    </StyledNameAttribution>
+    </span>
 );
 
-export const StyledNameAttribution = styled.span`
+export const NameAttribution = styled(UnstyledNameAttribution)`
     align-items: center;
     display: inline-flex;
     font-size: inherit;

--- a/src/js/subtraction/components/__tests__/Item.test.js
+++ b/src/js/subtraction/components/__tests__/Item.test.js
@@ -24,6 +24,12 @@ describe("<SubtractionItem />", () => {
         const wrapper = shallow(<SubtractionItem {...props} />);
         expect(wrapper).toMatchSnapshot();
     });
+
+    it.each([null, 0])("should render when [create_at=%p]", created_at => {
+        props.created_at = created_at;
+        const wrapper = shallow(<SubtractionItem {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
 });
 
 describe("mapStateToProps()", () => {

--- a/src/js/subtraction/components/__tests__/__snapshots__/Item.test.js.snap
+++ b/src/js/subtraction/components/__tests__/__snapshots__/Item.test.js.snap
@@ -1,5 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<SubtractionItem /> should render when [create_at=0] 1`] = `
+<Box__LinkBox
+  key="foo"
+  to="/subtraction/foo"
+>
+  <Item__StyledSubtractionItemHeader>
+    <span>
+      Foo
+    </span>
+    <span>
+      <SubtractionItemIcon
+        ready={true}
+      />
+       
+      Ready
+    </span>
+  </Item__StyledSubtractionItemHeader>
+  <SubtractionAttribution
+    handle="bar"
+    time={0}
+  />
+</Box__LinkBox>
+`;
+
+exports[`<SubtractionItem /> should render when [create_at=null] 1`] = `
+<Box__LinkBox
+  key="foo"
+  to="/subtraction/foo"
+>
+  <Item__StyledSubtractionItemHeader>
+    <span>
+      Foo
+    </span>
+    <span>
+      <SubtractionItemIcon
+        ready={true}
+      />
+       
+      Ready
+    </span>
+  </Item__StyledSubtractionItemHeader>
+  <SubtractionAttribution
+    handle="bar"
+    time={null}
+  />
+</Box__LinkBox>
+`;
+
 exports[`<SubtractionItem /> should render when [ready=false] 1`] = `
 <Box__LinkBox
   key="foo"


### PR DESCRIPTION
Converts attribution back to being a styled component to prevent it breaking the styling of parent components.