### PR TITLE
fix: reference settings align trash icons on right

### DIFF
--- a/src/js/references/components/SourceTypes/list.js
+++ b/src/js/references/components/SourceTypes/list.js
@@ -11,7 +11,7 @@ const StyledSourceTypeItem = styled(BoxGroupSection)`
     span: first-child {
         margin-right: 5px;
     }
-    i.fas {
+    button.fas {
         margin-left: auto;
     }
 `;


### PR DESCRIPTION
![Screenshot from 2022-07-15 08-05-27](https://user-images.githubusercontent.com/97321944/179251266-9f59625b-82e3-4375-94f9-20fd7bfd575e.png)
