### PR TITLE
fix: prevent crash in account view

### DIFF
--- a/src/js/account/components/Profile.jsx
+++ b/src/js/account/components/Profile.jsx
@@ -46,21 +46,11 @@ const AccountProfileHeader = styled.div`
 `;
 
 export const AccountProfile = ({ handle, groups, administrator }) => {
-    const groupLabels = map(groups, groupId => (
-        <Label key={groupId}>
-            <Icon name="users" /> {groupId}
+    const groupLabels = map(groups, ({ id, name }) => (
+        <Label key={id}>
+            <Icon name="users" /> {name}
         </Label>
     ));
-
-    let adminLabel;
-
-    if (administrator) {
-        adminLabel = (
-            <Label key="administrator" color="purple">
-                <Icon name="user-shield" /> Administrator
-            </Label>
-        );
-    }
 
     return (
         <div>
@@ -69,7 +59,11 @@ export const AccountProfile = ({ handle, groups, administrator }) => {
                 <div>
                     <h3>
                         {handle}
-                        {adminLabel}
+                        {administrator && (
+                            <Label key="administrator" color="purple">
+                                <Icon name="user-shield" /> Administrator
+                            </Label>
+                        )}
                     </h3>
                     <AccountProfileGroups>{groupLabels}</AccountProfileGroups>
                 </div>
@@ -82,9 +76,9 @@ export const AccountProfile = ({ handle, groups, administrator }) => {
 };
 
 export const mapStateToProps = state => ({
-    handle: getAccountHandle(state),
+    administrator: getAccountAdministrator(state),
     groups: state.account.groups,
-    administrator: getAccountAdministrator(state)
+    handle: getAccountHandle(state)
 });
 
 export default connect(mapStateToProps)(AccountProfile);

--- a/src/js/account/components/__tests__/Profile.test.jsx
+++ b/src/js/account/components/__tests__/Profile.test.jsx
@@ -6,7 +6,10 @@ describe("<AccountProfile />", () => {
     beforeEach(() => {
         props = {
             handle: "foo",
-            groups: ["test"],
+            groups: [
+                { id: "ac091sa1", name: "Technicians" },
+                { id: "980s921a", name: "Managers" }
+            ],
             administrator: false
         };
     });

--- a/src/js/account/components/__tests__/__snapshots__/Profile.test.jsx.snap
+++ b/src/js/account/components/__tests__/__snapshots__/Profile.test.jsx.snap
@@ -24,7 +24,7 @@ exports[`<AccountProfile /> > should render when administrator 1`] = `
       </h3>
       <styled.div>
         <styled.span
-          key="test"
+          key="ac091sa1"
         >
           <Icon
             faStyle="fas"
@@ -32,7 +32,18 @@ exports[`<AccountProfile /> > should render when administrator 1`] = `
             name="users"
           />
            
-          test
+          Technicians
+        </styled.span>
+        <styled.span
+          key="980s921a"
+        >
+          <Icon
+            faStyle="fas"
+            fixedWidth={false}
+            name="users"
+          />
+           
+          Managers
         </styled.span>
       </styled.div>
     </div>
@@ -55,7 +66,7 @@ exports[`<AccountProfile /> > should render when not administrator 1`] = `
       </h3>
       <styled.div>
         <styled.span
-          key="test"
+          key="ac091sa1"
         >
           <Icon
             faStyle="fas"
@@ -63,7 +74,18 @@ exports[`<AccountProfile /> > should render when not administrator 1`] = `
             name="users"
           />
            
-          test
+          Technicians
+        </styled.span>
+        <styled.span
+          key="980s921a"
+        >
+          <Icon
+            faStyle="fas"
+            fixedWidth={false}
+            name="users"
+          />
+           
+          Managers
         </styled.span>
       </styled.div>
     </div>


### PR DESCRIPTION
Happened during rendering of user groups.

The view rendered assuming that `groups` was a list of ids instead of a list of objects containing `name` and `id`.