### PR TITLE
Update reference list to show user handle for last build

### DIFF
--- a/src/js/references/components/Item/Build.js
+++ b/src/js/references/components/Item/Build.js
@@ -12,7 +12,7 @@ export const ReferenceItemBuild = ({ id, latestBuild, progress }) => {
                     <Link to={`/refs/${id}/indexes/${latestBuild.id}`}>Index {latestBuild.version}</Link>
                 </h4>
                 <p>
-                    Created <RelativeTime time={latestBuild.created_at} /> by {latestBuild.user.id}
+                    Created <RelativeTime time={latestBuild.created_at} /> by {latestBuild.user.handle}
                 </p>
             </ReferenceItemInfo>
         );

--- a/src/js/references/components/Item/__tests__/Build.test.js
+++ b/src/js/references/components/Item/__tests__/Build.test.js
@@ -10,7 +10,8 @@ describe("<ReferenceItemBuild />", () => {
                 created_at: "2018-01-01T00:00:00.000000Z",
                 id: "bar",
                 user: {
-                    id: "bob"
+                    id: "bob_id",
+                    handle: "bob"
                 },
                 version: 3
             },


### PR DESCRIPTION
Updated reference list view with handle for index build rather than id:
![image](https://user-images.githubusercontent.com/59776400/152433286-7aa509d5-c56c-4eca-af8f-3bbdf72d1d0d.png)
