### PR TITLE
clarify file upload status in ui

### DIFF
--- a/src/js/files/__tests__/reducer.test.js
+++ b/src/js/files/__tests__/reducer.test.js
@@ -6,7 +6,7 @@ import {
     UPLOAD_PROGRESS,
     FIND_FILES
 } from "../../app/actionTypes";
-import reducer, { initialState, cleanUploads } from "../reducer";
+import reducer, { initialState } from "../reducer";
 
 describe("filesReducer()", () => {
     it("should return the initial state on first pass", () => {
@@ -162,7 +162,8 @@ describe("filesReducer()", () => {
             expect(result).toEqual({
                 uploads: [
                     { localId: "foo", progress: 50 },
-                    { localId: "bar", progress: 22 }
+                    { localId: "bar", progress: 22 },
+                    { localId: "baz", progress: 100 }
                 ]
             });
         });
@@ -176,7 +177,8 @@ describe("filesReducer()", () => {
             expect(result).toEqual({
                 uploads: [
                     { localId: "foo", progress: 65 },
-                    { localId: "bar", progress: 0 }
+                    { localId: "bar", progress: 0 },
+                    { localId: "baz", progress: 100 }
                 ]
             });
         });
@@ -188,24 +190,33 @@ describe("filesReducer()", () => {
             };
             const result = reducer(state, action);
             expect(result).toEqual({
-                uploads: [{ localId: "bar", progress: 0 }]
+                uploads: [
+                    { localId: "foo", progress: 100 },
+                    { localId: "bar", progress: 0 },
+                    { localId: "baz", progress: 100 }
+                ]
             });
         });
     });
 
-    describe("cleanUploads()", () => {
-        it("should remove all and only finished uploads", () => {
-            const state = {
-                uploads: [
-                    { localId: "foo", progress: 32 },
-                    { localId: "bar", progress: 100 },
-                    { localId: "baz", progress: 0 }
-                ]
-            };
-
-            expect(cleanUploads(state)).toEqual({
-                uploads: [state.uploads[0], state.uploads[2]]
-            });
+    it("should remove upload when it successfully finishes", () => {
+        const state = {
+            uploads: [
+                { localId: "foo", progress: 50 },
+                { localId: "bar", progress: 0 },
+                { localId: "baz", progress: 100 }
+            ]
+        };
+        const action = {
+            type: UPLOAD.SUCCEEDED,
+            payload: { localId: "foo", progress: 100 }
+        };
+        const result = reducer(state, action);
+        expect(result).toEqual({
+            uploads: [
+                { localId: "bar", progress: 0 },
+                { localId: "baz", progress: 100 }
+            ]
         });
     });
 });

--- a/src/js/files/components/UploadItem.js
+++ b/src/js/files/components/UploadItem.js
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { getBorder } from "../../app/theme";
-import { AffixedProgressBar, Icon } from "../../base";
+import { AffixedProgressBar, Icon, Loader } from "../../base";
 import { byteSize } from "../../utils/utils";
 
 const StyledUploadItem = styled.div`
@@ -21,7 +21,9 @@ const UploadItemTitle = styled.div`
     i.fas {
         margin-right: 5px;
     }
-
+    div:first-child {
+        margin-right: 5px;
+    }
     span:last-child {
         margin-left: auto;
     }
@@ -31,7 +33,7 @@ export const UploadItem = ({ name, progress, size }) => (
     <StyledUploadItem>
         <AffixedProgressBar now={progress} />
         <UploadItemTitle>
-            <Icon name="upload" />
+            {progress === 100 ? <Loader size="14px" /> : <Icon name="upload" />}
             <span>{name}</span>
             <span>{byteSize(size)}</span>
         </UploadItemTitle>

--- a/src/js/files/reducer.js
+++ b/src/js/files/reducer.js
@@ -42,18 +42,6 @@ export const appendUpload = (state, action) => {
 };
 
 /**
- * Remove finished uploads.
- *
- * @func
- * @param state {object}
- * @returns {object}
- */
-export const cleanUploads = state => ({
-    ...state,
-    uploads: reject(state.uploads, { progress: 100 })
-});
-
-/**
  * Update the progress for an upload.
  *
  * @param state
@@ -104,13 +92,16 @@ export const filesReducer = createReducer(initialState, builder => {
             };
         })
         .addCase(UPLOAD.REQUESTED, (state, action) => {
-            return cleanUploads(appendUpload(state, action.payload));
+            return appendUpload(state, action.payload);
+        })
+        .addCase(UPLOAD.SUCCEEDED, (state, action) => {
+            state.uploads = reject(state.uploads, { localId: action.payload.localId });
         })
         .addCase(UPLOAD_SAMPLE_FILE.REQUESTED, (state, action) => {
-            return cleanUploads(appendUpload(state, action.payload));
+            return appendUpload(state, action.payload);
         })
         .addCase(UPLOAD_PROGRESS, (state, action) => {
-            return cleanUploads(updateProgress(state, action.payload));
+            return updateProgress(state, action.payload);
         });
 });
 

--- a/src/js/files/selectors.js
+++ b/src/js/files/selectors.js
@@ -8,7 +8,7 @@ export const getFilesById = createSelector(getFiles, files => keyBy(files, "id")
 export const getFilteredFileIds = createSelector(getFiles, list =>
     map(
         sortBy(
-            reject(list, document => document.reserved),
+            reject(list, document => document.reserved || !document.ready),
             "uploaded_at"
         ).reverse(),
         "id"


### PR DESCRIPTION
Changes:
 -  Removal of an item from the upload bar now occurs only when the file is ready.
 - When item is fully uploaded but not yet ready the upload bar displays a spinner instead of the the upload icon
 - File list is only updated with the new upload once the file is marked as ready

Screenshot of file manager when the file is done uploading but not ready:

![image](https://user-images.githubusercontent.com/59776400/149826527-8498f03a-87ba-40fe-9bf9-6a850b9a2981.png)
