### PR TITLE
Ensure correct value is sent for filtering otus by verification

### DIFF
--- a/src/js/otus/api.js
+++ b/src/js/otus/api.js
@@ -1,7 +1,7 @@
 import { Request } from "../app/request";
 
 export const find = ({ refId, term, verified, page }) =>
-    Request.get(`/api/refs/${refId}/otus`).query({ find: term, page, verified: verified ? false : undefined });
+    Request.get(`/api/refs/${refId}/otus`).query({ find: term, page, verified: verified || undefined });
 
 export const listNames = ({ refId }) => Request.get(`/api/refs/${refId}/otus?names=true`);
 


### PR DESCRIPTION
Was returning either nothing or false, changed to send no query parameter when `verified` is falsy or `verified` when verified is `Truthy`. Assumption is that verified should always be `true` or `false`