### PR TITLE
Correct links for subtraction and index file downloads

### DIFF
--- a/src/js/indexes/components/__tests__/Files.test.js
+++ b/src/js/indexes/components/__tests__/Files.test.js
@@ -7,9 +7,9 @@ describe("<IndexDetail />", () => {
     beforeEach(() => {
         props = {
             files: [
-                { id: "1", name: "foo", download_url: "https://Virtool.ca/testUrl/foo", size: "1024" },
+                { id: "1", name: "foo", download_url: "/testUrl/foo", size: "1024" },
 
-                { id: "2", name: "bar", download_url: "https://Virtool.ca/testUrl/bar", size: "2048" }
+                { id: "2", name: "bar", download_url: "/testUrl/bar", size: "2048" }
             ]
         };
     });
@@ -35,6 +35,6 @@ describe("<IndexDetail />", () => {
     });
     it("should include url", () => {
         renderWithProviders(<Files {...props} />);
-        expect(screen.getAllByRole("link", {})[0]).toHaveAttribute("href", "https://Virtool.ca/testUrl/foo");
+        expect(screen.getAllByRole("link", {})[0]).toHaveAttribute("href", "/api/testUrl/foo");
     });
 });

--- a/src/js/indexes/components/__tests__/__snapshots__/Files.test.js.snap
+++ b/src/js/indexes/components/__tests__/__snapshots__/Files.test.js.snap
@@ -14,7 +14,7 @@ exports[`<IndexDetail /> should render 1`] = `
   <File
     file={
       Object {
-        "download_url": "https://Virtool.ca/testUrl/foo",
+        "download_url": "/testUrl/foo",
         "id": "1",
         "name": "foo",
         "size": "1024",
@@ -25,7 +25,7 @@ exports[`<IndexDetail /> should render 1`] = `
   <File
     file={
       Object {
-        "download_url": "https://Virtool.ca/testUrl/bar",
+        "download_url": "/testUrl/bar",
         "id": "2",
         "name": "bar",
         "size": "2048",

--- a/src/js/subtraction/components/Detail/File.js
+++ b/src/js/subtraction/components/Detail/File.js
@@ -16,7 +16,7 @@ const StyledSubtractionFile = styled(BoxGroupSection)`
 
 export const File = ({ file: { download_url, name, size } }) => (
     <StyledSubtractionFile>
-        <a href={download_url}>{name}</a>
+        <a href={`/api${download_url}`}>{name}</a>
         <strong>{byteSize(size)}</strong>
     </StyledSubtractionFile>
 );


### PR DESCRIPTION
Current links don't get correctly routed to the back end. Fixed by appending `/api` onto the download when defining the download link href.