### PR TITLE
Prevent upload overlay file flickering

### DIFF
--- a/src/js/files/components/UploadOverlay.js
+++ b/src/js/files/components/UploadOverlay.js
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { map, reject, sortBy } from "lodash-es";
+import { map, reject, reverse } from "lodash-es";
 import { connect } from "react-redux";
 import { Badge, BoxGroup, BoxGroupHeader, BoxGroupSection } from "../../base";
 import { UploadItem } from "./UploadItem";
@@ -53,7 +53,7 @@ export const UploadOverlay = ({ uploads }) => {
 };
 
 export const mapStateToProps = state => {
-    return { uploads: sortBy(reject(state.files.uploads, { fileType: "reference" }), "progress") };
+    return { uploads: reverse(reject(state.files.uploads, { fileType: "reference" })) };
 };
 
 export default connect(mapStateToProps)(UploadOverlay);


### PR DESCRIPTION
Implemented as a possible solution to prevent the flickering that could result due to items in the list rapidly reordering. The new version displays uploads in the reverse order of when they were added to the upload queue rather than by upload completion. (newest at the top of the list) This solution was chosen as it is in line with how uploads are handled by other websites. (Ex: google drive, Dropbox, and onedrive) 

Another possible solution that would keep the ordering by progress but prevent the rapid flashing would be to throttle the sorting to only occur once every ~1-2s. Both solutions make sense to me.