### PR TITLE
Tilt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Build and Push
         uses: docker/build-push-action@v2
+        with:
+          target: dist
+
   release:
     runs-on: ubuntu-20.04
     needs: [test]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,12 +31,10 @@ jobs:
       packages: write
     if: github.repository_owner == 'Virtool'
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - name: Write VERSION file
         run: echo ${{ github.event.release.tag_name }} > VERSION
-      - name: Login to Registry
-        uses: docker/login-action@v1
+      - uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GH_USERNAME }}
@@ -46,10 +44,10 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/virtool/ui
-      - name: Build and Push
-        uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v2
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          target: dist
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY webpack.production.config.js ./
 COPY src /build/src
 RUN npx webpack --config webpack.production.config.js
 
-FROM library/node:16-buster as final
+FROM library/node:16-buster as dist
 WORKDIR /ui
 COPY --from=build /build/dist dist
 RUN npm install commander express http-proxy-middleware ejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,13 @@ CMD ["npx", "webpack-dev-server"]
 
 FROM npm as build
 COPY --from=npm /build/node_modules /build/node_modules
-COPY webpack.production.config.js ./
+COPY .eslintrc webpack.production.config.js ./
 COPY src /build/src
 RUN npx webpack --config webpack.production.config.js
 
 FROM library/node:16-buster as dist
 WORKDIR /ui
-COPY --from=build /build/dist dist
+COPY --from=build /build/dist /ui/dist
 RUN npm install commander express http-proxy-middleware ejs
 COPY run.js /ui/
 COPY ./server /ui/server

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,11 +48,10 @@ module.exports = {
   mode: "development",
 
   plugins: [
+    new CleanWebpackPlugin(),
     new ESLintPlugin({
       overrideConfigFile: path.resolve(__dirname, "./.eslintrc"),
     }),
-    new CleanWebpackPlugin(),
-
     new HTMLWebpackPlugin({
       filename: "index.html",
       title: "Virtool",
@@ -63,23 +62,18 @@ module.exports = {
   ],
   ignoreWarnings: [{ message: /Unexpected console statement/ }],
   devServer: {
-    hot: true,
-    proxy: {
-      "/api": {
-        target: "http://localhost:9950",
-        pathRewrite: {
-          "/api": "",
-        },
-      },
-      "/websocket": {
-        target: "ws://localhost:9950",
-        ws: true,
-        pathRewrite: {
-          "^/websocket": "/ws",
-        },
+    allowedHosts: "all",
+    client: {
+      webSocketURL: {
+        hostname: "localhost",
+        pathname: "/ws",
+        port: 9900,
+        protocol: "ws",
       },
     },
     historyApiFallback: true,
+    host: "0.0.0.0",
+    hot: true,
     port: 9900,
   },
 };


### PR DESCRIPTION
Make the webpack-dev-server work with Tilt.
* Stop using proxy. Tilt/Minikube will handle this using an ingress.
* Always use `localhost:9900` for HMR websocket client.
* Add a target to the `Dockerfile` that runs `webpack-dev-server`.