### PR TITLE
fix: prevent flash of previous analysis list

### DIFF
--- a/src/js/analyses/components/Analyses.js
+++ b/src/js/analyses/components/Analyses.js
@@ -11,7 +11,7 @@ import AnalysisDetail from "./Detail";
 
 export class Analyses extends React.Component {
     componentDidMount() {
-        this.props.onFindAnalyses(this.props.sampleId);
+        this.props.onFindAnalyses(this.props.match.params.sampleId);
         this.props.onFindHmms();
         this.props.onListReadyIndexes();
     }
@@ -35,7 +35,6 @@ export class Analyses extends React.Component {
 }
 
 const mapStateToProps = state => ({
-    sampleId: state.samples.detail.id,
     loading: state.analyses.documents === null || state.hmms.documents === null || state.analyses.readyIndexes === null
 });
 

--- a/src/js/analyses/components/__tests__/Analyses.test.js
+++ b/src/js/analyses/components/__tests__/Analyses.test.js
@@ -5,12 +5,12 @@ describe("<Analyses />", () => {
 
     beforeEach(() => {
         props = {
-            sampleId: "foo",
             loading: false,
             onFindAnalyses: jest.fn(),
             onClearAnalyses: jest.fn(),
             onFindHmms: jest.fn(),
-            onListReadyIndexes: jest.fn()
+            onListReadyIndexes: jest.fn(),
+            match: { params: { sampleId: "foo" } }
         };
     });
 


### PR DESCRIPTION
Sample analysis now gets `sampleId` from the url rather than state. This prevents fetching data for the wrong sample if  `sample.detail.documents` has not yet been updated. (the quick flash of wrong data was this freshly fetched data)
