### PR TITLE
restore proper spacing to upload overlay icons

### DIFF
--- a/src/js/files/components/UploadItem.js
+++ b/src/js/files/components/UploadItem.js
@@ -20,7 +20,8 @@ const UploadItemTitle = styled.div`
     display: flex;
     padding: 15px 15px 10px;
 
-    i.fas {
+    i.fas,
+    div:first-child {
         margin-right: 5px;
     }
     span:last-child {


### PR DESCRIPTION
Modified css to target the spinner as well.

Spinner screenshot:
![image](https://user-images.githubusercontent.com/59776400/155228389-9cf366c5-14a4-414c-867b-9a719872bd27.png)

Ongoing upload screenshot:
![image](https://user-images.githubusercontent.com/59776400/155228544-d8635313-0357-4649-a78e-de46a4cc8ca6.png)
