### PR TITLE
fix: sequence bottom border renders in otu view in firefox

### DIFF
--- a/src/js/sequences/components/Table/Table.js
+++ b/src/js/sequences/components/Table/Table.js
@@ -9,7 +9,6 @@ const SequenceCell = styled.td`
 
     textarea {
         width: 100%;
-        margin: 0 0 -4px 0;
         padding: 5px;
         border: none;
     }


### PR DESCRIPTION
Bottom border renders in otu view in firefox browser where bug originated. Border is unchanged in chrome browser.

![Screenshot from 2022-05-11 11-50-39](https://user-images.githubusercontent.com/97321944/167924375-2545b094-88fb-44df-b171-fd34c8bd5555.png)
