### PR TITLE
fix: prevent display of previous reference data in reference views

### DIFF
--- a/src/js/indexes/__tests__/reducer.test.js
+++ b/src/js/indexes/__tests__/reducer.test.js
@@ -112,6 +112,21 @@ describe("Indexes Reducer", () => {
     });
 
     it("should handle FIND_INDEXES_REQUESTED", () => {
+        const state = { refId: "foo" };
+        const term = "bar";
+        const refId = "foo";
+        const action = {
+            type: FIND_INDEXES.REQUESTED,
+            payload: { refId, term, page: 4 }
+        };
+        const result = reducer(state, action);
+        expect(result).toEqual({
+            term,
+            refId
+        });
+    });
+
+    it("should handle FIND_INDEXES_REQUESTED when [payload.refId != state.refId]", () => {
         const state = {};
         const term = "bar";
         const refId = "foo";
@@ -121,6 +136,7 @@ describe("Indexes Reducer", () => {
         };
         const result = reducer(state, action);
         expect(result).toEqual({
+            documents: null,
             term,
             refId
         });
@@ -143,13 +159,6 @@ describe("Indexes Reducer", () => {
             documents: [{ id: "1" }],
             page: 2
         });
-    });
-
-    it("should handle GET_INDEX_REQUESTED", () => {
-        const state = {};
-        const action = { type: GET_INDEX.REQUESTED, payload: {} };
-        const result = reducer(state, action);
-        expect(result).toEqual({ detail: null });
     });
 
     it("should handle GET_INDEX_SUCCEEDED", () => {

--- a/src/js/indexes/components/Detail.js
+++ b/src/js/indexes/components/Detail.js
@@ -34,8 +34,11 @@ export class IndexDetail extends React.Component {
         if (this.props.error) {
             return <NotFound />;
         }
-
-        if (this.props.detail === null || this.props.refDetail === null) {
+        if (
+            this.props.detail === null ||
+            this.props.refDetail === null ||
+            this.props.detail.id !== this.props.match.params.indexId
+        ) {
             return <LoadingPlaceholder />;
         }
 

--- a/src/js/indexes/reducer.js
+++ b/src/js/indexes/reducer.js
@@ -42,15 +42,14 @@ export const indexesReducer = createReducer(initialState, builder => {
             return state;
         })
         .addCase(FIND_INDEXES.REQUESTED, (state, action) => {
+            if (action.payload.refId !== state.refId) {
+                state.documents = null;
+            }
             state.term = action.payload.term;
             state.refId = action.payload.refId;
         })
         .addCase(FIND_INDEXES.SUCCEEDED, (state, action) => {
             return updateDocuments(state, action.payload, "version", true);
-        })
-        .addCase(GET_INDEX.REQUESTED, (state, action) => {
-            state.refId = action.payload.refId;
-            state.detail = null;
         })
         .addCase(GET_INDEX.SUCCEEDED, (state, action) => {
             state.detail = action.payload;

--- a/src/js/otus/__tests__/reducer.test.js
+++ b/src/js/otus/__tests__/reducer.test.js
@@ -143,8 +143,16 @@ describe("OTUs Reducer:", () => {
         const refId = "baz";
         const term = "foo";
         const action = { type: FIND_OTUS.REQUESTED, payload: { refId, term, page: 3 } };
-        const result = reducer({}, action);
+        const result = reducer({ refId: "baz" }, action);
         expect(result).toEqual({ term, refId });
+    });
+
+    it("should handle FIND_OTUS_REQUESTED when [payload.refId != state.refId]", () => {
+        const refId = "baz";
+        const term = "foo";
+        const action = { type: FIND_OTUS.REQUESTED, payload: { refId, term, page: 3 } };
+        const result = reducer({}, action);
+        expect(result).toEqual({ documents: null, term, refId });
     });
 
     it("should handle FIND_OTUS_SUCCEEDED", () => {

--- a/src/js/otus/reducer.js
+++ b/src/js/otus/reducer.js
@@ -115,6 +115,9 @@ export const OTUsReducer = createReducer(initialState, builder => {
             return remove(state, action.payload);
         })
         .addCase(FIND_OTUS.REQUESTED, (state, action) => {
+            if (action.payload.refId !== state.refId) {
+                state.documents = null;
+            }
             state.term = action.payload.term;
             state.verified = action.payload.verified;
             state.refId = action.payload.refId;
@@ -131,7 +134,7 @@ export const OTUsReducer = createReducer(initialState, builder => {
         .addCase(REMOVE_OTU.SUCCEEDED, state => {
             return hideOTUModal({ ...state, detail: null, activeIsolateId: null });
         })
-        .addCase(GET_OTU_HISTORY.REQUESTED, state => {
+        .addCase(GET_OTU_HISTORY.REQUESTED, (state, action) => {
             state.detailHistory = null;
         })
         .addCase(GET_OTU_HISTORY.SUCCEEDED, (state, action) => {


### PR DESCRIPTION
Small fix that prevents data from previous references being displayed when navigating to the `references/otus` and `references/indexes` views of a different reference. 


