### PR TITLE
Ensure css files served by express server

### DIFF
--- a/run.js
+++ b/run.js
@@ -78,7 +78,7 @@ app.set("views", path.join(__dirname, "dist"));
 app.locals.delimiter = "#";
 
 app.get(
-  /\.(?:js|map|ico|svg)$/,
+  /\.(?:js|map|ico|svg|css)$/,
   express.static(path.join(__dirname, "dist"), {
     maxAge: 31536000000,
   })


### PR DESCRIPTION
Fixes visual oddities resulting when the UI was being served via express. (random left side margin, tooltips not rendering properly, ect)