### PR TITLE
prevent non-finalized subtractions from appearing as default subtractions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - backend
 
   api:
-    image: virtool/virtool:6.5.0
+    image: virtool/virtool:6.6.3
     depends_on:
       - mongo
       - redis

--- a/src/js/analyses/components/Create/Create.js
+++ b/src/js/analyses/components/Create/Create.js
@@ -8,6 +8,7 @@ import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "../../../bas
 import { getDefaultSubtractions, getSampleDetailId, getSampleLibraryType } from "../../../samples/selectors";
 import { getDataTypeFromLibraryType } from "../../../samples/utils";
 import { shortlistSubtractions } from "../../../subtraction/actions";
+import { getReadySubtractionShortlist } from "../../../subtraction/selectors";
 import { routerLocationHasState } from "../../../utils/utils";
 import { analyze } from "../../actions";
 import { getCompatibleIndexesWithLibraryType } from "../../selectors";
@@ -120,7 +121,7 @@ export const mapStateToProps = state => ({
     hasHmm: !!state.hmms.total_count,
     sampleId: getSampleDetailId(state),
     show: routerLocationHasState(state, "createAnalysis"),
-    subtractionOptions: state.subtraction.shortlist
+    subtractionOptions: getReadySubtractionShortlist(state)
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/js/analyses/components/Create/Quick.js
+++ b/src/js/analyses/components/Create/Quick.js
@@ -8,13 +8,13 @@ import {
     Badge,
     Button,
     Icon,
+    InputError,
     Modal,
     ModalBody,
     ModalFooter,
     ModalHeader,
     ModalTabs,
-    TabLink,
-    InputError
+    TabLink
 } from "../../../base";
 import { deselectSamples } from "../../../samples/actions";
 import { getSelectedSamples } from "../../../samples/selectors";
@@ -32,8 +32,9 @@ import { SelectedSamples } from "./SelectedSamples";
 import { SubtractionSelector } from "./SubtractionSelector";
 import { CreateAnalysisSummary } from "./Summary";
 import { WorkflowSelector } from "./WorkflowSelector";
-import { Formik, Form, Field } from "formik";
+import { Field, Form, Formik } from "formik";
 import * as Yup from "yup";
+import { getReadySubtractionShortlist } from "../../../subtraction/selectors";
 
 const QuickAnalyzeFooter = styled(ModalFooter)`
     align-items: center;
@@ -174,7 +175,7 @@ export const mapStateToProps = state => ({
     hasHmm: !!state.hmms.total_count,
     mode: getQuickAnalysisMode(state),
     samples: getSelectedSamples(state),
-    subtractionOptions: state.subtraction.shortlist
+    subtractionOptions: getReadySubtractionShortlist(state)
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/js/analyses/components/Create/__tests__/Create.test.js
+++ b/src/js/analyses/components/Create/__tests__/Create.test.js
@@ -119,7 +119,7 @@ describe("mapStateToProps()", () => {
             hasHmm: false,
             sampleId: "foo",
             show: false,
-            subtractionOptions: null
+            subtractionOptions: []
         });
     });
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -13,7 +13,7 @@ if (module.hot) {
     module.hot.accept(err => {
         throw err;
     });
-    window.virtool.sentryDSN = "https://d9ea493cb0f34ad4a141da5506e6b03b@sentry.io/220541";
+    window.virtool.sentryDSN = null;
 }
 
 Sentry.init({

--- a/src/js/samples/components/Create/__tests__/Create.test.js
+++ b/src/js/samples/components/Create/__tests__/Create.test.js
@@ -45,8 +45,8 @@ describe("<CreateSample>", () => {
             },
             subtraction: {
                 shortlist: [
-                    { name: "Foo Subtraction", id: "foo_subtraction" },
-                    { name: "Bar Subtraction", id: "bar_subtraction" }
+                    { name: "Foo Subtraction", id: "foo_subtraction", ready: true },
+                    { name: "Bar Subtraction", id: "bar_subtraction", ready: true }
                 ]
             }
         };

--- a/src/js/samples/components/Sidebar/Subtractions.js
+++ b/src/js/samples/components/Sidebar/Subtractions.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import { SidebarHeader, SideBarSection } from "../../../base";
-import { getSubtractionOptions } from "../../selectors";
+import { getReadySubtractionShortlist } from "../../../subtraction/selectors";
 import { SampleSidebarList } from "./List";
 import { SampleSidebarSelector } from "./Selector";
 
@@ -26,7 +26,7 @@ export const DefaultSubtractions = ({ defaultSubtractions, subtractionOptions, o
 );
 
 export const mapStateToProps = state => ({
-    subtractionOptions: getSubtractionOptions(state)
+    subtractionOptions: getReadySubtractionShortlist(state)
 });
 
 export default connect(mapStateToProps)(DefaultSubtractions);

--- a/src/js/subtraction/selectors.js
+++ b/src/js/subtraction/selectors.js
@@ -1,3 +1,8 @@
-import { get } from "lodash-es";
+import { get, filter } from "lodash-es";
+import { createSelector } from "reselect";
 
 export const getSubtractionShortlist = state => get(state, "subtraction.shortlist");
+
+export const getReadySubtractionShortlist = createSelector(getSubtractionShortlist, subtractions =>
+    filter(subtractions, { ready: true })
+);


### PR DESCRIPTION
changes:
 - Updates API version in docker-compose 6.5.0 -> 6.6.3
 - Makes new getReadySubtractionShortlist selector 
 - Uses new subtraction selector in Sample Detail view for choosing default subtractions and both quick and regular analysis views.
 - Disables sentry when HMR is active
