### PR TITLE
Restore subtraction upload information icon

### DIFF
--- a/src/js/base/UploadBar.js
+++ b/src/js/base/UploadBar.js
@@ -44,14 +44,19 @@ export const UploadBar = ({ message, onDrop, validator, tip }) => {
     const rootProps = getRootProps({
         onClick: e => e.stopPropagation()
     });
-
     return (
         <StyledUploadBar active={isDragAccept}>
             <div {...rootProps}>
                 <input {...getInputProps()} data-testid="upload-input" />
                 {messageComponent}
                 {tip && tip.length && (
-                    <Icon aria-label="upload information" color="black" tip={tip} tipPlacement="top" />
+                    <Icon
+                        aria-label="upload information"
+                        name="info-circle"
+                        color="black"
+                        tip={tip}
+                        tipPlacement="top"
+                    />
                 )}
             </div>
             <Button color="blue" icon="upload" onClick={open}>

--- a/src/js/subtraction/components/Subtraction.js
+++ b/src/js/subtraction/components/Subtraction.js
@@ -9,7 +9,7 @@ import SubtractionList from "./List";
 export const SubtractionFileManager = () => (
     <FileManager
         fileType="subtraction"
-        message="Drag FASTA files here to upload"
+        message="Drag FASTA files here to upload."
         tip="Accepts files ending in fa, fasta, fa.gz, or fasta.gz."
         validationRegex={/.(?:fa|fasta)(?:.gz|.gzip)?$/}
     />

--- a/src/js/subtraction/components/__tests__/__snapshots__/Subtraction.test.js.snap
+++ b/src/js/subtraction/components/__tests__/__snapshots__/Subtraction.test.js.snap
@@ -50,7 +50,7 @@ exports[`<Subtraction /> should render 1`] = `
 exports[`<SubtractionFileManager /> should render 1`] = `
 <Connect(FileManager)
   fileType="subtraction"
-  message="Drag FASTA files here to upload"
+  message="Drag FASTA files here to upload."
   tip="Accepts files ending in fa, fasta, fa.gz, or fasta.gz."
   validationRegex={/\\.\\(\\?:fa\\|fasta\\)\\(\\?:\\.gz\\|\\.gzip\\)\\?\\$/}
 />


### PR DESCRIPTION
Small tweak to restore the information icon that was intended to be included once file type restrictions were put in place for the subtractions view file manager.

Screenshot without tooltip:
![image](https://user-images.githubusercontent.com/59776400/170738548-a9d690cd-c40f-40cc-81f2-93ad0936a9e6.png)


Screenshot with tooltip:
![image](https://user-images.githubusercontent.com/59776400/170738501-456cbd6a-a0a5-4750-918f-b9aa3d9f0184.png)
