### PR TITLE
Disable sample creation sidebar dropdowns when no options available

### DIFF
--- a/src/js/samples/components/Create/__tests__/Create.test.js
+++ b/src/js/samples/components/Create/__tests__/Create.test.js
@@ -4,6 +4,16 @@ import React from "react";
 import { createStore } from "redux";
 import { LIST_LABELS } from "../../../../app/actionTypes";
 import { CreateSample, mapDispatchToProps, mapStateToProps } from "../Create";
+import { BrowserRouter } from "react-router-dom";
+
+const routerRenderWithProviders = (ui, store) => {
+    const routerUi = <BrowserRouter> {ui} </BrowserRouter>;
+    return renderWithProviders(routerUi, store);
+};
+
+const createAppStore = state => {
+    return () => createStore(state => state, state);
+};
 
 describe("<CreateSample>", () => {
     const readFileName = "large";
@@ -78,7 +88,7 @@ describe("<CreateSample>", () => {
     });
 
     it("should fail to submit and show errors on empty submission", async () => {
-        renderWithProviders(<CreateSample {...props} />, createAppStore(state));
+        routerRenderWithProviders(<CreateSample {...props} />, createAppStore(state));
         // Ensure errors aren't shown prematurely
         expect(screen.queryByText("Required Field")).not.toBeInTheDocument();
         expect(screen.queryByText("At least one read file must be attached to the sample")).not.toBeInTheDocument();
@@ -94,7 +104,7 @@ describe("<CreateSample>", () => {
 
     it("should submit when required fields are completed", async () => {
         const { name } = values;
-        renderWithProviders(<CreateSample {...props} />, createAppStore(state));
+        routerRenderWithProviders(<CreateSample {...props} />, createAppStore(state));
         inputFormRequirements(name);
         submitForm();
 
@@ -102,7 +112,7 @@ describe("<CreateSample>", () => {
     });
 
     it("should submit expected results when form is fully completed", async () => {
-        renderWithProviders(<CreateSample {...props} />, createAppStore(state));
+        routerRenderWithProviders(<CreateSample {...props} />, createAppStore(state));
         const { name, isolate, host, locale, libraryType } = values;
         inputFormRequirements(name);
 
@@ -131,7 +141,7 @@ describe("<CreateSample>", () => {
     });
 
     it("should include labels when submitting a completed form", async () => {
-        renderWithProviders(<CreateSample {...props} />, createAppStore(state));
+        routerRenderWithProviders(<CreateSample {...props} />, createAppStore(state));
         const { name, isolate, host, locale, libraryType } = values;
         inputFormRequirements(name);
 
@@ -161,7 +171,7 @@ describe("<CreateSample>", () => {
     });
 
     it("should update the sample name when the magic icon is pressed", async () => {
-        renderWithProviders(<CreateSample {...props} />, createAppStore(state));
+        routerRenderWithProviders(<CreateSample {...props} />, createAppStore(state));
         const nameInput = screen.getByRole("textbox", { name: /Name/i });
         expect(nameInput.value).toBe("");
 
@@ -170,10 +180,6 @@ describe("<CreateSample>", () => {
         expect(nameInput.value).toBe(readFileName);
     });
 });
-
-const createAppStore = state => {
-    return () => createStore(state => state, state);
-};
 
 describe("mapStateToProps()", () => {
     it("should return props", () => {

--- a/src/js/samples/components/Sidebar/Labels.js
+++ b/src/js/samples/components/Sidebar/Labels.js
@@ -4,13 +4,26 @@ import { SidebarHeader, SideBarSection } from "../../../base";
 import { SmallSampleLabel } from "../Label";
 import { SampleSidebarList } from "./List";
 import { SampleSidebarSelector } from "./Selector";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+import { getFontSize, fontWeight, getColor } from "../../../app/theme";
 
 const SampleLabelInner = ({ name, color, description }) => (
-    <React.Fragment>
+    <>
         <SmallSampleLabel color={color} name={name} />
         <p>{description}</p>
-    </React.Fragment>
+    </>
 );
+
+const SampleLabelsFooter = styled.div`
+    display: flex;
+    color: ${props => getColor({ theme: props.theme, color: "greyDarkest" })};
+    a {
+        margin-left: 5px;
+        font-size: ${getFontSize("md")};
+        font-weight: ${fontWeight.thick};
+    }
+`;
 
 export const SampleLabels = ({ allLabels, sampleLabels, onUpdate }) => (
     <SideBarSection>
@@ -24,9 +37,15 @@ export const SampleLabels = ({ allLabels, sampleLabels, onUpdate }) => (
                 selectedItems={sampleLabels}
                 onUpdate={onUpdate}
                 selectionType="labels"
+                manageLink={"/samples/labels"}
             />
         </SidebarHeader>
         <SampleSidebarList items={allLabels.filter(item => sampleLabels.includes(item.id))} />
+        {Boolean(allLabels.length) || (
+            <SampleLabelsFooter>
+                No labels found. <Link to="/samples/labels">Create one</Link>.
+            </SampleLabelsFooter>
+        )}
     </SideBarSection>
 );
 

--- a/src/js/samples/components/Sidebar/Selector.js
+++ b/src/js/samples/components/Sidebar/Selector.js
@@ -5,15 +5,35 @@ import { BoxGroupSection, Icon, Input, SidebarHeaderButton } from "../../../base
 import { useFuse } from "../../../base/hooks";
 import { PopoverBody, usePopover } from "../../../base/Popover";
 import { SampleSidebarSelectorItem } from "./SelectorItem";
+import { Link } from "react-router-dom";
+import { getFontSize, fontWeight } from "../../../app/theme";
 
 const SampleSidebarSelectorInputContainer = styled(BoxGroupSection)`
     padding: 10px;
 `;
 
-export const SampleSidebarSelector = ({ render, sampleItems, selectedItems, sampleId, onUpdate, selectionType }) => {
+const StyledLinkButton = styled.div`
+    display: flex;
+
+    a {
+        margin-left: auto;
+        font-size: ${getFontSize("md")};
+        font-weight: ${fontWeight.thick};
+        padding: 10px 10px 10px 0px;
+    }
+`;
+
+export const SampleSidebarSelector = ({
+    render,
+    sampleItems,
+    selectedItems,
+    sampleId,
+    onUpdate,
+    selectionType,
+    manageLink
+}) => {
     const [results, term, setTerm] = useFuse(sampleItems, ["name"], [sampleId]);
     const [attributes, show, styles, setPopperElement, setReferenceElement, setShow] = usePopover();
-
     const handleToggle = useCallback(
         itemId => {
             onUpdate(xor(selectedItems, [itemId]));
@@ -32,15 +52,17 @@ export const SampleSidebarSelector = ({ render, sampleItems, selectedItems, samp
     ));
 
     return (
-        <React.Fragment>
-            <SidebarHeaderButton
-                aria-label={"select " + selectionType}
-                type="button"
-                ref={setReferenceElement}
-                onClick={setShow}
-            >
-                <Icon name="pen" />
-            </SidebarHeaderButton>
+        <>
+            {!sampleItems.length || (
+                <SidebarHeaderButton
+                    aria-label={`select ${selectionType}`}
+                    type="button"
+                    ref={setReferenceElement}
+                    onClick={setShow}
+                >
+                    <Icon name="pen" />
+                </SidebarHeaderButton>
+            )}
             {show && (
                 <PopoverBody ref={setPopperElement} show={show} style={styles.popper} {...attributes.popper}>
                     <SampleSidebarSelectorInputContainer>
@@ -53,8 +75,11 @@ export const SampleSidebarSelector = ({ render, sampleItems, selectedItems, samp
                         />
                     </SampleSidebarSelectorInputContainer>
                     {sampleItemComponents}
+                    <StyledLinkButton>
+                        <Link to={manageLink}> Manage</Link>
+                    </StyledLinkButton>
                 </PopoverBody>
             )}
-        </React.Fragment>
+        </>
     );
 };

--- a/src/js/samples/components/Sidebar/SelectorItem.js
+++ b/src/js/samples/components/Sidebar/SelectorItem.js
@@ -15,12 +15,17 @@ const StyledSampleSidebarSelectorItem = styled(BoxGroupSection)`
 `;
 
 const SampleSidebarSelectorItemCheck = styled.div`
-    align-items: start;
+    align-items: center;
     color: ${props => props.theme.color.greyDark};
     display: flex;
     justify-content: center;
     margin-right: 5px;
     width: 32px;
+`;
+
+const SampleSidebarSelectorItemContents = styled.div`
+    display: flex;
+    align-items: center;
 `;
 
 export const SampleSidebarSelectorItem = ({ checked, children, id, onClick }) => {
@@ -29,7 +34,7 @@ export const SampleSidebarSelectorItem = ({ checked, children, id, onClick }) =>
     return (
         <StyledSampleSidebarSelectorItem as="button" type={"button"} onClick={handleSelect}>
             <SampleSidebarSelectorItemCheck>{checked && <Icon name="check" />}</SampleSidebarSelectorItemCheck>
-            <div>{children}</div>
+            <SampleSidebarSelectorItemContents>{children}</SampleSidebarSelectorItemContents>
         </StyledSampleSidebarSelectorItem>
     );
 };

--- a/src/js/samples/components/Sidebar/Subtractions.js
+++ b/src/js/samples/components/Sidebar/Subtractions.js
@@ -4,8 +4,21 @@ import { SidebarHeader, SideBarSection } from "../../../base";
 import { getReadySubtractionShortlist } from "../../../subtraction/selectors";
 import { SampleSidebarList } from "./List";
 import { SampleSidebarSelector } from "./Selector";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+import { fontWeight, getColor, getFontSize } from "../../../app/theme";
 
 const SubtractionInner = ({ name }) => name;
+
+const SampleSubtractionFooter = styled.div`
+    display: flex;
+    color: ${props => getColor({ theme: props.theme, color: "greyDarkest" })};
+    a {
+        margin-left: 20px;
+        font-size: ${getFontSize("md")};
+        font-weight: ${fontWeight.thick};
+    }
+`;
 
 export const DefaultSubtractions = ({ defaultSubtractions, subtractionOptions, onUpdate }) => (
     <SideBarSection>
@@ -17,11 +30,17 @@ export const DefaultSubtractions = ({ defaultSubtractions, subtractionOptions, o
                 selectedItems={defaultSubtractions}
                 onUpdate={onUpdate}
                 selectionType="default subtractions"
+                manageLink={"/lol"}
             />
         </SidebarHeader>
         <SampleSidebarList
             items={subtractionOptions.filter(subtraction => defaultSubtractions.includes(subtraction.id))}
         />
+        {Boolean(subtractionOptions.length) || (
+            <SampleSubtractionFooter>
+                No subtractions found <Link to="/subtractions">Create one</Link>.
+            </SampleSubtractionFooter>
+        )}
     </SideBarSection>
 );
 


### PR DESCRIPTION
Images below for design proofing.

### **Outdated: see comment below for updated images**

No subtractions or labels available: 
![image](https://user-images.githubusercontent.com/59776400/149380790-24b98cc8-3c9e-438f-971d-416c9484f847.png)

Subtractions and labels available:
![image](https://user-images.githubusercontent.com/59776400/149381141-4d495861-4e2e-45e6-aca6-04cbdc22b5a1.png)
