### PR TITLE
fix: make filtering feature work on single character input and add tests

### DIFF
--- a/src/js/base/__tests__/hooks.test.js
+++ b/src/js/base/__tests__/hooks.test.js
@@ -1,0 +1,74 @@
+import { useFuse } from "../hooks";
+import { act, renderHook } from "@testing-library/react-hooks";
+
+describe("useFuseHook", () => {
+    let collection;
+    let keys;
+    let deps;
+
+    beforeEach(() => {
+        collection = [{ name: "nan" }, { name: "test1" }, { name: "aaaaa" }, { name: "zzzzz" }];
+        keys = ["name"];
+        deps = ["zzz"];
+    });
+
+    it("should render hook correctly and return collection when term = empty string", () => {
+        const { result } = renderHook(() => useFuse(collection, keys, deps));
+        const length = result.current.length;
+        expect(length).toBe(3);
+        expect(result.current[0]).toBe(collection);
+        expect(result.current[1]).toBe("");
+    });
+
+    it("should change returnObj to match useFuse result when term is changed to non empty single character", () => {
+        const { result } = renderHook(() => useFuse(collection, keys, deps));
+        const setTerm = result.current[2];
+
+        act(() => {
+            setTerm("z");
+        });
+        expect(result.current[0]).toEqual([{ item: { name: "zzzzz" }, refIndex: 3 }]);
+        expect(result.current[1]).toBe("z");
+    });
+
+    it("should return empty array when searchFuse yields no matches", () => {
+        const { result } = renderHook(() => useFuse(collection, keys, deps));
+        const setTerm = result.current[2];
+
+        act(() => {
+            setTerm("wwwwwwwww");
+        });
+        expect(result.current[1]).toBe("wwwwwwwww");
+        expect(result.current[0]).toEqual([]);
+    });
+
+    it("should return collection when term changed from non empty string to empty string", () => {
+        const { result } = renderHook(() => useFuse(collection, keys, deps));
+        const setTerm = result.current[2];
+
+        act(() => {
+            setTerm("z");
+        });
+        expect(result.current[1]).toBe("z");
+        expect(result.current[0]).toEqual([{ item: { name: "zzzzz" }, refIndex: 3 }]);
+        act(() => {
+            setTerm("");
+        });
+        expect(result.current[1]).toBe("");
+        expect(result.current[0]).toBe(collection);
+    });
+
+    it("should reset term to empty string when deps change", () => {
+        const { rerender, result } = renderHook(() => useFuse(collection, keys, deps));
+        const setTerm = result.current[2];
+
+        act(() => {
+            setTerm("z");
+        });
+
+        expect(result.current[1]).toBe("z");
+        deps = ["aaa"];
+        rerender();
+        expect(result.current[1]).toBe("");
+    });
+});

--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -58,7 +58,7 @@ export function createFuse(collection, keys, id) {
     return new Fuse(collection, {
         keys,
         id,
-        minMatchCharLength: 2,
+        minMatchCharLength: 1,
         threshold: 0.3,
         tokenize: true
     });


### PR DESCRIPTION
Usefuse returns results on single character inputs. And tests added for useFuse hook.

![Screenshot from 2022-05-27 09-05-43](https://user-images.githubusercontent.com/97321944/170736979-47858917-58dc-4cee-b23f-96babb11e949.png)
