### PR TITLE
change subtraction path to subtractions

### DIFF
--- a/src/js/analyses/components/Item.js
+++ b/src/js/analyses/components/Item.js
@@ -67,7 +67,7 @@ export const AnalysisItem = props => {
     const subtractionComponents = subtractions.map(subtraction => (
         <AnalysisItemTag key={subtraction.id}>
             <Icon name="not-equal" />
-            <Link to={`/subtraction/${subtraction.id}`}>{subtraction.name}</Link>
+            <Link to={`/subtractions/${subtraction.id}`}>{subtraction.name}</Link>
         </AnalysisItemTag>
     ));
     return (

--- a/src/js/analyses/components/Pathoscope/Mapping.js
+++ b/src/js/analyses/components/Pathoscope/Mapping.js
@@ -25,7 +25,7 @@ export const AnalysisMappingReferenceTitle = ({ index, reference }) => (
 );
 
 export const AnalysisMappingSubtractionTitle = ({ subtraction }) => (
-    <Link to={`/subtraction/${subtraction.id}`}>{subtraction.name}</Link>
+    <Link to={`/subtractions/${subtraction.id}`}>{subtraction.name}</Link>
 );
 
 const StyledAnalysisMapping = styled(Box)`

--- a/src/js/analyses/components/__tests__/__snapshots__/Item.test.js.snap
+++ b/src/js/analyses/components/__tests__/__snapshots__/Item.test.js.snap
@@ -54,7 +54,7 @@ exports[`<AnalysisItem /> should render 1`] = `
         name="not-equal"
       />
       <Link
-        to="/subtraction/pru"
+        to="/subtractions/pru"
       >
         Prunus persica
       </Link>
@@ -68,7 +68,7 @@ exports[`<AnalysisItem /> should render 1`] = `
         name="not-equal"
       />
       <Link
-        to="/subtraction/ara"
+        to="/subtractions/ara"
       >
         Arabidopsis thaliana
       </Link>
@@ -131,7 +131,7 @@ exports[`<AnalysisItem /> should render when [placeholder=true] 1`] = `
         name="not-equal"
       />
       <Link
-        to="/subtraction/pru"
+        to="/subtractions/pru"
       >
         Prunus persica
       </Link>
@@ -145,7 +145,7 @@ exports[`<AnalysisItem /> should render when [placeholder=true] 1`] = `
         name="not-equal"
       />
       <Link
-        to="/subtraction/ara"
+        to="/subtractions/ara"
       >
         Arabidopsis thaliana
       </Link>
@@ -208,7 +208,7 @@ exports[`<AnalysisItem /> should render when [ready=false] 1`] = `
         name="not-equal"
       />
       <Link
-        to="/subtraction/pru"
+        to="/subtractions/pru"
       >
         Prunus persica
       </Link>
@@ -222,7 +222,7 @@ exports[`<AnalysisItem /> should render when [ready=false] 1`] = `
         name="not-equal"
       />
       <Link
-        to="/subtraction/ara"
+        to="/subtractions/ara"
       >
         Arabidopsis thaliana
       </Link>

--- a/src/js/app/Main.js
+++ b/src/js/app/Main.js
@@ -63,7 +63,7 @@ export const Main = ({ ready, onLoad }) => {
                             <Route path="/samples" component={Samples} />
                             <Route path="/refs" component={References} />
                             <Route path="/hmm" component={HMM} />
-                            <Route path="/subtraction" component={Subtraction} />
+                            <Route path="/subtractions" component={Subtraction} />
                             <Route path="/administration" component={Administration} />
                             <Route path="/account" component={Account} />
                         </Switch>

--- a/src/js/jobs/components/JobArgs.js
+++ b/src/js/jobs/components/JobArgs.js
@@ -42,7 +42,7 @@ export const CreateSampleRows = ({ sample_id }) => (
 
 export const CreateSubtractionRows = ({ subtraction_id }) => (
     <JobArgsRow title="Subtraction">
-        <Link to={`/subtraction/${subtraction_id}`}>{subtraction_id}</Link>
+        <Link to={`/subtractions/${subtraction_id}`}>{subtraction_id}</Link>
     </JobArgsRow>
 );
 

--- a/src/js/jobs/components/__tests__/__snapshots__/TaskArgs.test.js.snap
+++ b/src/js/jobs/components/__tests__/__snapshots__/TaskArgs.test.js.snap
@@ -65,7 +65,7 @@ exports[`<CreateSubtractionRows /> renders correctly 1`] = `
   title="Subtraction"
 >
   <Link
-    to="/subtraction/foo"
+    to="/subtractions/foo"
   >
     foo
   </Link>

--- a/src/js/nav/components/NavBar.js
+++ b/src/js/nav/components/NavBar.js
@@ -62,7 +62,7 @@ export const Bar = ({ administrator, dev, userId, onLogout }) => (
             <NavBarItem to="/samples">Samples</NavBarItem>
             <NavBarItem to="/refs">References</NavBarItem>
             <NavBarItem to="/hmm">HMM</NavBarItem>
-            <NavBarItem to="/subtraction">Subtraction</NavBarItem>
+            <NavBarItem to="/subtractions">Subtractions</NavBarItem>
         </NavBarLeft>
 
         <NavBarRight>

--- a/src/js/nav/components/Sidebar.js
+++ b/src/js/nav/components/Sidebar.js
@@ -48,10 +48,10 @@ export const Sidebar = ({ administrator }) => (
                 {administrator ? <SidebarItem title="Settings" link="/refs/settings" icon="cogs" /> : null}
             </StyledSidebar>
         </Route>
-        <Route path="/subtraction">
+        <Route path="/subtractions">
             <StyledSidebar>
-                <SidebarItem exclude={["/subtraction/files"]} title="Browse" link="/subtraction" icon="th-list" />
-                <SidebarItem title="Files" link="/subtraction/files" icon="folder-open" />
+                <SidebarItem exclude={["/subtractions/files"]} title="Browse" link="/subtractions" icon="th-list" />
+                <SidebarItem title="Files" link="/subtractions/files" icon="folder-open" />
             </StyledSidebar>
         </Route>
         <Route path="/hmm">

--- a/src/js/nav/components/__tests__/__snapshots__/NavBar.test.js.snap
+++ b/src/js/nav/components/__tests__/__snapshots__/NavBar.test.js.snap
@@ -30,9 +30,9 @@ exports[`<Bar /> should render 1`] = `
       HMM
     </NavBarItem>
     <NavBarItem
-      to="/subtraction"
+      to="/subtractions"
     >
-      Subtraction
+      Subtractions
     </NavBarItem>
   </NavBar__NavBarLeft>
   <NavBar__NavBarRight>

--- a/src/js/subtraction/components/FileSelector.js
+++ b/src/js/subtraction/components/FileSelector.js
@@ -41,7 +41,7 @@ export const SubtractionFileSelector = ({ files, value, onClick, error }) => {
     if (!fileComponents.length) {
         return (
             <NoneFoundBox noun="files">
-                <Link to="/subtraction/files">Upload some</Link>
+                <Link to="/subtractions/files">Upload some</Link>
             </NoneFoundBox>
         );
     }

--- a/src/js/subtraction/components/Item.js
+++ b/src/js/subtraction/components/Item.js
@@ -26,7 +26,7 @@ const StyledSubtractionItemHeader = styled.div`
 
 export const SubtractionItem = ({ id, user, name, ready, created_at }) => {
     return (
-        <LinkBox key={id} to={`/subtraction/${id}`}>
+        <LinkBox key={id} to={`/subtractions/${id}`}>
             <StyledSubtractionItemHeader>
                 <span>{name}</span>
                 <span>

--- a/src/js/subtraction/components/List.js
+++ b/src/js/subtraction/components/List.js
@@ -37,9 +37,9 @@ export class SubtractionList extends React.Component {
 
         return (
             <React.Fragment>
-                <ViewHeader title="Subtraction">
+                <ViewHeader title="Subtractions">
                     <ViewHeaderTitle>
-                        Subtraction <Badge>{this.props.total_count}</Badge>
+                        Subtractions <Badge>{this.props.total_count}</Badge>
                     </ViewHeaderTitle>
                 </ViewHeader>
 

--- a/src/js/subtraction/components/Selector.js
+++ b/src/js/subtraction/components/Selector.js
@@ -14,7 +14,7 @@ export const SampleSubtractionSelector = ({ name, noun, selected, subtractions, 
     if (!subtractions.length) {
         return (
             <NoneFoundBox noun="subtractions">
-                <Link to="/subtraction"> Create one</Link>.
+                <Link to="/subtractions"> Create one</Link>.
             </NoneFoundBox>
         );
     }

--- a/src/js/subtraction/components/Subtraction.js
+++ b/src/js/subtraction/components/Subtraction.js
@@ -13,10 +13,10 @@ const Subtraction = () => (
     <Container>
         <NarrowContainer>
             <Switch>
-                <Route path="/subtraction" component={SubtractionList} exact />
-                <Route path="/subtraction/files" component={SubtractionFileManager} />
-                <Route path="/subtraction/create" component={SubtractionCreate} />
-                <Route path="/subtraction/:subtractionId" component={SubtractionDetail} />
+                <Route path="/subtractions" component={SubtractionList} exact />
+                <Route path="/subtractions/files" component={SubtractionFileManager} />
+                <Route path="/subtractions/create" component={SubtractionCreate} />
+                <Route path="/subtractions/:subtractionId" component={SubtractionDetail} />
             </Switch>
         </NarrowContainer>
     </Container>

--- a/src/js/subtraction/components/Toolbar.js
+++ b/src/js/subtraction/components/Toolbar.js
@@ -8,7 +8,7 @@ export const SubtractionToolbar = ({ term, onFind, canModify }) => {
     let createButton;
 
     if (canModify) {
-        createButton = <LinkButton color="blue" to="subtraction/create" icon="plus-square" tip="Create" />;
+        createButton = <LinkButton color="blue" to="subtractions/create" icon="plus-square" tip="Create" />;
     }
 
     return (

--- a/src/js/subtraction/components/__tests__/__snapshots__/Item.test.js.snap
+++ b/src/js/subtraction/components/__tests__/__snapshots__/Item.test.js.snap
@@ -3,7 +3,7 @@
 exports[`<SubtractionItem /> should render when [create_at=0] 1`] = `
 <Box__LinkBox
   key="foo"
-  to="/subtraction/foo"
+  to="/subtractions/foo"
 >
   <Item__StyledSubtractionItemHeader>
     <span>
@@ -27,7 +27,7 @@ exports[`<SubtractionItem /> should render when [create_at=0] 1`] = `
 exports[`<SubtractionItem /> should render when [create_at=null] 1`] = `
 <Box__LinkBox
   key="foo"
-  to="/subtraction/foo"
+  to="/subtractions/foo"
 >
   <Item__StyledSubtractionItemHeader>
     <span>
@@ -51,7 +51,7 @@ exports[`<SubtractionItem /> should render when [create_at=null] 1`] = `
 exports[`<SubtractionItem /> should render when [ready=false] 1`] = `
 <Box__LinkBox
   key="foo"
-  to="/subtraction/foo"
+  to="/subtractions/foo"
 >
   <Item__StyledSubtractionItemHeader>
     <span>
@@ -74,7 +74,7 @@ exports[`<SubtractionItem /> should render when [ready=false] 1`] = `
 exports[`<SubtractionItem /> should render when [ready=true] 1`] = `
 <Box__LinkBox
   key="foo"
-  to="/subtraction/foo"
+  to="/subtractions/foo"
 >
   <Item__StyledSubtractionItemHeader>
     <span>

--- a/src/js/subtraction/components/__tests__/__snapshots__/List.test.js.snap
+++ b/src/js/subtraction/components/__tests__/__snapshots__/List.test.js.snap
@@ -3,10 +3,10 @@
 exports[`<SubtractionList /> renders correctly 1`] = `
 <Fragment>
   <ViewHeader
-    title="Subtraction"
+    title="Subtractions"
   >
     <ViewHeader__ViewHeaderTitle>
-      Subtraction 
+      Subtractions 
       <Badge>
         1
       </Badge>

--- a/src/js/subtraction/components/__tests__/__snapshots__/Subtraction.test.js.snap
+++ b/src/js/subtraction/components/__tests__/__snapshots__/Subtraction.test.js.snap
@@ -15,11 +15,11 @@ exports[`<Subtraction /> should render 1`] = `
           }
         }
         exact={true}
-        path="/subtraction"
+        path="/subtractions"
       />
       <Route
         component={[Function]}
-        path="/subtraction/files"
+        path="/subtractions/files"
       />
       <Route
         component={
@@ -31,7 +31,7 @@ exports[`<Subtraction /> should render 1`] = `
             "type": [Function],
           }
         }
-        path="/subtraction/create"
+        path="/subtractions/create"
       />
       <Route
         component={
@@ -43,7 +43,7 @@ exports[`<Subtraction /> should render 1`] = `
             "type": [Function],
           }
         }
-        path="/subtraction/:subtractionId"
+        path="/subtractions/:subtractionId"
       />
     </Switch>
   </Container__NarrowContainer>

--- a/src/js/subtraction/components/__tests__/__snapshots__/Toolbar.test.js.snap
+++ b/src/js/subtraction/components/__tests__/__snapshots__/Toolbar.test.js.snap
@@ -22,7 +22,7 @@ exports[`<SubtractionToolbar /> should render create button when [canModify=true
     icon="plus-square"
     tip="Create"
     tipPlacement="top"
-    to="subtraction/create"
+    to="subtractions/create"
   />
 </Toolbar>
 `;

--- a/src/js/subtraction/sagas.js
+++ b/src/js/subtraction/sagas.js
@@ -25,7 +25,7 @@ export function* createSubtraction(action) {
     const resp = yield apiCall(subtractionAPI.create, action.payload, CREATE_SUBTRACTION);
 
     if (resp.ok) {
-        yield put(push("/subtraction"));
+        yield put(push("/subtractions"));
     }
 }
 
@@ -45,7 +45,7 @@ export function* removeSubtraction(action) {
     const resp = yield apiCall(subtractionAPI.remove, action.payload, REMOVE_SUBTRACTION);
 
     if (resp.ok) {
-        yield put(push("/subtraction"));
+        yield put(push("/subtractions"));
     }
 }
 


### PR DESCRIPTION
Changes:
- change subtraction path to be `subtractions` rather than `subtraction`
- change name of the page title and header of `/subtractions`  from `subtraction` to `subtractions`
- update links from other components to point to the new URL
- update tests as needed to accommodate the new links.