### PR TITLE
Ensure all displayed files are ready

### DIFF
--- a/src/js/files/api.js
+++ b/src/js/files/api.js
@@ -7,7 +7,8 @@ import { Request } from "../app/request";
 
 export const find = ({ fileType }) =>
     Request.get("/api/uploads").query({
-        type: fileType
+        type: fileType,
+        ready: true
     });
 
 /**
@@ -20,7 +21,8 @@ export const find = ({ fileType }) =>
  */
 export const list = ({ fileType }) =>
     Request.get("/api/uploads").query({
-        type: fileType
+        type: fileType,
+        ready: true
     });
 
 /**


### PR DESCRIPTION
Seems like all file requests are made through one of two api call so this was a really small fix. I kept this PR small in scope but I noticed a couple of low priority oddities that might be worth addressing in later issues.

  1. The file `find` and `list` api calls are functionally identical despite the comments suggesting list should support pagination. From the looks of things the API doesn't even support specifying page numbers. It would probably make sense to merge `list` and `find` into a single api call definition, unless the difference is there to support a planned feature.
  2. The way the returned files are stored varies depending on the component. `subtractions` keeps the files in the `file` components slice of redux state whereas `samples` stores the files in its own slice of redux state. This isn't really a problem, more of a codebase consistency thing.