### PR TITLE
fix: add overflow handling to label chooser in create sample view to prevent overflow

### DIFF
--- a/src/js/samples/components/Sidebar/Selector.js
+++ b/src/js/samples/components/Sidebar/Selector.js
@@ -11,7 +11,7 @@ const SampleSidebarSelectorInputContainer = styled(BoxGroupSection)`
     padding: 10px;
 `;
 
-const StyledLinkButton = styled.div`
+const SampleSidebarSelectorButton = styled.div`
     display: flex;
 
     a {
@@ -20,6 +20,11 @@ const StyledLinkButton = styled.div`
         font-weight: ${fontWeight.thick};
         padding: 10px 10px 10px 0px;
     }
+`;
+
+const SampleItemComponentsContainer = styled.div`
+    max-height: 300px;
+    overflow-y: scroll;
 `;
 
 export const SampleSidebarSelector = ({
@@ -69,10 +74,12 @@ export const SampleSidebarSelector = ({
                             autoFocus
                         />
                     </SampleSidebarSelectorInputContainer>
-                    {sampleItemComponents}
-                    <StyledLinkButton>
-                        <Link to={manageLink}> Manage</Link>
-                    </StyledLinkButton>
+                    <SampleItemComponentsContainer>
+                        {sampleItemComponents}
+                        <SampleSidebarSelectorButton>
+                            <Link to={manageLink}> Manage</Link>
+                        </SampleSidebarSelectorButton>
+                    </SampleItemComponentsContainer>
                 </PopoverBody>
             )}
         </>


### PR DESCRIPTION
Overflow handling added to label chooser in create sample view

![Screenshot from 2022-05-13 10-30-34](https://user-images.githubusercontent.com/97321944/168336968-e9584acf-1818-4902-874c-f4b59f39390d.png)
.