### PR TITLE
fix: prevent crash when adding member group in reference settings view

### DIFF
--- a/src/js/references/components/Detail/AddMember.js
+++ b/src/js/references/components/Detail/AddMember.js
@@ -86,7 +86,11 @@ export class AddReferenceMember extends React.Component {
 
         if (this.props.documents.length) {
             addMemberComponents = map(this.props.documents, document => (
-                <AddMemberItem key={document.id} handle={document.handle} onClick={() => this.handleAdd(document.id)} />
+                <AddMemberItem
+                    key={document.id}
+                    handle={document.handle || document.id}
+                    onClick={() => this.handleAdd(document.id)}
+                />
             ));
         } else {
             addMemberComponents = <NoneFoundSection noun={`other ${this.props.noun}s`} />;


### PR DESCRIPTION
Simple fix, allowed the `addMember` component to pass  `document.id` to `AddMemberItem` as a backup in the case that `document.handle` is not available .