### PR TITLE
Prevent excessive websocket requests for unauthenticated users

### DIFF
--- a/src/js/app/Main.js
+++ b/src/js/app/Main.js
@@ -12,7 +12,7 @@ import UploadOverlay from "../files/components/UploadOverlay";
 import NavBar from "../nav/components/NavBar";
 import Sidebar from "../nav/components/Sidebar";
 import { listTasks } from "../tasks/actions";
-import WSConnection from "./websocket";
+import WSConnection, { ABANDONED, INITIALIZING } from "./websocket";
 
 const Administration = lazy(() => import("../administration/components/Settings"));
 const Account = lazy(() => import("../account/components/Account"));
@@ -36,7 +36,7 @@ const setupWebSocket = () => {
     if (!window.ws) {
         window.ws = new WSConnection(window.store);
     }
-    if (includes(["abandoned", "initializing"], window.ws.connectionStatus)) {
+    if (includes([ABANDONED, INITIALIZING], window.ws.connectionStatus)) {
         window.ws.establishConnection();
     }
 };

--- a/src/js/app/Main.js
+++ b/src/js/app/Main.js
@@ -1,3 +1,4 @@
+import { includes } from "lodash-es";
 import React, { lazy, Suspense, useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
@@ -34,6 +35,8 @@ const MainContainer = styled.div`
 const setupWebSocket = () => {
     if (!window.ws) {
         window.ws = new WSConnection(window.store);
+    }
+    if (includes(["abandoned", "initializing"], window.ws.connectionStatus)) {
         window.ws.establishConnection();
     }
 };

--- a/src/js/app/websocket.js
+++ b/src/js/app/websocket.js
@@ -77,6 +77,12 @@ const modifiers = {
     delete: removers
 };
 
+export const INITIALIZING = "initializing";
+export const CONNECTING = "connecting";
+export const CONNECTED = "connected";
+export const ABANDONED = "abandoned";
+export const RECONNECTING = "reconnecting";
+
 export default function WSConnection({ getState, dispatch }) {
     // The Redux store's dispatch method.
     this.dispatch = dispatch;
@@ -104,7 +110,7 @@ export default function WSConnection({ getState, dispatch }) {
     };
 
     this.interval = 500;
-    this.connectionStatus = "initializing";
+    this.connectionStatus = INITIALIZING;
 
     this.establishConnection = () => {
         const protocol = window.location.protocol === "https:" ? "wss" : "ws";
@@ -113,11 +119,11 @@ export default function WSConnection({ getState, dispatch }) {
             : `${protocol}://${window.location.host}/ws`;
 
         this.connection = new window.WebSocket(websocketTarget);
-        this.connectionStatus = "connecting";
+        this.connectionStatus = CONNECTING;
 
         this.connection.onopen = () => {
             this.interval = 500;
-            this.connectionStatus = "connected";
+            this.connectionStatus = CONNECTED;
         };
 
         this.connection.onmessage = e => {
@@ -131,13 +137,13 @@ export default function WSConnection({ getState, dispatch }) {
 
             if (e.code === 4000) {
                 this.dispatch({ type: LOGOUT.SUCCEEDED });
-                this.connectionStatus = "abandoned";
+                this.connectionStatus = ABANDONED;
                 return;
             }
 
             setTimeout(() => {
                 this.establishConnection();
-                this.connectionStatus = "reconnecting";
+                this.connectionStatus = RECONNECTING;
             }, this.interval);
         };
     };


### PR DESCRIPTION
**(NB: Dependent on PR 2662 in virtool to properly function)**

Changes:

  -  Allows UI to interpret custom error code for API when authentication fails and does not attempt to reconnect
  - Adds support for reconnecting to web socket upon the user logging back in