### PR TITLE
Display indexes in alphabetical order in create analysis modal

### DIFF
--- a/src/js/analyses/components/Create/IndexSelector.js
+++ b/src/js/analyses/components/Create/IndexSelector.js
@@ -1,6 +1,6 @@
-import { differenceWith, groupBy, intersectionWith, xor } from "lodash-es";
+import { differenceWith, intersectionWith, sortBy, xor } from "lodash-es";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useMemo } from "react";
 import { useFuse } from "../../../base/hooks";
 import { CreateAnalysisField, CreateAnalysisFieldTitle } from "./Field";
 import { IndexSelectorItem } from "./IndexSelectorItem";
@@ -10,7 +10,8 @@ import { CreateAnalysisSelectorSearch } from "./Search";
 import { CreateAnalysisSelectorList } from "./CreateAnalysisSelectorList";
 
 export const IndexSelector = ({ hasError, indexes, selected, onChange }) => {
-    const [results, term, setTerm] = useFuse(indexes, ["reference.name"], [1]);
+    const sortedIndexes = useMemo(() => sortBy(indexes, "reference.name"), [indexes]);
+    const [results, term, setTerm] = useFuse(sortedIndexes, ["reference.name"], [1]);
 
     const unselectedIndexes = differenceWith(
         results.map(result => result.item || result),
@@ -18,7 +19,7 @@ export const IndexSelector = ({ hasError, indexes, selected, onChange }) => {
         (index, id) => index.id === id
     );
 
-    const selectedIndexes = intersectionWith(indexes, selected, (index, id) => index.id === id);
+    const selectedIndexes = intersectionWith(sortedIndexes, selected, (index, id) => index.id === id);
 
     const toggle = id => onChange(xor(selected, [id]));
 

--- a/src/js/analyses/components/Create/IndexSelectorItem.js
+++ b/src/js/analyses/components/Create/IndexSelectorItem.js
@@ -8,11 +8,8 @@ const StyledIndexSelectorItem = styled(BoxGroupSection)`
     display: flex;
     width: 100%;
 
-    span {
-        flex: 1 0 auto;
-    }
-
     span:first-child {
+        flex: 1 0 auto;
         font-weight: ${getFontWeight("thick")};
         overflow: hidden;
         white-space: nowrap;


### PR DESCRIPTION
Two small tweaks to the new analysis view modal:

 1. Indexes are now sorted alphabetical order
 2. the index version tag is fully right justified

**Old:**
![image](https://user-images.githubusercontent.com/59776400/183528178-7b00fd53-520f-44de-82c1-aefae4c4d4e0.png)


**New**
![image](https://user-images.githubusercontent.com/59776400/183528008-835e9ae2-5f3c-4b29-b0ae-55f51e25ac3c.png)
