### PR TITLE
fix: reformat default subtraction style to match default label

### DIFF
--- a/src/js/samples/components/Sidebar/Subtractions.js
+++ b/src/js/samples/components/Sidebar/Subtractions.js
@@ -15,7 +15,7 @@ const SampleSubtractionFooter = styled.div`
     display: flex;
     color: ${props => getColor({ theme: props.theme, color: "greyDarkest" })};
     a {
-        margin-left: 20px;
+        margin-left: 5px;
         font-size: ${getFontSize("md")};
         font-weight: ${fontWeight.thick};
     }
@@ -41,7 +41,7 @@ export const DefaultSubtractions = ({ defaultSubtractions, subtractionOptions, o
         />
         {Boolean(subtractionOptions.length) || (
             <SampleSubtractionFooter>
-                No subtractions found <Link to="/subtractions">Create one</Link>.
+                No subtractions found. <Link to="/subtractions">Create one</Link>.
             </SampleSubtractionFooter>
         )}
     </SideBarSection>


### PR DESCRIPTION
Default subtraction styling matches default label styling.

![Screenshot from 2022-05-17 09-23-03](https://user-images.githubusercontent.com/97321944/168861621-e1476da8-db02-4d6a-98b2-5516634f45b9.png)
