### PR TITLE
Update the reference settings add user dialog to show human readable name

### DIFF
--- a/src/js/references/components/Detail/AddMember.js
+++ b/src/js/references/components/Detail/AddMember.js
@@ -47,9 +47,9 @@ const StyledAddMemberItem = styled(BoxGroupSection)`
     }
 `;
 
-const AddMemberItem = ({ id, onClick }) => (
+const AddMemberItem = ({ handle, onClick }) => (
     <StyledAddMemberItem onClick={onClick}>
-        <InitialIcon size="md" handle={id} /> {id}
+        <InitialIcon size="md" handle={handle} /> {handle}
     </StyledAddMemberItem>
 );
 
@@ -86,7 +86,7 @@ export class AddReferenceMember extends React.Component {
 
         if (this.props.documents.length) {
             addMemberComponents = map(this.props.documents, document => (
-                <AddMemberItem key={document.id} id={document.id} onClick={() => this.handleAdd(document.id)} />
+                <AddMemberItem key={document.id} handle={document.handle} onClick={() => this.handleAdd(document.id)} />
             ));
         } else {
             addMemberComponents = <NoneFoundSection noun={`other ${this.props.noun}s`} />;

--- a/src/js/references/components/Detail/Settings.js
+++ b/src/js/references/components/Detail/Settings.js
@@ -5,12 +5,12 @@ import ReferenceMembers from "./Members";
 import RemoveReference from "./Remove";
 
 export const ReferenceSettings = ({ isRemote }) => (
-    <React.Fragment>
+    <>
         {isRemote ? null : <SourceTypes />}
         <ReferenceMembers noun="user" />
         <ReferenceMembers noun="group" />
         <RemoveReference />
-    </React.Fragment>
+    </>
 );
 
 export const mapStateToProps = state => ({


### PR DESCRIPTION
Swaps id for handle in `addMemberItem`. 

Updated add user dialog:
![image](https://user-images.githubusercontent.com/59776400/152043415-c8bb773e-2b26-41b7-bef1-b4ee29f6a339.png)

