### PR TITLE
fix: display login page when session expires

### DIFF
--- a/src/js/app/App.jsx
+++ b/src/js/app/App.jsx
@@ -17,7 +17,7 @@ function mapStateToProps(state) {
     return {
         first,
         login,
-        reset
+        reset,
     };
 }
 
@@ -45,7 +45,23 @@ const ConnectedApp = connect(mapStateToProps)(({ first, login, reset }) => {
     return <Main />;
 });
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            onError: error => {
+                if (error.response.status === 401) {
+                    window.location.reload();
+                }
+            },
+            retry: (failureCount, error) => {
+                if (error.response.status === 401) {
+                    return false;
+                }
+                return failureCount <= 3;
+            },
+        },
+    },
+});
 
 export default function App({ store, history }) {
     return (


### PR DESCRIPTION
Changes Query client logic to:

- When getting a 401 error:
  - Not retry the request (new)
  - force reload the page (new)
  
- When getting any other error:
  - retry the request up to 3 times (same as before)
  - allow the components to handle the error (same as before)