### PR TITLE
Modify pathoscope mapping percentage

### DIFF
--- a/src/js/analyses/components/Pathoscope/Mapping.js
+++ b/src/js/analyses/components/Pathoscope/Mapping.js
@@ -49,7 +49,7 @@ const StyledAnalysisMapping = styled(Box)`
 
 export const AnalysisMapping = ({ index, reference, subtraction, toReference, total, toSubtraction = 0 }) => {
     const totalMapped = toReference + toSubtraction;
-    const sumPercent = totalMapped / total;
+    const sumPercent = toReference / total;
 
     const referenceTitle = <AnalysisMappingReferenceTitle index={index} reference={reference} />;
     const subtractionTitle = <AnalysisMappingSubtractionTitle subtraction={subtraction} />;
@@ -59,7 +59,7 @@ export const AnalysisMapping = ({ index, reference, subtraction, toReference, to
             <h3>
                 {numbro(sumPercent).format({ output: "percent", mantissa: 2 })} mapped
                 <small>
-                    {toThousand(totalMapped)} of {toThousand(total)} reads
+                    {toThousand(toReference)} of {toThousand(total)} reads
                 </small>
             </h3>
 


### PR DESCRIPTION
**Changes:**    
    - display mapping percentage as the percentage of reads mapped to references
    - display number of reads mapped to reference rather than total number of reads mapped anything

Screenshot with example data:
![image](https://user-images.githubusercontent.com/59776400/173694264-c29460e5-ad60-40d4-971f-504167b9533b.png)

