### PR TITLE
fix: make logout button visible from jobs page

### DIFF
--- a/src/js/base/ScrollList.js
+++ b/src/js/base/ScrollList.js
@@ -8,6 +8,8 @@ export const getScrollRatio = () =>
 
 const StyledScrollList = styled.div`
     padding-bottom: 20px;
+    position: relative;
+    z-index: 0;
 `;
 
 export class ScrollList extends React.Component {

--- a/src/js/base/__tests__/__snapshots__/ScrollList.test.js.snap
+++ b/src/js/base/__tests__/__snapshots__/ScrollList.test.js.snap
@@ -3,6 +3,8 @@
 exports[`<ScrollList /> should render when [noContainer=false] 1`] = `
 .c0 {
   padding-bottom: 20px;
+  position: relative;
+  z-index: 0;
 }
 
 <ScrollList
@@ -49,6 +51,8 @@ exports[`<ScrollList /> should return LoadingPlaceholder when [documents=null] a
 
 .c0 {
   padding-bottom: 20px;
+  position: relative;
+  z-index: 0;
 }
 
 <ScrollList
@@ -103,6 +107,8 @@ exports[`<ScrollList /> should return LoadingPlaceholder when [documents=null] a
 exports[`<ScrollList /> should return React.Fragment when [noContainer=true] 1`] = `
 .c0 {
   padding-bottom: 20px;
+  position: relative;
+  z-index: 0;
 }
 
 <ScrollList

--- a/src/js/nav/components/NavBar.js
+++ b/src/js/nav/components/NavBar.js
@@ -54,7 +54,7 @@ const StyledNavBar = styled.div`
     z-index: 90;
 `;
 
-const StyledDivider = styled.div`
+const SampleDivider = styled.div`
     color: ${props => props.theme.color.greyLight};
     border-top: 2px solid;
 `;
@@ -90,7 +90,7 @@ export const Bar = ({ administrator, dev, userId, onLogout, handle }) => (
                         Signed in as <strong>{handle}</strong>
                     </DropdownMenuLink>
 
-                    <StyledDivider />
+                    <SampleDivider />
                     <DropdownMenuLink to="/account">Account</DropdownMenuLink>
                     {administrator && <DropdownMenuLink to="/administration">Administration </DropdownMenuLink>}
                     <DropdownMenuLink

--- a/src/js/nav/components/__tests__/__snapshots__/NavBar.test.js.snap
+++ b/src/js/nav/components/__tests__/__snapshots__/NavBar.test.js.snap
@@ -57,7 +57,7 @@ exports[`<Bar /> should render 1`] = `
           Signed in as 
           <strong />
         </Dropdown__DropdownMenuLink>
-        <NavBar__StyledDivider />
+        <NavBar__SampleDivider />
         <Dropdown__DropdownMenuLink
           to="/account"
         >


### PR DESCRIPTION
Logout button is visible when the jobs page is open and jobs list is being displayed.

![Screenshot from 2022-05-19 11-43-20](https://user-images.githubusercontent.com/97321944/169377814-15eb6a87-3cf9-458f-8dc8-d1e2c57f7863.png)
