### PR TITLE
Prevent ambiguity in job step timestamps

### DIFF
--- a/src/js/jobs/components/Step.js
+++ b/src/js/jobs/components/Step.js
@@ -25,7 +25,7 @@ const JobStepLoader = styled(Loader)`
 const JobStepTimestamp = ({ timestamp }) => (
     <StyledJobStepTimestamp>
         <Icon name="clock" />
-        <span>{format(new Date(timestamp), "hh:mm:ss")}</span>
+        <span>{format(new Date(timestamp), "HH:mm:ss")}</span>
         <Icon name="calendar" />
         <span>{format(new Date(timestamp), "yyyy-MM-dd")}</span>
     </StyledJobStepTimestamp>


### PR DESCRIPTION
A one line change that requests that date's hours printed in 24hr rather than 12hr time.

Ex:
![image](https://user-images.githubusercontent.com/59776400/159094917-e2342fd8-c4d2-422b-ba30-4ed74914ee99.png)
