### PR TITLE
Prevent unexpected removal of samples from quick analysis selection

### DIFF
--- a/src/js/samples/components/List.js
+++ b/src/js/samples/components/List.js
@@ -12,6 +12,7 @@ import { SampleFilters } from "./Filter/Filters";
 import SampleItem from "./Item/Item";
 import SampleToolbar from "./Toolbar";
 import SampleLabels from "./Sidebar/ManageLabels";
+import { useLocation } from "react-router-dom";
 
 const SamplesListHeader = styled.div`
     grid-column: 1;
@@ -31,7 +32,6 @@ const StyledSamplesList = styled.div`
 export const SamplesList = ({
     documents,
     loading,
-    match,
     page,
     pageCount,
     totalCount,
@@ -41,9 +41,10 @@ export const SamplesList = ({
 }) => {
     useEffect(onFindOther, [null]);
 
+    const { search } = useLocation();
     useEffect(() => {
         onFindSamples(1);
-    }, [match]);
+    }, [search]);
 
     if (loading) {
         return <LoadingPlaceholder />;


### PR DESCRIPTION
Changes `sampleList` so that it only refreshes the sample list only when the filters change. (and on full reload of course) Prevents the quick analysis opening resulting in the sample list reload, and therefore forgetting any samples beyond the 25 sample cutoff of the first page.