### PR TITLE
Prevent crash in sample creation view

### DIFF
--- a/src/js/samples/components/Create/Create.jsx
+++ b/src/js/samples/components/Create/Create.jsx
@@ -217,7 +217,7 @@ export const CreateSample = ({
                                     as={SampleUserGroup}
                                     aria-label="User Group"
                                     name="group"
-                                    group={values.group}
+                                    selected={values.group}
                                     groups={groups}
                                     onChange={e => setFieldValue("group", e.target.value)}
                                 />

--- a/src/js/samples/components/Create/UserGroup.jsx
+++ b/src/js/samples/components/Create/UserGroup.jsx
@@ -7,17 +7,17 @@ const SampleUserGroupItem = styled.option`
     text-transform: capitalize;
 `;
 
-export const SampleUserGroup = ({ group, groups, onChange }) => {
-    const groupComponents = map(groups, groupId => (
-        <SampleUserGroupItem key={groupId} value={groupId}>
-            {groupId}
+export const SampleUserGroup = ({ selected, groups, onChange }) => {
+    const groupComponents = map(groups, group => (
+        <SampleUserGroupItem key={group.id} value={group.id}>
+            {group.name}
         </SampleUserGroupItem>
     ));
 
     return (
         <InputGroup>
             <InputLabel>User Group</InputLabel>
-            <Select value={group} onChange={onChange}>
+            <Select value={selected} onChange={onChange}>
                 <option key="none" value="none">
                     None
                 </option>

--- a/src/js/samples/components/Create/__tests__/UserGroup.test.jsx
+++ b/src/js/samples/components/Create/__tests__/UserGroup.test.jsx
@@ -5,9 +5,9 @@ describe("SampleUserGroup", () => {
     let props;
     beforeEach(() => {
         props = {
-            groups: ["foo"],
+            groups: [{ name: "bar", id: "bar_id" }],
             onChange: vi.fn(),
-            group: "bar"
+            selected: "bar"
         };
     });
 

--- a/src/js/samples/components/Create/__tests__/__snapshots__/UserGroup.test.jsx.snap
+++ b/src/js/samples/components/Create/__tests__/__snapshots__/UserGroup.test.jsx.snap
@@ -16,10 +16,10 @@ exports[`SampleUserGroup > should render 1`] = `
       None
     </option>
     <styled.option
-      key="foo"
-      value="foo"
+      key="bar_id"
+      value="bar_id"
     >
-      foo
+      bar
     </styled.option>
   </Select>
 </InputGroup>


### PR DESCRIPTION
Changes the `UserGroup` component to display the group `name` while using the `id` as value. 