### PR TITLE
fix: improve response using cache header

### DIFF
--- a/run.js
+++ b/run.js
@@ -91,7 +91,13 @@ app.engine("html", require("ejs").renderFile);
 app.set("views", path.join(__dirname, "dist"));
 app.locals.delimiter = "#";
 
-app.get(/\.(?:js|map|ico|svg)$/, express.static(path.join(__dirname, "dist")));
+app.get(
+  /\.(?:js|map|ico|svg)$/,
+  express.static(path.join(__dirname, "dist"), {
+    maxAge: 31536000000,
+  })
+);
+
 app.get("*", defaultPath(templateOptions));
 
 app.listen(options.port, options.host, () => {


### PR DESCRIPTION
Set a long max age on static assets. They were being downloaded fresh on every refresh.