### PR TITLE
fix: label filtering working in sample detail view

### DIFF
--- a/src/js/samples/components/Sidebar/Selector.js
+++ b/src/js/samples/components/Sidebar/Selector.js
@@ -34,17 +34,20 @@ export const SampleSidebarSelector = ({
 }) => {
     const [results, term, setTerm] = useFuse(sampleItems, ["name"], [sampleId]);
     const [attributes, show, styles, setPopperElement, setReferenceElement, setShow] = usePopover();
-    const sampleItemComponents = results.map(item => (
-        <SampleSidebarSelectorItem
-            key={item.id}
-            selected={selectedItems.includes(item.id)}
-            partiallySelected={partiallySelectedItems.includes(item.id)}
-            {...item}
-            onClick={onUpdate}
-        >
-            {render(item)}
-        </SampleSidebarSelectorItem>
-    ));
+    const sampleItemComponents = results.map(item => {
+        const result = item.id ? item : item.item;
+        return (
+            <SampleSidebarSelectorItem
+                key={result.id}
+                selected={selectedItems.includes(result.id)}
+                partiallySelected={partiallySelectedItems.includes(result.id)}
+                {...result}
+                onClick={onUpdate}
+            >
+                {render(result)}
+            </SampleSidebarSelectorItem>
+        );
+    });
 
     return (
         <>


### PR DESCRIPTION
Label filtering works in sample detail view. The bug was caused by the structure of the results object being different when no filter is provided vs when a filter is typed.

![Screenshot from 2022-05-12 10-53-09](https://user-images.githubusercontent.com/97321944/168138135-803dfa79-a15d-4b54-9c8f-a8ce882f100d.png)

