### PR TITLE
feat: use pagination for uploaded files

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { ThemeProvider } from "styled-components";
 import { theme } from "../src/js/app/theme";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter } from "react-router-dom";
 import { GlobalStyles } from "../src/js/app/GlobalStyles";
 
 export const decorators = [

--- a/src/js/app/actionTypes.js
+++ b/src/js/app/actionTypes.js
@@ -76,6 +76,7 @@ export const WS_INSERT_FILE = "WS_INSERT_FILE";
 export const WS_UPDATE_FILE = "WS_UPDATE_FILE";
 export const WS_REMOVE_FILE = "WS_REMOVE_FILE";
 export const FIND_FILES = createRequestActionType("FIND_FILES");
+export const WS_REFRESH_FILES = createRequestActionType("WS_REFRESH_FILES");
 export const REMOVE_FILE = createRequestActionType("REMOVE_FILE");
 export const UPLOAD = createRequestActionType("UPLOAD");
 export const UPLOAD_SAMPLE_FILE = createRequestActionType("UPLOAD_SAMPLE_FILE");

--- a/src/js/base/Button.jsx
+++ b/src/js/base/Button.jsx
@@ -95,7 +95,7 @@ export const StyledButton = styled.button`
     }
 `;
 
-export const LinkButton = ({ children, color, className, icon, replace, tip, to }) => {
+export const LinkButton = ({ children, color, className, icon, replace, tip, to, disabled }) => {
     const button = (
         <StyledButton
             as={NavLink}
@@ -104,6 +104,7 @@ export const LinkButton = ({ children, color, className, icon, replace, tip, to 
             color={color}
             replace={replace}
             to={to}
+            disabled={disabled}
         >
             {icon && <Icon name={icon} />}
             {children ? <span>{children}</span> : null}

--- a/src/js/base/Button.jsx
+++ b/src/js/base/Button.jsx
@@ -95,7 +95,7 @@ export const StyledButton = styled.button`
     }
 `;
 
-export const LinkButton = ({ children, color, className, icon, replace, tip, to, disabled }) => {
+export const LinkButton = ({ children, color, className, icon, replace, tip, to, disabled, onClick }) => {
     const button = (
         <StyledButton
             as={NavLink}
@@ -105,6 +105,7 @@ export const LinkButton = ({ children, color, className, icon, replace, tip, to,
             replace={replace}
             to={to}
             disabled={disabled}
+            onClick={onClick}
         >
             {icon && <Icon name={icon} />}
             {children ? <span>{children}</span> : null}

--- a/src/js/base/Pagination.jsx
+++ b/src/js/base/Pagination.jsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useMemo } from "react";
+import React from "react";
 import styled from "styled-components";
 import { map, max, min, range } from "lodash-es";
-import { Link, useHistory, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { LinkButton } from "./Button";
-import { connect } from "react-redux";
 
 import { getColor, getFontSize } from "../app/theme";
 

--- a/src/js/base/Pagination.jsx
+++ b/src/js/base/Pagination.jsx
@@ -1,25 +1,34 @@
-import React, { useMemo } from "react";
-import { Button } from "../base";
+import React, { useMemo, useEffect } from "react";
 import styled from "styled-components";
 import { range, min, max, map } from "lodash-es";
+import { Link, useHistory, useLocation } from "react-router-dom";
+import { LinkButton } from "./Button";
 
 const StyledPaginationBox = styled.div`
     display: flex;
     width: 500px;
     justify-content: center;
     margin-left: 25%;
+    align-items: center;
+`;
 
-    button:first-child {
-        width: 100px;
-    }
-    button:last-child {
-        width: 100px;
-    }
+const StyledLink = styled(Link)`
+    margin: 5px;
+    font-size: ${props => props.theme.fontSize.lg};
+    pointer-events: ${props => (props.disabled ? "none" : "")};
+    color: ${props => (props.active === "true" ? props.theme.color.blue : props.theme.color.blueDarkest)};
+`;
 
-    button {
-        margin: 5px;
-        height: 25px;
-    }
+const StyledNextLink = styled(LinkButton)`
+    display: flex;
+    margin: 5px;
+    width: 60px;params
+    justify-content: center;
+    pointer-events: ${props => (props.disabled ? "none" : "")};
+`;
+
+const StyledPaginationItemsContainer = styled.div`
+    padding-bottom: 5px;
 `;
 
 const usePagination = (pageCount, currentPage) => {
@@ -36,33 +45,62 @@ const usePagination = (pageCount, currentPage) => {
     return paginationRange;
 };
 
-export const Pagination = ({ currentPage, pageCount, onPageChange }) => {
+export const Pagination = ({ documents, renderRow, currentPage, pageCount, onLoadNextPage }) => {
     const paginationRange = usePagination(pageCount, currentPage);
+    const location = useLocation();
+    const page = new URLSearchParams(location.search).get("page");
+
+    const history = useHistory();
+    useEffect(() => {
+        if (page > 1 && page > pageCount) {
+            history.push({ search: `?page=${page - 1}` });
+        } else {
+            history.push({ search: `?page=${page}` });
+        }
+    }, [pageCount]);
+
+    const entries = map(documents, (_, index) => renderRow(index));
+
+    useEffect(() => {
+        if (page !== currentPage) {
+            onLoadNextPage(page);
+        }
+    }, [page]);
 
     const pageButtons = map(paginationRange, pageNumber => (
-        <Button
-            color={currentPage === pageNumber ? "blue" : ""}
+        <StyledLink
             key={pageNumber}
-            active={currentPage === pageNumber}
-            onClick={() => onPageChange(pageNumber)}
+            to={`?page=${pageNumber}`}
+            active={currentPage !== pageNumber ? "true" : "false"}
+            disabled={currentPage === pageNumber}
         >
             {pageNumber}
-        </Button>
+        </StyledLink>
     ));
 
     return (
-        <StyledPaginationBox>
-            <Button onClick={() => onPageChange(currentPage - 1)} color="blue" disabled={currentPage === 1}>
-                Previous
-            </Button>
-            {pageButtons}
-            <Button
-                onClick={() => onPageChange(currentPage + 1)}
-                color="blue"
-                disabled={currentPage === pageCount ? true : false}
-            >
-                Next
-            </Button>
-        </StyledPaginationBox>
+        <div>
+            <StyledPaginationItemsContainer>{entries}</StyledPaginationItemsContainer>
+            {pageCount > 1 && (
+                <StyledPaginationBox>
+                    <StyledLink
+                        to={`?page=${currentPage - 1}`}
+                        color="blue"
+                        disabled={currentPage === 1}
+                        active={currentPage !== 1 ? "true" : "false"}
+                    >
+                        Previous
+                    </StyledLink>
+                    {pageButtons}
+                    <StyledNextLink
+                        to={`?page=${currentPage + 1}`}
+                        color="blue"
+                        disabled={currentPage === pageCount || !pageCount}
+                    >
+                        Next
+                    </StyledNextLink>
+                </StyledPaginationBox>
+            )}
+        </div>
     );
 };

--- a/src/js/base/__tests__/Pagination.test.jsx
+++ b/src/js/base/__tests__/Pagination.test.jsx
@@ -9,6 +9,7 @@ describe("<Pagination />", () => {
         props = {
             pageCount: 6,
             currentPage: 1,
+            storedPage: 1,
             onLoadNextPage: vi.fn()
         };
     });
@@ -27,8 +28,8 @@ describe("<Pagination />", () => {
         expect(screen.queryByRole("link", { name: "6" })).not.toBeInTheDocument();
     });
 
-    it("should render correclty when pageCount=6 and currentPage = 3", () => {
-        props.currentPage = 3;
+    it("should render correctly when pageCount=6 and currentPage = 3", () => {
+        props.storedPage = 3;
         renderWithProviders(
             <MemoryRouter initialEntries={[{ pathname: "/samples/files", search: "?page=1" }]}>
                 <Pagination {...props} />

--- a/src/js/base/__tests__/Pagination.test.jsx
+++ b/src/js/base/__tests__/Pagination.test.jsx
@@ -1,5 +1,6 @@
 import { Pagination } from "../Pagination";
 import { screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 
 describe("<Pagination />", () => {
     let props;
@@ -7,49 +8,66 @@ describe("<Pagination />", () => {
     beforeEach(() => {
         props = {
             pageCount: 6,
-            currentPage: 1
+            currentPage: 1,
+            onLoadNextPage: vi.fn()
         };
     });
 
     it("Should render correctly when pageCount=6 and currentPage=1", () => {
-        renderWithProviders(<Pagination {...props} />);
-        expect(screen.getByRole("button", { name: "Previous" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "1" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "3" })).toBeInTheDocument();
-        expect(screen.queryByRole("button", { name: "5" })).not.toBeInTheDocument();
-        expect(screen.queryByRole("button", { name: "6" })).not.toBeInTheDocument();
+        renderWithProviders(
+            <MemoryRouter initialEntries={[{ pathname: "/samples/files", search: "?page=1" }]}>
+                <Pagination {...props} />
+            </MemoryRouter>
+        );
+        expect(screen.getByRole("link", { name: "Previous" })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "Next" })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "1" })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "3" })).toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: "5" })).not.toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: "6" })).not.toBeInTheDocument();
     });
 
     it("should render correclty when pageCount=6 and currentPage = 3", () => {
         props.currentPage = 3;
-        renderWithProviders(<Pagination {...props} />);
-        expect(screen.getByRole("button", { name: "Previous" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "2" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "3" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "5" })).toBeInTheDocument();
-        expect(screen.queryByRole("button", { name: "1" })).not.toBeInTheDocument();
-        expect(screen.queryByRole("button", { name: "6" })).not.toBeInTheDocument();
+        renderWithProviders(
+            <MemoryRouter initialEntries={[{ pathname: "/samples/files", search: "?page=1" }]}>
+                <Pagination {...props} />
+            </MemoryRouter>
+        );
+        expect(screen.getByRole("link", { name: "Previous" })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "Next" })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "2" })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "3" })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "5" })).toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: "1" })).not.toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: "6" })).not.toBeInTheDocument();
     });
 
     it("should render correctly when pageCount=0", () => {
         props.pageCount = 0;
-        renderWithProviders(<Pagination {...props} />);
-        expect(screen.getByRole("button", { name: "Previous" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
-        expect(screen.queryByRole("button", { name: "1" })).not.toBeInTheDocument();
-        expect(screen.queryByRole("button", { name: "3" })).not.toBeInTheDocument();
+        renderWithProviders(
+            <MemoryRouter initialEntries={[{ pathname: "/samples/files", search: "?page=1" }]}>
+                <Pagination {...props} />
+            </MemoryRouter>
+        );
+        expect(screen.queryByRole("link", { name: "Previous" })).not.toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: "Next" })).not.toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: "1" })).not.toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: "3" })).not.toBeInTheDocument();
     });
 
     it("should render correctly when pageCount=3", () => {
         props.pageCount = 3;
-        renderWithProviders(<Pagination {...props} />);
-        expect(screen.getByRole("button", { name: "Previous" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "1" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "2" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "3" })).toBeInTheDocument();
-        expect(screen.queryByRole("button", { name: "4" })).not.toBeInTheDocument();
+        renderWithProviders(
+            <MemoryRouter initialEntries={[{ pathname: "/samples/files", search: "?page=1" }]}>
+                <Pagination {...props} />
+            </MemoryRouter>
+        );
+        expect(screen.getByRole("link", { name: "Previous" })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "Next" })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "1" })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "2" })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "3" })).toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: "4" })).not.toBeInTheDocument();
     });
 });

--- a/src/js/base/index.js
+++ b/src/js/base/index.js
@@ -49,5 +49,6 @@ export * from "./Toolbar";
 export * from "./Tooltip";
 export * from "./UploadBar";
 export * from "./ViewHeader";
+export * from "./Pagination";
 
 export { Flex, FlexItem, ScrollList };

--- a/src/js/base/stories/Pagination.stories.js
+++ b/src/js/base/stories/Pagination.stories.js
@@ -1,8 +1,13 @@
-import React, { useState } from "react";
+import React, { useMemo } from "react";
 import { Pagination } from "../Pagination";
+import { useArgs } from "@storybook/client-api";
+import { faker } from "@faker-js/faker";
+import { map } from "lodash-es";
+import { UserItem } from "../../users/components/Item";
+import { Box } from "../";
 
 export default {
-    title: "base/pagination",
+    title: "base/Pagination",
     component: Pagination,
     parameters: {
         docs: {
@@ -15,13 +20,35 @@ export default {
 };
 
 const Template = args => {
-    const [currentPage, setCurrentPage] = useState(1);
-    return <Pagination onLoadNextPage={page => setCurrentPage(page)} currentPage={currentPage} {...args} />;
+    const [_, updateArgs] = useArgs();
+    const items = useMemo(() => fakeUserListFactory(args.storedPage, 7), [args.storedPage]);
+    const onLoadNextPage = page => {
+        updateArgs({ currentPage: page, storedPage: page });
+    };
+
+    return (
+        <Box>
+            <Pagination onLoadNextPage={onLoadNextPage} renderRow={UserItem} items={items} {...args} />
+        </Box>
+    );
 };
 
-export const testPagination = Template.bind({});
+export const ExamplePagination = Template.bind({});
 
-testPagination.args = {
+ExamplePagination.args = {
     pageCount: 10,
-    currentPage: 1
+    currentPage: 1,
+    storedPage: 1
 };
+
+const fakeUserListFactory = (seed, numItems) => {
+    faker.seed(seed);
+    let userList = Array(numItems);
+    return map(userList, () => fakeUserFactory());
+};
+
+const fakeUserFactory = () => ({
+    id: faker.random.alphaNumeric(6),
+    handle: `${faker.name.firstName()}${faker.name.lastName()}`,
+    administrator: false
+});

--- a/src/js/base/stories/Pagination.stories.js
+++ b/src/js/base/stories/Pagination.stories.js
@@ -1,6 +1,5 @@
-import React from "react";
+import React, { useState } from "react";
 import { Pagination } from "../Pagination";
-import { useArgs } from "@storybook/client-api";
 
 export default {
     title: "base/pagination",
@@ -16,8 +15,8 @@ export default {
 };
 
 const Template = args => {
-    const [{ currentPage }, updateArgs] = useArgs(1);
-    return <Pagination onPageChange={page => updateArgs({ currentPage: page })} currentPage={currentPage} {...args} />;
+    const [currentPage, setCurrentPage] = useState(1);
+    return <Pagination onLoadNextPage={page => setCurrentPage(page)} currentPage={currentPage} {...args} />;
 };
 
 export const testPagination = Template.bind({});

--- a/src/js/files/__tests__/actions.test.js
+++ b/src/js/files/__tests__/actions.test.js
@@ -62,10 +62,11 @@ describe("Files Action Creators", () => {
         const fileType = "reads";
         const term = "foo";
         const page = 3;
-        const result = findFiles(fileType, "foo", page);
+        const paginate = false;
+        const result = findFiles(fileType, term, paginate, page);
         expect(result).toEqual({
             type: FIND_FILES.REQUESTED,
-            payload: { fileType, term, page }
+            payload: { fileType, term, paginate, page }
         });
     });
 

--- a/src/js/files/__tests__/reducer.test.js
+++ b/src/js/files/__tests__/reducer.test.js
@@ -16,30 +16,6 @@ describe("filesReducer()", () => {
         expect(result).toEqual(initialState);
     });
 
-    describe("should handle WS_INSERT_FILE", () => {
-        it("if list is empty or fileType doesn't match, return state", () => {
-            const state = { fileType: "reads" };
-            const action = {
-                type: WS_INSERT_FILE,
-                payload: { type: "subtraction" }
-            };
-            const result = reducer(state, action);
-            expect(result).toEqual(state);
-        });
-
-        it("otherwise insert entry into list", () => {
-            const state = {
-                stale: true
-            };
-            const action = {
-                type: WS_INSERT_FILE,
-                payload: { type: "reads", id: "test" }
-            };
-            const result = reducer(state, action);
-            expect(result).toEqual({ stale: true });
-        });
-    });
-
     it("should handle WS_UPDATE_FILE", () => {
         const state = {
             documents: [{ id: "test", foo: "bar" }]
@@ -52,46 +28,32 @@ describe("filesReducer()", () => {
         expect(result).toEqual({ ...state, documents: [action.payload] });
     });
 
-    it("should handle WS_REMOVE_FILE", () => {
-        const state = {
-            documents: [{ id: "test", foo: "bar" }],
-            total_count: 1,
-            stale: true
-        };
-        const action = {
-            type: WS_REMOVE_FILE,
-            payload: ["test"]
-        };
-        const result = reducer(state, action);
-        expect(result).toEqual({ documents: [{ id: "test", foo: "bar" }], total_count: 1, stale: true });
-    });
-
     it("should handle LIST_FILES_REQUESTED", () => {
-        const state = {};
+        const state = { items: [], fileType: "test_filetype" };
         const action = {
             type: FIND_FILES.REQUESTED,
-            payload: { term: "foo", page: 5 }
+            payload: { term: "foo", paginate: true, fileType: "test_filetype" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
+            ...state,
             term: "foo",
-            fileType: ""
+            paginate: true
         });
     });
 
     it("should handle LIST_FILES_SUCCEEDED", () => {
-        const state = { documents: [], page: 1 };
+        const state = { items: [], page: 1 };
         const action = {
             type: FIND_FILES.SUCCEEDED,
-            payload: { documents: [] },
+            payload: { items: [] },
             context: { fileType: "test" }
         };
         const result = reducer(state, action);
         expect(result).toEqual({
             ...state,
             ...action.payload,
-            fileType: "test",
-            stale: false
+            fileType: "test"
         });
     });
 

--- a/src/js/files/__tests__/reducer.test.js
+++ b/src/js/files/__tests__/reducer.test.js
@@ -1,12 +1,10 @@
 import {
-    WS_INSERT_FILE,
-    WS_UPDATE_FILE,
-    WS_REMOVE_FILE,
-    UPLOAD,
-    UPLOAD_PROGRESS,
     FIND_FILES,
+    REMOVE_UPLOAD,
+    UPLOAD,
     UPLOAD_FAILED,
-    REMOVE_UPLOAD
+    UPLOAD_PROGRESS,
+    WS_UPDATE_FILE
 } from "../../app/actionTypes";
 import reducer, { initialState } from "../reducer";
 

--- a/src/js/files/__tests__/reducer.test.js
+++ b/src/js/files/__tests__/reducer.test.js
@@ -29,19 +29,14 @@ describe("filesReducer()", () => {
 
         it("otherwise insert entry into list", () => {
             const state = {
-                fetched: true,
-                fileType: "reads",
-                documents: [],
-                page: 1,
-                per_page: 3,
-                total_count: 0
+                stale: true
             };
             const action = {
                 type: WS_INSERT_FILE,
                 payload: { type: "reads", id: "test" }
             };
             const result = reducer(state, action);
-            expect(result).toEqual({ ...state, documents: [action.payload], total_count: 0 });
+            expect(result).toEqual({ stale: true });
         });
     });
 
@@ -60,14 +55,15 @@ describe("filesReducer()", () => {
     it("should handle WS_REMOVE_FILE", () => {
         const state = {
             documents: [{ id: "test", foo: "bar" }],
-            total_count: 1
+            total_count: 1,
+            stale: true
         };
         const action = {
             type: WS_REMOVE_FILE,
             payload: ["test"]
         };
         const result = reducer(state, action);
-        expect(result).toEqual({ documents: [], total_count: 1 });
+        expect(result).toEqual({ documents: [{ id: "test", foo: "bar" }], total_count: 1, stale: true });
     });
 
     it("should handle LIST_FILES_REQUESTED", () => {
@@ -94,7 +90,8 @@ describe("filesReducer()", () => {
         expect(result).toEqual({
             ...state,
             ...action.payload,
-            fileType: "test"
+            fileType: "test",
+            stale: false
         });
     });
 

--- a/src/js/files/__tests__/selectors.test.js
+++ b/src/js/files/__tests__/selectors.test.js
@@ -6,7 +6,7 @@ describe("getFilteredFileIds()", () => {
     beforeEach(() => {
         state = {
             files: {
-                documents: [
+                items: [
                     { id: "foo", ready: true, reserved: false, uploaded_at: "2020-01-24T23:54:02Z" },
                     { id: "bar", ready: true, reserved: false, uploaded_at: "2020-04-24T23:54:02Z" },
                     { id: "baz", ready: true, reserved: false, uploaded_at: "2020-02-24T23:54:02Z" }
@@ -15,14 +15,8 @@ describe("getFilteredFileIds()", () => {
         };
     });
 
-    it("should return all document ids when appropriate", () => {
+    it("should return all document ids", () => {
         const result = getFilteredFileIds(state);
-        expect(result).toEqual(["bar", "baz", "foo"]);
-    });
-
-    it("should return only non-reserved document ids", () => {
-        state.files.documents[1].reserved = true;
-        const result = getFilteredFileIds(state);
-        expect(result).toEqual(["baz", "foo"]);
+        expect(result).toEqual(["foo", "bar", "baz"]);
     });
 });

--- a/src/js/files/actions.js
+++ b/src/js/files/actions.js
@@ -48,13 +48,16 @@ export const wsRemoveFile = createAction(WS_REMOVE_FILE, data => ({
  *
  * @func
  * @param fileType {string} a file type to filter the returned documents by
+ * @param term {number} search term to filter by
+ * @param pagination {boolean} should the results by paginated
  * @param page {number} which page of results to return
  * @returns {object}
  */
-export const findFiles = createAction(FIND_FILES.REQUESTED, (fileType, term, page) => ({
+export const findFiles = createAction(FIND_FILES.REQUESTED, (fileType, term, paginate, page) => ({
     payload: {
         fileType,
         term,
+        paginate,
         page
     }
 }));

--- a/src/js/files/api.js
+++ b/src/js/files/api.js
@@ -19,10 +19,12 @@ export const find = ({ fileType }) =>
  * @param page {number} the page of results to get
  * @returns {promise}
  */
-export const list = ({ fileType }) =>
+export const list = ({ fileType, page }) =>
     Request.get("/api/uploads").query({
         type: fileType,
-        ready: true
+        ready: true,
+        paginate: true,
+        page
     });
 
 /**

--- a/src/js/files/api.js
+++ b/src/js/files/api.js
@@ -5,12 +5,6 @@
  */
 import { Request } from "../app/request";
 
-export const find = ({ fileType }) =>
-    Request.get("/api/uploads").query({
-        type: fileType,
-        ready: true
-    });
-
 /**
  * Get files of the given ``fileType``. Get a specific page of results using the ``page`` argument.
  *
@@ -19,11 +13,11 @@ export const find = ({ fileType }) =>
  * @param page {number} the page of results to get
  * @returns {promise}
  */
-export const list = ({ fileType, page }) =>
+export const list = ({ fileType, paginate, page }) =>
     Request.get("/api/uploads").query({
-        type: fileType,
+        upload_type: fileType,
         ready: true,
-        paginate: true,
+        paginate,
         page
     });
 

--- a/src/js/files/components/Manager.jsx
+++ b/src/js/files/components/Manager.jsx
@@ -1,4 +1,4 @@
-import { capitalize, forEach, toString } from "lodash-es";
+import { capitalize, forEach, max, min, toString } from "lodash-es";
 import React, { useEffect } from "react";
 import { connect } from "react-redux";
 import {
@@ -16,12 +16,13 @@ import { checkAdminOrPermission, createRandomString } from "../../utils/utils";
 import { findFiles, upload } from "../actions";
 import { getFilteredFileIds } from "../selectors";
 import File from "./File";
+import UploadToolbar from "./Toolbar";
+import { replace } from "connected-react-router";
+const renderRow = item => <File key={item} id={item} />;
 
 export const FileManager = ({
     onLoadNextPage,
-    canUpload,
-    onDrop,
-    documents,
+    items,
     validationRegex,
     message,
     total_count,
@@ -29,64 +30,19 @@ export const FileManager = ({
     tip,
     fileType,
     page_count,
-    urlPage,
-    stale,
+    URLPage,
     loading,
     found_count
 }) => {
     useEffect(() => {
-        if (stale || loading) {
-            onLoadNextPage(fileType, "1", urlPage);
-        }
-    }, [stale]);
+        onLoadNextPage(fileType, "", min([URLPage, page_count]));
+    }, []);
 
     if (loading) {
         return <LoadingPlaceholder />;
     }
 
-    const handleDrop = acceptedFiles => {
-        if (canUpload) {
-            onDrop(fileType, acceptedFiles);
-        }
-    };
-
-    const renderRow = index => {
-        const id = documents[index];
-        return <File key={id} id={id} />;
-    };
-
-    const validateExtensions = file => {
-        return validationRegex.test(file.name) ? null : { code: "Invalid file type" };
-    };
-
-    let toolbar;
-
-    if (canUpload) {
-        toolbar = (
-            <UploadBar
-                onDrop={handleDrop}
-                message={message || "Drag file here to upload."}
-                validator={validationRegex ? validateExtensions : null}
-                tip={tip}
-            />
-        );
-    } else {
-        toolbar = (
-            <Alert color="orange" level>
-                <Icon name="exclamation-circle" />
-                <span>
-                    <strong>You do not have permission to upload files.</strong>
-                    <span> Contact an administrator.</span>
-                </span>
-            </Alert>
-        );
-    }
-
-    let noneFound;
-
-    if (!documents.length) {
-        noneFound = found_count === 0 ? <NoneFoundBox noun="files" /> : <LoadingPlaceholder />;
-    }
+    const noneFound = found_count === 0 && <NoneFoundBox noun="files" />;
 
     const title = `${fileType === "reads" ? "Read" : capitalize(fileType)} Files`;
 
@@ -96,13 +52,14 @@ export const FileManager = ({
             <ViewHeaderTitle>
                 {title} <Badge>{total_count}</Badge>
             </ViewHeaderTitle>
-            {toolbar}
+            <UploadToolbar fileType={fileType} message={message} validationRegex={validationRegex} tip={tip} />
             {noneFound}
 
             <Pagination
-                documents={documents}
+                items={items}
                 renderRow={renderRow}
-                currentPage={page}
+                storedPage={page}
+                currentPage={URLPage}
                 pageCount={page_count}
                 onLoadNextPage={pageNumber => onLoadNextPage(fileType, toString(pageNumber), pageNumber)}
             />
@@ -111,35 +68,24 @@ export const FileManager = ({
 };
 
 export const mapStateToProps = (state, ownProps) => {
-    const { found_count, page, page_count, total_count, per_page } = state.files;
-    const documents = getFilteredFileIds(state);
-    const storedFileType = state.files.fileType;
-
+    const { found_count, page, page_count, total_count, per_page, fileType } = state.files;
+    const items = getFilteredFileIds(state);
     return {
         found_count,
         per_page,
         page,
         page_count,
         total_count,
-        canUpload: checkAdminOrPermission(state, "upload_file"),
-        documents,
-        storedFileType,
-        urlPage: new URLSearchParams(state.router?.location.search).get("page") || 1,
+        items,
+        URLPage: parseInt(new URLSearchParams(state.router?.location.search).get("page")) || 1,
         stale: state.files.stale,
-        loading: documents === null || (storedFileType && ownProps?.fileType !== storedFileType)
+        loading: items === null || (fileType && ownProps?.fileType !== fileType)
     };
 };
 
 export const mapDispatchToProps = dispatch => ({
-    onDrop: (fileType, acceptedFiles) => {
-        forEach(acceptedFiles, file => {
-            const localId = createRandomString();
-            dispatch(upload(localId, file, fileType));
-        });
-    },
-
-    onLoadNextPage: (fileType, term, page = 1) => {
-        dispatch(findFiles(fileType, term, page || 1));
+    onLoadNextPage: (fileType, term, page) => {
+        dispatch(findFiles(fileType, term, true, page));
     }
 });
 

--- a/src/js/files/components/Manager.jsx
+++ b/src/js/files/components/Manager.jsx
@@ -1,23 +1,12 @@
-import { capitalize, forEach, max, min, toString } from "lodash-es";
+import { capitalize, min, toString } from "lodash-es";
 import React, { useEffect } from "react";
 import { connect } from "react-redux";
-import {
-    Alert,
-    Badge,
-    Icon,
-    LoadingPlaceholder,
-    NoneFoundBox,
-    UploadBar,
-    ViewHeader,
-    ViewHeaderTitle,
-    Pagination
-} from "../../base";
-import { checkAdminOrPermission, createRandomString } from "../../utils/utils";
-import { findFiles, upload } from "../actions";
+import { Badge, LoadingPlaceholder, NoneFoundBox, Pagination, ViewHeader, ViewHeaderTitle } from "../../base";
+import { findFiles } from "../actions";
 import { getFilteredFileIds } from "../selectors";
 import File from "./File";
 import UploadToolbar from "./Toolbar";
-import { replace } from "connected-react-router";
+
 const renderRow = item => <File key={item} id={item} />;
 
 export const FileManager = ({

--- a/src/js/files/components/Toolbar.jsx
+++ b/src/js/files/components/Toolbar.jsx
@@ -1,0 +1,48 @@
+import { Alert, Icon, UploadBar } from "../../base";
+import React from "react";
+import { forEach } from "lodash-es";
+import { checkAdminOrPermission, createRandomString } from "../../utils/utils";
+import { upload } from "../actions";
+import { connect } from "react-redux";
+
+export const UploadToolbar = ({ canUpload, onDrop, fileType, message, validationRegex, tip }) => {
+    if (!canUpload) {
+        return (
+            <Alert color="orange" level>
+                <Icon name="exclamation-circle" />
+                <span>
+                    <strong>You do not have permission to upload files.</strong>
+                    <span> Contact an administrator.</span>
+                </span>
+            </Alert>
+        );
+    }
+
+    const handleDrop = acceptedFiles => {
+        onDrop(fileType, acceptedFiles);
+    };
+
+    const validateExtensions = file => (validationRegex.test(file.name) ? null : { code: "Invalid file type" });
+
+    return (
+        <UploadBar
+            onDrop={handleDrop}
+            message={message || "Drag file here to upload."}
+            validator={validationRegex ? validateExtensions : null}
+            tip={tip}
+        />
+    );
+};
+
+export const mapStateToProps = state => ({ canUpload: checkAdminOrPermission(state, "upload_file") });
+
+export const mapDispatchToProps = dispatch => ({
+    onDrop: (fileType, acceptedFiles) => {
+        forEach(acceptedFiles, file => {
+            const localId = createRandomString();
+            dispatch(upload(localId, file, fileType));
+        });
+    }
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(UploadToolbar);

--- a/src/js/files/components/__tests__/File.test.jsx
+++ b/src/js/files/components/__tests__/File.test.jsx
@@ -58,7 +58,7 @@ describe("mapStateToProps()", () => {
         ownProps = { id: "foo" };
         state = {
             files: {
-                documents: [
+                items: [
                     {
                         id: "foo",
                         name: "Foo",

--- a/src/js/files/components/__tests__/Manager.test.jsx
+++ b/src/js/files/components/__tests__/Manager.test.jsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createStore } from "redux";
 import { FileManager, mapDispatchToProps, mapStateToProps } from "../Manager";
+import { MemoryRouter } from "react-router-dom";
 
 const createAppStore = state => {
     return () => createStore(state => state, state);
@@ -28,7 +29,7 @@ describe("<FileManager>", () => {
         };
         state = {
             files: {
-                documents: [
+                items: [
                     {
                         id: 1,
                         name: "subtraction.fq.gz",
@@ -49,7 +50,13 @@ describe("<FileManager>", () => {
     });
 
     it("should render", () => {
-        renderWithProviders(<FileManager {...props} />, createAppStore(state));
+        renderWithProviders(
+            <MemoryRouter initialEntries={[{ pathname: "/samples/files", search: "?page=1" }]}>
+                <FileManager {...props} />
+            </MemoryRouter>,
+
+            createAppStore(state)
+        );
         expect(screen.getByText("Drag file here to upload.")).toBeInTheDocument();
         expect(screen.getByText("subtraction.fq.gz")).toBeInTheDocument();
         expect(screen.getByRole("button", { name: "Browse Files" })).toBeInTheDocument();
@@ -57,20 +64,38 @@ describe("<FileManager>", () => {
 
     it("should remove upload bar if canUpload is false", () => {
         props.canUpload = false;
-        renderWithProviders(<FileManager {...props} />, createAppStore(state));
+        renderWithProviders(
+            <MemoryRouter initialEntries={[{ pathname: "/samples/files", search: "?page=1" }]}>
+                <FileManager {...props} />
+            </MemoryRouter>,
+
+            createAppStore(state)
+        );
         expect(screen.getByText("You do not have permission to upload files.")).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: "Upload" })).not.toBeInTheDocument();
     });
 
     it("should change message if passed", () => {
         props.message = "test_message";
-        renderWithProviders(<FileManager {...props} />, createAppStore(state));
+        renderWithProviders(
+            <MemoryRouter initialEntries={[{ pathname: "/samples/files", search: "?page=1" }]}>
+                <FileManager {...props} />
+            </MemoryRouter>,
+
+            createAppStore(state)
+        );
         expect(screen.getByText("test_message")).toBeInTheDocument();
     });
 
     it("should filter files according to passed regex", async () => {
         props.validationRegex = /.(?:fa|fasta)(?:.gz|.gzip)?$/;
-        renderWithProviders(<FileManager {...props} />, createAppStore(state));
+        renderWithProviders(
+            <MemoryRouter initialEntries={[{ pathname: "/samples/files", search: "?page=1" }]}>
+                <FileManager {...props} />
+            </MemoryRouter>,
+
+            createAppStore(state)
+        );
         const invalidFile = new File(["test"], "test_invalid_file.gz", { type: "application/gzip" });
         const validFile = new File(["test"], "test_valid_file.fa.gz", { type: "application/gzip" });
         await userEvent.upload(screen.getByLabelText("Upload file"), [invalidFile, validFile]);
@@ -87,11 +112,12 @@ describe("mapStateToProps()", () => {
         state = {
             files: {
                 found_count: 6,
+                per_page: 1,
                 page: 1,
                 page_count: 1,
                 total_count: 1,
                 fileType: "test_fileType",
-                documents: [
+                items: [
                     {
                         id: 1,
                         name: "subtraction.fq.gz",
@@ -114,12 +140,16 @@ describe("mapStateToProps()", () => {
     it("should return correct values", () => {
         const expected = {
             found_count: 6,
+            per_page: 1,
             page: 1,
             page_count: 1,
             total_count: 1,
             storedFileType: "test_fileType",
             documents: [1],
-            canUpload: true
+            canUpload: true,
+            urlPage: 1,
+            stale: undefined,
+            loading: true
         };
         expect(mapStateToProps(state)).toEqual(expected);
     });

--- a/src/js/files/components/__tests__/Manager.test.jsx
+++ b/src/js/files/components/__tests__/Manager.test.jsx
@@ -3,8 +3,6 @@ import userEvent from "@testing-library/user-event";
 import { createStore } from "redux";
 import { FileManager, mapDispatchToProps, mapStateToProps } from "../Manager";
 import { MemoryRouter } from "react-router-dom";
-import { connect } from "react-redux";
-import { UploadToolbar } from "../Toolbar";
 import { UPLOAD } from "../../../app/actionTypes";
 
 const createAppStore = state => {

--- a/src/js/files/reducer.js
+++ b/src/js/files/reducer.js
@@ -16,7 +16,7 @@ import {
     WS_REMOVE_FILE,
     WS_UPDATE_FILE
 } from "../app/actionTypes";
-import { insert, remove, update, updateDocuments } from "../utils/reducers";
+import { update, updateDocuments } from "../utils/reducers";
 
 /**
  * The initial state to give the reducer.
@@ -30,7 +30,8 @@ export const initialState = {
     found_count: 0,
     page: 0,
     total_count: 0,
-    uploads: []
+    uploads: [],
+    stale: true
 };
 
 export const appendUpload = (state, action) => {
@@ -77,15 +78,14 @@ export const filesReducer = createReducer(initialState, builder => {
     builder
         .addCase(WS_INSERT_FILE, (state, action) => {
             if (action.payload.type === state.fileType) {
-                return insert(state, action.payload, "uploaded_at", true);
+                state.stale = true;
             }
-            return state;
         })
         .addCase(WS_UPDATE_FILE, (state, action) => {
             return update(state, action.payload, "uploaded_at", true);
         })
-        .addCase(WS_REMOVE_FILE, (state, action) => {
-            return remove(state, action.payload);
+        .addCase(WS_REMOVE_FILE, state => {
+            state.stale = true;
         })
         .addCase(FIND_FILES.REQUESTED, (state, action) => {
             state.term = action.payload.term;
@@ -95,7 +95,8 @@ export const filesReducer = createReducer(initialState, builder => {
         .addCase(FIND_FILES.SUCCEEDED, (state, action) => {
             return {
                 ...updateDocuments(state, action.payload, "uploaded_at", true),
-                fileType: action.context.fileType
+                fileType: action.context.fileType,
+                stale: false
             };
         })
         .addCase(UPLOAD.REQUESTED, (state, action) => {

--- a/src/js/files/reducer.js
+++ b/src/js/files/reducer.js
@@ -12,12 +12,10 @@ import {
     UPLOAD_FAILED,
     UPLOAD_PROGRESS,
     UPLOAD_SAMPLE_FILE,
-    WS_INSERT_FILE,
     WS_REFRESH_FILES,
-    WS_REMOVE_FILE,
     WS_UPDATE_FILE
 } from "../app/actionTypes";
-import { insert, remove, update } from "../utils/reducers";
+import { update } from "../utils/reducers";
 
 /**
  * The initial state to give the reducer.
@@ -90,6 +88,7 @@ export const filesReducer = createReducer(initialState, builder => {
                     items: sortBy(action.payload.items || action.payload.documents, "uploaded_at").reverse()
                 };
             }
+            return state;
         })
         .addCase(FIND_FILES.REQUESTED, (state, action) => {
             state.term = action.payload.term;

--- a/src/js/files/selectors.js
+++ b/src/js/files/selectors.js
@@ -1,19 +1,13 @@
-import { keyBy, map, reject, sortBy } from "lodash-es";
+import { keyBy, map } from "lodash-es";
 import { createSelector } from "reselect";
 
-const getFiles = state => state.files.documents;
+const getFiles = state => state.files.items;
 
 export const getFilesById = createSelector(getFiles, files => keyBy(files, "id"));
 
 export const getFilteredFileIds = createSelector(getFiles, documents => {
     if (documents) {
-        return map(
-            sortBy(
-                reject(documents, document => document.reserved || !document.ready),
-                "uploaded_at"
-            ).reverse(),
-            "id"
-        );
+        return map(documents, document => document.id);
     }
 
     return null;

--- a/src/js/files/selectors.js
+++ b/src/js/files/selectors.js
@@ -1,13 +1,13 @@
 import { keyBy, map } from "lodash-es";
 import { createSelector } from "reselect";
 
-const getFiles = state => state.files.items;
+export const getFiles = state => state.files.items;
 
 export const getFilesById = createSelector(getFiles, files => keyBy(files, "id"));
 
-export const getFilteredFileIds = createSelector(getFiles, documents => {
-    if (documents) {
-        return map(documents, document => document.id);
+export const getFilteredFileIds = createSelector(getFiles, files => {
+    if (files) {
+        return map(files, file => file.id);
     }
 
     return null;

--- a/src/js/nav/components/Sidebar.jsx
+++ b/src/js/nav/components/Sidebar.jsx
@@ -32,7 +32,7 @@ export const Sidebar = ({ administrator }) => (
                     link="/samples"
                     icon="th-list"
                 />
-                <SidebarItem title="Files" link="/samples/files" icon="folder-open" />
+                <SidebarItem title="Files" link="/samples/files?page=1" icon="folder-open" />
                 <SidebarItem title="Labels" link="/samples/labels" icon="fas fa-tag" />
                 {administrator ? <SidebarItem title="Settings" link="/samples/settings" icon="cogs" /> : null}
             </StyledSidebar>
@@ -46,7 +46,7 @@ export const Sidebar = ({ administrator }) => (
         <Route path="/subtractions">
             <StyledSidebar>
                 <SidebarItem exclude={["/subtractions/files"]} title="Browse" link="/subtractions" icon="th-list" />
-                <SidebarItem title="Files" link="/subtractions/files" icon="folder-open" />
+                <SidebarItem title="Files" link="/subtractions/files?page=1" icon="folder-open" />
             </StyledSidebar>
         </Route>
         <Route path="/hmm">

--- a/src/js/samples/sagas.js
+++ b/src/js/samples/sagas.js
@@ -80,11 +80,10 @@ export function* findSamples(action) {
 
 export function* findReadFiles() {
     yield apiCall(
-        filesAPI.find,
+        filesAPI.list,
         {
             fileType: "reads",
-            page: 1,
-            perPage: 500
+            paginate: false
         },
         FIND_READ_FILES
     );

--- a/src/js/subtraction/components/Create.jsx
+++ b/src/js/subtraction/components/Create.jsx
@@ -17,6 +17,7 @@ import { findFiles } from "../../files/actions";
 import PersistForm from "../../forms/components/PersistForm";
 import { createSubtraction } from "../actions";
 import SubtractionFileSelector from "./FileSelector";
+import { getFiles } from "../../files/selectors";
 
 const validationSchema = Yup.object().shape({
     name: Yup.string().required("A name is required"),
@@ -86,17 +87,19 @@ export const CreateSubtraction = ({ onListFiles, onCreate, files }) => {
     );
 };
 
-const mapStateToProps = state => ({
-    files: state.files.fileType === "subtraction" ? filter(state.files.documents, { type: "subtraction" }) : null
-});
+const mapStateToProps = state => {
+    console.log(state.router.location);
+    return {
+        files: state.files.fileType === "subtraction" ? getFiles(state) : null
+    };
+};
 
 const mapDispatchToProps = dispatch => ({
     onCreate: ({ uploadId, name, nickname }) => {
         dispatch(createSubtraction(uploadId, name, nickname));
     },
-
     onListFiles: () => {
-        dispatch(findFiles("subtraction"));
+        dispatch(findFiles("subtraction", "", false));
     }
 });
 

--- a/src/js/subtraction/components/Create.jsx
+++ b/src/js/subtraction/components/Create.jsx
@@ -1,5 +1,5 @@
 import { Field, Form, Formik } from "formik";
-import { filter, find } from "lodash-es";
+import { find } from "lodash-es";
 import React, { useEffect } from "react";
 import { connect } from "react-redux";
 import * as Yup from "yup";
@@ -87,12 +87,9 @@ export const CreateSubtraction = ({ onListFiles, onCreate, files }) => {
     );
 };
 
-const mapStateToProps = state => {
-    console.log(state.router.location);
-    return {
-        files: state.files.fileType === "subtraction" ? getFiles(state) : null
-    };
-};
+const mapStateToProps = state => ({
+    files: state.files.fileType === "subtraction" ? getFiles(state) : null
+});
 
 const mapDispatchToProps = dispatch => ({
     onCreate: ({ uploadId, name, nickname }) => {

--- a/src/js/subtraction/components/__tests__/FileManager.test.jsx
+++ b/src/js/subtraction/components/__tests__/FileManager.test.jsx
@@ -4,6 +4,7 @@ import { createStore } from "redux";
 import { SubtractionFileManager } from "../FileManager";
 import { screen, waitFor } from "@testing-library/react";
 import { UPLOAD } from "../../../app/actionTypes";
+import { MemoryRouter } from "react-router-dom";
 
 const createAppStore = (state, reducer) => {
     return () => createStore(reducer ? reducer : state => state, state);
@@ -16,7 +17,7 @@ const createFiles = fileNames => {
 describe("<SubtractionFileManager />", () => {
     const state = {
         files: {
-            documents: [
+            items: [
                 {
                     id: 1,
                     name: "subtraction.fq.gz",
@@ -36,7 +37,12 @@ describe("<SubtractionFileManager />", () => {
     };
 
     it("should render", () => {
-        renderWithProviders(<SubtractionFileManager />, createAppStore(state));
+        renderWithProviders(
+            <MemoryRouter initialEntries={[{ pathname: "/samples/files", search: "?page=1" }]}>
+                <SubtractionFileManager />
+            </MemoryRouter>,
+            createAppStore(state)
+        );
         expect(screen.getByText("Drag FASTA files here to upload")).toBeInTheDocument();
         expect(screen.getByText("Accepts files ending in fa, fasta, fa.gz, or fasta.gz.")).toBeInTheDocument();
     });
@@ -48,7 +54,12 @@ describe("<SubtractionFileManager />", () => {
             return state;
         };
 
-        renderWithProviders(<SubtractionFileManager />, createAppStore(state, reducer));
+        renderWithProviders(
+            <MemoryRouter initialEntries={[{ pathname: "/samples/files", search: "?page=1" }]}>
+                <SubtractionFileManager />
+            </MemoryRouter>,
+            createAppStore(state, reducer)
+        );
 
         const validFiles = createFiles(["test.fa", "test.fa.gz", "test.fasta", "test.fasta.gz"]);
         const invalidFiles = createFiles([

--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -6,7 +6,6 @@ import Fuse from "fuse.js";
 import { capitalize, forEach, get, replace, sampleSize, split, startCase, upperFirst } from "lodash-es";
 import numbro from "numbro";
 import { getAccountAdministrator } from "../account/selectors";
-import { getLocation, push } from "connected-react-router";
 
 /**
  * A string containing all alphanumeric digits in both cases.

--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -3,9 +3,10 @@
  *
  */
 import Fuse from "fuse.js";
-import { capitalize, get, replace, sampleSize, split, startCase, upperFirst } from "lodash-es";
+import { capitalize, forEach, get, replace, sampleSize, split, startCase, upperFirst } from "lodash-es";
 import numbro from "numbro";
 import { getAccountAdministrator } from "../account/selectors";
+import { getLocation, push } from "connected-react-router";
 
 /**
  * A string containing all alphanumeric digits in both cases.
@@ -213,4 +214,22 @@ export const getSessionStorage = key => {
     } catch (e) {
         return null;
     }
+};
+
+/**
+ * Return a search string with specified passed parameters updated
+ *
+ * @func
+ * @param {string} search URL ready search string to be updated
+ * @param {object} params
+ * @returns {string}
+ */
+export const updateSearchString = (search, params) => {
+    const searchParams = new URLSearchParams(search);
+
+    forEach(params, (value, key) => {
+        searchParams.set(key, value);
+    });
+
+    return searchParams.toString();
 };


### PR DESCRIPTION
Currently there is no way to tell when removing a file that it is the correct type so it is necessary to assume that it is. Additionally, the documents come back in a weird order. Adding a new document sometimes adds it to a page other than the first. And documents are not always returned in order. The order does not change on refresh. There does not appear to be a reason that the documents are loaded in the order they are. These issues may be related to the backend.

Additionally, storybook does not appear to have a good way of handling the links present in this component. The story functions correctly and the current page can be changed by using the storybook controls. But clicking the buttons does not change the page. I think this story could be optimised in a future pr.

![Screenshot from 2022-11-28 14-15-13](https://user-images.githubusercontent.com/97321944/204392286-96cafbe1-b4f1-472e-ad6f-4762198456fd.png)
