### PR TITLE
feat: add multiselect label managment to sample view

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - backend
 
   api:
-    image: virtool/virtool:6.6.5
+    image: virtool/virtool:6.6.9
     depends_on:
       - mongo
       - redis
@@ -60,7 +60,7 @@ services:
       - vt_data:/data
 
   jobs-api:
-    image: virtool/virtool:6.6.5
+    image: virtool/virtool:6.6.3
     depends_on:
       - mongo
       - redis

--- a/src/js/base/SideBar.js
+++ b/src/js/base/SideBar.js
@@ -43,6 +43,7 @@ export const SidebarHeader = styled.h3`
     font-size: ${getFontSize("lg")};
     font-weight: ${fontWeight.thick};
     margin: 5px 0 10px;
+    height: 32px;
 
     ${SidebarHeaderButton}, a {
         margin-left: auto;

--- a/src/js/indexes/components/__tests__/Files.test.js
+++ b/src/js/indexes/components/__tests__/Files.test.js
@@ -35,7 +35,6 @@ describe("<IndexDetail />", () => {
     });
     it("should include url", () => {
         renderWithProviders(<Files {...props} />);
-        // console.log(screen.getAllByRole("link", {})[0]);
         expect(screen.getAllByRole("link", {})[0]).toHaveAttribute("href", "https://Virtool.ca/testUrl/foo");
     });
 });

--- a/src/js/samples/components/Label.js
+++ b/src/js/samples/components/Label.js
@@ -43,6 +43,13 @@ export const SampleLabel = styled(({ className, color, name, role }) => (
     </StyledSampleLabel>
 ))``;
 
+export const SampleMultiSelectLabel = styled(({ className, color, name, role, partiallySelected }) => (
+    <StyledSampleLabel className={className} color={color} role={role}>
+        {color && <Icon name={partiallySelected ? "adjust" : "circle"} />}
+        {name}
+    </StyledSampleLabel>
+))``;
+
 export const SmallSampleLabel = styled(SampleLabel)`
     font-size: ${getFontSize("sm")};
     padding: 2px 7px 2px 5px;

--- a/src/js/samples/components/List.js
+++ b/src/js/samples/components/List.js
@@ -11,6 +11,7 @@ import { findSamples } from "../actions";
 import { SampleFilters } from "./Filter/Filters";
 import SampleItem from "./Item/Item";
 import SampleToolbar from "./Toolbar";
+import SampleLabels from "./Sidebar/ManageLabels";
 
 const SamplesListHeader = styled.div`
     grid-column: 1;
@@ -55,7 +56,7 @@ export const SamplesList = ({
     }
 
     return (
-        <React.Fragment>
+        <>
             <QuickAnalysis />
             <StyledSamplesList>
                 <SamplesListHeader>
@@ -77,9 +78,9 @@ export const SamplesList = ({
                         />
                     )}
                 </SamplesListContent>
-                {!selected.length && <SampleFilters />}
+                {selected.length ? <SampleLabels /> : <SampleFilters />}
             </StyledSamplesList>
-        </React.Fragment>
+        </>
     );
 };
 

--- a/src/js/samples/components/Sidebar/Labels.js
+++ b/src/js/samples/components/Sidebar/Labels.js
@@ -7,6 +7,7 @@ import { SampleSidebarSelector } from "./Selector";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { getFontSize, fontWeight, getColor } from "../../../app/theme";
+import { xor } from "lodash-es";
 
 const SampleLabelInner = ({ name, color, description }) => (
     <>
@@ -35,7 +36,9 @@ export const SampleLabels = ({ allLabels, sampleLabels, onUpdate }) => (
                 )}
                 sampleItems={allLabels}
                 selectedItems={sampleLabels}
-                onUpdate={onUpdate}
+                onUpdate={labelId => {
+                    onUpdate(xor(sampleLabels, [labelId]));
+                }}
                 selectionType="labels"
                 manageLink={"/samples/labels"}
             />

--- a/src/js/samples/components/Sidebar/List.js
+++ b/src/js/samples/components/Sidebar/List.js
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
-import { SampleLabel } from "../Label";
+import { SampleLabel, SampleMultiSelectLabel } from "../Label";
+import { map } from "lodash-es";
 
 const SampleSidebarListItem = styled(SampleLabel)`
     background-color: ${props => props.theme.color.white};
@@ -16,6 +17,23 @@ const StyledSampleSidebarList = styled.div`
 export const SampleSidebarList = ({ items }) => {
     const sampleItemComponents = items.map(item => (
         <SampleSidebarListItem key={item.id} color={item.color} name={item.name} />
+    ));
+
+    return <StyledSampleSidebarList>{sampleItemComponents}</StyledSampleSidebarList>;
+};
+
+const SampleSidebarMultiSelectListItem = styled(SampleMultiSelectLabel)`
+    background-color: ${props => props.theme.color.white};
+    display: inline;
+    margin: 4px 0px;
+    :not(:last-child) {
+        margin-right: 8px;
+    }
+`;
+
+export const SampleSidebarMultiselectList = ({ items }) => {
+    const sampleItemComponents = map(items, ({ id, color, name, allLabeled }) => (
+        <SampleSidebarMultiSelectListItem key={id} color={color} name={name} partiallySelected={!allLabeled} />
     ));
 
     return <StyledSampleSidebarList>{sampleItemComponents}</StyledSampleSidebarList>;

--- a/src/js/samples/components/Sidebar/ManageLabels.js
+++ b/src/js/samples/components/Sidebar/ManageLabels.js
@@ -1,0 +1,90 @@
+import React from "react";
+import { connect } from "react-redux";
+import { SidebarHeader, SideBarSection } from "../../../base";
+import { SmallSampleLabel } from "../Label";
+import { SampleSidebarMultiselectList } from "./List";
+import { SampleSidebarSelector } from "./Selector";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+import { getFontSize, fontWeight, getColor } from "../../../app/theme";
+import { map, forEach, union, reject } from "lodash-es";
+import { editSample } from "../../actions";
+import { getSelectedSamples, getSelectedLabels, getPartiallySelectedLabels } from "../../selectors";
+
+const SampleLabelsFooter = styled.div`
+    display: flex;
+    color: ${props => getColor({ theme: props.theme, color: "greyDarkest" })};
+    a {
+        margin-left: 5px;
+        font-size: ${getFontSize("md")};
+        font-weight: ${fontWeight.thick};
+    }
+`;
+
+const StyledSideBarSection = styled(SideBarSection)`
+    grid-row: 2;
+    align-self: start;
+`;
+
+const SampleLabelInner = ({ name, color, description }) => (
+    <>
+        <SmallSampleLabel color={color} name={name} />
+        <p>{description}</p>
+    </>
+);
+
+export const ManageLabels = ({
+    allLabels,
+    selectedSamples,
+    selectedLabels,
+    onLabelUpdate,
+    partiallySelectedLabels
+}) => {
+    const onUpdate = label => onLabelUpdate(selectedSamples, selectedLabels, label);
+    return (
+        <StyledSideBarSection>
+            <SidebarHeader>
+                Manage Labels
+                <SampleSidebarSelector
+                    render={({ name, color, description }) => (
+                        <SampleLabelInner name={name} color={color} description={description} />
+                    )}
+                    sampleItems={allLabels}
+                    selectedItems={map(selectedLabels, label => label.id)}
+                    partiallySelectedItems={map(partiallySelectedLabels, label => label.id)}
+                    onUpdate={onUpdate}
+                    selectionType="labels"
+                    manageLink={"/samples/labels"}
+                />
+            </SidebarHeader>
+            <SampleSidebarMultiselectList items={selectedLabels} onUpdate={onUpdate} />
+            {Boolean(allLabels.length) || (
+                <SampleLabelsFooter>
+                    No labels found. <Link to="/samples/labels">Create one</Link>.
+                </SampleLabelsFooter>
+            )}
+        </StyledSideBarSection>
+    );
+};
+
+export const mapStateToProps = state => ({
+    allLabels: state.labels.documents,
+    selectedSamples: getSelectedSamples(state),
+    selectedLabels: getSelectedLabels(state),
+    partiallySelectedLabels: getPartiallySelectedLabels(state)
+});
+
+export const mapDispatchToProps = dispatch => ({
+    onLabelUpdate: (selectedSamples, selectedLabels, label) => {
+        forEach(selectedSamples, sample => {
+            const sampleLabelIds = map(sample.labels, label => label.id);
+            if (!selectedLabels[label] || !selectedLabels[label].allLabeled) {
+                dispatch(editSample(sample.id, { labels: union(sampleLabelIds, [label]) }));
+            } else {
+                dispatch(editSample(sample.id, { labels: reject(sampleLabelIds, id => label === id) }));
+            }
+        });
+    }
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ManageLabels);

--- a/src/js/samples/components/Sidebar/Selector.js
+++ b/src/js/samples/components/Sidebar/Selector.js
@@ -1,5 +1,4 @@
-import { xor } from "lodash-es";
-import React, { useCallback } from "react";
+import React from "react";
 import styled from "styled-components";
 import { BoxGroupSection, Icon, Input, SidebarHeaderButton } from "../../../base";
 import { useFuse } from "../../../base/hooks";
@@ -27,6 +26,7 @@ export const SampleSidebarSelector = ({
     render,
     sampleItems,
     selectedItems,
+    partiallySelectedItems = [],
     sampleId,
     onUpdate,
     selectionType,
@@ -34,18 +34,13 @@ export const SampleSidebarSelector = ({
 }) => {
     const [results, term, setTerm] = useFuse(sampleItems, ["name"], [sampleId]);
     const [attributes, show, styles, setPopperElement, setReferenceElement, setShow] = usePopover();
-    const handleToggle = useCallback(
-        itemId => {
-            onUpdate(xor(selectedItems, [itemId]));
-        },
-        [sampleId, selectedItems, onUpdate]
-    );
     const sampleItemComponents = results.map(item => (
         <SampleSidebarSelectorItem
             key={item.id}
-            checked={selectedItems.includes(item.id)}
+            selected={selectedItems.includes(item.id)}
+            partiallySelected={partiallySelectedItems.includes(item.id)}
             {...item}
-            onClick={handleToggle}
+            onClick={onUpdate}
         >
             {render(item)}
         </SampleSidebarSelectorItem>

--- a/src/js/samples/components/Sidebar/SelectorItem.js
+++ b/src/js/samples/components/Sidebar/SelectorItem.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React from "react";
 import styled from "styled-components";
 import { getFontSize } from "../../../app/theme";
 import { BoxGroupSection, Icon } from "../../../base";
@@ -28,12 +28,14 @@ const SampleSidebarSelectorItemContents = styled.div`
     align-items: center;
 `;
 
-export const SampleSidebarSelectorItem = ({ checked, children, id, onClick }) => {
-    const handleSelect = useCallback(() => onClick(id), [id, onClick]);
+export const SampleSidebarSelectorItem = ({ selected, partiallySelected, children, id, onClick, name }) => {
+    const handleSelect = () => onClick(id);
 
     return (
-        <StyledSampleSidebarSelectorItem as="button" type={"button"} onClick={handleSelect}>
-            <SampleSidebarSelectorItemCheck>{checked && <Icon name="check" />}</SampleSidebarSelectorItemCheck>
+        <StyledSampleSidebarSelectorItem as="button" type={"button"} onClick={handleSelect} aria-label={name}>
+            <SampleSidebarSelectorItemCheck>
+                {selected && <Icon name={partiallySelected ? "minus" : "check"} />}
+            </SampleSidebarSelectorItemCheck>
             <SampleSidebarSelectorItemContents>{children}</SampleSidebarSelectorItemContents>
         </StyledSampleSidebarSelectorItem>
     );

--- a/src/js/samples/components/Sidebar/Subtractions.js
+++ b/src/js/samples/components/Sidebar/Subtractions.js
@@ -7,6 +7,7 @@ import { SampleSidebarSelector } from "./Selector";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { fontWeight, getColor, getFontSize } from "../../../app/theme";
+import { xor } from "lodash-es";
 
 const SubtractionInner = ({ name }) => name;
 
@@ -28,9 +29,11 @@ export const DefaultSubtractions = ({ defaultSubtractions, subtractionOptions, o
                 render={({ name }) => <SubtractionInner name={name} />}
                 sampleItems={subtractionOptions}
                 selectedItems={defaultSubtractions}
-                onUpdate={onUpdate}
+                onUpdate={subtractionId => {
+                    onUpdate(xor(defaultSubtractions, [subtractionId]));
+                }}
                 selectionType="default subtractions"
-                manageLink={"/lol"}
+                manageLink={"/subtractions"}
             />
         </SidebarHeader>
         <SampleSidebarList

--- a/src/js/samples/components/Sidebar/__tests__/ManageLabels.test.js
+++ b/src/js/samples/components/Sidebar/__tests__/ManageLabels.test.js
@@ -1,0 +1,171 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { ManageLabels, mapDispatchToProps } from "../ManageLabels";
+import { BrowserRouter } from "react-router-dom";
+import { getSelectedSamples, getSelectedLabels, getPartiallySelectedLabels } from "../../../selectors";
+
+const routerRenderWithProviders = ui => {
+    const routerUi = <BrowserRouter> {ui} </BrowserRouter>;
+    return renderWithProviders(routerUi);
+};
+
+describe("<ManageLabels>", () => {
+    let props;
+    let state;
+    beforeEach(() => {
+        state = {
+            samples: {
+                selected: ["foo_sample"],
+                documents: [
+                    {
+                        name: "Foo Sample",
+                        id: "foo_sample",
+                        labels: [{ description: "", id: 1, name: "test", color: "#FCA5A5" }]
+                    },
+                    {
+                        name: "Bar Sample",
+                        id: "bar_sample",
+                        labels: [
+                            { description: "", id: 1, name: "test", color: "#FCA5A5" },
+                            { description: "", id: 2, name: "test2", color: "#FCA5A5" }
+                        ]
+                    }
+                ]
+            }
+        };
+        props = {
+            allLabels: [
+                { description: "", id: 1, name: "test", color: "#FCA5A5" },
+                { description: "", id: 2, name: "test2", color: "#FCA5A5" },
+                { description: "", id: 3, name: "test3", color: "#FCA5A5" }
+            ],
+            selectedSamples: [
+                {
+                    name: "Foo Sample",
+                    id: "foo_sample",
+                    labels: [{ description: "", id: 1, name: "test", color: "#FCA5A5" }]
+                }
+            ],
+            selectedLabels: {
+                1: {
+                    description: "",
+                    id: 1,
+                    name: "test",
+                    color: "#FCA5A5",
+                    allLabeled: true
+                }
+            },
+            partiallySelectedLabels: [],
+            onLabelUpdate: jest.fn()
+        };
+    });
+
+    const updateProps = (props, state) => ({
+        ...props,
+        selectedSamples: getSelectedSamples(state),
+        selectedLabels: getSelectedLabels(state),
+        partiallySelectedLabels: getPartiallySelectedLabels(state)
+    });
+
+    it("should render", () => {
+        const wrapper = shallow(<ManageLabels {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it("should be disabled if no labels exist", () => {
+        props.allLabels = [];
+        const wrapper = shallow(<ManageLabels {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it("should display labels of one selected document", () => {
+        renderWithProviders(<ManageLabels {...props} />);
+        expect(screen.getByText("test")).toBeInTheDocument();
+    });
+    it("should display labels of two selected documents", () => {
+        state.samples.selected = ["foo_sample", "bar_sample"];
+        renderWithProviders(<ManageLabels {...updateProps(props, state)} />);
+        expect(screen.getByText(`test2`)).toBeInTheDocument();
+    });
+
+    it("should call onLabelUpdate with selectedSamples, selectedLabels, and the label to be changed", () => {
+        state.samples.selected = ["foo_sample", "bar_sample"];
+        props = updateProps(props, state);
+        routerRenderWithProviders(<ManageLabels {...props} />);
+        userEvent.click(screen.getByRole("button", { name: "select labels" }));
+        userEvent.click(screen.getByRole("button", { name: "test3" }));
+        expect(props.onLabelUpdate).toHaveBeenCalledWith(props.selectedSamples, props.selectedLabels, 3);
+    });
+});
+
+describe("mapDispatchToProps", () => {
+    let selectedSamples;
+    let selectedLabels;
+    let dispatch;
+    let onLabelUpdate;
+
+    beforeEach(() => {
+        selectedSamples = [
+            {
+                name: "Foo Sample",
+                id: "foo_sample",
+                labels: [{ description: "", id: 1, name: "test", color: "#FCA5A5" }]
+            },
+            {
+                name: "Bar Sample",
+                id: "bar_sample",
+                labels: [
+                    { description: "", id: 1, name: "test", color: "#FCA5A5" },
+                    { description: "", id: 2, name: "test2", color: "#FCA5A5" }
+                ]
+            }
+        ];
+        selectedLabels = {
+            1: {
+                description: "",
+                id: 1,
+                name: "test",
+                color: "#FCA5A5",
+                allLabeled: true
+            },
+            2: { description: "", id: 2, name: "test2", color: "#FCA5A5", allLabeled: false }
+        };
+        dispatch = jest.fn();
+        onLabelUpdate = mapDispatchToProps(dispatch).onLabelUpdate;
+    });
+
+    it("should add new label when label is unselected", () => {
+        onLabelUpdate(selectedSamples, selectedLabels, 3);
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith({
+            payload: { sampleId: "foo_sample", update: { labels: [1, 3] } },
+            type: "UPDATE_SAMPLE_REQUESTED"
+        });
+        expect(dispatch).toHaveBeenCalledWith({
+            payload: { sampleId: "bar_sample", update: { labels: [1, 2, 3] } },
+            type: "UPDATE_SAMPLE_REQUESTED"
+        });
+    });
+
+    it("should add new label when label is partly selected", () => {
+        onLabelUpdate(selectedSamples, selectedLabels, 2);
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith({
+            payload: { sampleId: "foo_sample", update: { labels: [1, 2] } },
+            type: "UPDATE_SAMPLE_REQUESTED"
+        });
+    });
+    it("remove label from all samples when it is selected for all", () => {
+        onLabelUpdate(selectedSamples, selectedLabels, 1);
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith({
+            payload: { sampleId: "foo_sample", update: { labels: [] } },
+            type: "UPDATE_SAMPLE_REQUESTED"
+        });
+        expect(dispatch).toHaveBeenCalledWith({
+            payload: { sampleId: "bar_sample", update: { labels: [2] } },
+            type: "UPDATE_SAMPLE_REQUESTED"
+        });
+    });
+});

--- a/src/js/samples/components/Sidebar/__tests__/__snapshots__/ManageLabels.test.js.snap
+++ b/src/js/samples/components/Sidebar/__tests__/__snapshots__/ManageLabels.test.js.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ManageLabels> should be disabled if no labels exist 1`] = `
+<ManageLabels__StyledSideBarSection>
+  <SideBar__SidebarHeader>
+    Manage Labels
+    <SampleSidebarSelector
+      manageLink="/samples/labels"
+      onUpdate={[Function]}
+      partiallySelectedItems={Array []}
+      render={[Function]}
+      sampleItems={Array []}
+      selectedItems={
+        Array [
+          1,
+        ]
+      }
+      selectionType="labels"
+    />
+  </SideBar__SidebarHeader>
+  <SampleSidebarMultiselectList
+    items={
+      Object {
+        "1": Object {
+          "allLabeled": true,
+          "color": "#FCA5A5",
+          "description": "",
+          "id": 1,
+          "name": "test",
+        },
+      }
+    }
+    onUpdate={[Function]}
+  />
+  <ManageLabels__SampleLabelsFooter>
+    No labels found. 
+    <Link
+      to="/samples/labels"
+    >
+      Create one
+    </Link>
+    .
+  </ManageLabels__SampleLabelsFooter>
+</ManageLabels__StyledSideBarSection>
+`;
+
+exports[`<ManageLabels> should render 1`] = `
+<ManageLabels__StyledSideBarSection>
+  <SideBar__SidebarHeader>
+    Manage Labels
+    <SampleSidebarSelector
+      manageLink="/samples/labels"
+      onUpdate={[Function]}
+      partiallySelectedItems={Array []}
+      render={[Function]}
+      sampleItems={
+        Array [
+          Object {
+            "color": "#FCA5A5",
+            "description": "",
+            "id": 1,
+            "name": "test",
+          },
+          Object {
+            "color": "#FCA5A5",
+            "description": "",
+            "id": 2,
+            "name": "test2",
+          },
+          Object {
+            "color": "#FCA5A5",
+            "description": "",
+            "id": 3,
+            "name": "test3",
+          },
+        ]
+      }
+      selectedItems={
+        Array [
+          1,
+        ]
+      }
+      selectionType="labels"
+    />
+  </SideBar__SidebarHeader>
+  <SampleSidebarMultiselectList
+    items={
+      Object {
+        "1": Object {
+          "allLabeled": true,
+          "color": "#FCA5A5",
+          "description": "",
+          "id": 1,
+          "name": "test",
+        },
+      }
+    }
+    onUpdate={[Function]}
+  />
+  <Component />
+</ManageLabels__StyledSideBarSection>
+`;


### PR DESCRIPTION
**Changelog:**

Multiselect version of sample list view now permits label management for multiple samples at a time
 - Selecting a label will attempt to apply the label to all selected samples unless all select samples already have the label applied
 - selecting a label that is already applied to all selected labels will result in the label being cleared from all samples
 -  dropdown and label list indicate which labels are fully selected vs partly selected vs not selected. 
 - dropdown allows addition or removal of labels.

Images updated: 28/01/2022
Nothing selected:
![image](https://user-images.githubusercontent.com/59776400/151613209-3b736038-fb7c-474b-a2eb-46ee38af6bfd.png)


**Multiselect no dropdown:**
![image](https://user-images.githubusercontent.com/59776400/151613245-919c238d-7902-401c-9fd5-850e77438c7f.png)


**Multiselect dropdown:**
![image](https://user-images.githubusercontent.com/59776400/151613279-264e61da-335d-4a3f-a709-4b058a1441c4.png)


