### PR TITLE
Prevent sample colours in label managment modal from turning white

### DIFF
--- a/src/js/base/Color.js
+++ b/src/js/base/Color.js
@@ -63,6 +63,7 @@ const ColorSquare = styled(UnstyledColorSquare)`
     cursor: pointer;
     flex: 1 0 auto;
     width: auto;
+    transform: translateY(0);
 
     &:first-child {
         border-bottom-left-radius: ${borderRadius.sm};


### PR DESCRIPTION
Appears to be a rendering bug in chromium. Adding a transform to the non-hover state prevents the loss of color. Working in chrome version 97.0.4692.71, and edge version 97.0.1072.55.