### PR TITLE
fix: display correct value for primary group in user detail view

### DIFF
--- a/src/js/users/__tests__/reducer.test.js
+++ b/src/js/users/__tests__/reducer.test.js
@@ -53,12 +53,12 @@ describe("Users Reducer", () => {
             payload: defaultUser
         };
         const result = reducer(state, action);
-        const expectedResult = { documents: [User(action.payload)] };
+        const expectedResult = { documents: [new User(action.payload)] };
         expect(JSON.stringify(result)).toEqual(JSON.stringify(expectedResult));
     });
     it("should handle WS_UPDATE_USER", () => {
         const state = {
-            documents: [User({ ...defaultUser, id: "user_1" }), User({ ...defaultUser, id: "user_2" })]
+            documents: [new User({ ...defaultUser, id: "user_1" }), new User({ ...defaultUser, id: "user_2" })]
         };
         const action = {
             type: WS_UPDATE_USER,
@@ -67,8 +67,8 @@ describe("Users Reducer", () => {
         const result = reducer(state, action);
         const expectedResult = {
             documents: [
-                User({ ...defaultUser, id: "user_1", administrator: true }),
-                User({ ...defaultUser, id: "user_2" })
+                new User({ ...defaultUser, id: "user_1", administrator: true }),
+                new User({ ...defaultUser, id: "user_2" })
             ]
         };
         expect(JSON.stringify(result)).toEqual(JSON.stringify(expectedResult));
@@ -108,7 +108,7 @@ describe("Users Reducer", () => {
             }
         };
         const result = reducer({}, action);
-        const expectedResult = { documents: [User(action.payload.documents[0])] };
+        const expectedResult = { documents: [new User(action.payload.documents[0])] };
         expect(JSON.stringify(result)).toEqual(JSON.stringify(expectedResult));
     });
 

--- a/src/js/users/components/Groups.js
+++ b/src/js/users/components/Groups.js
@@ -1,4 +1,4 @@
-import { includes, map, xor } from "lodash-es";
+import { map, some, xor } from "lodash-es";
 import React from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
@@ -13,7 +13,7 @@ const UserGroupsList = styled(BoxGroup)`
 
 export class UserGroups extends React.Component {
     handleEdit = groupId => {
-        this.props.onEditGroup(this.props.userId, xor(this.props.memberGroups, [groupId]));
+        this.props.onEditGroup(this.props.userId, xor(map(this.props.memberGroups, "id"), [groupId]));
     };
 
     render() {
@@ -22,7 +22,7 @@ export class UserGroups extends React.Component {
         }
 
         let groupComponents = map(this.props.documents, ({ id }) => (
-            <UserGroup key={id} id={id} toggled={includes(this.props.memberGroups, id)} onClick={this.handleEdit} />
+            <UserGroup key={id} id={id} toggled={some(this.props.memberGroups, { id })} onClick={this.handleEdit} />
         ));
 
         if (!groupComponents.length) {

--- a/src/js/users/components/PrimaryGroup.js
+++ b/src/js/users/components/PrimaryGroup.js
@@ -15,16 +15,15 @@ export const PrimaryGroup = ({ groups, id, primaryGroup, onSetPrimaryGroup }) =>
         [id, primaryGroup]
     );
 
-    const groupOptions = map(groups, groupId => (
-        <PrimaryGroupOption key={groupId} value={groupId}>
-            {capitalize(groupId)}
+    const groupOptions = map(groups, ({ id }) => (
+        <PrimaryGroupOption key={id} value={id}>
+            {capitalize(id)}
         </PrimaryGroupOption>
     ));
-
     return (
         <InputGroup>
             <InputLabel>Primary Group</InputLabel>
-            <Select value={primaryGroup || "none"} onChange={handleSetPrimaryGroup}>
+            <Select value={primaryGroup?.id || "none"} onChange={handleSetPrimaryGroup}>
                 <option key="none" value="none">
                     None
                 </option>

--- a/src/js/users/components/__tests__/Groups.test.js
+++ b/src/js/users/components/__tests__/Groups.test.js
@@ -7,7 +7,7 @@ describe("<UserGroups />", () => {
     beforeEach(() => {
         props = {
             documents: [{ id: "foo" }, { id: "bar" }, { id: "baz" }],
-            memberGroups: ["foo"],
+            memberGroups: [{ id: "foo" }],
             userId: "bob",
             onEditGroup: jest.fn()
         };

--- a/src/js/users/components/__tests__/PrimaryGroup.test.js
+++ b/src/js/users/components/__tests__/PrimaryGroup.test.js
@@ -4,9 +4,9 @@ import { mapDispatchToProps, mapStateToProps, PrimaryGroup } from "../PrimaryGro
 
 describe("<PrimaryGroup />", () => {
     const props = {
-        groups: ["foo", "bar", "baz"],
+        groups: [{ id: "foo" }, { id: "bar" }, { id: "baz" }],
         id: "bob",
-        primaryGroup: "bar",
+        primaryGroup: { id: "bar" },
         onSetPrimaryGroup: jest.fn()
     };
 

--- a/src/js/users/models.js
+++ b/src/js/users/models.js
@@ -17,17 +17,27 @@ export const Permissions = Model({
  */
 export class Groups extends ArrayModel([String, { id: String }]) {
     constructor(groups) {
-        super(map(groups, item => (typeof item === "string" ? item : { id: item })));
+        super(map(groups, group => (typeof group === "string" ? { id: group } : group)));
     }
 }
 
-export const User = ObjectModel({
+/**
+ * @todo Remove primary_group reformatting logic once API provides groups as objects by default
+ */
+export class User extends ObjectModel({
     handle: String,
     administrator: Boolean,
     groups: Groups,
     permissions: Permissions,
-    primary_group: [String],
+    primary_group: [String, { id: String }, null],
     force_reset: Boolean,
     last_password_change: String,
     id: String
-});
+}) {
+    constructor(user) {
+        super({
+            ...user,
+            primary_group: typeof user.primary_group === "string" ? { id: user.primary_group } : user.primary_group
+        });
+    }
+}

--- a/src/js/users/reducer.js
+++ b/src/js/users/reducer.js
@@ -23,10 +23,10 @@ export const initialState = {
 const reducer = createReducer(initialState, builder => {
     builder
         .addCase(WS_INSERT_USER, (state, action) => {
-            return insert(state, User(action.payload), "handle");
+            return insert(state, new User(action.payload), "handle");
         })
         .addCase(WS_UPDATE_USER, (state, action) => {
-            return update(state, User(action.payload), "handle");
+            return update(state, new User(action.payload), "handle");
         })
         .addCase(WS_REMOVE_USER, (state, action) => {
             return remove(state, action.payload);

--- a/src/js/utils/reducers.js
+++ b/src/js/utils/reducers.js
@@ -25,7 +25,7 @@ export const updateModeledDocuments = (state, payload, model, sortKey, sortRever
         documents.reverse();
     }
 
-    return { ...state, ...payload, documents: map(documents, document => model(document)) };
+    return { ...state, ...payload, documents: map(documents, document => new model(document)) };
 };
 
 export const insert = (state, payload, sortKey, sortReverse = false) => {


### PR DESCRIPTION
Changes:

  - Modified `PrimaryGroup` component to expect all `groups` to be objects rather than a strings.
  - Modified User Object model to accept reformat String `primary_group` values into objects
  - Updated tests as needed
