### PR TITLE
fix: make manage button visible in label chooser overflow

### DIFF
--- a/src/js/samples/components/Sidebar/Selector.js
+++ b/src/js/samples/components/Sidebar/Selector.js
@@ -13,6 +13,11 @@ const SampleSidebarSelectorInputContainer = styled(BoxGroupSection)`
 
 const SampleSidebarSelectorButton = styled.div`
     display: flex;
+    border-top: 1px solid;
+    border-color: ${props => props.theme.color.greyLight};
+    width: 100%;
+    display: flex;
+    align-items: right;
 
     a {
         margin-left: auto;
@@ -77,12 +82,10 @@ export const SampleSidebarSelector = ({
                             autoFocus
                         />
                     </SampleSidebarSelectorInputContainer>
-                    <SampleItemComponentsContainer>
-                        {sampleItemComponents}
-                        <SampleSidebarSelectorButton>
-                            <Link to={manageLink}> Manage</Link>
-                        </SampleSidebarSelectorButton>
-                    </SampleItemComponentsContainer>
+                    <SampleItemComponentsContainer>{sampleItemComponents}</SampleItemComponentsContainer>
+                    <SampleSidebarSelectorButton>
+                        <Link to={manageLink}> Manage</Link>
+                    </SampleSidebarSelectorButton>
                 </PopoverBody>
             )}
         </>


### PR DESCRIPTION
Manage button remains visible in create sample label chooser overflow.

![Screenshot from 2022-05-20 09-22-42](https://user-images.githubusercontent.com/97321944/169571562-a9f5edca-f0a5-4b6b-963b-e740e22e0b33.png)
