### PR TITLE
fix retain job filtering options after refresh

### DIFF
--- a/src/js/jobs/components/List.jsx
+++ b/src/js/jobs/components/List.jsx
@@ -28,7 +28,15 @@ const JobsListEmpty = styled(Box)`
 `;
 
 export const JobsList = ({ canArchive, canCancel, jobs, noJobs, onLoadNextPage, page, page_count, states }) => {
-    useEffect(() => onLoadNextPage(["preparing", "running"], 1), []);
+    const initialStates = ["preparing", "running"];
+
+    useEffect(() => {
+        if (!states?.length) {
+            onLoadNextPage(initialStates, 1);
+        } else {
+            onLoadNextPage(states, 1);
+        }
+    }, []);
 
     if (jobs === null) {
         return <LoadingPlaceholder />;

--- a/src/js/jobs/components/List.jsx
+++ b/src/js/jobs/components/List.jsx
@@ -27,15 +27,11 @@ const JobsListEmpty = styled(Box)`
     }
 `;
 
-export const JobsList = ({ canArchive, canCancel, jobs, noJobs, onLoadNextPage, page, page_count, states }) => {
-    const initialStates = ["preparing", "running"];
+const initialState = ["preparing", "running"];
 
+export const JobsList = ({ canArchive, canCancel, jobs, noJobs, onLoadNextPage, page, page_count, states }) => {
     useEffect(() => {
-        if (!states?.length) {
-            onLoadNextPage(initialStates, 1);
-        } else {
-            onLoadNextPage(states, 1);
-        }
+        onLoadNextPage(states?.length ? states : initialState, 1);
     }, []);
 
     if (jobs === null) {


### PR DESCRIPTION
Job filtering options on initial render include preparing and running. 
Switching pages and coming back results in the initial render. 
Refreshing the page preserves all filtering options except: when no filtering options are selected and a refresh occurs the initial options are once again displayed.