### PR TITLE
fix: Update usefuse return matches on single character input and data…

### DIFF
--- a/src/js/base/ScrollList.js
+++ b/src/js/base/ScrollList.js
@@ -8,6 +8,8 @@ export const getScrollRatio = () =>
 
 const StyledScrollList = styled.div`
     padding-bottom: 20px;
+    position: relative;
+    z-index: 0;
 `;
 
 export class ScrollList extends React.Component {

--- a/src/js/base/__tests__/UseFuse.test.js
+++ b/src/js/base/__tests__/UseFuse.test.js
@@ -1,0 +1,71 @@
+import { useFuse } from "../hooks";
+import { act, renderHook } from "@testing-library/react-hooks";
+
+describe("useFuseHook", () => {
+    let collection;
+    let keys; 
+    let deps; 
+
+    beforeEach(()=>{
+        collection = [{name: "nan"}, {name: "test1"}, {name: "aaaaa"}, {name: "zzzzz"}];
+        keys = ['name'];
+        deps = ['zzz'];
+    })
+
+    it("term = empty string and return object = collection and component mounts correctly", ()=> {
+        const { result } = renderHook(() => useFuse(collection, keys, deps));
+        const [ returnObj, term, setTerm] = result.current;
+        const length = result.current.length;
+        expect(length).toBe(3);
+        expect(result.current[0]).toBe(collection);
+        expect(result.current[1]).toBe("");
+    })
+    
+    it("after term changed to non empty string returnObj should change", () => {
+        const { result } = renderHook(() => useFuse(collection, keys, deps));
+        const [ returnObj, term, setTerm] = result.current;
+
+        act(() => {
+            setTerm("z");
+        });
+        expect(result.current[0]).toEqual( [ { item: { name: 'zzzzz' }, refIndex: 3 } ]);
+        expect(result.current[1]).toBe("z"); 
+    });
+
+    it("searchFuse that yields no matches will return the original results", ()=> {
+        const { result } = renderHook(() => useFuse(collection, keys, deps));
+        const [ returnObj, term, setTerm] = result.current;
+        
+        act(()=> {
+            setTerm("wwwwwwwww");
+        });
+        expect(result.current[1]).toBe("wwwwwwwww");
+        expect(result.current[0]).toEqual([]);
+    });
+
+    it("when the term is changed from nonempty string to empty string collection is returned", ()=> {
+        const { result } = renderHook(() => useFuse(collection, keys, deps));
+        const [ returnObj, term, setTerm] = result.current;
+        
+        act(()=> {
+            setTerm("z");
+            setTerm("");
+        });
+        expect(result.current[1]).toBe("");
+        expect(result.current[0]).toBe(collection);
+    })
+
+    it("term is reset to empty string if deps changes", ()=> {
+        const { rerender, result } = renderHook(() => useFuse(collection, keys, deps));
+        const [ returnObj, term, setTerm] = result.current;
+        
+        act(()=>{
+            setTerm("z");
+        });
+        
+        expect(result.current[1]).toBe("z");
+        deps = ["aaa"];
+        rerender();
+        expect(result.current[1]).toBe(""); 
+    });
+})

--- a/src/js/base/__tests__/__snapshots__/ScrollList.test.js.snap
+++ b/src/js/base/__tests__/__snapshots__/ScrollList.test.js.snap
@@ -3,6 +3,8 @@
 exports[`<ScrollList /> should render when [noContainer=false] 1`] = `
 .c0 {
   padding-bottom: 20px;
+  position: relative;
+  z-index: 0;
 }
 
 <ScrollList
@@ -49,6 +51,8 @@ exports[`<ScrollList /> should return LoadingPlaceholder when [documents=null] a
 
 .c0 {
   padding-bottom: 20px;
+  position: relative;
+  z-index: 0;
 }
 
 <ScrollList
@@ -103,6 +107,8 @@ exports[`<ScrollList /> should return LoadingPlaceholder when [documents=null] a
 exports[`<ScrollList /> should return React.Fragment when [noContainer=true] 1`] = `
 .c0 {
   padding-bottom: 20px;
+  position: relative;
+  z-index: 0;
 }
 
 <ScrollList

--- a/src/js/nav/components/NavBar.js
+++ b/src/js/nav/components/NavBar.js
@@ -54,7 +54,7 @@ const StyledNavBar = styled.div`
     z-index: 90;
 `;
 
-const StyledDivider = styled.div`
+const SampleDivider = styled.div`
     color: ${props => props.theme.color.greyLight};
     border-top: 2px solid;
 `;
@@ -90,7 +90,7 @@ export const Bar = ({ administrator, dev, userId, onLogout, handle }) => (
                         Signed in as <strong>{handle}</strong>
                     </DropdownMenuLink>
 
-                    <StyledDivider />
+                    <SampleDivider />
                     <DropdownMenuLink to="/account">Account</DropdownMenuLink>
                     {administrator && <DropdownMenuLink to="/administration">Administration </DropdownMenuLink>}
                     <DropdownMenuLink

--- a/src/js/nav/components/__tests__/__snapshots__/NavBar.test.js.snap
+++ b/src/js/nav/components/__tests__/__snapshots__/NavBar.test.js.snap
@@ -57,7 +57,7 @@ exports[`<Bar /> should render 1`] = `
           Signed in as 
           <strong />
         </Dropdown__DropdownMenuLink>
-        <NavBar__StyledDivider />
+        <NavBar__SampleDivider />
         <Dropdown__DropdownMenuLink
           to="/account"
         >


### PR DESCRIPTION
Usefuse returns matches if they exist on a single character input. Data is also returned in a consistent format regardless of what is entered in the search filter.

![Screenshot from 2022-05-13 11-37-49](https://user-images.githubusercontent.com/97321944/168346395-b92db2d2-5293-4956-bb2a-e38862de4012.png)
