### PR TITLE
Add job archival option to job list and detail views

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - backend
 
   api:
-    image: virtool/virtool:7.1.4
+    image: virtool/virtool:7.6.3
     depends_on:
       - mongo
       - redis
@@ -62,7 +62,7 @@ services:
       - vt_data:/data
 
   jobs-api:
-    image: virtool/virtool:7.1.4
+    image: virtool/virtool:7.6.3
     depends_on:
       - mongo
       - redis

--- a/src/js/app/actionTypes.js
+++ b/src/js/app/actionTypes.js
@@ -130,6 +130,7 @@ export const GET_LINKED_JOB = createRequestActionType("GET_LINKED_JOB");
 export const CANCEL_JOB = createRequestActionType("CANCEL_JOB");
 export const REMOVE_JOB = createRequestActionType("REMOVE_JOB");
 export const CLEAR_JOBS = createRequestActionType("CLEAR_JOBS");
+export const ARCHIVE_JOB = createRequestActionType("ARCHIVE_JOB");
 
 // OTU
 export const WS_INSERT_OTU = "WS_INSERT_OTU";

--- a/src/js/jobs/__tests__/actions.test.js
+++ b/src/js/jobs/__tests__/actions.test.js
@@ -1,14 +1,13 @@
 import {
-    WS_INSERT_JOB,
-    WS_UPDATE_JOB,
-    WS_REMOVE_JOB,
-    GET_JOB,
+    ARCHIVE_JOB,
     CANCEL_JOB,
-    REMOVE_JOB,
-    CLEAR_JOBS,
-    FIND_JOBS
+    FIND_JOBS,
+    GET_JOB,
+    WS_INSERT_JOB,
+    WS_REMOVE_JOB,
+    WS_UPDATE_JOB
 } from "../../app/actionTypes";
-import { wsInsertJob, wsUpdateJob, wsRemoveJob, getJob, cancelJob, removeJob, clearJobs, findJobs } from "../actions";
+import { archiveJob, cancelJob, findJobs, getJob, wsInsertJob, wsRemoveJob, wsUpdateJob } from "../actions";
 
 describe("Jobs Action Creators:", () => {
     it("wsInsertJob: returns action for job insert via websocket", () => {
@@ -44,7 +43,7 @@ describe("Jobs Action Creators:", () => {
         const result = findJobs(term, page);
         expect(result).toEqual({
             type: FIND_JOBS.REQUESTED,
-            payload: { term, page }
+            payload: { term, page, archived: false }
         });
     });
 
@@ -66,21 +65,12 @@ describe("Jobs Action Creators:", () => {
         });
     });
 
-    it("removeJob: returns action for removing a specific job", () => {
+    it("ArchiveJob: returns action for archiving a specific job", () => {
         const jobId = "tester";
-        const result = removeJob(jobId);
+        const result = archiveJob(jobId);
         expect(result).toEqual({
-            type: REMOVE_JOB.REQUESTED,
+            type: ARCHIVE_JOB.REQUESTED,
             payload: { jobId }
-        });
-    });
-
-    it("clearJobs: returns action to clear a subset of jobs", () => {
-        const scope = "filter";
-        const result = clearJobs(scope);
-        expect(result).toEqual({
-            type: CLEAR_JOBS.REQUESTED,
-            payload: { scope }
         });
     });
 });

--- a/src/js/jobs/actions.js
+++ b/src/js/jobs/actions.js
@@ -1,15 +1,15 @@
+import { createAction } from "@reduxjs/toolkit";
 import {
+    ARCHIVE_JOB,
     CANCEL_JOB,
-    CLEAR_JOBS,
     FIND_JOBS,
     GET_JOB,
     GET_LINKED_JOB,
-    REMOVE_JOB,
     WS_INSERT_JOB,
     WS_REMOVE_JOB,
     WS_UPDATE_JOB
 } from "../app/actionTypes";
-import { createAction } from "@reduxjs/toolkit";
+
 /**
  * Returns an action that should be dispatched when a job document is inserted via websocket.
  *
@@ -44,8 +44,8 @@ export const wsRemoveJob = createAction(WS_REMOVE_JOB);
  * @returns {object}
  */
 
-export const findJobs = createAction(FIND_JOBS.REQUESTED, (term, page) => ({
-    payload: { term, page }
+export const findJobs = createAction(FIND_JOBS.REQUESTED, (term, page, archived = false) => ({
+    payload: { term, page, archived }
 }));
 
 /**
@@ -69,19 +69,10 @@ export const getLinkedJob = createAction(GET_LINKED_JOB.REQUESTED, jobId => ({ p
 export const cancelJob = createAction(CANCEL_JOB.REQUESTED, jobId => ({ payload: { jobId } }));
 
 /**
- * Returns action that can trigger an API call for removing a specific job.
+ * Returns action that can trigger an API call for archiving a specific job.
  *
  * @func
- * @param jobId {string} the id for the specific job
+ * @param jobId {string} id of the specific job
  * @returns {object}
  */
-export const removeJob = createAction(REMOVE_JOB.REQUESTED, jobId => ({ payload: { jobId } }));
-
-/**
- * Returns action that can trigger an API call for clearing a subset of listed jobs.
- *
- * @func
- * @param scope {string} keyword for a category of jobs
- * @returns {object}
- */
-export const clearJobs = createAction(CLEAR_JOBS.REQUESTED, scope => ({ payload: { scope } }));
+export const archiveJob = createAction(ARCHIVE_JOB.REQUESTED, jobId => ({ payload: { jobId } }));

--- a/src/js/jobs/api.js
+++ b/src/js/jobs/api.js
@@ -1,11 +1,10 @@
 import { Request } from "../app/request";
 
-export const find = ({ term, page }) => Request.get("/api/jobs").query({ find: term, page });
+export const find = ({ term, page, archived }) =>
+    Request.get("/api/jobs").query({ find: term, page, archived, beta: true });
 
 export const get = ({ jobId }) => Request.get(`/api/jobs/${jobId}`);
 
 export const cancel = ({ jobId }) => Request.put(`/api/jobs/${jobId}/cancel`);
 
-export const remove = ({ jobId }) => Request.delete(`/api/jobs/${jobId}`);
-
-export const clear = ({ scope }) => Request.delete("/api/jobs").query({ filter: scope || "finished" });
+export const archive = ({ jobId }) => Request.patch(`/api/jobs/${jobId}/archive`);

--- a/src/js/jobs/components/Detail.js
+++ b/src/js/jobs/components/Detail.js
@@ -13,11 +13,12 @@ import {
     ViewHeaderTitle
 } from "../../base";
 import { checkAdminOrPermission, getWorkflowDisplayName } from "../../utils/utils";
-import { cancelJob, getJob, removeJob } from "../actions";
+import { archiveJob, cancelJob, getJob } from "../actions";
 import JobError from "./Error";
-import JobSteps from "./Steps";
-import { JobArgs } from "./JobArgs";
 import { JobAction } from "./Item/Action";
+import { JobArgs } from "./JobArgs";
+import JobSteps from "./Steps";
+
 const JobDetailBadge = styled(Badge)`
     text-transform: capitalize;
 `;
@@ -64,9 +65,9 @@ class JobDetail extends React.Component {
                             <JobAction
                                 state={detail.state}
                                 onCancel={() => this.props.onCancel(this.props.detail.id)}
-                                onRemove={() => this.props.onRemove(this.props.detail.id)}
+                                onArchive={() => this.props.onArchive(this.props.detail.id)}
                                 canCancel={this.props.canCancel}
-                                canRemove={this.props.canRemove}
+                                canArchive={this.props.canArchive}
                             />
                         </ViewHeaderIcons>
                     </ViewHeaderTitle>
@@ -87,7 +88,7 @@ const mapStateToProps = state => ({
     error: get(state, "errors.GET_JOB_ERROR", null),
     detail: state.jobs.detail,
     canCancel: checkAdminOrPermission(state, "cancel_job"),
-    canRemove: checkAdminOrPermission(state, "remove_job")
+    canArchive: checkAdminOrPermission(state, "remove_job")
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -97,8 +98,8 @@ const mapDispatchToProps = dispatch => ({
     onCancel: jobId => {
         dispatch(cancelJob(jobId));
     },
-    onRemove: jobId => {
-        dispatch(removeJob(jobId));
+    onArchive: jobId => {
+        dispatch(archiveJob(jobId));
         dispatch(push("/jobs"));
     }
 });

--- a/src/js/jobs/components/Item/Action.js
+++ b/src/js/jobs/components/Item/Action.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Icon } from "../../../base";
 
-export function JobAction({ state, canCancel, canRemove, onCancel, onRemove }) {
+export function JobAction({ state, canCancel, canArchive, onCancel, onArchive }) {
     if (state === "waiting" || state === "running") {
         if (canCancel) {
             return <Icon color="red" name="ban" onClick={onCancel} />;
@@ -10,8 +10,8 @@ export function JobAction({ state, canCancel, canRemove, onCancel, onRemove }) {
         return null;
     }
 
-    if (canRemove) {
-        return <Icon color="red" name="trash" onClick={onRemove} />;
+    if (canArchive) {
+        return <Icon color="red" name="archive" onClick={onArchive} />;
     }
 
     return null;

--- a/src/js/jobs/components/Item/Item.js
+++ b/src/js/jobs/components/Item/Item.js
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { getFontSize, getFontWeight } from "../../../app/theme";
 import { AffixedProgressBar, Attribution, LinkBox } from "../../../base";
 import { getWorkflowDisplayName } from "../../../utils/utils";
-import { cancelJob, removeJob } from "../../actions";
+import { archiveJob, cancelJob } from "../../actions";
 import { JobAction } from "./Action";
 import { JobStatus } from "./Status";
 
@@ -43,9 +43,20 @@ const JobActionOverlay = styled.div`
     z-index: 20;
 `;
 
-export function JobItem({ id, workflow, state, progress, created_at, user, canCancel, canRemove, onCancel, onRemove }) {
+export function JobItem({
+    id,
+    workflow,
+    state,
+    progress,
+    created_at,
+    user,
+    canCancel,
+    canArchive,
+    onCancel,
+    onArchive
+}) {
     const handleCancel = useCallback(() => onCancel(id), [id, onCancel]);
-    const handleRemove = useCallback(() => onRemove(id), [id, onRemove]);
+    const handleArchive = useCallback(() => onArchive(id), [id, onArchive]);
 
     let progressColor = "green";
 
@@ -56,7 +67,6 @@ export function JobItem({ id, workflow, state, progress, created_at, user, canCa
     if (state === "error" || state === "cancelled") {
         progressColor = "red";
     }
-
     // Create the option components for the selected fields.
     return (
         <JobItemContainer>
@@ -66,7 +76,7 @@ export function JobItem({ id, workflow, state, progress, created_at, user, canCa
                 <JobItemBody>
                     <JobItemHeader>
                         <span>{getWorkflowDisplayName(workflow)}</span>
-                        <JobStatus state={state} pad={canCancel || canRemove} />
+                        <JobStatus state={state} pad={canCancel || canArchive} />
                     </JobItemHeader>
                     <Attribution time={created_at} user={user.handle} />
                 </JobItemBody>
@@ -76,9 +86,9 @@ export function JobItem({ id, workflow, state, progress, created_at, user, canCa
                     key={state}
                     state={state}
                     canCancel={canCancel}
-                    canRemove={canRemove}
+                    canArchive={canArchive}
                     onCancel={handleCancel}
-                    onRemove={handleRemove}
+                    onArchive={handleArchive}
                 />
             </JobActionOverlay>
         </JobItemContainer>
@@ -90,8 +100,8 @@ export const mapDispatchToProps = dispatch => ({
         dispatch(cancelJob(jobId));
     },
 
-    onRemove: jobId => {
-        dispatch(removeJob(jobId));
+    onArchive: jobId => {
+        dispatch(archiveJob(jobId));
     }
 });
 

--- a/src/js/jobs/components/Item/__tests__/Action.test.js
+++ b/src/js/jobs/components/Item/__tests__/Action.test.js
@@ -7,9 +7,9 @@ describe("<JobActionIcon />", () => {
         props = {
             state: "waiting",
             canCancel: true,
-            canRemove: true,
+            canArchive: true,
             onCancel: jest.fn(),
-            onRemove: jest.fn()
+            onArchive: jest.fn()
         };
     });
 
@@ -25,9 +25,9 @@ describe("<JobActionIcon />", () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render when [state="complete"] and [canRemove=false]', () => {
+    it('should render when [state="complete"] and [canArchive=false]', () => {
         props.state = "complete";
-        props.canRemove = false;
+        props.canArchive = false;
         const wrapper = shallow(<JobAction {...props} />);
         expect(wrapper).toMatchSnapshot();
     });
@@ -38,10 +38,10 @@ describe("<JobActionIcon />", () => {
         expect(props.onCancel).toHaveBeenCalled();
     });
 
-    it("should call onRemove() when remove icon clicked", () => {
+    it("should call onArchive() when archive icon clicked", () => {
         props.state = "complete";
         const wrapper = shallow(<JobAction {...props} />);
         wrapper.find("Icon").prop("onClick")();
-        expect(props.onRemove).toHaveBeenCalled();
+        expect(props.onArchive).toHaveBeenCalled();
     });
 });

--- a/src/js/jobs/components/Item/__tests__/Item.test.js
+++ b/src/js/jobs/components/Item/__tests__/Item.test.js
@@ -14,9 +14,9 @@ describe("<JobItem />", () => {
                 handle: "bob"
             },
             canCancel: true,
-            canRemove: true,
+            canArchive: true,
             onCancel: jest.fn(),
-            onRemove: jest.fn()
+            onArchive: jest.fn()
         };
     });
 
@@ -31,11 +31,11 @@ describe("<JobItem />", () => {
         [true, false],
         [false, true],
         [false, false]
-    ])("should render when [canCancel=%p] and [canRemove=%p]", (canCancel, canRemove) => {
+    ])("should render when [canCancel=%p] and [canArchive=%p]", (canCancel, canArchive) => {
         props = {
             ...props,
             canCancel,
-            canRemove
+            canArchive
         };
         const wrapper = shallow(<JobItem {...props} />);
         expect(wrapper).toMatchSnapshot();
@@ -54,15 +54,15 @@ describe("mapDispatchToProps", () => {
             payload: { jobId: "foo" }
         });
     });
-    it("should return onRemove() in props", () => {
+    it("should return onArchive() in props", () => {
         const dispatch = jest.fn();
         const props = mapDispatchToProps(dispatch);
 
-        props.onRemove("foo");
+        props.onArchive("foo");
 
         expect(dispatch).toHaveBeenCalledWith({
             payload: { jobId: "foo" },
-            type: "REMOVE_JOB_REQUESTED"
+            type: "ARCHIVE_JOB_REQUESTED"
         });
     });
 });

--- a/src/js/jobs/components/Item/__tests__/__snapshots__/Action.test.js.snap
+++ b/src/js/jobs/components/Item/__tests__/__snapshots__/Action.test.js.snap
@@ -5,7 +5,7 @@ exports[`<JobActionIcon /> should render when [state="cancelled"] 1`] = `
   color="red"
   faStyle="fas"
   fixedWidth={false}
-  name="trash"
+  name="archive"
   onClick={[MockFunction]}
 />
 `;
@@ -15,19 +15,19 @@ exports[`<JobActionIcon /> should render when [state="complete"] 1`] = `
   color="red"
   faStyle="fas"
   fixedWidth={false}
-  name="trash"
+  name="archive"
   onClick={[MockFunction]}
 />
 `;
 
-exports[`<JobActionIcon /> should render when [state="complete"] and [canRemove=false] 1`] = `""`;
+exports[`<JobActionIcon /> should render when [state="complete"] and [canArchive=false] 1`] = `""`;
 
 exports[`<JobActionIcon /> should render when [state="error"] 1`] = `
 <Icon
   color="red"
   faStyle="fas"
   fixedWidth={false}
-  name="trash"
+  name="archive"
   onClick={[MockFunction]}
 />
 `;

--- a/src/js/jobs/components/Item/__tests__/__snapshots__/Item.test.js.snap
+++ b/src/js/jobs/components/Item/__tests__/__snapshots__/Item.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<JobItem /> should render when [canCancel=false] and [canRemove=false] 1`] = `
+exports[`<JobItem /> should render when [canCancel=false] and [canArchive=false] 1`] = `
 <Item__JobItemContainer>
   <Item__JobItemLinkBox
     to="/jobs/foo"
@@ -26,16 +26,16 @@ exports[`<JobItem /> should render when [canCancel=false] and [canRemove=false] 
   </Item__JobItemLinkBox>
   <Item__JobActionOverlay>
     <JobAction
+      canArchive={false}
       canCancel={false}
-      canRemove={false}
+      onArchive={[Function]}
       onCancel={[Function]}
-      onRemove={[Function]}
     />
   </Item__JobActionOverlay>
 </Item__JobItemContainer>
 `;
 
-exports[`<JobItem /> should render when [canCancel=false] and [canRemove=true] 1`] = `
+exports[`<JobItem /> should render when [canCancel=false] and [canArchive=true] 1`] = `
 <Item__JobItemContainer>
   <Item__JobItemLinkBox
     to="/jobs/foo"
@@ -61,16 +61,16 @@ exports[`<JobItem /> should render when [canCancel=false] and [canRemove=true] 1
   </Item__JobItemLinkBox>
   <Item__JobActionOverlay>
     <JobAction
+      canArchive={true}
       canCancel={false}
-      canRemove={true}
+      onArchive={[Function]}
       onCancel={[Function]}
-      onRemove={[Function]}
     />
   </Item__JobActionOverlay>
 </Item__JobItemContainer>
 `;
 
-exports[`<JobItem /> should render when [canCancel=true] and [canRemove=false] 1`] = `
+exports[`<JobItem /> should render when [canCancel=true] and [canArchive=false] 1`] = `
 <Item__JobItemContainer>
   <Item__JobItemLinkBox
     to="/jobs/foo"
@@ -96,16 +96,16 @@ exports[`<JobItem /> should render when [canCancel=true] and [canRemove=false] 1
   </Item__JobItemLinkBox>
   <Item__JobActionOverlay>
     <JobAction
+      canArchive={false}
       canCancel={true}
-      canRemove={false}
+      onArchive={[Function]}
       onCancel={[Function]}
-      onRemove={[Function]}
     />
   </Item__JobActionOverlay>
 </Item__JobItemContainer>
 `;
 
-exports[`<JobItem /> should render when [canCancel=true] and [canRemove=true] 1`] = `
+exports[`<JobItem /> should render when [canCancel=true] and [canArchive=true] 1`] = `
 <Item__JobItemContainer>
   <Item__JobItemLinkBox
     to="/jobs/foo"
@@ -131,10 +131,10 @@ exports[`<JobItem /> should render when [canCancel=true] and [canRemove=true] 1`
   </Item__JobItemLinkBox>
   <Item__JobActionOverlay>
     <JobAction
+      canArchive={true}
       canCancel={true}
-      canRemove={true}
+      onArchive={[Function]}
       onCancel={[Function]}
-      onRemove={[Function]}
     />
   </Item__JobActionOverlay>
 </Item__JobItemContainer>
@@ -167,11 +167,11 @@ exports[`<JobItem /> should render when [state="cancelled"] 1`] = `
   </Item__JobItemLinkBox>
   <Item__JobActionOverlay>
     <JobAction
+      canArchive={true}
       canCancel={true}
-      canRemove={true}
       key="cancelled"
+      onArchive={[Function]}
       onCancel={[Function]}
-      onRemove={[Function]}
       state="cancelled"
     />
   </Item__JobActionOverlay>
@@ -205,11 +205,11 @@ exports[`<JobItem /> should render when [state="complete"] 1`] = `
   </Item__JobItemLinkBox>
   <Item__JobActionOverlay>
     <JobAction
+      canArchive={true}
       canCancel={true}
-      canRemove={true}
       key="complete"
+      onArchive={[Function]}
       onCancel={[Function]}
-      onRemove={[Function]}
       state="complete"
     />
   </Item__JobActionOverlay>
@@ -243,11 +243,11 @@ exports[`<JobItem /> should render when [state="error"] 1`] = `
   </Item__JobItemLinkBox>
   <Item__JobActionOverlay>
     <JobAction
+      canArchive={true}
       canCancel={true}
-      canRemove={true}
       key="error"
+      onArchive={[Function]}
       onCancel={[Function]}
-      onRemove={[Function]}
       state="error"
     />
   </Item__JobActionOverlay>
@@ -281,11 +281,11 @@ exports[`<JobItem /> should render when [state="running"] 1`] = `
   </Item__JobItemLinkBox>
   <Item__JobActionOverlay>
     <JobAction
+      canArchive={true}
       canCancel={true}
-      canRemove={true}
       key="running"
+      onArchive={[Function]}
       onCancel={[Function]}
-      onRemove={[Function]}
       state="running"
     />
   </Item__JobActionOverlay>
@@ -319,11 +319,11 @@ exports[`<JobItem /> should render when [state="waiting"] 1`] = `
   </Item__JobItemLinkBox>
   <Item__JobActionOverlay>
     <JobAction
+      canArchive={true}
       canCancel={true}
-      canRemove={true}
       key="waiting"
+      onArchive={[Function]}
       onCancel={[Function]}
-      onRemove={[Function]}
       state="waiting"
     />
   </Item__JobActionOverlay>

--- a/src/js/jobs/components/List.js
+++ b/src/js/jobs/components/List.js
@@ -15,7 +15,7 @@ export class JobsList extends React.Component {
     renderRow = index => {
         const document = this.props.documents[index];
         return (
-            <Job key={document.id} {...document} canRemove={this.props.canRemove} canCancel={this.props.canCancel} />
+            <Job key={document.id} {...document} canArchive={this.props.canArchive} canCancel={this.props.canCancel} />
         );
     };
 
@@ -58,7 +58,7 @@ export const mapStateToProps = state => ({
     ...state.jobs,
     term: getTerm(state),
     canCancel: checkAdminOrPermission(state, "cancel_job"),
-    canRemove: checkAdminOrPermission(state, "remove_job")
+    canArchive: checkAdminOrPermission(state, "remove_job")
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/js/jobs/components/Toolbar.js
+++ b/src/js/jobs/components/Toolbar.js
@@ -1,32 +1,21 @@
 import React from "react";
 import { connect } from "react-redux";
-import { Button, Icon, SearchInput, Toolbar } from "../../base";
-import { checkAdminOrPermission } from "../../utils/utils";
-import { clearJobs, findJobs } from "../actions";
+import { SearchInput, Toolbar } from "../../base";
+import { findJobs } from "../actions";
 
-export const JobsToolbar = ({ onClear, onFind, canRemove, term }) => (
+export const JobsToolbar = ({ onFind, term }) => (
     <Toolbar>
         <SearchInput value={term} onChange={onFind} placeholder="User or workflow" />
-        {canRemove && (
-            <Button onClick={() => onClear("finished")} tip="Clear Finished">
-                <Icon name="trash" />
-            </Button>
-        )}
     </Toolbar>
 );
 
 export const mapStateToProps = state => ({
-    term: state.jobs.term,
-    canRemove: checkAdminOrPermission(state, "remove_job")
+    term: state.jobs.term
 });
 
 export const mapDispatchToProps = dispatch => ({
     onFind: e => {
         dispatch(findJobs(e.target.value, 1));
-    },
-
-    onClear: scope => {
-        dispatch(clearJobs(scope));
     }
 });
 

--- a/src/js/jobs/components/__tests__/List.test.js
+++ b/src/js/jobs/components/__tests__/List.test.js
@@ -14,7 +14,7 @@ describe("<JobsList />", () => {
             page_count: 3,
             term: "foo",
             onLoadNextPage: jest.fn(),
-            canRemove: jest.fn(),
+            canArchive: jest.fn(),
             canCancel: jest.fn()
         };
     });
@@ -94,7 +94,7 @@ describe("mapStateToProps", () => {
         );
 
         expect(result.canCancel).toEqual("bar");
-        expect(result.canRemove).toEqual("bar");
+        expect(result.canArchive).toEqual("bar");
     });
 });
 
@@ -104,6 +104,9 @@ describe("mapDispatchToProps", () => {
         const props = mapDispatchToProps(dispatch);
 
         props.onLoadNextPage("foo", "bar");
-        expect(dispatch).toHaveBeenCalledWith({ payload: { term: "foo", page: "bar" }, type: "FIND_JOBS_REQUESTED" });
+        expect(dispatch).toHaveBeenCalledWith({
+            payload: { term: "foo", page: "bar", archived: false },
+            type: "FIND_JOBS_REQUESTED"
+        });
     });
 });

--- a/src/js/jobs/components/__tests__/Toolbar.test.js
+++ b/src/js/jobs/components/__tests__/Toolbar.test.js
@@ -1,6 +1,5 @@
 import React from "react";
-import { CLEAR_JOBS, FIND_JOBS } from "../../../app/actionTypes";
-import { checkAdminOrPermission } from "../../../utils/utils";
+import { FIND_JOBS } from "../../../app/actionTypes";
 import { JobsToolbar, mapDispatchToProps, mapStateToProps } from "../Toolbar.js";
 
 jest.mock("../../../utils/utils");
@@ -10,28 +9,19 @@ describe("<JobsToolbar />", () => {
 
     beforeEach(() => {
         props = {
-            onClear: jest.fn(),
             onFind: jest.fn(),
-            canRemove: true,
             term: "foo"
         };
     });
 
-    it("should render when [canRemove=true]", () => {
-        const wrapper = shallow(<JobsToolbar {...props} />);
-        expect(wrapper).toMatchSnapshot();
-    });
-
-    it("should render when [canRemove=false]", () => {
-        props.canRemove = false;
+    it("should render", () => {
         const wrapper = shallow(<JobsToolbar {...props} />);
         expect(wrapper).toMatchSnapshot();
     });
 });
 
 describe("mapStateToProps", () => {
-    it.each([true, false])("should return props with [canRemove=%p]", canRemove => {
-        checkAdminOrPermission.mockReturnValue(canRemove);
+    it("should return correct props", () => {
         const state = {
             jobs: {
                 term: "bar"
@@ -43,10 +33,8 @@ describe("mapStateToProps", () => {
         };
         const props = mapStateToProps(state);
         expect(props).toEqual({
-            term: "bar",
-            canRemove
+            term: "bar"
         });
-        expect(checkAdminOrPermission).toHaveBeenCalledWith(state, "remove_job");
     });
 });
 
@@ -62,18 +50,7 @@ describe("mapDispatchToProps", () => {
         props.onFind(e, "foo", "bar");
         expect(dispatch).toHaveBeenCalledWith({
             type: FIND_JOBS.REQUESTED,
-            payload: { term: "Foo", page: 1 }
-        });
-    });
-
-    it("should return onClear() in props", () => {
-        const dispatch = jest.fn();
-        const props = mapDispatchToProps(dispatch);
-
-        props.onClear("Foo");
-        expect(dispatch).toHaveBeenCalledWith({
-            type: CLEAR_JOBS.REQUESTED,
-            payload: { scope: "Foo" }
+            payload: { term: "Foo", page: 1, archived: false }
         });
     });
 });

--- a/src/js/jobs/components/__tests__/__snapshots__/Toolbar.test.js.snap
+++ b/src/js/jobs/components/__tests__/__snapshots__/Toolbar.test.js.snap
@@ -1,35 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<JobsToolbar /> should render when [canRemove=false] 1`] = `
+exports[`<JobsToolbar /> should render 1`] = `
 <Toolbar>
   <SearchInput
     onChange={[MockFunction]}
     placeholder="User or workflow"
     value="foo"
   />
-</Toolbar>
-`;
-
-exports[`<JobsToolbar /> should render when [canRemove=true] 1`] = `
-<Toolbar>
-  <SearchInput
-    onChange={[MockFunction]}
-    placeholder="User or workflow"
-    value="foo"
-  />
-  <Button
-    color="grey"
-    disabled={false}
-    onClick={[Function]}
-    tip="Clear Finished"
-    tipPlacement="top"
-    type="button"
-  >
-    <Icon
-      faStyle="fas"
-      fixedWidth={false}
-      name="trash"
-    />
-  </Button>
 </Toolbar>
 `;

--- a/src/js/jobs/reducer.js
+++ b/src/js/jobs/reducer.js
@@ -1,6 +1,14 @@
 import { createReducer } from "@reduxjs/toolkit";
 import { assign } from "lodash-es";
-import { FIND_JOBS, GET_JOB, GET_LINKED_JOB, WS_INSERT_JOB, WS_REMOVE_JOB, WS_UPDATE_JOB } from "../app/actionTypes";
+import {
+    ARCHIVE_JOB,
+    FIND_JOBS,
+    GET_JOB,
+    GET_LINKED_JOB,
+    WS_INSERT_JOB,
+    WS_REMOVE_JOB,
+    WS_UPDATE_JOB
+} from "../app/actionTypes";
 import { insert, remove, update, updateDocuments } from "../utils/reducers";
 
 export const initialState = {
@@ -39,6 +47,9 @@ export const jobsReducer = createReducer(initialState, builder => {
         })
         .addCase(GET_JOB.SUCCEEDED, (state, action) => {
             state.detail = action.payload;
+        })
+        .addCase(ARCHIVE_JOB.SUCCEEDED, (state, action) => {
+            return remove(state, action.payload);
         });
 });
 

--- a/src/js/jobs/sagas.js
+++ b/src/js/jobs/sagas.js
@@ -1,27 +1,9 @@
 import { has } from "lodash-es";
 import { select, takeEvery, takeLatest } from "redux-saga/effects";
-import {
-    CANCEL_JOB,
-    CLEAR_JOBS,
-    FIND_JOBS,
-    GET_JOB,
-    GET_LINKED_JOB,
-    REMOVE_JOB,
-    WS_UPDATE_JOB
-} from "../app/actionTypes";
+import { ARCHIVE_JOB, CANCEL_JOB, FIND_JOBS, GET_JOB, GET_LINKED_JOB, WS_UPDATE_JOB } from "../app/actionTypes";
 import { apiCall, pushFindTerm } from "../utils/sagas";
 import * as jobsAPI from "./api";
 import { getJobDetailId, getLinkedJobs } from "./selectors";
-
-export function* watchJobs() {
-    yield takeLatest(FIND_JOBS.REQUESTED, findJobs);
-    yield takeLatest(GET_JOB.REQUESTED, getJob);
-    yield takeEvery(CANCEL_JOB.REQUESTED, cancelJob);
-    yield takeEvery(REMOVE_JOB.REQUESTED, removeJob);
-    yield takeLatest(CLEAR_JOBS.REQUESTED, clearJobs);
-    yield takeLatest(WS_UPDATE_JOB, wsUpdateJob);
-    yield takeEvery(GET_LINKED_JOB.REQUESTED, getLinkedJob);
-}
 
 export function* wsUpdateJob(action) {
     const jobId = action.payload.id;
@@ -55,10 +37,15 @@ export function* cancelJob(action) {
     yield apiCall(jobsAPI.cancel, action.payload, CANCEL_JOB);
 }
 
-export function* removeJob(action) {
-    yield apiCall(jobsAPI.remove, action.payload, REMOVE_JOB);
+export function* archiveJob(action) {
+    yield apiCall(jobsAPI.archive, action.payload, ARCHIVE_JOB);
 }
 
-export function* clearJobs(action) {
-    yield apiCall(jobsAPI.clear, action.payload, REMOVE_JOB);
+export function* watchJobs() {
+    yield takeLatest(FIND_JOBS.REQUESTED, findJobs);
+    yield takeLatest(GET_JOB.REQUESTED, getJob);
+    yield takeEvery(CANCEL_JOB.REQUESTED, cancelJob);
+    yield takeEvery(ARCHIVE_JOB.REQUESTED, archiveJob);
+    yield takeLatest(WS_UPDATE_JOB, wsUpdateJob);
+    yield takeEvery(GET_LINKED_JOB.REQUESTED, getLinkedJob);
 }


### PR DESCRIPTION
### Changes:
  - Removes all job removal and clearing UI elements and backing logic.
  - Adds support of archival of single jobs in list or detail view, By default the jobs list will not show archived jobs
    - NB: Does not add support for mass archival of jobs as no backend APIs currently support this 
    - Modifies `findJobs` action to request that the jobs list be sent without default jobs by default

### Screenshots

**List View**
![image](https://user-images.githubusercontent.com/59776400/170556833-ad574fa2-0a11-42b3-b07d-d346e027757e.png)


**Detail View**
![image](https://user-images.githubusercontent.com/59776400/170556912-be0a3755-978e-4e02-93d8-1ef6d3409207.png)
