### PR TITLE
Prevent upload of non-fasta files as subtractions

### DIFF
--- a/src/js/base/UploadBar.js
+++ b/src/js/base/UploadBar.js
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { useDropzone } from "react-dropzone";
 import styled from "styled-components";
-import { Button } from "./index";
+import { Button, Icon } from "./index";
 
 const StyledUploadBar = styled.div`
     align-items: stretch;
@@ -26,16 +26,20 @@ const StyledUploadBar = styled.div`
         flex: 0 0 auto;
         margin-left: 3px;
     }
+
+    & > div > div:last-child {
+        margin-left: 5px;
+    }
 `;
 
-export const UploadBar = ({ message, onDrop }) => {
+export const UploadBar = ({ message, onDrop, validator, tip }) => {
     const messageComponent = <span>{message && message.length ? message : "Drag file here to upload"}</span>;
 
     const handleDrop = useCallback(acceptedFiles => {
         onDrop(acceptedFiles);
     }, []);
 
-    const { getRootProps, getInputProps, isDragAccept, open } = useDropzone({ onDrop: handleDrop });
+    const { getRootProps, getInputProps, isDragAccept, open } = useDropzone({ onDrop: handleDrop, validator });
 
     const rootProps = getRootProps({
         onClick: e => e.stopPropagation()
@@ -46,6 +50,9 @@ export const UploadBar = ({ message, onDrop }) => {
             <div {...rootProps}>
                 <input {...getInputProps()} data-testid="upload-input" />
                 {messageComponent}
+                {tip && tip.length && (
+                    <Icon aria-label="upload information" color="black" tip={tip} tipPlacement="top" />
+                )}
             </div>
             <Button color="blue" icon="upload" onClick={open}>
                 Upload

--- a/src/js/files/components/Manager.js
+++ b/src/js/files/components/Manager.js
@@ -17,7 +17,7 @@ import { findFiles, upload } from "../actions";
 import { getFilteredFileIds } from "../selectors";
 import File from "./File";
 
-class FileManager extends React.Component {
+export class FileManager extends React.Component {
     componentDidMount() {
         this.props.onLoadNextPage(this.props.fileType, this.props.term, 1);
     }
@@ -33,6 +33,10 @@ class FileManager extends React.Component {
         return <File key={id} id={id} />;
     };
 
+    validateExtensions = file => {
+        return this.props.validationRegex.test(file.name) ? null : { code: "Invalid file type" };
+    };
+
     render() {
         if (
             this.props.documents === null ||
@@ -44,7 +48,14 @@ class FileManager extends React.Component {
         let toolbar;
 
         if (this.props.canUpload) {
-            toolbar = <UploadBar onDrop={this.handleDrop} />;
+            toolbar = (
+                <UploadBar
+                    onDrop={this.handleDrop}
+                    message={this.props.message || "Drag file here to upload."}
+                    validator={this.props.validationRegex ? this.validateExtensions : null}
+                    tip={this.props.tip}
+                />
+            );
         } else {
             toolbar = (
                 <Alert color="orange" level>
@@ -88,7 +99,7 @@ class FileManager extends React.Component {
     }
 }
 
-const mapStateToProps = state => {
+export const mapStateToProps = state => {
     const { found_count, page, page_count, total_count } = state.files;
 
     return {
@@ -102,7 +113,7 @@ const mapStateToProps = state => {
     };
 };
 
-const mapDispatchToProps = dispatch => ({
+export const mapDispatchToProps = dispatch => ({
     onDrop: (fileType, acceptedFiles) => {
         forEach(acceptedFiles, file => {
             const localId = createRandomString();

--- a/src/js/files/components/__tests__/Manager.test.js
+++ b/src/js/files/components/__tests__/Manager.test.js
@@ -1,0 +1,160 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createStore } from "redux";
+import { FileManager, mapDispatchToProps, mapStateToProps } from "../Manager";
+
+const createAppStore = state => {
+    return () => createStore(state => state, state);
+};
+
+describe("<FileManager>", () => {
+    let props;
+    let state;
+    beforeEach(() => {
+        props = {
+            found_count: 6,
+            page: 1,
+            page_count: 1,
+            total_count: 1,
+            canUpload: true,
+            documents: [1],
+            storedFileType: "test_file_type",
+            fileType: "test_file_type",
+            message: "",
+            tip: "",
+            validationRegex: "",
+            onDrop: jest.fn(),
+            onLoadNextPage: jest.fn()
+        };
+        state = {
+            files: {
+                documents: [
+                    {
+                        id: 1,
+                        name: "subtraction.fq.gz",
+                        name_on_disk: "1-subtraction.fq.gz",
+                        ready: true,
+                        removed: false,
+                        removed_at: null,
+                        reserved: false,
+                        size: 1024,
+                        type: "subtraction",
+                        uploaded_at: "2022-04-13T20:22:25.000000Z",
+                        user: { handle: "test_handle", id: "n91xt5wq", administrator: true }
+                    }
+                ]
+            },
+            account: { administrator: true }
+        };
+    });
+
+    it("should render", () => {
+        renderWithProviders(<FileManager {...props} />, createAppStore(state));
+        expect(screen.getByText("Drag file here to upload.")).toBeInTheDocument();
+        expect(screen.getByText("subtraction.fq.gz")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Upload" })).toBeInTheDocument();
+    });
+
+    it("should remove upload bar if canUpload is false", () => {
+        props.canUpload = false;
+        renderWithProviders(<FileManager {...props} />, createAppStore(state));
+        expect(screen.getByText("You do not have permission to upload files.")).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Upload" })).not.toBeInTheDocument();
+    });
+
+    it("should change message if passed", () => {
+        props.message = "test_message";
+        renderWithProviders(<FileManager {...props} />, createAppStore(state));
+        expect(screen.getByText("test_message")).toBeInTheDocument();
+    });
+
+    it("should add tooltip if passed", () => {
+        props.tip = "test_tip";
+        renderWithProviders(<FileManager {...props} />, createAppStore(state));
+        userEvent.hover(screen.getByLabelText("upload information"));
+        expect(screen.getByText("test_tip")).toBeInTheDocument();
+    });
+
+    it("should filter files according to passed regex", async () => {
+        props.validationRegex = /.(?:fa|fasta)(?:.gz|.gzip)?$/;
+        renderWithProviders(<FileManager {...props} />, createAppStore(state));
+        const invalidFile = new File(["test"], "test_invalid_file.gz", { type: "application/gzip" });
+        const validFile = new File(["test"], "test_valid_file.fa.gz", { type: "application/gzip" });
+        await userEvent.upload(screen.getByTestId("upload-input"), [invalidFile, validFile]);
+        await waitFor(() => {
+            expect(props.onDrop).toHaveBeenCalledWith(props.fileType, [validFile]);
+        });
+    });
+});
+
+describe("mapStateToProps()", () => {
+    let state;
+
+    beforeEach(() => {
+        state = {
+            files: {
+                found_count: 6,
+                page: 1,
+                page_count: 1,
+                total_count: 1,
+                fileType: "test_fileType",
+                documents: [
+                    {
+                        id: 1,
+                        name: "subtraction.fq.gz",
+                        name_on_disk: "1-subtraction.fq.gz",
+                        ready: true,
+                        removed: false,
+                        removed_at: null,
+                        reserved: false,
+                        size: 1024,
+                        type: "subtraction",
+                        uploaded_at: "2022-04-13T20:22:25.000000Z",
+                        user: { handle: "test_handle", id: "n91xt5wq", administrator: true }
+                    }
+                ]
+            },
+            account: { administrator: true }
+        };
+    });
+
+    it("should return correct values", () => {
+        const expected = {
+            found_count: 6,
+            page: 1,
+            page_count: 1,
+            total_count: 1,
+            storedFileType: "test_fileType",
+            documents: [1],
+            canUpload: true
+        };
+        expect(mapStateToProps(state)).toEqual(expected);
+    });
+});
+
+describe("mapDispatchToProps", () => {
+    let dispatch;
+    beforeEach(() => {
+        dispatch = jest.fn();
+    });
+
+    it("should return onDrop", () => {
+        const { onDrop } = mapDispatchToProps(dispatch);
+        const file = new File(["test"], "test_file.fa.gz", { type: "application/gzip" });
+        onDrop("test_fileType", [file]);
+        expect(dispatch).toHaveBeenCalledWith({
+            type: "UPLOAD_REQUESTED",
+            payload: { context: {}, file, fileType: "test_fileType", localId: expect.stringMatching(/.{8}/) }
+        });
+    });
+    it("should return onLoadNextPage", () => {
+        const { onLoadNextPage } = mapDispatchToProps(dispatch);
+        const payload = { fileType: "test_fileType", term: "test", page: 2 };
+        const { fileType, term, page } = payload;
+        onLoadNextPage(fileType, term, page);
+        expect(dispatch).toHaveBeenCalledWith({
+            type: "FIND_FILES_REQUESTED",
+            payload
+        });
+    });
+});

--- a/src/js/subtraction/components/Subtraction.js
+++ b/src/js/subtraction/components/Subtraction.js
@@ -1,13 +1,19 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
 import { Container, NarrowContainer } from "../../base";
-
 import FileManager from "../../files/components/Manager";
 import SubtractionCreate from "./Create";
 import SubtractionDetail from "./Detail/Detail";
 import SubtractionList from "./List";
 
-export const SubtractionFileManager = () => <FileManager fileType="subtraction" />;
+export const SubtractionFileManager = () => (
+    <FileManager
+        fileType="subtraction"
+        message="Drag FASTA files here to upload"
+        tip="Accepts files ending in fa, fasta, fa.gz, or fasta.gz."
+        validationRegex={/.(?:fa|fasta)(?:.gz|.gzip)?$/}
+    />
+);
 
 const Subtraction = () => (
     <Container>

--- a/src/js/subtraction/components/__tests__/__snapshots__/Subtraction.test.js.snap
+++ b/src/js/subtraction/components/__tests__/__snapshots__/Subtraction.test.js.snap
@@ -50,5 +50,8 @@ exports[`<Subtraction /> should render 1`] = `
 exports[`<SubtractionFileManager /> should render 1`] = `
 <Connect(FileManager)
   fileType="subtraction"
+  message="Drag FASTA files here to upload"
+  tip="Accepts files ending in fa, fasta, fa.gz, or fasta.gz."
+  validationRegex={/\\.\\(\\?:fa\\|fasta\\)\\(\\?:\\.gz\\|\\.gzip\\)\\?\\$/}
 />
 `;


### PR DESCRIPTION
Changes: 
  - Add ability to pass regex for filtering files for upload to `<FileManager>`
  - Add ability to pass tip text which gets place in a information icon in  `<FileManager>`
  - Created RTL tests for `<fileManager>`
  - Updated `Subtraction` view file manager Filter inputs to fasta files which are either compressed or uncompressed

Subtraction view file manager Screenshot: 
![image](https://user-images.githubusercontent.com/59776400/164106158-9c00436e-11af-42a2-afd0-857337f9dd8c.png)

