### PR TITLE
Ensure analysis reference selector always displays label

### DIFF
--- a/src/js/analyses/components/Create/ReferenceSelector.js
+++ b/src/js/analyses/components/Create/ReferenceSelector.js
@@ -33,14 +33,17 @@ export const ReferenceSelector = ({ hasError, indexes, selected, onChange }) => 
 
     if (!referenceComponents.length) {
         return (
-            <NoneFoundBox noun="references">
-                <Link to="/refs">Import one</Link>.
-            </NoneFoundBox>
+            <>
+                <label htmlFor="references">References</label>
+                <NoneFoundBox noun="references" id="references">
+                    <Link to="/refs">Create one</Link>.
+                </NoneFoundBox>
+            </>
         );
     }
 
     return (
-        <React.Fragment>
+        <>
             <label>References</label>
             <MultiSelector
                 error={hasError && "Reference(s) must be selected"}
@@ -50,7 +53,7 @@ export const ReferenceSelector = ({ hasError, indexes, selected, onChange }) => 
             >
                 {referenceComponents}
             </MultiSelector>
-        </React.Fragment>
+        </>
     );
 };
 


### PR DESCRIPTION
Changes the `ReferenceSelector` component shared by quick analysis and standard analysis to:

1. Always display the label
2. Use the same creation syntax in the NoneFound message
![image](https://user-images.githubusercontent.com/59776400/149034183-472d66fb-9fc1-4d85-896b-03c5696890c0.png)
