### PR TITLE
chore: optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM library/node:16-buster as build
 WORKDIR /build
-COPY src /build/src
 COPY .eslintrc /build/
 COPY babel.config.js /build/
 COPY package.json /build/
@@ -8,6 +7,7 @@ COPY package-lock.json /build/
 COPY webpack.config.babel.js /build/
 COPY webpack.production.config.babel.js /build/
 RUN npm i
+COPY src /build/src
 RUN npx webpack --config webpack.production.config.babel.js
 
 FROM library/node:16-buster


### PR DESCRIPTION
Install packages before copying `src` and building. This will allow the package layers to be cached as they change far less frequently than the source code.

Current pull looks like this:
```
Pulling ui (virtool/ui:2.12.0)...
2.12.0: Pulling from virtool/ui
a024302f8a01: Pull complete
289773030fdc: Pull complete
81bb8b3399fe: Pull complete
9c63da771697: Pull complete
bcf1b23b1e4b: Pull complete
53a5e10666cb: Pull complete
c9872a0dc1d7: Pull complete
e8b67599ff06: Pull complete
...
```

Should look more like this:
```
2.0.10: Pulling from virtool/pathoscope
c4cc477c22ba: Already exists
...
4855ab417397: Already exists
76f56900605c: Already exists
6f237eea218a: Already exists
d70b9b34f615: Already exists
c44e2fcf5bf5: Already exists
1a636600c094: Already exists
5fedd09a73b1: Pull complete
0577d1424f6c: Pull complete
63439fe4baba: Pull complete
```