### PR TITLE
Restore infinite scrolling to jobs view

### DIFF
--- a/src/js/base/__tests__/ScrollList.test.js
+++ b/src/js/base/__tests__/ScrollList.test.js
@@ -35,8 +35,8 @@ describe("<ScrollList />", () => {
         window.removeEventListener = jest.fn();
 
         const wrapper = mount(<ScrollList {...props} />);
-
-        expect(window.addEventListener).toHaveBeenCalledWith("scroll", wrapper.instance().onScroll);
+        expect(window.addEventListener.mock.calls.slice(-1)[0][0]).toBe("scroll");
+        expect(window.addEventListener.mock.calls.slice(-1)[0][1]).toBeInstanceOf(Function);
     });
 
     it("componentWillUnmount() should call removeEventListener()", () => {
@@ -44,9 +44,9 @@ describe("<ScrollList />", () => {
         window.removeEventListener = jest.fn();
 
         const wrapper = mount(<ScrollList {...props} />);
-        const onScroll = wrapper.instance().onScroll;
         wrapper.unmount();
 
-        expect(window.removeEventListener).toHaveBeenCalledWith("scroll", onScroll);
+        expect(window.removeEventListener.mock.calls.slice(-2)[0][0]).toBe("scroll");
+        expect(window.removeEventListener.mock.calls.slice(-2)[0][1]).toBeInstanceOf(Function);
     });
 });

--- a/src/js/base/__tests__/ScrollList.test.js
+++ b/src/js/base/__tests__/ScrollList.test.js
@@ -34,7 +34,8 @@ describe("<ScrollList />", () => {
         window.addEventListener = jest.fn();
         window.removeEventListener = jest.fn();
 
-        const wrapper = mount(<ScrollList {...props} />);
+        mount(<ScrollList {...props} />);
+
         expect(window.addEventListener.mock.calls.slice(-1)[0][0]).toBe("scroll");
         expect(window.addEventListener.mock.calls.slice(-1)[0][1]).toBeInstanceOf(Function);
     });

--- a/src/js/jobs/__tests__/actions.test.js
+++ b/src/js/jobs/__tests__/actions.test.js
@@ -39,9 +39,9 @@ describe("Jobs Action Creators:", () => {
 
     it("findJobs: returns action to retrieve specific page of job documents", () => {
         const states = ["running", "errored"];
-        const result = findJobs(states, true);
+        const result = findJobs(states, 1, true);
         expect(result).toEqual({
-            payload: { states, archived: true },
+            payload: { states, page: 1, archived: true },
             type: FIND_JOBS.REQUESTED
         });
     });

--- a/src/js/jobs/actions.js
+++ b/src/js/jobs/actions.js
@@ -43,8 +43,8 @@ export const wsRemoveJob = createAction(WS_REMOVE_JOB);
  * @returns {object}
  */
 
-export const findJobs = createAction(FIND_JOBS.REQUESTED, (states, archived = false) => ({
-    payload: { archived, states }
+export const findJobs = createAction(FIND_JOBS.REQUESTED, (states, page = 1, archived = false) => ({
+    payload: { archived, states, page }
 }));
 
 /**

--- a/src/js/jobs/api.js
+++ b/src/js/jobs/api.js
@@ -1,8 +1,8 @@
 import { forEach } from "lodash-es";
 import { Request } from "../app/request";
 
-export const find = ({ archived, states }) => {
-    const request = Request.get("/api/jobs").query({ archived, beta: true });
+export const find = ({ archived, states, page }) => {
+    const request = Request.get("/api/jobs").query({ archived, page });
     forEach(states, state => request.query({ state }));
     return request;
 };

--- a/src/js/jobs/components/__tests__/List.test.js
+++ b/src/js/jobs/components/__tests__/List.test.js
@@ -32,7 +32,7 @@ describe("<JobsList />", () => {
                     workflow: "create_sample"
                 }
             ],
-            onFind: jest.fn(),
+            onLoadNextPage: jest.fn(),
             canArchive: true,
             canCancel: true
         };
@@ -53,7 +53,7 @@ describe("<JobsList />", () => {
 
     it("should render", () => {
         renderWithAllProviders(<JobsList {...props} />, createAppStore(state));
-        expect(props.onFind).toHaveBeenCalled();
+        expect(props.onLoadNextPage).toHaveBeenCalled();
         expect(screen.getByText("Create Sample")).toBeInTheDocument();
     });
 
@@ -143,9 +143,9 @@ describe("mapDispatchToProps", () => {
 
         const states = ["running", "preparing"];
 
-        props.onFind(states);
+        props.onLoadNextPage(states, 1);
         expect(dispatch).toHaveBeenCalledWith({
-            payload: { states, archived: false },
+            payload: { states, page: 1, archived: false },
             type: "FIND_JOBS_REQUESTED"
         });
     });

--- a/src/js/jobs/reducer.js
+++ b/src/js/jobs/reducer.js
@@ -1,7 +1,7 @@
 import { createReducer } from "@reduxjs/toolkit";
-import { assign, sortBy } from "lodash-es";
+import { assign } from "lodash-es";
 import { ARCHIVE_JOB, FIND_JOBS, GET_JOB, GET_LINKED_JOB } from "../app/actionTypes";
-import { remove } from "../utils/reducers";
+import { remove, updateDocuments } from "../utils/reducers";
 
 export const initialState = {
     documents: null,
@@ -23,7 +23,7 @@ export const jobsReducer = createReducer(initialState, builder => {
             state.term = action.payload.term;
         })
         .addCase(FIND_JOBS.SUCCEEDED, (state, action) => {
-            return { ...state, ...action.payload, documents: sortBy(action.payload.documents, "created_at") };
+            return updateDocuments(state, action.payload, "created_at");
         })
         .addCase(GET_JOB.REQUESTED, state => {
             state.detail = null;

--- a/src/js/references/components/__tests__/Clone.test.js
+++ b/src/js/references/components/__tests__/Clone.test.js
@@ -28,7 +28,7 @@ describe("<CloneReference />", () => {
         expect(screen.getByText("5 OTUs")).toBeInTheDocument();
         expect(screen.getByText("foo_name")).toBeInTheDocument();
         expect(screen.getByText(/foo_user_id.+created/)).toBeInTheDocument();
-        expect(screen.getByText("3 years ago")).toBeInTheDocument();
+        expect(screen.getByText("4 years ago")).toBeInTheDocument();
         expect(screen.getByRole("textbox")).toHaveValue("Clone of foo_name");
         expect(screen.getByRole("button", { name: "Clone" })).toBeInTheDocument();
     });


### PR DESCRIPTION
**NB: Prospective fix for probable issues created when jobs API is updated to support pagination Intended for merge after jobs API is updated to provide pagination, not compatible with none paginating API** 

Changes:
  - Updates Redux logic to permit inclusion of page number in requests
  - Updates `ScrollList` to hooks, and prevents bug that breaks infinite scrolling that can occur when changing filtering settings

(No visual changes)