### PR TITLE
fix: label management label description render below component

### DIFF
--- a/src/js/samples/components/Sidebar/Labels.js
+++ b/src/js/samples/components/Sidebar/Labels.js
@@ -9,7 +9,7 @@ import styled from "styled-components";
 import { getFontSize, fontWeight, getColor } from "../../../app/theme";
 import { xor } from "lodash-es";
 
-const SampleLabelInner = ({ name, color, description }) => (
+export const SampleLabelInner = ({ name, color, description }) => (
     <div>
         <SmallSampleLabel color={color} name={name} />
         <StyledParagraph>{description}</StyledParagraph>

--- a/src/js/samples/components/Sidebar/ManageLabels.js
+++ b/src/js/samples/components/Sidebar/ManageLabels.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import { SidebarHeader, SideBarSection } from "../../../base";
-import { SmallSampleLabel } from "../Label";
+import { SampleLabelInner } from "./Labels";
 import { SampleSidebarMultiselectList } from "./List";
 import { SampleSidebarSelector } from "./Selector";
 import { Link } from "react-router-dom";
@@ -25,13 +25,6 @@ const StyledSideBarSection = styled(SideBarSection)`
     grid-row: 2;
     align-self: start;
 `;
-
-const SampleLabelInner = ({ name, color, description }) => (
-    <>
-        <SmallSampleLabel color={color} name={name} />
-        <p>{description}</p>
-    </>
-);
 
 export const ManageLabels = ({
     allLabels,


### PR DESCRIPTION
Styling in label management drop down matches sample detail view when description rendered.

![Screenshot from 2022-07-11 07-42-48](https://user-images.githubusercontent.com/97321944/178291520-689ae847-91fd-4b61-a8b5-ed9023bf0de4.png)
