### PR TITLE
fix: render icons as buttons and fix tests

### DIFF
--- a/src/js/base/Icon.js
+++ b/src/js/base/Icon.js
@@ -15,6 +15,8 @@ const fixedWidth = css`
 `;
 
 const StyledIcon = styled.i`
+    background: inherit;
+    border: none;
     color: ${getIconColor};
     ${props => (props.hoverable || props.onClick ? "cursor: pointer;" : "")};
     ${props => (props.fixedWidth ? fixedWidth : "")};
@@ -31,9 +33,10 @@ export const Icon = ({ hoverable, style, ...props }) => {
     const handleClick = useCallback(props.onClick, [props.onClick]);
 
     const className = `${props.className ? props.className + " " : ""} ${props.faStyle} fa-${props.name}`;
-
     const icon = (
         <StyledIcon
+            as={props.onClick ? "button" : "i"}
+            type="button"
             className={className}
             fixedWidth={props.fixedWidth}
             hoverable={hoverable}
@@ -41,7 +44,6 @@ export const Icon = ({ hoverable, style, ...props }) => {
             onClick={props.onClick ? handleClick : null}
             color={props.color}
             shade={props.shade}
-            data-testid={props["data-testid"]}
             aria-label={props["aria-label"]}
         />
     );
@@ -68,7 +70,6 @@ Icon.propTypes = {
     fixedWidth: PropTypes.bool,
     style: PropTypes.object,
     "aria-label": PropTypes.string,
-    "data-testid": PropTypes.string,
     hoverable: PropTypes.bool,
     shade: PropTypes.string
 };

--- a/src/js/base/__tests__/__snapshots__/Icon.test.js.snap
+++ b/src/js/base/__tests__/__snapshots__/Icon.test.js.snap
@@ -2,9 +2,11 @@
 
 exports[`<Icon /> should render 1`] = `
 <Icon__StyledIcon
+  as="i"
   className=" fas fa-test"
   fixedWidth={false}
   onClick={null}
+  type="button"
 />
 `;
 
@@ -14,9 +16,11 @@ exports[`<Icon /> should render placed tooltip when tipPlacement props defined 1
   tip="Tooltip"
 >
   <Icon__StyledIcon
+    as="i"
     className=" fas fa-test"
     fixedWidth={false}
     onClick={null}
+    type="button"
   />
 </Tooltip>
 `;
@@ -27,25 +31,31 @@ exports[`<Icon /> should render tooltip when tip props is defined 1`] = `
   tip="Tooltip"
 >
   <Icon__StyledIcon
+    as="i"
     className=" fas fa-test"
     fixedWidth={false}
     onClick={null}
+    type="button"
   />
 </Tooltip>
 `;
 
 exports[`<Icon /> should render when [fixedWith=true] 1`] = `
 <Icon__StyledIcon
+  as="i"
   className=" fas fa-test"
   fixedWidth={true}
   onClick={null}
+  type="button"
 />
 `;
 
 exports[`<Icon /> should render when className prop provided 1`] = `
 <Icon__StyledIcon
+  as="i"
   className="heavy  fas fa-test"
   fixedWidth={false}
   onClick={null}
+  type="button"
 />
 `;

--- a/src/js/samples/components/Create/Create.js
+++ b/src/js/samples/components/Create/Create.js
@@ -204,7 +204,7 @@ export const CreateSample = ({
                                 />
                                 <InputIcon
                                     name="magic"
-                                    data-testid="Auto Fill"
+                                    aria-label="Auto Fill"
                                     onClick={e => autofill(values.readFiles, setFieldValue, e)}
                                     disabled={!values.readFiles.length}
                                 />

--- a/src/js/samples/components/Create/__tests__/Create.test.js
+++ b/src/js/samples/components/Create/__tests__/Create.test.js
@@ -202,7 +202,7 @@ describe("<CreateSample>", () => {
         expect(nameInput.value).toBe("");
 
         userEvent.click(screen.getByText(props.readyReads[0].name));
-        userEvent.click(screen.getByTestId("Auto Fill"));
+        userEvent.click(screen.getByRole("button", {name: "Auto Fill" }));
         expect(nameInput.value).toBe(readFileName);
     });
 });

--- a/src/js/wall/__tests__/FirstUser.test.js
+++ b/src/js/wall/__tests__/FirstUser.test.js
@@ -26,7 +26,7 @@ describe("<FirstUser />", () => {
         expect(screen.getByText("Create an initial administrative user to start using Virtool.")).toBeInTheDocument();
         expect(screen.getByRole("textbox", "username")).toBeInTheDocument();
         expect(screen.getByRole("textbox", "password")).toBeInTheDocument();
-        expect(screen.getByRole("button", "Create user")).toBeInTheDocument();
+        expect(screen.getByRole("button", {name: "Create User"})).toBeInTheDocument();
     });
 
     it.each(["username", "password"])("should render when %p changed", name => {


### PR DESCRIPTION
Icons are rendered as buttons when onClick function is defined. Instances of data-testid work around have been removed.