### PR TITLE
fix: add title and description for terminated jobs

### DIFF
--- a/src/js/jobs/utils.js
+++ b/src/js/jobs/utils.js
@@ -219,6 +219,13 @@ export const getStepDescription = (stage, state, workflow) => {
         };
     }
 
+    if (state === "terminated") {
+        return {
+            title: "Terminated",
+            description: "There was a system malfunction"
+        };
+    }
+
     return get(stepDescriptions, [workflow, stage], {
         description: "",
         title: startCase(stage)


### PR DESCRIPTION
Title and description added for jobs in the terminated state.

![Screenshot from 2022-05-17 10-04-13](https://user-images.githubusercontent.com/97321944/168871289-556ff38e-0e4d-4942-8793-3bd5b3899054.png)
