### PR TITLE
Move multiselect sample options into sidebar

### DIFF
--- a/src/js/base/SideBar.js
+++ b/src/js/base/SideBar.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
-import { Box } from "./Box";
 import { borderRadius, boxShadow, fontWeight, getFontSize } from "../app/theme";
+import { Box } from "./Box";
 
 export const SideBarSection = styled(Box)`
     background-color: #f8fafc;

--- a/src/js/samples/components/List.js
+++ b/src/js/samples/components/List.js
@@ -27,7 +27,17 @@ const StyledSamplesList = styled.div`
     grid-template-columns: minmax(auto, 1150px) max(320px, 10%);
 `;
 
-export const SamplesList = ({ documents, loading, match, page, pageCount, totalCount, onFindSamples, onFindOther }) => {
+export const SamplesList = ({
+    documents,
+    loading,
+    match,
+    page,
+    pageCount,
+    totalCount,
+    onFindSamples,
+    onFindOther,
+    selected
+}) => {
     useEffect(onFindOther, [null]);
 
     useEffect(() => {
@@ -67,7 +77,7 @@ export const SamplesList = ({ documents, loading, match, page, pageCount, totalC
                         />
                     )}
                 </SamplesListContent>
-                <SampleFilters />
+                {!selected.length && <SampleFilters />}
             </StyledSamplesList>
         </React.Fragment>
     );

--- a/src/js/samples/components/SelectionToolbar.js
+++ b/src/js/samples/components/SelectionToolbar.js
@@ -1,10 +1,15 @@
 import React from "react";
 import styled from "styled-components";
-import { Box, Button } from "../../base";
+import { Button } from "../../base";
 
 const SampleSelectionToolbarTop = styled.div`
     align-items: center;
     display: flex;
+    margin-bottom: 15px;
+
+    button {
+        height: 38px;
+    }
 
     button:first-child {
         align-items: center;
@@ -15,20 +20,13 @@ const SampleSelectionToolbarTop = styled.div`
     }
 `;
 
-const StyledSampleSelectionToolbar = styled(Box)`
-    height: 185px;
-    margin-bottom: 15px;
-`;
-
 export const SampleSelectionToolbar = ({ onClear, onQuickAnalyze, selected }) => (
-    <StyledSampleSelectionToolbar>
-        <SampleSelectionToolbarTop>
-            <Button icon="times-circle" onClick={onClear}>
-                Clear selection of {selected.length} samples
-            </Button>
-            <Button color="green" icon="chart-area" onClick={() => onQuickAnalyze(selected)}>
-                Quick Analyze
-            </Button>
-        </SampleSelectionToolbarTop>
-    </StyledSampleSelectionToolbar>
+    <SampleSelectionToolbarTop>
+        <Button icon="times-circle" onClick={onClear}>
+            Clear selection of {selected.length} samples
+        </Button>
+        <Button color="green" icon="chart-area" onClick={() => onQuickAnalyze(selected)}>
+            Quick Analyze
+        </Button>
+    </SampleSelectionToolbarTop>
 );


### PR DESCRIPTION
Changes
- Removes large box when in sample multi select view. 
- Removes filter components from sidebar in multi select view.

Screenshot:
![image](https://user-images.githubusercontent.com/59776400/148595881-41c6e9bf-ece8-4263-ac43-044527cc73c0.png)

(Note: regular sample view remains unchanged)
