### PR TITLE
Ensure proper content alignment in login view

### DIFF
--- a/src/js/nav/components/NavBar.js
+++ b/src/js/nav/components/NavBar.js
@@ -56,7 +56,7 @@ const StyledNavBar = styled.div`
 export const Bar = ({ administrator, dev, userId, onLogout }) => (
     <StyledNavBar>
         <NavBarLeft>
-            <NavBarLogo />
+            <NavBarLogo color="white" />
             <NavBarItem to="/home">Home</NavBarItem>
             <NavBarItem to="/jobs">Jobs</NavBarItem>
             <NavBarItem to="/samples">Samples</NavBarItem>

--- a/src/js/nav/components/__tests__/__snapshots__/NavBar.test.js.snap
+++ b/src/js/nav/components/__tests__/__snapshots__/NavBar.test.js.snap
@@ -3,7 +3,9 @@
 exports[`<Bar /> should render 1`] = `
 <NavBar__StyledNavBar>
   <NavBar__NavBarLeft>
-    <NavBar__NavBarLogo />
+    <NavBar__NavBarLogo
+      color="white"
+    />
     <NavBarItem
       to="/home"
     >

--- a/src/js/wall/B2CLogin.js
+++ b/src/js/wall/B2CLogin.js
@@ -11,8 +11,6 @@ const StyledB2CLogin = styled.div`
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    margin: 10px 0px;
-    padding: 0px 15px;
 `;
 
 const BetaTag = styled.span`

--- a/src/js/wall/Login.js
+++ b/src/js/wall/Login.js
@@ -70,11 +70,11 @@ export class Login extends React.Component {
             <WallContainer>
                 <WallDialog>
                     <WallLoginContainer>
-                        <WallTitle />
-                        <WallHeader>Login</WallHeader>
-                        {window.b2c.use && <B2cLogin />}
-                        <form onSubmit={this.handleSubmit}>
-                            <BoxGroupSection>
+                        <BoxGroupSection>
+                            <WallTitle />
+                            <WallHeader>Login</WallHeader>
+                            {window.b2c.use && <B2cLogin />}
+                            <form onSubmit={this.handleSubmit}>
                                 <WallSubheader>
                                     Sign in with your {window.b2c.use && "legacy"} Virtool account
                                 </WallSubheader>
@@ -109,8 +109,8 @@ export class Login extends React.Component {
                                 <LoginButton type="submit" color="blue">
                                     Login
                                 </LoginButton>
-                            </BoxGroupSection>
-                        </form>
+                            </form>
+                        </BoxGroupSection>
                     </WallLoginContainer>
                 </WallDialog>
             </WallContainer>


### PR DESCRIPTION
Corrects the alignment of "Login" in the `Login` view and the `navBar` `VTLogo` back to white.

**Screenshots:**
Login:
![image](https://user-images.githubusercontent.com/59776400/165182071-d62a0a74-9a0d-45f5-812b-ebe04a98f49d.png)

NavBar
![image](https://user-images.githubusercontent.com/59776400/165182102-9a7a5666-9062-4d3c-8694-b2342128fcd5.png)
