### PR TITLE
Improve messaging when no targets exist for barcode references

### DIFF
--- a/src/js/references/components/Detail/Targets/Add.js
+++ b/src/js/references/components/Detail/Targets/Add.js
@@ -1,7 +1,9 @@
 import { toNumber } from "lodash-es";
 import React from "react";
 import { connect } from "react-redux";
+import { pushState } from "../../../../app/actions";
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "../../../../base";
+import { routerLocationHasState } from "../../../../utils/utils";
 import { editReference } from "../../../actions";
 import { TargetForm } from "./Form";
 
@@ -94,12 +96,17 @@ export const mapStateToProps = state => ({
     dataType: state.references.detail.data_type,
     documents: state.references.documents,
     refId: state.references.detail.id,
-    targets: state.references.detail.targets
+    targets: state.references.detail.targets,
+    show: routerLocationHasState(state, "addTarget")
 });
 
 export const mapDispatchToProps = dispatch => ({
     onSubmit: (refId, update) => {
         dispatch(editReference(refId, update));
+    },
+
+    onHide: () => {
+        dispatch(pushState({ addTarget: false }));
     }
 });
 

--- a/src/js/references/components/Detail/Targets/Edit.js
+++ b/src/js/references/components/Detail/Targets/Edit.js
@@ -1,8 +1,10 @@
-import { find, map, toNumber } from "lodash-es";
+import { find, get, map, toNumber } from "lodash-es";
 import React from "react";
 
 import { connect } from "react-redux";
+import { pushState } from "../../../../app/actions";
 import { Button, ModalBody, ModalFooter, Modal, ModalHeader } from "../../../../base";
+import { routerLocationHasState } from "../../../../utils/utils";
 import { editReference } from "../../../actions";
 import { TargetForm } from "./Form";
 
@@ -70,7 +72,7 @@ export class EditTarget extends React.Component {
                             description={this.state.description}
                             length={this.state.length}
                             required={this.state.required}
-                            errorName={this.errorName}
+                            errorName={this.state.errorName}
                         />
                     </ModalBody>
 
@@ -85,9 +87,8 @@ export class EditTarget extends React.Component {
     }
 }
 
-export const mapStateToProps = (state, ownProps) => {
-    const activeName = ownProps.activeName;
-
+export const mapStateToProps = state => {
+    const activeName = get(state, "router.location.state.editTarget") || "";
     let target = {};
 
     if (activeName) {
@@ -102,13 +103,18 @@ export const mapStateToProps = (state, ownProps) => {
         length,
         required,
         targets: state.references.detail.targets,
-        refId: state.references.detail.id
+        refId: state.references.detail.id,
+        show: routerLocationHasState(state, "editTarget")
     };
 };
 
 export const mapDispatchToProps = dispatch => ({
     onSubmit: (refId, update) => {
         dispatch(editReference(refId, update));
+    },
+
+    onHide: () => {
+        dispatch(pushState({ editTarget: "" }));
     }
 });
 

--- a/src/js/references/components/Detail/Targets/Item.js
+++ b/src/js/references/components/Detail/Targets/Item.js
@@ -33,8 +33,8 @@ export const TargetItem = ({ canModify, description, name, onEdit, onRemove }) =
     if (canModify) {
         icons = (
             <span>
-                <Icon name="edit" color="orange" tip="Modify" onClick={handleEdit} />
-                <Icon name="trash" color="red" tip="Remove" onClick={handleRemove} />
+                <Icon name="edit" aria-label="edit" color="orange" tip="Modify" onClick={handleEdit} />
+                <Icon name="trash" aria-label="remove" color="red" tip="Remove" onClick={handleRemove} />
             </span>
         );
     }

--- a/src/js/references/components/Detail/Targets/Targets.js
+++ b/src/js/references/components/Detail/Targets/Targets.js
@@ -1,7 +1,9 @@
 import { map, reject } from "lodash-es";
 import React from "react";
 import { connect } from "react-redux";
+import { Link } from "react-router-dom";
 import styled from "styled-components";
+import { pushState } from "../../../../app/actions";
 import { BoxGroup, BoxGroupHeader, NoneFoundSection } from "../../../../base";
 import { editReference } from "../../../actions";
 import { checkReferenceRight } from "../../../selectors";
@@ -16,28 +18,11 @@ const TargetsHeader = styled(BoxGroupHeader)`
     }
 `;
 
-const getInitialState = () => ({
-    showAdd: false,
-    showEdit: false
-});
-
 export class Targets extends React.Component {
     constructor(props) {
         super(props);
-        this.state = getInitialState();
+        this.state = {};
     }
-
-    handleHide = () => {
-        this.setState({ showAdd: false, showEdit: false });
-    };
-
-    showAdd = () => {
-        this.setState({ showAdd: true });
-    };
-
-    showEdit = name => {
-        this.setState({ showEdit: true, activeName: name });
-    };
 
     handleRemove = name => {
         this.props.onRemove(this.props.refId, {
@@ -55,7 +40,7 @@ export class Targets extends React.Component {
                 key={target.name}
                 {...target}
                 canModify={this.props.canModify}
-                onEdit={this.showEdit}
+                onEdit={this.props.onShowEdit}
                 onRemove={this.handleRemove}
             />
         ));
@@ -64,20 +49,12 @@ export class Targets extends React.Component {
         let modals;
 
         if (this.props.canModify) {
-            addButton = (
-                <a href="#" onClick={this.showAdd}>
-                    Add target
-                </a>
-            );
+            addButton = <Link to={{ state: { addTarget: true } }}>Add target</Link>;
 
             modals = (
                 <>
-                    <AddTarget show={this.state.showAdd} onHide={this.handleHide} />
-                    <EditTarget
-                        show={this.state.showEdit}
-                        onHide={this.handleHide}
-                        activeName={this.state.activeName}
-                    />
+                    <AddTarget />
+                    <EditTarget />
                 </>
             );
         }
@@ -116,6 +93,9 @@ export const mapStateToProps = state => ({
 export const mapDispatchToProps = dispatch => ({
     onRemove: (refId, update) => {
         dispatch(editReference(refId, update));
+    },
+    onShowEdit: name => {
+        dispatch(pushState({ editTarget: name }));
     }
 });
 export default connect(mapStateToProps, mapDispatchToProps)(Targets);

--- a/src/js/references/components/Detail/Targets/__tests__/Add.test.js
+++ b/src/js/references/components/Detail/Targets/__tests__/Add.test.js
@@ -101,7 +101,8 @@ describe("mapStateToProps()", () => {
                     id: "boo",
                     targets: [{ Foo: "Bar" }]
                 }
-            }
+            },
+            router: { location: { state: { addTarget: true } } }
         };
         const result = mapStateToProps(state);
         expect(result).toEqual({
@@ -109,7 +110,8 @@ describe("mapStateToProps()", () => {
             dataType: "bar",
             documents: "baz",
             refId: "boo",
-            targets: [{ Foo: "Bar" }]
+            targets: [{ Foo: "Bar" }],
+            show: true
         });
     });
 });

--- a/src/js/references/components/Detail/Targets/__tests__/Edit.test.js
+++ b/src/js/references/components/Detail/Targets/__tests__/Edit.test.js
@@ -116,13 +116,9 @@ describe("<EditTarget />", () => {
 });
 
 describe("mapStateToProps()", () => {
-    let ownProps;
     let state;
 
     beforeEach(() => {
-        ownProps = {
-            activeName: "foo"
-        };
         state = {
             references: {
                 detail: {
@@ -132,12 +128,13 @@ describe("mapStateToProps()", () => {
                         { name: "Foo", description: "Bar", length: 2, required: true }
                     ]
                 }
-            }
+            },
+            router: { location: { state: { editTarget: "foo" } } }
         };
     });
 
     it("should return props when name matches a target", () => {
-        const result = mapStateToProps(state, ownProps);
+        const result = mapStateToProps(state);
         expect(result).toEqual({
             targets: [
                 { name: "foo", description: "bar", length: 1, required: false },
@@ -147,13 +144,14 @@ describe("mapStateToProps()", () => {
             description: "bar",
             length: 1,
             required: false,
-            refId: "baz"
+            refId: "baz",
+            show: true
         });
     });
 
     it("should return props when name does not match a target", () => {
-        ownProps.activeName = "fee";
-        const result = mapStateToProps(state, ownProps);
+        state.router.location.state = {};
+        const result = mapStateToProps(state);
 
         expect(result).toEqual({
             targets: [
@@ -164,7 +162,8 @@ describe("mapStateToProps()", () => {
             description: undefined,
             length: undefined,
             required: undefined,
-            refId: "baz"
+            refId: "baz",
+            show: false
         });
     });
 });

--- a/src/js/references/components/Detail/Targets/__tests__/__snapshots__/Edit.test.js.snap
+++ b/src/js/references/components/Detail/Targets/__tests__/__snapshots__/Edit.test.js.snap
@@ -16,6 +16,7 @@ exports[`<EditTarget /> should render 1`] = `
     <Modal__ModalBody>
       <TargetForm
         description="Bar description"
+        errorName=""
         length={490}
         name="Bar"
         onChange={[Function]}
@@ -53,6 +54,7 @@ exports[`<EditTarget /> should render error when submitted without name 1`] = `
     <Modal__ModalBody>
       <TargetForm
         description="This is a test"
+        errorName="Required field"
         length={310}
         name=""
         onChange={[Function]}
@@ -90,6 +92,7 @@ exports[`<EditTarget /> should update when TargetForm onChange() prop called 1`]
     <Modal__ModalBody>
       <TargetForm
         description="Bar description"
+        errorName=""
         length={490}
         name="Foo"
         onChange={[Function]}

--- a/src/js/references/components/Detail/Targets/__tests__/__snapshots__/Item.test.js.snap
+++ b/src/js/references/components/Detail/Targets/__tests__/__snapshots__/Item.test.js.snap
@@ -19,6 +19,7 @@ exports[`<TargetItem /> should render when [canModify=true] 1`] = `
     foo
     <span>
       <Icon
+        aria-label="edit"
         color="orange"
         faStyle="fas"
         fixedWidth={false}
@@ -27,6 +28,7 @@ exports[`<TargetItem /> should render when [canModify=true] 1`] = `
         tip="Modify"
       />
       <Icon
+        aria-label="remove"
         color="red"
         faStyle="fas"
         fixedWidth={false}
@@ -50,6 +52,7 @@ exports[`<TargetItem /> should render with no description 1`] = `
     foo
     <span>
       <Icon
+        aria-label="edit"
         color="orange"
         faStyle="fas"
         fixedWidth={false}
@@ -58,6 +61,7 @@ exports[`<TargetItem /> should render with no description 1`] = `
         tip="Modify"
       />
       <Icon
+        aria-label="remove"
         color="red"
         faStyle="fas"
         fixedWidth={false}

--- a/src/js/references/components/Detail/Targets/__tests__/__snapshots__/Targets.test.js.snap
+++ b/src/js/references/components/Detail/Targets/__tests__/__snapshots__/Targets.test.js.snap
@@ -18,7 +18,7 @@ exports[`<Targets /> should render when [canModify=false] 1`] = `
     canModify={false}
     key="foo"
     name="foo"
-    onEdit={[Function]}
+    onEdit={[MockFunction]}
     onRemove={[Function]}
   />
 </Box__BoxGroup>
@@ -31,12 +31,17 @@ exports[`<Targets /> should render when [canModify=true] 1`] = `
       <span>
         Targets
       </span>
-      <a
-        href="#"
-        onClick={[Function]}
+      <Link
+        to={
+          Object {
+            "state": Object {
+              "addTarget": true,
+            },
+          }
+        }
       >
         Add target
-      </a>
+      </Link>
     </h2>
     <p>
       Manage the allowable sequence targets for this barcode reference.
@@ -46,16 +51,10 @@ exports[`<Targets /> should render when [canModify=true] 1`] = `
     canModify={true}
     key="foo"
     name="foo"
-    onEdit={[Function]}
+    onEdit={[MockFunction]}
     onRemove={[Function]}
   />
-  <Connect(AddTarget)
-    onHide={[Function]}
-    show={false}
-  />
-  <Connect(EditTarget)
-    onHide={[Function]}
-    show={false}
-  />
+  <Connect(AddTarget) />
+  <Connect(EditTarget) />
 </Box__BoxGroup>
 `;

--- a/src/js/sequences/components/AddLink.js
+++ b/src/js/sequences/components/AddLink.js
@@ -2,12 +2,14 @@ import React from "react";
 import { connect } from "react-redux";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
+import { getColor } from "../../app/theme";
 import { Icon } from "../../base";
+import { getTargets } from "../../otus/selectors";
 import { getCanModifyReferenceOTU, getDataType } from "../../references/selectors";
 import { getUnreferencedTargets } from "../selectors";
 
 const AddSequenceLinkMessage = styled.span`
-    color: ${props => props.theme.color.green};
+    color: ${getColor};
     margin-left: auto;
 `;
 
@@ -15,14 +17,18 @@ const StyledAddSequenceLink = styled(Link)`
     margin-left: auto;
 `;
 
-export const AddSequenceLink = ({ canModify, dataType, hasUnreferencedTargets }) => {
+export const AddSequenceLink = ({ canModify, dataType, hasUnreferencedTargets, hasTargets }) => {
     if (canModify) {
-        if (dataType === "barcode" && !hasUnreferencedTargets) {
-            return (
-                <AddSequenceLinkMessage>
-                    <Icon name="check-double" /> All targets defined
-                </AddSequenceLinkMessage>
-            );
+        if (dataType === "barcode") {
+            if (!hasTargets) return null;
+
+            if (!hasUnreferencedTargets) {
+                return (
+                    <AddSequenceLinkMessage color="green">
+                        <Icon name="check-double" /> All targets defined
+                    </AddSequenceLinkMessage>
+                );
+            }
         }
 
         return <StyledAddSequenceLink to={{ state: { addSequence: true } }}>Add Sequence</StyledAddSequenceLink>;
@@ -31,13 +37,11 @@ export const AddSequenceLink = ({ canModify, dataType, hasUnreferencedTargets })
     return null;
 };
 
-export const mapStateToProps = state => {
-    const dataType = getDataType(state);
-    return {
-        canModify: getCanModifyReferenceOTU(state),
-        dataType,
-        hasUnreferencedTargets: dataType === "barcode" && getUnreferencedTargets(state).length > 0
-    };
-};
+export const mapStateToProps = state => ({
+    canModify: getCanModifyReferenceOTU(state),
+    dataType: getDataType(state),
+    hasUnreferencedTargets: Boolean(getUnreferencedTargets(state)?.length),
+    hasTargets: Boolean(getTargets(state)?.length)
+});
 
 export default connect(mapStateToProps)(AddSequenceLink);

--- a/src/js/sequences/selectors.js
+++ b/src/js/sequences/selectors.js
@@ -1,4 +1,4 @@
-import { compact, find, get, indexOf, map, reject, sortBy } from "lodash-es";
+import { compact, filter, find, get, indexOf, map, reject, sortBy } from "lodash-es";
 import { createSelector } from "reselect";
 import { getActiveIsolate, getSchema, getTargets } from "../otus/selectors";
 
@@ -80,7 +80,7 @@ export const getUnreferencedTargets = createSelector(
     [getInactiveSequences, getTargets],
     (inactiveSequences, targets) => {
         const referencedTargetNames = map(inactiveSequences, sequence => sequence.target);
-        return targets.filter(target => !referencedTargetNames.includes(target.name));
+        return filter(targets, target => !referencedTargetNames.includes(target.name));
     }
 );
 


### PR DESCRIPTION
Update: I was looking through deep source flagged problems and noticed that the majority related to pre-existing code for the add and edit target modals. I fixed a functionality bug, but most of the problems seem stylistic and out of scope for this PR. Components seem to work as intended, but I created a new low priority backlog issue in linear to hookify both modals.

Changes:
   - When no targets exist:
     - Display a no targets found message
     - Prevent "all targets defined" message from displaying
   - Update the `create` and `edit` target modals opening and closing are controlled to use router state.

Screenshots: 

No targets defined:

![image](https://user-images.githubusercontent.com/59776400/176552873-764d780b-6019-4e56-afab-065ff2d66b12.png)

Targets defined, no sequences:
![image](https://user-images.githubusercontent.com/59776400/176553019-0f32a207-b8f0-49bf-b6f0-19cb44c63de4.png)

All targets defined:
![image](https://user-images.githubusercontent.com/59776400/176553236-4c55b14a-a8a1-496e-9ea2-0e0c5d947347.png)

