### PR TITLE
Update user data modeling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "virtool-ui",
       "dependencies": {
         "@azure/msal-browser": "^2.22.0",
         "@azure/msal-react": "^1.3.0",
@@ -42,6 +41,7 @@
         "minimist": "^1.2.6",
         "normalize.css": "^8.0.1",
         "numbro": "^2.3.6",
+        "objectmodel": "^4.3.0",
         "prop-types": "^15.8.1",
         "re-reselect": "^4.0.0",
         "react": "^17.0.2",
@@ -11754,6 +11754,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/objectmodel": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/objectmodel/-/objectmodel-4.3.0.tgz",
+      "integrity": "sha512-YTIsWLslHgFrhjY+ANcv8AlX5neSojNV9HxA6hf01NdFJcSEz3pykPGa7wcMUx6mxYnaJ6tNz9oQOz8NtzrdKQ=="
     },
     "node_modules/obuf": {
       "version": "1.1.2",
@@ -24241,6 +24246,11 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.1"
       }
+    },
+    "objectmodel": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/objectmodel/-/objectmodel-4.3.0.tgz",
+      "integrity": "sha512-YTIsWLslHgFrhjY+ANcv8AlX5neSojNV9HxA6hf01NdFJcSEz3pykPGa7wcMUx6mxYnaJ6tNz9oQOz8NtzrdKQ=="
     },
     "obuf": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "minimist": "^1.2.6",
     "normalize.css": "^8.0.1",
     "numbro": "^2.3.6",
+    "objectmodel": "^4.3.0",
     "prop-types": "^15.8.1",
     "re-reselect": "^4.0.0",
     "react": "^17.0.2",
@@ -126,7 +127,7 @@
     "testURL": "https://www.virtool.ca",
     "testEnvironment": "jsdom",
     "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!(lodash-es/|d3.*/).*|internmap|delaunator|robust-predicates)"
+      "<rootDir>/node_modules/(?!(lodash-es/|d3.*/).*|internmap|delaunator|robust-predicates|objectmodel)"
     ]
   }
 }

--- a/src/js/groups/components/Detail.js
+++ b/src/js/groups/components/Detail.js
@@ -1,4 +1,4 @@
-import { filter, find, get, includes, map, transform } from "lodash-es";
+import { filter, find, get, map, some, transform } from "lodash-es";
 import React, { useCallback } from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
@@ -42,7 +42,7 @@ export const GroupDetail = ({ group, pending, users, onRemove, onSetPermission }
     }
 
     if (group) {
-        members = filter(users, user => includes(user.groups, group.id));
+        members = filter(users, user => some(user.groups, { id: group.id }));
     }
 
     const memberComponents =

--- a/src/js/users/__tests__/reducer.test.js
+++ b/src/js/users/__tests__/reducer.test.js
@@ -1,13 +1,34 @@
 import {
-    WS_INSERT_USER,
-    WS_UPDATE_USER,
-    WS_REMOVE_USER,
+    CREATE_USER,
+    EDIT_USER,
     FIND_USERS,
     GET_USER,
-    CREATE_USER,
-    EDIT_USER
+    WS_INSERT_USER,
+    WS_REMOVE_USER,
+    WS_UPDATE_USER
 } from "../../app/actionTypes";
+import { User } from "../models";
 import reducer, { initialState } from "../reducer";
+
+const defaultUser = {
+    id: "bill",
+    handle: "test_handle",
+    administrator: false,
+    groups: ["test"],
+    primary_group: "test_group",
+    force_reset: false,
+    last_password_change: "date",
+    permissions: {
+        cancel_job: Boolean,
+        create_ref: Boolean,
+        create_sample: Boolean,
+        modify_hmm: Boolean,
+        modify_subtraction: Boolean,
+        remove_file: Boolean,
+        remove_job: Boolean,
+        upload_file: Boolean
+    }
+};
 
 describe("Users Reducer", () => {
     it("should return the initial state on first pass", () => {
@@ -29,36 +50,28 @@ describe("Users Reducer", () => {
         };
         const action = {
             type: WS_INSERT_USER,
-            payload: {
-                id: "bill"
-            }
+            payload: defaultUser
         };
         const result = reducer(state, action);
-        expect(result).toEqual({
-            documents: [action.payload]
-        });
+        const expectedResult = { documents: [User(action.payload)] };
+        expect(JSON.stringify(result)).toEqual(JSON.stringify(expectedResult));
     });
     it("should handle WS_UPDATE_USER", () => {
         const state = {
-            documents: [
-                { id: "bob", administrator: true },
-                { id: "fred", administrator: false }
-            ]
+            documents: [User({ ...defaultUser, id: "user_1" }), User({ ...defaultUser, id: "user_2" })]
         };
         const action = {
             type: WS_UPDATE_USER,
-            payload: {
-                id: "fred",
-                administrator: true
-            }
+            payload: { ...defaultUser, id: "user_1", administrator: true }
         };
         const result = reducer(state, action);
-        expect(result).toEqual({
+        const expectedResult = {
             documents: [
-                { id: "bob", administrator: true },
-                { id: "fred", administrator: true }
+                User({ ...defaultUser, id: "user_1", administrator: true }),
+                User({ ...defaultUser, id: "user_2" })
             ]
-        });
+        };
+        expect(JSON.stringify(result)).toEqual(JSON.stringify(expectedResult));
     });
 
     it("should handle WS_REMOVE_USER", () => {
@@ -91,11 +104,33 @@ describe("Users Reducer", () => {
         const action = {
             type: FIND_USERS.SUCCEEDED,
             payload: {
-                documents: [{ id: "foo" }]
+                documents: [
+                    {
+                        id: "bill",
+                        handle: "test_handle",
+                        administrator: false,
+                        groups: [{ id: "test" }],
+                        primary_group: "test_group",
+                        force_reset: false,
+                        last_password_change: "date",
+                        permissions: {
+                            cancel_job: Boolean,
+                            create_ref: Boolean,
+                            create_sample: Boolean,
+                            modify_hmm: Boolean,
+                            modify_subtraction: Boolean,
+                            remove_file: Boolean,
+                            remove_job: Boolean,
+                            upload_file: Boolean
+                        }
+                    }
+                ]
             }
         };
         const result = reducer({}, action);
-        expect(result).toEqual(action.payload);
+        console.log(result.documents[0]);
+        const expectedResult = { documents: [User(action.payload.documents[0])] };
+        expect(JSON.stringify(result)).toEqual(JSON.stringify(expectedResult));
     });
 
     it("should handle GET_USER_REQUESTED", () => {

--- a/src/js/users/models.js
+++ b/src/js/users/models.js
@@ -1,0 +1,33 @@
+import { map } from "lodash-es";
+import { ArrayModel, Model, ObjectModel } from "objectmodel";
+
+export const Permissions = Model({
+    cancel_job: Boolean,
+    create_ref: Boolean,
+    create_sample: Boolean,
+    modify_hmm: Boolean,
+    modify_subtraction: Boolean,
+    remove_file: Boolean,
+    remove_job: Boolean,
+    upload_file: Boolean
+});
+
+/**
+ * @todo Remove group reformatting logic once API provides groups as objects be default
+ */
+export class Groups extends ArrayModel([String, { id: String }]) {
+    constructor(groups) {
+        super(map(groups, item => (typeof item === "string" ? item : { id: item })));
+    }
+}
+
+export const User = ObjectModel({
+    handle: String,
+    administrator: Boolean,
+    groups: Groups,
+    permissions: Permissions,
+    primary_group: String,
+    force_reset: Boolean,
+    last_password_change: String,
+    id: String
+});

--- a/src/js/users/reducer.js
+++ b/src/js/users/reducer.js
@@ -8,7 +8,8 @@ import {
     WS_REMOVE_USER,
     WS_UPDATE_USER
 } from "../app/actionTypes";
-import { insert, remove, update, updateDocuments } from "../utils/reducers";
+import { insert, remove, update, updateModeledDocuments } from "../utils/reducers";
+import { User } from "./models";
 
 export const initialState = {
     documents: null,
@@ -22,10 +23,10 @@ export const initialState = {
 const reducer = createReducer(initialState, builder => {
     builder
         .addCase(WS_INSERT_USER, (state, action) => {
-            return insert(state, action.payload, "handle");
+            return insert(state, User(action.payload), "handle");
         })
         .addCase(WS_UPDATE_USER, (state, action) => {
-            return update(state, action.payload, "handle");
+            return update(state, User(action.payload), "handle");
         })
         .addCase(WS_REMOVE_USER, (state, action) => {
             return remove(state, action.payload);
@@ -34,7 +35,7 @@ const reducer = createReducer(initialState, builder => {
             state.term = action.payload.term;
         })
         .addCase(FIND_USERS.SUCCEEDED, (state, action) => {
-            return updateDocuments(state, action.payload, "handle");
+            return updateModeledDocuments(state, action.payload, User, "handle");
         })
         .addCase(GET_USER.REQUESTED, state => {
             state.detail = null;

--- a/src/js/utils/reducers.js
+++ b/src/js/utils/reducers.js
@@ -1,4 +1,4 @@
-import { reject, map, includes, sortBy, unionBy } from "lodash-es";
+import { includes, map, reject, sortBy, unionBy } from "lodash-es";
 
 export const updateDocuments = (state, payload, sortKey, sortReverse) => {
     const existing = payload.page === 1 ? [] : state.documents || [];
@@ -14,6 +14,18 @@ export const updateDocuments = (state, payload, sortKey, sortReverse) => {
         ...payload,
         documents
     };
+};
+
+export const updateModeledDocuments = (state, payload, model, sortKey, sortReverse) => {
+    const existing = payload.page === 1 ? [] : state.documents || [];
+
+    const documents = sortBy(unionBy(payload.documents, existing, "id"), sortKey);
+
+    if (sortReverse) {
+        documents.reverse();
+    }
+
+    return { ...state, ...payload, documents: map(documents, document => model(document)) };
 };
 
 export const insert = (state, payload, sortKey, sortReverse = false) => {


### PR DESCRIPTION
Changes:

  - Adds object modeling for `user` objects returned by GET requests to `/users`
     - Model enforces formatting of `user` object `groups` array items to object format. (`{id: String}`)
       - If passed groups array contains string they will be assumed to be group ids and reformatted to object format at model creation time
  - Changes tests as required to accommodate modeled user data