### PR TITLE
Refresh job counts when updates received

### DIFF
--- a/src/js/app/actionTypes.js
+++ b/src/js/app/actionTypes.js
@@ -128,8 +128,6 @@ export const FIND_JOBS = createRequestActionType("FIND_JOBS");
 export const GET_JOB = createRequestActionType("GET_JOB");
 export const GET_LINKED_JOB = createRequestActionType("GET_LINKED_JOB");
 export const CANCEL_JOB = createRequestActionType("CANCEL_JOB");
-export const REMOVE_JOB = createRequestActionType("REMOVE_JOB");
-export const CLEAR_JOBS = createRequestActionType("CLEAR_JOBS");
 export const ARCHIVE_JOB = createRequestActionType("ARCHIVE_JOB");
 
 // OTU

--- a/src/js/jobs/__tests__/reducer.test.js
+++ b/src/js/jobs/__tests__/reducer.test.js
@@ -1,4 +1,4 @@
-import { FIND_JOBS, GET_JOB, WS_INSERT_JOB, WS_REMOVE_JOB, WS_UPDATE_JOB } from "../../app/actionTypes";
+import { FIND_JOBS, GET_JOB } from "../../app/actionTypes";
 import reducer, { initialState as reducerInitialState } from "../reducer";
 
 describe("Job Reducer", () => {
@@ -15,98 +15,16 @@ describe("Job Reducer", () => {
         expect(result).toEqual(reducerInitialState);
     });
 
-    describe("should handle WS_INSERT_JOB", () => {
-        it("when documents are not yet fetched, returns state", () => {
-            const document = { id: "foo" };
-            const action = { type: WS_INSERT_JOB, payload: document };
-            const result = reducer({}, action);
-            expect(result).toEqual({
-                documents: [document]
-            });
-        });
-
-        it("otherwise insert entry into list", () => {
-            const state = {
-                documents: null,
-                page: 1
-            };
-            const action = { type: WS_INSERT_JOB, payload: { id: "test" } };
-            const result = reducer(state, action);
-            expect(result).toEqual({
-                ...state,
-                documents: [{ id: "test" }]
-            });
-        });
-    });
-
-    it("should handle WS_UPDATE_JOB", () => {
-        const state = {
-            documents: [
-                {
-                    id: "foo",
-                    workflow: "test_job"
-                },
-                {
-                    id: "bar",
-                    workflow: "running_job"
-                }
-            ]
-        };
-        const action = {
-            type: WS_UPDATE_JOB,
-            payload: {
-                id: "bar",
-                workflow: "finish_job"
-            }
-        };
-        const result = reducer(state, action);
-        expect(result).toEqual({
-            ...state,
-            documents: [
-                {
-                    id: "foo",
-                    workflow: "test_job"
-                },
-                {
-                    id: "bar",
-                    workflow: "finish_job"
-                }
-            ]
-        });
-    });
-
-    it("should handle WS_REMOVE_JOB", () => {
-        const state = {
-            documents: [{ id: "test1" }, { id: "test2" }]
-        };
-        const action = {
-            type: WS_REMOVE_JOB,
-            payload: ["test2"]
-        };
-        const result = reducer(state, action);
-        expect(result).toEqual({
-            ...state,
-            documents: [{ id: "test1" }]
-        });
-    });
-
-    it("should handle FIND_JOBS_REQUESTED", () => {
-        const action = { type: FIND_JOBS.REQUESTED, payload: { term: "foo" } };
-        const result = reducer({}, action);
-        expect(result).toEqual({ term: "foo" });
-    });
-
     it("should handle FIND_JOBS_SUCCEEDED", () => {
-        const state = { documents: null, page: 1 };
+        const state = { documents: null };
         const documents = [{ id: "foo" }];
         const action = {
             type: FIND_JOBS.SUCCEEDED,
-            payload: { documents, page: 2 }
+            payload: { documents }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
-            documents,
-            page: 2
+            documents
         });
     });
 

--- a/src/js/jobs/components/Summary.js
+++ b/src/js/jobs/components/Summary.js
@@ -1,4 +1,4 @@
-import { map, reduce } from "lodash-es";
+import { isEmpty, map, reduce } from "lodash-es";
 import React from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
@@ -74,7 +74,7 @@ export const JobsSummary = ({ allCounts }) => {
         return allCounts[state] ? <SummaryTag counts={allCounts[state]} name={state} key={state} /> : null;
     });
 
-    return <JobsSummaryContainer>{summaries}</JobsSummaryContainer>;
+    return isEmpty(allCounts) || <JobsSummaryContainer>{summaries}</JobsSummaryContainer>;
 };
 
 export const mapStateToProps = state => {

--- a/src/js/jobs/reducer.js
+++ b/src/js/jobs/reducer.js
@@ -1,20 +1,11 @@
 import { createReducer } from "@reduxjs/toolkit";
-import { assign } from "lodash-es";
-import {
-    ARCHIVE_JOB,
-    FIND_JOBS,
-    GET_JOB,
-    GET_LINKED_JOB,
-    WS_INSERT_JOB,
-    WS_REMOVE_JOB,
-    WS_UPDATE_JOB
-} from "../app/actionTypes";
-import { insert, remove, update, updateDocuments } from "../utils/reducers";
+import { assign, sortBy } from "lodash-es";
+import { ARCHIVE_JOB, FIND_JOBS, GET_JOB, GET_LINKED_JOB } from "../app/actionTypes";
+import { remove } from "../utils/reducers";
 
 export const initialState = {
     documents: null,
     term: "",
-    page: 0,
     total_count: 0,
     detail: null,
     filter: "",
@@ -25,15 +16,6 @@ export const initialState = {
 
 export const jobsReducer = createReducer(initialState, builder => {
     builder
-        .addCase(WS_INSERT_JOB, (state, action) => {
-            return insert(state, action.payload, "created_at");
-        })
-        .addCase(WS_UPDATE_JOB, (state, action) => {
-            return update(state, action.payload, "created_at");
-        })
-        .addCase(WS_REMOVE_JOB, (state, action) => {
-            return remove(state, action.payload);
-        })
         .addCase(GET_LINKED_JOB.SUCCEEDED, (state, action) => {
             assign(state.linkedJobs, { [action.payload.id]: action.payload });
         })
@@ -41,7 +23,7 @@ export const jobsReducer = createReducer(initialState, builder => {
             state.term = action.payload.term;
         })
         .addCase(FIND_JOBS.SUCCEEDED, (state, action) => {
-            return updateDocuments(state, action.payload, "created_at");
+            return { ...state, ...action.payload, documents: sortBy(action.payload.documents, "created_at") };
         })
         .addCase(GET_JOB.REQUESTED, state => {
             state.detail = null;

--- a/src/js/jobs/sagas.js
+++ b/src/js/jobs/sagas.js
@@ -1,9 +1,18 @@
 import { has } from "lodash-es";
 import { select, takeEvery, takeLatest } from "redux-saga/effects";
-import { ARCHIVE_JOB, CANCEL_JOB, FIND_JOBS, GET_JOB, GET_LINKED_JOB, WS_UPDATE_JOB } from "../app/actionTypes";
+import {
+    ARCHIVE_JOB,
+    CANCEL_JOB,
+    FIND_JOBS,
+    GET_JOB,
+    GET_LINKED_JOB,
+    WS_INSERT_JOB,
+    WS_REMOVE_JOB,
+    WS_UPDATE_JOB
+} from "../app/actionTypes";
 import { apiCall, pushFindTerm } from "../utils/sagas";
 import * as jobsAPI from "./api";
-import { getJobDetailId, getLinkedJobs } from "./selectors";
+import { getJobDetailId, getLinkedJobs, getTerm } from "./selectors";
 
 export function* wsUpdateJob(action) {
     const jobId = action.payload.id;
@@ -18,6 +27,11 @@ export function* wsUpdateJob(action) {
     if (has(linkedJobs, jobId)) {
         yield apiCall(jobsAPI.get, { jobId }, GET_LINKED_JOB);
     }
+}
+
+export function* getJobCount() {
+    const term = yield select(getTerm);
+    yield apiCall(jobsAPI.find, { term, archived: false }, FIND_JOBS);
 }
 
 export function* findJobs(action) {
@@ -47,5 +61,6 @@ export function* watchJobs() {
     yield takeEvery(CANCEL_JOB.REQUESTED, cancelJob);
     yield takeEvery(ARCHIVE_JOB.REQUESTED, archiveJob);
     yield takeLatest(WS_UPDATE_JOB, wsUpdateJob);
+    yield takeLatest([WS_INSERT_JOB, WS_REMOVE_JOB, WS_UPDATE_JOB], getJobCount);
     yield takeEvery(GET_LINKED_JOB.REQUESTED, getLinkedJob);
 }


### PR DESCRIPTION
Updated: 22/06/2022

### Changes:
 - Makes API request to refresh jobs list whenever a jobs related websocket message is received (insert, update or remove) 
 - Removes websocket reducer logic in Jobs reducer
    - Functionality made redundant since whole list is refreshed when a websocket update is received 
 - Also removes gray background from job status bar when no jobs exist.