### PR TITLE
prevent ScrollList page request duplication

### DIFF
--- a/src/js/base/ScrollList.js
+++ b/src/js/base/ScrollList.js
@@ -8,6 +8,7 @@ export const getScrollRatio = () =>
 export class ScrollList extends React.Component {
     componentDidMount() {
         window.addEventListener("scroll", this.onScroll);
+        this.prevPage = 0;
     }
 
     componentWillUnmount() {
@@ -15,7 +16,13 @@ export class ScrollList extends React.Component {
     }
 
     onScroll = () => {
-        if (this.props.documents.length && this.props.page < this.props.pageCount && getScrollRatio() > 0.8) {
+        if (
+            this.props.page !== this.prevPage &&
+            this.props.documents.length &&
+            this.props.page < this.props.pageCount &&
+            getScrollRatio() > 0.8
+        ) {
+            this.prevPage = this.props.page;
             this.props.onLoadNextPage(this.props.page + 1);
         }
     };


### PR DESCRIPTION
Prevents page request spam by having `ScrollList` remember the last page requested and prevent sending a repeat request if it matches the current page being requested.

Alternative solution would be to throttle via Sagas or Lodash, but both of those solutions would permit duplication in the case that the user had a very slow connection and/or potentially slow down legitimate scrolling.