### PR TITLE
fix: get favicon once

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -27,7 +27,7 @@
         };
 
     </script>
-    <link rel="shortcut icon" href="<%= htmlWebpackPlugin.files.favicon %>?v=2" type="images/x-icon"/>
+    <link rel="shortcut icon" href="/images/favicon.ico" type="image/x-icon"/>
 </head>
 
 <body>


### PR DESCRIPTION
It looks like most browsers automatically request the favicon. This is true with google chrome and was causing the second fetch. On Firefox the favicon was only ever fetched once. 

The fix results in the favicon being fetched only once in both chrome and firefox.

![Screenshot from 2022-09-17 11-03-55](https://user-images.githubusercontent.com/97321944/190870629-757064cb-adac-41fa-9518-d4e484a7c742.png)
