### PR TITLE
Reduce extra space and show search icon in reference add user view

### DIFF
--- a/src/js/base/Input.js
+++ b/src/js/base/Input.js
@@ -19,7 +19,7 @@ export const InputError = styled.p`
 
 export const StyledInputGroup = styled.div`
     margin: 0 0 15px;
-    min-height: 73px;
+    padding-bottom: 10px;
 `;
 
 export const InputGroup = ({ children, className, error }) => (

--- a/src/js/references/components/Detail/AddMember.js
+++ b/src/js/references/components/Detail/AddMember.js
@@ -22,8 +22,8 @@ import { addReferenceGroup, addReferenceUser } from "../../actions";
 const AddUserSearch = ({ term, onChange }) => (
     <InputGroup>
         <InputContainer align="left">
-            <InputIcon name="search" />
             <Input value={term} onChange={e => onChange(e.target.value)} />
+            <InputIcon name="search" />
         </InputContainer>
     </InputGroup>
 );


### PR DESCRIPTION
Changes:
  - Removed minimum height from Input group so that an excessive amount of space is not taken for inputs which don't have a text label
    - Added 10px of bottom padding to the element to ensure components still have sufficient breathing room  
  - Ensured that the search icon on `addMember` renders on top of the search bar by swapping component render order.

Modified Add User Dialogue:
![image](https://user-images.githubusercontent.com/59776400/152877486-429e3b87-59e5-4840-8a81-b7d6bd4138e4.png)


Create Sample page with modified input group:
![image](https://user-images.githubusercontent.com/59776400/152877400-ec8a734c-3ba3-46ab-8c2d-4fda596ff691.png)


