### PR TITLE
improve spacing consistency of user attribution messages

### DIFF
--- a/src/js/base/Attribution.js
+++ b/src/js/base/Attribution.js
@@ -7,9 +7,9 @@ import { RelativeTime } from "./RelativeTime";
 export const UnstyledAttribution = ({ className, time, user, verb = "created" }) => (
     <span className={className}>
         {user ? <InitialIcon size="md" handle={user} /> : null}
-        <span>{user}</span>
-        <span>{user ? verb : capitalize(verb)}</span>
-        <RelativeTime time={time} />
+        <span>
+            {user} {user ? verb : capitalize(verb)} <RelativeTime time={time} />
+        </span>
     </span>
 );
 
@@ -17,10 +17,6 @@ export const Attribution = styled(UnstyledAttribution)`
     align-items: center;
     display: inline-flex;
     font-size: inherit;
-
-    *:not(:first-child) {
-        margin-left: 3px;
-    }
     .InitialIcon {
         margin-right: 5px;
     }
@@ -28,9 +24,7 @@ export const Attribution = styled(UnstyledAttribution)`
 
 export const UnstyledNameAttribution = ({ className, user, verb = "created" }) => (
     <span className={className}>
-        <span>{capitalize(verb)} by </span>
-        {user ? <InitialIcon size="md" handle={user} /> : null}
-        <span>{user}</span>
+        {capitalize(verb)} by {user ? <InitialIcon size="md" handle={user} /> : null} {user}
     </span>
 );
 
@@ -39,11 +33,9 @@ export const NameAttribution = styled(UnstyledNameAttribution)`
     display: inline-flex;
     font-size: inherit;
 
-    *:not(:first-child) {
-        margin-left: 3px;
-    }
+
     .InitialIcon {
-        margin-right: 1px;
-        margin-left 7px;
+        margin-right: 3px;
+        margin-left 6px;
     }
 `;

--- a/src/js/base/InitialIcon.js
+++ b/src/js/base/InitialIcon.js
@@ -25,7 +25,7 @@ const getFontSize = size => fontSize[size];
 
 export const StyledInitialIcon = styled.span`
     border-radius: 50%;
-    display: flex;
+    display: inline-flex;
     flex: 0 0 auto;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
Changed spacing from using css margins to using regular spaces to normalize the distances.

**OTU:**
![image](https://user-images.githubusercontent.com/59776400/151214738-a9ba7843-a081-461d-a59c-fdc2a82e4947.png)

**Samples:**
![image](https://user-images.githubusercontent.com/59776400/151214778-a3c00484-011c-4d0d-ada0-058e657e1660.png)

**Subtractions:**
![image](https://user-images.githubusercontent.com/59776400/151214808-175b52ba-2d5f-468f-8cc6-849c04f088de.png)
