### PR TITLE
Ensure proper progress bar styling across web browsers

### DIFF
--- a/src/js/base/ProgressBar.js
+++ b/src/js/base/ProgressBar.js
@@ -9,6 +9,8 @@ const StyledProgress = styled.progress`
     height: 20px;
     margin-bottom: 10px;
     width: 100%;
+    background-color: ${props => props.theme.color.grey};
+    border: 0px;
 
     ::-webkit-progress-value {
         background-color: ${getProgressColor};
@@ -28,6 +30,7 @@ const StyledAffixedProgress = styled(StyledProgress)`
     margin: 0;
     overflow: hidden;
     position: absolute;
+    background-color: transparent;
 
     ${props => (props.bottom ? "bottom" : "top")}: 0;
 


### PR DESCRIPTION
Just a few small css tweaks needed to overwrite the default styling choices of Firefox

Jobs on Chrome:
![image](https://user-images.githubusercontent.com/59776400/154776338-2bc9d284-55eb-4062-a7b3-acc55a58c846.png)

Jobs on firefox:
![image](https://user-images.githubusercontent.com/59776400/154776593-2c22852e-b181-42d6-b53e-983a017c0195.png)


