### PR TITLE
Prevent unintended navigation when adding isolate to otu

### DIFF
--- a/src/js/otus/__tests__/actions.test.js
+++ b/src/js/otus/__tests__/actions.test.js
@@ -15,7 +15,6 @@ import {
     REVERT,
     SELECT_ISOLATE,
     SET_ISOLATE_AS_DEFAULT,
-    SHOW_ADD_ISOLATE,
     SHOW_EDIT_ISOLATE,
     SHOW_EDIT_OTU,
     SHOW_REMOVE_ISOLATE,
@@ -42,7 +41,6 @@ import {
     revert,
     selectIsolate,
     setIsolateAsDefault,
-    showAddIsolate,
     showEditIsolate,
     showEditOTU,
     showRemoveIsolate,
@@ -205,10 +203,6 @@ describe("OTUs Action Creators", () => {
 
     it("showRemoveOTU: returns action to display remove otu modal", () => {
         expect(showRemoveOTU()).toEqual({ type: SHOW_REMOVE_OTU });
-    });
-
-    it("showAddIsolate: returns action to display add isolate modal", () => {
-        expect(showAddIsolate()).toEqual({ type: SHOW_ADD_ISOLATE });
     });
 
     it("showEditIsolate: returns action to display edit isolate modal", () => {

--- a/src/js/otus/__tests__/reducer.test.js
+++ b/src/js/otus/__tests__/reducer.test.js
@@ -15,7 +15,6 @@ import {
     REVERT,
     SELECT_ISOLATE,
     SET_ISOLATE_AS_DEFAULT,
-    SHOW_ADD_ISOLATE,
     SHOW_EDIT_ISOLATE,
     SHOW_EDIT_OTU,
     SHOW_REMOVE_ISOLATE,
@@ -283,12 +282,6 @@ describe("OTUs Reducer:", () => {
         expect(result).toEqual({ remove: true });
     });
 
-    it("should handle SHOW_ADD_ISOLATE", () => {
-        const action = { type: SHOW_ADD_ISOLATE };
-        const result = reducer({}, action);
-        expect(result).toEqual({ addIsolate: true });
-    });
-
     it("should handle SHOW_EDIT_ISOLATE", () => {
         const action = { type: SHOW_EDIT_ISOLATE };
         const result = reducer({}, action);
@@ -309,7 +302,6 @@ describe("OTUs Reducer:", () => {
 
     it("should handle HIDE_OTU_MODAL", () => {
         const state = {
-            addIsolate: true,
             edit: true,
             editIsolate: true,
             remove: false,
@@ -319,7 +311,6 @@ describe("OTUs Reducer:", () => {
         const action = { type: HIDE_OTU_MODAL };
         const result = reducer(state, action);
         expect(result).toEqual({
-            addIsolate: false,
             edit: false,
             editIsolate: false,
             remove: false,

--- a/src/js/otus/actions.js
+++ b/src/js/otus/actions.js
@@ -1,3 +1,4 @@
+import { createAction } from "@reduxjs/toolkit";
 import {
     ADD_ISOLATE,
     ADD_SEQUENCE,
@@ -15,7 +16,6 @@ import {
     REVERT,
     SELECT_ISOLATE,
     SET_ISOLATE_AS_DEFAULT,
-    SHOW_ADD_ISOLATE,
     SHOW_EDIT_ISOLATE,
     SHOW_EDIT_OTU,
     SHOW_REMOVE_ISOLATE,
@@ -25,8 +25,6 @@ import {
     WS_REMOVE_OTU,
     WS_UPDATE_OTU
 } from "../app/actionTypes";
-
-import { createAction } from "@reduxjs/toolkit";
 
 /**
  * Returns an action that should be dispatched when an OTU is inserted via websocket.
@@ -319,14 +317,6 @@ export const showEditOTU = createAction(SHOW_EDIT_OTU);
  * @returns {object}
  */
 export const showRemoveOTU = createAction(SHOW_REMOVE_OTU);
-
-/**
- * Returns action for displaying the add isolate modal.
- *
- * @func
- * @returns {object}
- */
-export const showAddIsolate = createAction(SHOW_ADD_ISOLATE);
 
 /**
  * Returns action for displaying the edit isolate modal.

--- a/src/js/otus/components/Detail/Editor.js
+++ b/src/js/otus/components/Detail/Editor.js
@@ -1,11 +1,12 @@
 import { map } from "lodash-es";
 import React from "react";
 import { connect } from "react-redux";
+import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { getFontSize, getFontWeight } from "../../../app/theme";
 import { Badge, Box, BoxGroup, NoneFoundBox, SubviewHeader, SubviewHeaderTitle } from "../../../base";
 import { getCanModifyReferenceOTU } from "../../../references/selectors";
-import { selectIsolate, showAddIsolate } from "../../actions";
+import { selectIsolate } from "../../actions";
 import IsolateDetail from "./Isolates/Detail";
 import IsolateItem from "./Isolates/Item";
 
@@ -59,11 +60,7 @@ const IsolateEditor = props => {
         />
     ));
 
-    const addIsolateLink = props.canModify ? (
-        <a href="#" onClick={props.onShowAddIsolate}>
-            Add Isolate
-        </a>
-    ) : null;
+    const addIsolateLink = props.canModify ? <Link to={{ state: { addIsolate: true } }}>Add Isolate</Link> : null;
 
     const body = isolateComponents.length ? (
         <IsolateEditorContainer>
@@ -100,10 +97,6 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
     onSelectIsolate: isolateId => {
         dispatch(selectIsolate(isolateId));
-    },
-
-    onShowAddIsolate: () => {
-        dispatch(showAddIsolate());
     }
 });
 

--- a/src/js/otus/components/Detail/Isolates/Add.js
+++ b/src/js/otus/components/Detail/Isolates/Add.js
@@ -1,7 +1,9 @@
 import React from "react";
 import { connect } from "react-redux";
+import { pushState } from "../../../../app/actions";
 import { Modal, ModalHeader } from "../../../../base";
-import { addIsolate, hideOTUModal } from "../../../actions";
+import { routerLocationHasState } from "../../../../utils/utils";
+import { addIsolate } from "../../../actions";
 import IsolateForm from "./Form";
 
 const getInitialState = props => ({
@@ -57,7 +59,7 @@ class Add extends React.Component {
 }
 
 const mapStateToProps = state => ({
-    show: state.otus.addIsolate,
+    show: routerLocationHasState(state, "addIsolate"),
     otuId: state.otus.detail.id,
     allowedSourceTypes: state.references.detail.source_types,
     restrictSourceTypes: state.references.detail.restrict_source_types
@@ -65,7 +67,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     onHide: () => {
-        dispatch(hideOTUModal());
+        dispatch(pushState({ addIsolate: false }));
     },
 
     onSave: (otuId, sourceType, sourceName) => {

--- a/src/js/otus/reducer.js
+++ b/src/js/otus/reducer.js
@@ -17,7 +17,6 @@ import {
     REVERT,
     SELECT_ISOLATE,
     SET_ISOLATE_AS_DEFAULT,
-    SHOW_ADD_ISOLATE,
     SHOW_EDIT_ISOLATE,
     SHOW_EDIT_OTU,
     SHOW_REMOVE_ISOLATE,
@@ -154,9 +153,6 @@ export const OTUsReducer = createReducer(initialState, builder => {
         .addCase(SHOW_REMOVE_OTU, state => {
             state.remove = true;
         })
-        .addCase(SHOW_ADD_ISOLATE, state => {
-            state.addIsolate = true;
-        })
         .addCase(SHOW_EDIT_ISOLATE, state => {
             state.editIsolate = true;
         })
@@ -169,7 +165,6 @@ export const OTUsReducer = createReducer(initialState, builder => {
         .addCase(HIDE_OTU_MODAL, state => {
             state.edit = false;
             state.remove = false;
-            state.addIsolate = false;
             state.editIsolate = false;
             state.removeIsolate = false;
             state.removeSequence = false;


### PR DESCRIPTION
Link converted to use history state rather than redux store for modal managment. Fixes unintended navigation when trying to add an isolate to an otu.