### PR TITLE
Restore NuVs analysis view functionallity

### DIFF
--- a/src/js/analyses/components/NuVs/Detail.jsx
+++ b/src/js/analyses/components/NuVs/Detail.jsx
@@ -10,6 +10,7 @@ import NuVsBLAST from "./BLAST";
 import { NuVsORF } from "./ORF";
 import { NuVsSequence } from "./Sequence";
 import { NuVsValues } from "./Values";
+import { calculateAnnotatedOrfCount } from "../../utils";
 
 const StyledNuVsFamilies = styled.div`
     border: ${getBorder};
@@ -104,7 +105,7 @@ export const NuVsDetail = ({ filterORFs, hit, maxSequenceLength }) => {
                     Sequence {index}
                     <Badge>{sequence.length} bp</Badge>
                 </h3>
-                <NuVsValues e={e} orfCount={orfs.length} />
+                <NuVsValues e={e} orfCount={calculateAnnotatedOrfCount(orfs)} />
                 <NuVsFamilies families={families} />
             </NuVsDetailTitle>
             <NuVsLayout>

--- a/src/js/analyses/components/NuVs/Item.jsx
+++ b/src/js/analyses/components/NuVs/Item.jsx
@@ -1,4 +1,3 @@
-import { filter } from "lodash-es";
 import numbro from "numbro";
 import React, { useCallback } from "react";
 import { connect } from "react-redux";

--- a/src/js/analyses/components/NuVs/Item.jsx
+++ b/src/js/analyses/components/NuVs/Item.jsx
@@ -9,8 +9,6 @@ import { getActiveHit, getMatches } from "../../selectors";
 import { AnalysisViewerItem } from "../Viewer/Item";
 import { NuVsValues } from "./Values";
 
-const calculateAnnotatedOrfCount = orfs => filter(orfs, orf => orf.hits.length).length;
-
 const NuVsItemHeader = styled.div`
     align-items: center;
     display: flex;
@@ -24,24 +22,23 @@ const StyledNuVsItem = styled(AnalysisViewerItem)`
     margin: 0;
 `;
 
-export const NuVsItem = ({ active, e, orfs, sequence, sequenceIndex, style, onSetActiveId }) => {
+export const NuVsItem = ({ active, e, orfCount, sequence, sequenceIndex, style, onSetActiveId }) => {
     const handleClick = useCallback(() => onSetActiveId(sequenceIndex), [sequenceIndex]);
-
     return (
         <StyledNuVsItem active={active} onClick={handleClick} style={style}>
             <NuVsItemHeader>
                 <strong>Sequence {sequenceIndex}</strong>
                 <Badge>{sequence.length}</Badge>
             </NuVsItemHeader>
-            <NuVsValues e={numbro(e).format()} orfCount={calculateAnnotatedOrfCount(orfs)} />
+            <NuVsValues e={numbro(e).format()} orfCount={orfCount} />
         </StyledNuVsItem>
     );
 };
 
 const mapStateToProps = (state, ownProps) => {
     const activeId = getActiveHit(state).index;
-    const { e, index, orfs, sequence } = getMatches(state)[ownProps.index];
-    return { e, orfs, sequence, sequenceIndex: index, active: activeId === index };
+    const { e, index, annotatedOrfCount, sequence } = getMatches(state)[ownProps.index];
+    return { e, orfCount: annotatedOrfCount, sequence, sequenceIndex: index, active: activeId === index };
 };
 
 const mapDispatchToProps = dispatch => ({

--- a/src/js/analyses/components/NuVs/Toolbar.jsx
+++ b/src/js/analyses/components/NuVs/Toolbar.jsx
@@ -5,6 +5,7 @@ import { Button, LinkButton, SearchInput, Toolbar } from "../../../base";
 import { setAnalysisSortKey, setSearchIds, toggleFilterORFs, toggleFilterSequences } from "../../actions";
 import { getFuse, getResults } from "../../selectors";
 import { AnalysisViewerSort } from "../Viewer/Sort";
+import { map } from "lodash-es";
 
 const StyledNuVsToolbar = styled(Toolbar)`
     margin-bottom: 10px;
@@ -71,7 +72,8 @@ const mapDispatchToProps = dispatch => ({
         dispatch(toggleFilterORFs());
     },
     onSearch: (term, fuse) => {
-        dispatch(setSearchIds(term ? fuse.search(term) : null));
+        const searchIds = map(fuse.search(term), hit => hit.item.id);
+        dispatch(setSearchIds(searchIds.length ? searchIds : null));
     },
     onSelect: sortKey => {
         dispatch(setAnalysisSortKey(sortKey));

--- a/src/js/analyses/components/NuVs/__tests__/Item.test.jsx
+++ b/src/js/analyses/components/NuVs/__tests__/Item.test.jsx
@@ -17,6 +17,7 @@ describe("<NuVsItem />", () => {
                     hits: [1]
                 }
             ],
+            orfCount: 2,
             onSetActiveId: vi.fn()
         };
     });

--- a/src/js/analyses/components/Viewer/List.jsx
+++ b/src/js/analyses/components/Viewer/List.jsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 import { getBorder, getFontSize } from "../../../app/theme";
 import { Key } from "../../../base";
 import { setActiveHitId } from "../../actions";
-import { getActiveHit, getMatches, getResults } from "../../selectors";
+import { getActiveHit, getHits, getMatches, getResults } from "../../selectors";
 import { useKeyNavigation } from "./hooks";
 
 const AnalysisViewerListHeader = styled.div`
@@ -92,10 +92,9 @@ export const mapStateToProps = state => {
             nextId = matches[nextIndex].id;
         }
     }
-
     return {
         shown: matches.length,
-        total: getResults(state).length,
+        total: getHits(state).length,
         activeId,
         nextId,
         nextIndex,

--- a/src/js/analyses/components/Viewer/List.jsx
+++ b/src/js/analyses/components/Viewer/List.jsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 import { getBorder, getFontSize } from "../../../app/theme";
 import { Key } from "../../../base";
 import { setActiveHitId } from "../../actions";
-import { getActiveHit, getHits, getMatches, getResults } from "../../selectors";
+import { getActiveHit, getHits, getMatches } from "../../selectors";
 import { useKeyNavigation } from "./hooks";
 
 const AnalysisViewerListHeader = styled.div`

--- a/src/js/analyses/components/Viewer/__tests__/List.test.jsx
+++ b/src/js/analyses/components/Viewer/__tests__/List.test.jsx
@@ -1,4 +1,4 @@
-import { getMatches, getResults } from "../../../selectors";
+import { getMatches, getHits } from "../../../selectors";
 import { mapStateToProps, AnalysisViewerList } from "../List";
 
 vi.mock("../../../selectors.js");
@@ -17,7 +17,7 @@ describe("<AnalysisViewerList />", () => {
 
 describe("mapStateToProps()", () => {
     getMatches.mockReturnValue(["foo", "bar"]);
-    getResults.mockReturnValue(["foo", "bar", "baz", "bat", "fob"]);
+    getHits.mockReturnValue(["foo", "bar", "baz", "bat", "fob"]);
 
     const state = {
         foo: "bar"
@@ -26,7 +26,7 @@ describe("mapStateToProps()", () => {
     it("should return props", () => {
         const props = mapStateToProps(state);
         expect(getMatches).toHaveBeenCalledWith(state);
-        expect(getResults).toHaveBeenCalledWith(state);
+        expect(getHits).toHaveBeenCalledWith(state);
         expect(props).toEqual({
             shown: 2,
             total: 5

--- a/src/js/analyses/utils.js
+++ b/src/js/analyses/utils.js
@@ -1,6 +1,7 @@
 import {
     compact,
     fill,
+    filter,
     flatMap,
     fromPairs,
     has,
@@ -19,7 +20,7 @@ import {
 } from "lodash-es";
 import { formatIsolateName } from "../utils/utils";
 
-const calculateAnnotatedOrfCount = orfs => reject(orfs, { "hits.length": 0 }).length;
+export const calculateAnnotatedOrfCount = orfs => filter(orfs, orf => orf.hits.length).length;
 
 const calculateORFMinimumE = hits => {
     if (hits.length === 0) {


### PR DESCRIPTION
**Fixes:** 
 - ensure search function correctly displays filtered otus
 - only count annotated otus for sorting and detail view
 - display the total number of sequences in list sidebar