### PR TITLE
feat: display and permit removal of failed uploads in upload overlay

### DIFF
--- a/src/js/app/actionTypes.js
+++ b/src/js/app/actionTypes.js
@@ -84,6 +84,8 @@ export const REMOVE_FILE = createRequestActionType("REMOVE_FILE");
 export const UPLOAD = createRequestActionType("UPLOAD");
 export const UPLOAD_SAMPLE_FILE = createRequestActionType("UPLOAD_SAMPLE_FILE");
 export const UPLOAD_PROGRESS = "UPLOAD_PROGRESS";
+export const UPLOAD_FAILED = "UPLOAD_FAILED";
+export const REMOVE_UPLOAD = "REMOVE_UPLOAD";
 
 // Groups
 export const WS_INSERT_GROUP = "WS_INSERT_GROUP";

--- a/src/js/base/Icon.js
+++ b/src/js/base/Icon.js
@@ -20,7 +20,10 @@ const StyledIcon = styled.i`
     ${props => (props.fixedWidth ? fixedWidth : "")};
 
     :hover {
-        color: ${getIconHoverColor};
+        ${props =>
+            props.hoverable || props.onClick
+                ? `color: ${getIconHoverColor({ color: props.color, theme: props.theme })};`
+                : ""};
     }
 `;
 
@@ -39,6 +42,7 @@ export const Icon = ({ hoverable, style, ...props }) => {
             color={props.color}
             shade={props.shade}
             data-testid={props["data-testid"]}
+            aria-label={props["aria-label"]}
         />
     );
 
@@ -62,7 +66,8 @@ Icon.propTypes = {
     onClick: PropTypes.func,
     className: PropTypes.string,
     fixedWidth: PropTypes.bool,
-    style: PropTypes.object
+    style: PropTypes.object,
+    "aria-label": PropTypes.string
 };
 
 Icon.defaultProps = {

--- a/src/js/base/ProgressBar.js
+++ b/src/js/base/ProgressBar.js
@@ -13,6 +13,9 @@ const StyledProgress = styled.progress`
     ::-webkit-progress-value {
         background-color: ${getProgressColor};
     }
+    ::-moz-progress-bar {
+        background-color: ${getProgressColor};
+    }
 
     ::-webkit-progress-bar {
         background-color: ${props => props.theme.color.grey};

--- a/src/js/errors/reducer.js
+++ b/src/js/errors/reducer.js
@@ -34,7 +34,8 @@ import {
     LOGIN,
     UPDATE_ACCOUNT,
     UPDATE_SAMPLE,
-    UPDATE_SETTINGS
+    UPDATE_SETTINGS,
+    UPLOAD
 } from "../app/actionTypes";
 import { reportAPIError } from "../utils/utils";
 
@@ -123,6 +124,7 @@ export const errorsReducer = createReducer({}, builder => {
                     case FIND_USERS.FAILED:
                     case GET_USER.FAILED:
                     case LOGIN.FAILED:
+                    case UPLOAD.FAILED:
                         state[errorName] = errorPayload;
                         break;
                     case CREATE_FIRST_USER.FAILED:

--- a/src/js/files/__tests__/actions.test.js
+++ b/src/js/files/__tests__/actions.test.js
@@ -1,13 +1,25 @@
 import {
-    WS_INSERT_FILE,
-    WS_UPDATE_FILE,
-    WS_REMOVE_FILE,
     FIND_FILES,
     REMOVE_FILE,
+    REMOVE_UPLOAD,
     UPLOAD,
-    UPLOAD_PROGRESS
+    UPLOAD_FAILED,
+    UPLOAD_PROGRESS,
+    WS_INSERT_FILE,
+    WS_REMOVE_FILE,
+    WS_UPDATE_FILE
 } from "../../app/actionTypes";
-import { wsInsertFile, wsUpdateFile, wsRemoveFile, findFiles, upload, removeFile, uploadProgress } from "../actions";
+import {
+    findFiles,
+    removeFile,
+    removeUpload,
+    upload,
+    uploadFailed,
+    uploadProgress,
+    wsInsertFile,
+    wsRemoveFile,
+    wsUpdateFile
+} from "../actions";
 
 describe("Files Action Creators", () => {
     it("wsInsertFile: returns action with websocket file insert data", () => {
@@ -78,7 +90,6 @@ describe("Files Action Creators", () => {
             payload: { fileId }
         });
     });
-
     it("uploadProgress: returns action with upload progress", () => {
         const localId = "random_string";
         const progress = 6;
@@ -86,6 +97,23 @@ describe("Files Action Creators", () => {
         expect(result).toEqual({
             type: UPLOAD_PROGRESS,
             payload: { localId, progress }
+        });
+    });
+
+    it("uploadFailed: returns action with failed upload Id", () => {
+        const localId = "random_string";
+        const result = uploadFailed(localId);
+        expect(result).toEqual({
+            type: UPLOAD_FAILED,
+            payload: { localId }
+        });
+    });
+    it("removeUpload: returns Id of upload to be removed", () => {
+        const localId = "random_string";
+        const result = removeUpload(localId);
+        expect(result).toEqual({
+            type: REMOVE_UPLOAD,
+            payload: { localId }
         });
     });
 });

--- a/src/js/files/__tests__/reducer.test.js
+++ b/src/js/files/__tests__/reducer.test.js
@@ -4,7 +4,9 @@ import {
     WS_REMOVE_FILE,
     UPLOAD,
     UPLOAD_PROGRESS,
-    FIND_FILES
+    FIND_FILES,
+    UPLOAD_FAILED,
+    REMOVE_UPLOAD
 } from "../../app/actionTypes";
 import reducer, { initialState } from "../reducer";
 
@@ -125,7 +127,7 @@ describe("filesReducer()", () => {
         const result = reducer(state, action);
 
         expect(result).toEqual({
-            uploads: [...state.uploads, { localId, name, context, size, type, progress: 0 }]
+            uploads: [...state.uploads, { localId, name, context, size, type, progress: 0, failed: false }]
         });
     });
 
@@ -210,6 +212,49 @@ describe("filesReducer()", () => {
         const action = {
             type: UPLOAD.SUCCEEDED,
             payload: { localId: "foo", progress: 100 }
+        };
+        const result = reducer(state, action);
+        expect(result).toEqual({
+            uploads: [
+                { localId: "bar", progress: 0 },
+                { localId: "baz", progress: 100 }
+            ]
+        });
+    });
+
+    it("should update status of upload to failed when required", () => {
+        const state = {
+            uploads: [
+                { localId: "foo", progress: 50 },
+                { localId: "bar", progress: 0 },
+                { localId: "baz", progress: 100 }
+            ]
+        };
+        const action = {
+            type: UPLOAD_FAILED,
+            payload: { localId: "foo" }
+        };
+        const result = reducer(state, action);
+        expect(result).toEqual({
+            uploads: [
+                { localId: "foo", progress: 50, failed: true },
+                { localId: "bar", progress: 0 },
+                { localId: "baz", progress: 100 }
+            ]
+        });
+    });
+
+    it("should remove upload when requested", () => {
+        const state = {
+            uploads: [
+                { localId: "foo", progress: 50 },
+                { localId: "bar", progress: 0 },
+                { localId: "baz", progress: 100 }
+            ]
+        };
+        const action = {
+            type: REMOVE_UPLOAD,
+            payload: { localId: "foo" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({

--- a/src/js/files/actions.js
+++ b/src/js/files/actions.js
@@ -11,7 +11,9 @@ import {
     FIND_FILES,
     REMOVE_FILE,
     UPLOAD,
-    UPLOAD_PROGRESS
+    UPLOAD_PROGRESS,
+    UPLOAD_FAILED,
+    REMOVE_UPLOAD
 } from "../app/actionTypes";
 import { createAction } from "@reduxjs/toolkit";
 
@@ -97,4 +99,26 @@ export const removeFile = createAction(REMOVE_FILE.REQUESTED, fileId => ({
  */
 export const uploadProgress = createAction(UPLOAD_PROGRESS, (localId, progress) => ({
     payload: { localId, progress }
+}));
+
+/**
+ * Returns and action that sets the status of an ongoing upload to failed
+ *
+ * @func
+ * @param localId {string} the local id for the upload (NOT the fileId)
+ * @returns {object}
+ */
+export const uploadFailed = createAction(UPLOAD_FAILED, localId => ({
+    payload: { localId }
+}));
+
+/**
+ * Returns and action that triggers the removal of the upload file specified
+ *
+ * @func
+ * @param localId {string} the local id for the upload (NOT the fileId)
+ * @returns {object}
+ */
+export const removeUpload = createAction(REMOVE_UPLOAD, localId => ({
+    payload: { localId }
 }));

--- a/src/js/files/components/UploadItem.js
+++ b/src/js/files/components/UploadItem.js
@@ -1,8 +1,10 @@
 import React from "react";
 import styled from "styled-components";
-import { getBorder } from "../../app/theme";
+import { getBorder, getColor, getFontWeight } from "../../app/theme";
 import { AffixedProgressBar, Icon, Loader } from "../../base";
 import { byteSize } from "../../utils/utils";
+import { connect } from "react-redux";
+import { removeUpload } from "../actions";
 
 const StyledUploadItem = styled.div`
     padding: 0;
@@ -21,21 +23,52 @@ const UploadItemTitle = styled.div`
     i.fas {
         margin-right: 5px;
     }
-    div:first-child {
-        margin-right: 5px;
-    }
     span:last-child {
         margin-left: auto;
+        color: ${props => (props.failed ? getColor({ theme: props.theme, color: "red" }) : "inherit")};
+    }
+    i.fa-times {
+        font-size: 20px;
+    }
+    i.fa-trash {
+        margin-left: 5px;
+        font-size: 14px;
     }
 `;
 
-export const UploadItem = ({ name, progress, size }) => (
-    <StyledUploadItem>
-        <AffixedProgressBar now={progress} />
-        <UploadItemTitle>
-            {progress === 100 ? <Loader size="14px" /> : <Icon name="upload" />}
-            <span>{name}</span>
-            <span>{byteSize(size)}</span>
-        </UploadItemTitle>
-    </StyledUploadItem>
-);
+const StyledFilename = styled.span`
+    font-weight: ${getFontWeight("thick")};
+`;
+
+export const UploadItem = ({ name, progress, size, failed, localId, onRemove }) => {
+    let uploadIcon = progress === 100 ? <Loader size="14px" /> : <Icon name="upload" />;
+    let uploadBookend = byteSize(size);
+
+    if (failed) {
+        uploadIcon = <Icon name="times" color={"red"} hoverable={false} />;
+        uploadBookend = (
+            <>
+                Failed <Icon aria-label={`delete ${name}`} name="trash" color="red" onClick={() => onRemove(localId)} />
+            </>
+        );
+    }
+
+    return (
+        <StyledUploadItem>
+            <AffixedProgressBar now={failed ? 100 : progress} color={failed ? "red" : "blue"} />
+            <UploadItemTitle failed={failed}>
+                {uploadIcon}
+                <StyledFilename>{name}</StyledFilename>
+                <span>{uploadBookend}</span>
+            </UploadItemTitle>
+        </StyledUploadItem>
+    );
+};
+
+const mapDispatchToProps = dispatch => ({
+    onRemove: localId => {
+        dispatch(removeUpload(localId));
+    }
+});
+
+export default connect(null, mapDispatchToProps)(UploadItem);

--- a/src/js/files/components/UploadOverlay.js
+++ b/src/js/files/components/UploadOverlay.js
@@ -3,7 +3,8 @@ import styled from "styled-components";
 import { map, reject, reverse } from "lodash-es";
 import { connect } from "react-redux";
 import { Badge, BoxGroup, BoxGroupHeader, BoxGroupSection } from "../../base";
-import { UploadItem } from "./UploadItem";
+import UploadItem from "./UploadItem";
+import { getFontWeight, getFontSize } from "../../app/theme";
 
 const StyledUploadOverlay = styled.div`
     bottom: 0;
@@ -23,6 +24,8 @@ const UploadOverlayContent = styled(BoxGroup)`
 
     ${BoxGroupHeader} {
         display: block;
+        font-weight: ${getFontWeight("thick")};
+        font-size: ${getFontSize("lg")};
     }
 `;
 
@@ -41,7 +44,7 @@ export const UploadOverlay = ({ uploads }) => {
             <StyledUploadOverlay show={uploads.length}>
                 <UploadOverlayContent>
                     <BoxGroupHeader>
-                        <strong>Uploads</strong> <Badge>{uploadComponents.length}</Badge>
+                        Uploads <Badge>{uploadComponents.length}</Badge>
                     </BoxGroupHeader>
                     <UploadOverlayList>{uploadComponents}</UploadOverlayList>
                 </UploadOverlayContent>

--- a/src/js/files/components/__tests__/UploadItem.test.js
+++ b/src/js/files/components/__tests__/UploadItem.test.js
@@ -1,4 +1,5 @@
 import { UploadItem } from "../UploadItem";
+import userEvent from "@testing-library/user-event";
 
 describe("<UploadItem />", () => {
     let props;
@@ -7,7 +8,10 @@ describe("<UploadItem />", () => {
         props = {
             name: "Foo.fa",
             progress: 0,
-            size: 871290
+            size: 871290,
+            onRemove: jest.fn(),
+            localId: "foo_id",
+            failed: false
         };
     });
 
@@ -20,5 +24,12 @@ describe("<UploadItem />", () => {
         props.progress = 51;
         const wrapper = shallow(<UploadItem {...props} />);
         expect(wrapper).toMatchSnapshot();
+    });
+
+    it("should dispatch action to remove sample", () => {
+        props.failed = true;
+        const screen = renderWithProviders(<UploadItem {...props} />);
+        userEvent.click(screen.getByLabelText("delete Foo.fa"));
+        expect(props.onRemove).toHaveBeenCalledWith(props.localId);
     });
 });

--- a/src/js/files/components/__tests__/__snapshots__/UploadItem.test.js.snap
+++ b/src/js/files/components/__tests__/__snapshots__/UploadItem.test.js.snap
@@ -3,17 +3,20 @@
 exports[`<UploadItem /> should render when [progress === 0] 1`] = `
 <UploadItem__StyledUploadItem>
   <ProgressBar__AffixedProgressBar
+    color="blue"
     now={0}
   />
-  <UploadItem__UploadItemTitle>
+  <UploadItem__UploadItemTitle
+    failed={false}
+  >
     <Icon
       faStyle="fas"
       fixedWidth={false}
       name="upload"
     />
-    <span>
+    <UploadItem__StyledFilename>
       Foo.fa
-    </span>
+    </UploadItem__StyledFilename>
     <span>
       871.3KB
     </span>
@@ -24,17 +27,20 @@ exports[`<UploadItem /> should render when [progress === 0] 1`] = `
 exports[`<UploadItem /> should render when [progress > 0] 1`] = `
 <UploadItem__StyledUploadItem>
   <ProgressBar__AffixedProgressBar
+    color="blue"
     now={51}
   />
-  <UploadItem__UploadItemTitle>
+  <UploadItem__UploadItemTitle
+    failed={false}
+  >
     <Icon
       faStyle="fas"
       fixedWidth={false}
       name="upload"
     />
-    <span>
+    <UploadItem__StyledFilename>
       Foo.fa
-    </span>
+    </UploadItem__StyledFilename>
     <span>
       871.3KB
     </span>

--- a/src/js/files/components/__tests__/__snapshots__/UploadOverlay.test.js.snap
+++ b/src/js/files/components/__tests__/__snapshots__/UploadOverlay.test.js.snap
@@ -6,16 +6,13 @@ exports[`<UploadOverlay /> should render 1`] = `
 >
   <UploadOverlay__UploadOverlayContent>
     <Box__BoxGroupHeader>
-      <strong>
-        Uploads
-      </strong>
-       
+      Uploads 
       <Badge>
         3
       </Badge>
     </Box__BoxGroupHeader>
     <UploadOverlay__UploadOverlayList>
-      <UploadItem
+      <Connect(UploadItem)
         fileType="subtraction"
         key="123abc"
         localId="123abc"
@@ -23,7 +20,7 @@ exports[`<UploadOverlay /> should render 1`] = `
         progress={100}
         size={1024}
       />
-      <UploadItem
+      <Connect(UploadItem)
         fileType="reads"
         key="456def"
         localId="456def"
@@ -31,7 +28,7 @@ exports[`<UploadOverlay /> should render 1`] = `
         progress={0}
         size={1024}
       />
-      <UploadItem
+      <Connect(UploadItem)
         fileType="reads"
         key="789ghi"
         localId="789ghi"

--- a/src/js/files/reducer.js
+++ b/src/js/files/reducer.js
@@ -4,12 +4,14 @@
  * @module files/reducer
  */
 import { createReducer } from "@reduxjs/toolkit";
-import { map, reject } from "lodash-es";
+import { forEach, map, reject } from "lodash-es";
 import {
     FIND_FILES,
     UPLOAD,
     UPLOAD_PROGRESS,
+    UPLOAD_FAILED,
     UPLOAD_SAMPLE_FILE,
+    REMOVE_UPLOAD,
     WS_INSERT_FILE,
     WS_REMOVE_FILE,
     WS_UPDATE_FILE
@@ -37,7 +39,7 @@ export const appendUpload = (state, action) => {
 
     return {
         ...state,
-        uploads: state.uploads.concat([{ localId, progress: 0, name, size, type: fileType, context }])
+        uploads: state.uploads.concat([{ localId, progress: 0, name, size, type: fileType, context, failed: false }])
     };
 };
 
@@ -102,6 +104,16 @@ export const filesReducer = createReducer(initialState, builder => {
         })
         .addCase(UPLOAD_PROGRESS, (state, action) => {
             return updateProgress(state, action.payload);
+        })
+        .addCase(UPLOAD_FAILED, (state, action) => {
+            forEach(state.uploads, upload => {
+                if (upload.localId === action.payload.localId) {
+                    upload.failed = true;
+                }
+            });
+        })
+        .addCase(REMOVE_UPLOAD, (state, action) => {
+            state.uploads = reject(state.uploads, { localId: action.payload.localId });
         });
 });
 

--- a/src/js/files/sagas.js
+++ b/src/js/files/sagas.js
@@ -3,7 +3,7 @@ import { buffers, END, eventChannel } from "redux-saga";
 import { call, put, take, takeEvery, throttle } from "redux-saga/effects";
 import { FIND_FILES, REMOVE_FILE, UPLOAD } from "../app/actionTypes";
 import { apiCall, putGenericError } from "../utils/sagas";
-import { uploadProgress } from "./actions";
+import { uploadFailed, uploadProgress } from "./actions";
 import * as filesAPI from "./api";
 
 export function* watchFiles() {
@@ -61,6 +61,7 @@ export function* watchUploadChannel(channel, actionType, localId) {
         const { progress = 0, response, err } = yield take(channel);
 
         if (err) {
+            yield put(uploadFailed(localId));
             return yield putGenericError(actionType, err);
         }
         if (response) {

--- a/src/js/utils/sagas.js
+++ b/src/js/utils/sagas.js
@@ -63,10 +63,11 @@ export function* pushFindTerm(term, contains) {
  * @param error {object} the HTTP error from Superagent
  */
 export function* putGenericError(actionType, error) {
-    const { body, status } = error.response;
+    const { body, status } = error.response ? error.response : {};
 
+    const message = body ? body.message : null;
     yield put({
         type: actionType.FAILED,
-        payload: { message: body.message, error, status }
+        payload: { message, error, status }
     });
 }


### PR DESCRIPTION
**Changes:**
 - Adds an error state to upload items and displays a new UploadItemError component for any upload that has failed
   - New component is visually distinct from UploadItem and add a button to remove the failed upload.
 - Modifies `base/ProgressBar` to allow colour changes in firefox as well as chrome
 - Adds test for new components using ReactTestingLibrary
 -  modifies `putGenericError` to prevent a client side crash in the event that the server error does not have a body or status 

Update: 16/02/2022

Updated overlay:
![image](https://user-images.githubusercontent.com/59776400/154318927-6e795b37-7215-4a06-bdc9-ca7a2734072a.png)

