### PR TITLE
fix: skull icon display for terminated jobs

### DIFF
--- a/src/js/jobs/components/Item/Status.js
+++ b/src/js/jobs/components/Item/Status.js
@@ -27,23 +27,13 @@ export const JobStatus = ({ pad, state }) => {
         );
     }
 
-    if (state === "complete") {
-        return (
-            <StyledJobStatus pad={pad}>
-                <Icon name="check fa-fw" color="green" />
-                <span>{state}</span>
-            </StyledJobStatus>
-        );
-    }
-
-    if (state === "error" || state === "cancelled" || state === "terminated") {
-        return (
-            <StyledJobStatus pad={pad}>
-                <Icon name="times fa-fw" color="red" />
-                <span>{state}</span>
-            </StyledJobStatus>
-        );
-    }
-
-    return null;
+    return (
+        <StyledJobStatus pad={pad}>
+            <Icon
+                name={`${state === "complete" ? "check" : state === "terminated" ? "skull" : "times"} fa-fw`}
+                color={`${state === "complete" ? "green" : "red"}`}
+            />
+            <span>{state}</span>
+        </StyledJobStatus>
+    );
 };


### PR DESCRIPTION
Skull icon is displayed for terminated jobs. 

![Screenshot from 2022-05-10 14-26-22](https://user-images.githubusercontent.com/97321944/167724610-a4693db4-8d8b-41b6-b698-31426859aaee.png)

