### PR TITLE
fix: label description renders below label component

### DIFF
--- a/src/js/samples/components/Sidebar/Labels.js
+++ b/src/js/samples/components/Sidebar/Labels.js
@@ -10,10 +10,10 @@ import { getFontSize, fontWeight, getColor } from "../../../app/theme";
 import { xor } from "lodash-es";
 
 const SampleLabelInner = ({ name, color, description }) => (
-    <>
+    <div>
         <SmallSampleLabel color={color} name={name} />
-        <p>{description}</p>
-    </>
+        <StyledParagraph>{description}</StyledParagraph>
+    </div>
 );
 
 const SampleLabelsFooter = styled.div`
@@ -24,6 +24,11 @@ const SampleLabelsFooter = styled.div`
         font-size: ${getFontSize("md")};
         font-weight: ${fontWeight.thick};
     }
+`;
+
+const StyledParagraph = styled.div`
+    color: ${props => getColor({ theme: props.theme, color: "greyDarkest" })};
+    font-size: ${getFontSize("sm")};
 `;
 
 export const SampleLabels = ({ allLabels, sampleLabels, onUpdate }) => (


### PR DESCRIPTION
Label descriptions render below the label component.

![Screenshot from 2022-05-11 09-49-43](https://user-images.githubusercontent.com/97321944/167905979-de5899ea-5cbe-46c5-a9a0-037a3a88e4e0.png)
