### PR TITLE
Ensure correct initial icon centering across browsers

### DIFF
--- a/src/js/account/components/Profile.js
+++ b/src/js/account/components/Profile.js
@@ -3,7 +3,7 @@ import React from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
 import { getFontSize, getFontWeight } from "../../app/theme";
-import { Icon, InitialIcon, Label, StyledInitialIcon } from "../../base";
+import { Icon, InitialIcon, Label } from "../../base";
 import { getAccountAdministrator, getAccountHandle } from "../selectors";
 import Email from "./Email";
 import ChangePassword from "./Password";
@@ -24,9 +24,6 @@ const AccountProfileHeader = styled.div`
     align-items: center;
     display: flex;
     margin-bottom: 15px;
-    > ${StyledInitialIcon} {
-        flex: 0 0 auto;
-    }
     > div {
         flex: 2 0 auto;
         margin-left: 15px;

--- a/src/js/base/InitialIcon.js
+++ b/src/js/base/InitialIcon.js
@@ -23,18 +23,22 @@ const fontSize = {
 const getIconSize = size => iconSize[size];
 const getFontSize = size => fontSize[size];
 
-export const StyledInitialIcon = styled.span`
-    border-radius: 50%;
-    display: inline-flex;
-    flex: 0 0 auto;
-    justify-content: center;
-    align-items: center;
+const StyledInitialIcon = styled.svg`
     height: ${props => getIconSize(props.size)};
     width: ${props => getIconSize(props.size)};
-    font-size: ${props => getFontSize(props.size)};
-    font-weight: ${getFontWeight("bold")};
-    color: ${getColor({ color: "white", theme })};
-    background: ${props => `hsl(${props.hash}, 83%, 21%);`};
+
+    circle {
+        cx: ${props => getFontSize(props.size)};
+        cy: ${props => getFontSize(props.size)};
+        r: ${props => getFontSize(props.size)};
+        fill: ${props => `hsl(${props.hash}, 83%, 21%);`};
+    }
+    text {
+        text-anchor: middle;
+        fill: ${getColor({ color: "white", theme })};
+        font-size: ${props => getFontSize(props.size)};
+        font-weight: ${getFontWeight("bold")};
+    }
 `;
 
 const colorHash = (hash, newChar) => (hash << 5) - newChar.charCodeAt(0);
@@ -42,8 +46,11 @@ const colorHash = (hash, newChar) => (hash << 5) - newChar.charCodeAt(0);
 export const InitialIcon = ({ handle, size }) => {
     const hash = useMemo(() => reduce(handle.split(""), colorHash, 0) % 360, [handle]);
     return (
-        <StyledInitialIcon hash={hash} size={size} className="InitialIcon">
-            {handle.slice(0, 2).toUpperCase()}
+        <StyledInitialIcon size={size} hash={hash} className="InitialIcon">
+            <circle>{handle.slice(0, 2).toUpperCase()}</circle>
+            <text x="1em" y="1em" dy=".35em">
+                {handle.slice(0, 2).toUpperCase()}
+            </text>
         </StyledInitialIcon>
     );
 };

--- a/src/js/references/components/Detail/MemberItem.js
+++ b/src/js/references/components/Detail/MemberItem.js
@@ -8,11 +8,17 @@ const StyledMemberItem = styled(BoxGroupSection)`
     display: flex;
 `;
 
+const StyledMemberItemIcon = styled(FlexItem)`
+    display: flex;
+    align-items: center;
+    padding-right: 8px;
+`;
+
 const MemberItemIcon = ({ handle }) => {
     return (
-        <FlexItem grow={0} shrink={0} style={{ paddingRight: "8px" }}>
+        <StyledMemberItemIcon grow={0} shrink={0}>
             <InitialIcon handle={handle} size="lg" />
-        </FlexItem>
+        </StyledMemberItemIcon>
     );
 };
 


### PR DESCRIPTION
Changes the initial icon to using a browser rendered SVG rather than a standard div. Provides pixel perfect centering on Ubuntu for both Chrome and Firefox. 

Chrome:
Sample list view:
![image](https://user-images.githubusercontent.com/59776400/155795658-aa0b334a-073a-4457-abde-79370f387361.png)
Reference settings:
![image](https://user-images.githubusercontent.com/59776400/155795802-1660a3bc-3f1d-4a79-9666-8eebac041352.png)

Firefox:
Sample list view:
![image](https://user-images.githubusercontent.com/59776400/155796183-a8728cca-1585-41c0-816d-6ed563b48338.png)
Reference settings:
![image](https://user-images.githubusercontent.com/59776400/155796264-a3f6299e-f319-4879-ad1f-177d2a3a750e.png)


Very close to perfect on windows. Can be off by a pixel if the font is not an even number of pixels tall.

Windows, Chrome: 

Sample list view: 
![image](https://user-images.githubusercontent.com/59776400/155799061-e64df73c-2f69-46d1-9198-9989542c79a9.png)

Reference Settings
![image](https://user-images.githubusercontent.com/59776400/155799179-ab0b3cc4-a999-45c1-85ed-1a56c210428c.png)

