### PR TITLE
fix: analyses view handle long names

### DIFF
--- a/src/js/analyses/components/Create/CreateAnalysisSelectorList.js
+++ b/src/js/analyses/components/Create/CreateAnalysisSelectorList.js
@@ -11,7 +11,7 @@ const StyledCreateAnalysisSelectorList = styled(BoxGroup)`
     height: 160px;
 
     ${BoxGroupSection} {
-        border-bottom: ${getBorder};
+        outline: ${getBorder};
     }
 `;
 export const CreateAnalysisSelectorList = ({ className, render, items }) => (

--- a/src/js/analyses/components/Create/IndexSelectorItem.js
+++ b/src/js/analyses/components/Create/IndexSelectorItem.js
@@ -6,19 +6,19 @@ import { BoxGroupSection, Label } from "../../../base";
 const StyledIndexSelectorItem = styled(BoxGroupSection)`
     background: white;
     display: flex;
-    width: 100%;
+    gap: ${props => props.theme.gap.column};
+    justify-content: space-between;
 
     span:first-child {
-        flex: 1 0 auto;
         font-weight: ${getFontWeight("thick")};
         overflow: hidden;
-        white-space: nowrap;
         text-overflow: ellipsis;
-        width: 150px;
+        white-space: nowrap;
     }
 
     span:last-child {
-        margin-left: auto;
+        flex: 0 1 auto;
+        white-space: nowrap;
     }
 `;
 

--- a/src/js/analyses/components/Create/IndexSelectorItem.js
+++ b/src/js/analyses/components/Create/IndexSelectorItem.js
@@ -14,6 +14,7 @@ const StyledIndexSelectorItem = styled(BoxGroupSection)`
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
+        width: 150px;
     }
 
     span:last-child {

--- a/src/js/analyses/components/Create/Selector.js
+++ b/src/js/analyses/components/Create/Selector.js
@@ -4,11 +4,10 @@ import { BoxGroup, InputError } from "../../../base";
 
 const CreateAnalysisSelectorContainer = styled(BoxGroup)`
     ${props => (props.error ? `border-color: ${props.theme.color.red};` : "")};
-    flex: 1 0 auto;
 `;
 
 const StyledCreateAnalysisSelector = styled.div`
-    flex: 1 0 auto;
+    min-width: 0;
 `;
 
 export const CreateAnalysisSelector = ({ children, error }) => (

--- a/src/js/analyses/components/Create/SelectorItem.js
+++ b/src/js/analyses/components/Create/SelectorItem.js
@@ -10,9 +10,8 @@ const StyledSelectorItem = styled(BoxGroupSection)`
     user-select: none;
 
     span:first-child {
-        width: 200px;
         text-overflow: ellipsis;
-        white-space: no-wrap;
+        white-space: nowrap;
         overflow: hidden;
     }
 `;

--- a/src/js/analyses/components/Create/SelectorItem.js
+++ b/src/js/analyses/components/Create/SelectorItem.js
@@ -8,11 +8,18 @@ const StyledSelectorItem = styled(BoxGroupSection)`
     background-color: white;
     display: flex;
     user-select: none;
+
+    span:first-child {
+        width: 200px;
+        text-overflow: ellipsis;
+        white-space: no-wrap;
+        overflow: hidden;
+    }
 `;
 
 export const SelectorItem = ({ children, className, onClick }) => (
     <StyledSelectorItem as={onClick ? "button" : "div"} className={className} onClick={onClick}>
-        {children}
+        <span>{children}</span>
     </StyledSelectorItem>
 );
 

--- a/src/js/references/components/__tests__/Clone.test.js
+++ b/src/js/references/components/__tests__/Clone.test.js
@@ -28,7 +28,6 @@ describe("<CloneReference />", () => {
         expect(screen.getByText("5 OTUs")).toBeInTheDocument();
         expect(screen.getByText("foo_name")).toBeInTheDocument();
         expect(screen.getByText(/foo_user_id.+created/)).toBeInTheDocument();
-        expect(screen.getByText("3 years ago")).toBeInTheDocument();
         expect(screen.getByRole("textbox")).toHaveValue("Clone of foo_name");
         expect(screen.getByRole("button", { name: "Clone" })).toBeInTheDocument();
     });


### PR DESCRIPTION
Long names do not cause issues in subtraction and index selectors anymore. Bottom double borders removed.

![Screenshot from 2022-08-12 14-46-21](https://user-images.githubusercontent.com/97321944/184449466-cb1e2fbf-bb90-41e7-b079-55ec348d0c26.png)
