### PR TITLE
Restore icon styling for form restore alert

### DIFF
--- a/src/js/forms/components/Alert.js
+++ b/src/js/forms/components/Alert.js
@@ -7,7 +7,7 @@ const StyledAlert = styled(Alert)`
     display: flex;
     align-items: center;
 
-    i.fas {
+    button {
         margin-left: 10px;
         color: ${props => getColor({ color: "greyDark", theme: props.theme })};
         :hover {


### PR DESCRIPTION
Broken styling: (outdated)
![image](https://user-images.githubusercontent.com/59776400/176557813-67a41a84-f8d0-4b44-87fe-34b74b180c46.png)

Restored styling: (current)
![image](https://user-images.githubusercontent.com/59776400/176557763-65bde3b7-b1cf-4149-9a7f-8dfcc540fe20.png)
