### PR TITLE
update pathoscope analysis export links

### DIFF
--- a/src/js/analyses/components/Pathoscope/Toolbar.js
+++ b/src/js/analyses/components/Pathoscope/Toolbar.js
@@ -84,13 +84,15 @@ export const PathoscopeToolbar = ({
             </Button>
             <Dropdown>
                 <DropdownButton>
-                    <Icon name="file-download" /> Export <Icon name="caret-down" />
+                    <span>
+                        <Icon name="file-download" /> Export <Icon name="caret-down" />
+                    </span>
                 </DropdownButton>
                 <DropdownMenuList>
-                    <DropdownMenuItem onSelect={() => followDownload(`/download/analyses/${analysisId}.csv`)}>
+                    <DropdownMenuItem onSelect={() => followDownload(`api/analyses/documents/${analysisId}.csv`)}>
                         <Icon name="file-csv" /> CSV
                     </DropdownMenuItem>
-                    <DropdownMenuItem onSelect={() => followDownload(`/download/analyses/${analysisId}.xlsx`)}>
+                    <DropdownMenuItem onSelect={() => followDownload(`api/analyses/documents/${analysisId}.xlsx`)}>
                         <Icon name="file-excel" /> Excel
                     </DropdownMenuItem>
                 </DropdownMenuList>

--- a/src/js/analyses/components/Pathoscope/__tests__/__snapshots__/Toolbar.test.js.snap
+++ b/src/js/analyses/components/Pathoscope/__tests__/__snapshots__/Toolbar.test.js.snap
@@ -64,17 +64,19 @@ exports[`<Toolbar /> should render 1`] = `
   </Button>
   <Menu>
     <DropdownButton>
-      <Icon
-        faStyle="fas"
-        fixedWidth={false}
-        name="file-download"
-      />
-       Export 
-      <Icon
-        faStyle="fas"
-        fixedWidth={false}
-        name="caret-down"
-      />
+      <span>
+        <Icon
+          faStyle="fas"
+          fixedWidth={false}
+          name="file-download"
+        />
+         Export 
+        <Icon
+          faStyle="fas"
+          fixedWidth={false}
+          name="caret-down"
+        />
+      </span>
     </DropdownButton>
     <Dropdown__DropdownMenuList>
       <Dropdown__DropdownMenuItem
@@ -166,17 +168,19 @@ exports[`<Toolbar /> should render when [filterIsolates=false] 1`] = `
   </Button>
   <Menu>
     <DropdownButton>
-      <Icon
-        faStyle="fas"
-        fixedWidth={false}
-        name="file-download"
-      />
-       Export 
-      <Icon
-        faStyle="fas"
-        fixedWidth={false}
-        name="caret-down"
-      />
+      <span>
+        <Icon
+          faStyle="fas"
+          fixedWidth={false}
+          name="file-download"
+        />
+         Export 
+        <Icon
+          faStyle="fas"
+          fixedWidth={false}
+          name="caret-down"
+        />
+      </span>
     </DropdownButton>
     <Dropdown__DropdownMenuList>
       <Dropdown__DropdownMenuItem
@@ -268,17 +272,19 @@ exports[`<Toolbar /> should render when [filterOTUs=false] 1`] = `
   </Button>
   <Menu>
     <DropdownButton>
-      <Icon
-        faStyle="fas"
-        fixedWidth={false}
-        name="file-download"
-      />
-       Export 
-      <Icon
-        faStyle="fas"
-        fixedWidth={false}
-        name="caret-down"
-      />
+      <span>
+        <Icon
+          faStyle="fas"
+          fixedWidth={false}
+          name="file-download"
+        />
+         Export 
+        <Icon
+          faStyle="fas"
+          fixedWidth={false}
+          name="caret-down"
+        />
+      </span>
     </DropdownButton>
     <Dropdown__DropdownMenuList>
       <Dropdown__DropdownMenuItem
@@ -370,17 +376,19 @@ exports[`<Toolbar /> should render when [showPathoscopeReads=true] 1`] = `
   </Button>
   <Menu>
     <DropdownButton>
-      <Icon
-        faStyle="fas"
-        fixedWidth={false}
-        name="file-download"
-      />
-       Export 
-      <Icon
-        faStyle="fas"
-        fixedWidth={false}
-        name="caret-down"
-      />
+      <span>
+        <Icon
+          faStyle="fas"
+          fixedWidth={false}
+          name="file-download"
+        />
+         Export 
+        <Icon
+          faStyle="fas"
+          fixedWidth={false}
+          name="caret-down"
+        />
+      </span>
     </DropdownButton>
     <Dropdown__DropdownMenuList>
       <Dropdown__DropdownMenuItem
@@ -472,17 +480,19 @@ exports[`<Toolbar /> should render when [sortDescending=false] 1`] = `
   </Button>
   <Menu>
     <DropdownButton>
-      <Icon
-        faStyle="fas"
-        fixedWidth={false}
-        name="file-download"
-      />
-       Export 
-      <Icon
-        faStyle="fas"
-        fixedWidth={false}
-        name="caret-down"
-      />
+      <span>
+        <Icon
+          faStyle="fas"
+          fixedWidth={false}
+          name="file-download"
+        />
+         Export 
+        <Icon
+          faStyle="fas"
+          fixedWidth={false}
+          name="caret-down"
+        />
+      </span>
     </DropdownButton>
     <Dropdown__DropdownMenuList>
       <Dropdown__DropdownMenuItem
@@ -574,17 +584,19 @@ exports[`<Toolbar /> should render when [sortKey="depth"] 1`] = `
   </Button>
   <Menu>
     <DropdownButton>
-      <Icon
-        faStyle="fas"
-        fixedWidth={false}
-        name="file-download"
-      />
-       Export 
-      <Icon
-        faStyle="fas"
-        fixedWidth={false}
-        name="caret-down"
-      />
+      <span>
+        <Icon
+          faStyle="fas"
+          fixedWidth={false}
+          name="file-download"
+        />
+         Export 
+        <Icon
+          faStyle="fas"
+          fixedWidth={false}
+          name="caret-down"
+        />
+      </span>
     </DropdownButton>
     <Dropdown__DropdownMenuList>
       <Dropdown__DropdownMenuItem
@@ -676,17 +688,19 @@ exports[`<Toolbar /> should render when [sortKey="weight"] 1`] = `
   </Button>
   <Menu>
     <DropdownButton>
-      <Icon
-        faStyle="fas"
-        fixedWidth={false}
-        name="file-download"
-      />
-       Export 
-      <Icon
-        faStyle="fas"
-        fixedWidth={false}
-        name="caret-down"
-      />
+      <span>
+        <Icon
+          faStyle="fas"
+          fixedWidth={false}
+          name="file-download"
+        />
+         Export 
+        <Icon
+          faStyle="fas"
+          fixedWidth={false}
+          name="caret-down"
+        />
+      </span>
     </DropdownButton>
     <Dropdown__DropdownMenuList>
       <Dropdown__DropdownMenuItem


### PR DESCRIPTION
**Changes:**
 - Updates export links for the pathoscope analysis view
 - Wraps export dropdown button children in span to prevent flexbox removing spaces between icons and text.


Wrapped with span:
![image](https://user-images.githubusercontent.com/59776400/152034899-a04640bd-1888-4ad1-8a0d-51656f3c6847.png)

Unwrapped:
![image](https://user-images.githubusercontent.com/59776400/152034954-d7c442c4-1a65-446e-bae3-6b76c7255df5.png)
