### PR TITLE
restore spacing during sample creation in list view

### DIFF
--- a/src/js/samples/components/Item/Item.js
+++ b/src/js/samples/components/Item/Item.js
@@ -17,14 +17,9 @@ const SampleIconContainer = styled.div`
     bottom: 0;
     display: flex;
     justify-content: center;
-
-    > div {
-        align-items: center;
-        display: flex;
-
-        strong {
-            margin-left: 5px;
-        }
+    margin-left: auto;
+    strong {
+        margin-left: 5px;
     }
 `;
 
@@ -33,11 +28,11 @@ const SampleItemCheckboxContainer = styled.div`
     cursor: pointer;
     display: flex;
     padding-right: 15px;
+    max-width: 30px;
 `;
 
 const SampleItemLabels = styled.div`
     margin-top: 10px;
-
     & > *:not(:last-child) {
         margin-right: 5px;
     }
@@ -48,6 +43,7 @@ const SampleItemData = styled.div`
     display: flex;
     flex: 3;
     flex-direction: column;
+    min-width: 250px;
 `;
 
 const SampleItemMain = styled.div`
@@ -60,30 +56,33 @@ const SampleItemWorkflows = styled.div`
     grid-column-start: 3;
     display: flex;
     flex: 2;
+    white-space: nowrap;
 `;
 
 const SampleItemIcon = styled.div`
-    grid-column-start: 4;
     display: flex;
-    margin-left: auto;
+    min-width: 80px;
 `;
 
 const SampleItemTitle = styled.div`
     display: flex;
     flex-direction: column;
     flex: 3;
+    overflow: hidden;
 
     a {
         font-size: ${getFontSize("lg")};
         font-weight: ${getFontWeight("thick")};
         margin: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 `;
 
 const StyledSampleItem = styled(Box)`
     align-items: stretch;
-    display: grid;
-    grid-template-columns: 3% 57% 33% 7%;
+    display: flex;
+    flex-basis: 0px;
 `;
 
 class SampleItem extends React.Component {
@@ -114,10 +113,8 @@ class SampleItem extends React.Component {
         } else {
             endIcon = (
                 <SampleIconContainer>
-                    <React.Fragment>
-                        <Loader size="14px" color="primary" />
-                        <strong>Creating</strong>
-                    </React.Fragment>
+                    <Loader size="14px" color="primary" />
+                    <strong>Creating</strong>
                 </SampleIconContainer>
             );
         }

--- a/src/js/samples/components/List.js
+++ b/src/js/samples/components/List.js
@@ -18,6 +18,7 @@ const SamplesListHeader = styled.div`
 
 const SamplesListContent = styled.div`
     grid-row: 2;
+    min-width: 550px;
 `;
 
 const StyledSamplesList = styled.div`


### PR DESCRIPTION
Updated:
 - The sample loading spinner is now formatted properly
 - On resize elements stay within the borders of the list
 - Sample names that are too long for the current window size are truncated 
Images showing the new bar at full size and smallest size

![image](https://user-images.githubusercontent.com/59776400/147163887-5802863d-26a5-4334-8073-d25630e07f97.png)
![image](https://user-images.githubusercontent.com/59776400/147163907-5f619c4a-83e6-4f34-97d4-56db39ea5fc2.png)
