### PR TITLE
Append `/api` to requests automatically

### DIFF
--- a/src/js/account/api.js
+++ b/src/js/account/api.js
@@ -12,7 +12,7 @@ import { Request } from "../app/request";
  * @func
  * @returns {promise}
  */
-export const get = () => Request.get("/api/account");
+export const get = () => Request.get("/account");
 
 /**
  * Updates the complete data for the current account.
@@ -21,7 +21,7 @@ export const get = () => Request.get("/api/account");
  * @param update {object} the update to apply to current account.
  * @returns {promise}
  */
-export const update = ({ update }) => Request.patch("/api/account").send(update);
+export const update = ({ update }) => Request.patch("/account").send(update);
 
 /**
  * Gets the settings object for the current account.
@@ -29,7 +29,7 @@ export const update = ({ update }) => Request.patch("/api/account").send(update)
  * @func
  * @returns {promise}
  */
-export const getSettings = () => Request.get("/api/account/settings");
+export const getSettings = () => Request.get("/account/settings");
 
 /**
  * Updates the settings for the current account.
@@ -38,7 +38,7 @@ export const getSettings = () => Request.get("/api/account/settings");
  * @param update {object} the update to apply to account settings
  * @returns {promise}
  */
-export const updateSettings = ({ update }) => Request.patch("/api/account/settings").send(update);
+export const updateSettings = ({ update }) => Request.patch("/account/settings").send(update);
 
 /**
  * Changes the password for the current account.
@@ -49,9 +49,9 @@ export const updateSettings = ({ update }) => Request.patch("/api/account/settin
  * @returns {promise}
  */
 export const changePassword = ({ old_password, password }) =>
-    Request.patch("/api/account").send({
+    Request.patch("/account").send({
         old_password,
-        password
+        password,
     });
 
 /**
@@ -59,7 +59,7 @@ export const changePassword = ({ old_password, password }) =>
  *
  * @returns {promise}
  */
-export const getAPIKeys = () => Request.get("/api/account/keys");
+export const getAPIKeys = () => Request.get("/account/keys");
 
 /**
  * Create a new API key for the current account.
@@ -70,9 +70,9 @@ export const getAPIKeys = () => Request.get("/api/account/keys");
  * @returns {promise}
  */
 export const createAPIKey = ({ name, permissions }) =>
-    Request.post("/api/account/keys").send({
+    Request.post("/account/keys").send({
         name,
-        permissions
+        permissions,
     });
 
 /**
@@ -84,8 +84,8 @@ export const createAPIKey = ({ name, permissions }) =>
  * @returns {promise}
  */
 export const updateAPIKey = ({ keyId, permissions }) =>
-    Request.patch(`/api/account/keys/${keyId}`).send({
-        permissions
+    Request.patch(`/account/keys/${keyId}`).send({
+        permissions,
     });
 
 /**
@@ -94,10 +94,10 @@ export const updateAPIKey = ({ keyId, permissions }) =>
  * @param keyId
  * @returns {promise}
  */
-export const removeAPIKey = ({ keyId }) => Request.delete(`/api/account/keys/${keyId}`);
+export const removeAPIKey = ({ keyId }) => Request.delete(`/account/keys/${keyId}`);
 
 export const login = ({ username, password, remember }) =>
-    Request.post("/api/account/login").send({ username, password, remember });
+    Request.post("/account/login").send({ username, password, remember });
 
 /**
  * Logs out the current session.
@@ -105,7 +105,7 @@ export const login = ({ username, password, remember }) =>
  * @func
  * @returns {promise}
  */
-export const logout = () => Request.get("/api/account/logout");
+export const logout = () => Request.get("/account/logout");
 
 export const resetPassword = ({ password, resetCode }) =>
-    Request.post("/api/account/reset").send({ password, reset_code: resetCode });
+    Request.post("/account/reset").send({ password, reset_code: resetCode });

--- a/src/js/administration/api.js
+++ b/src/js/administration/api.js
@@ -1,5 +1,5 @@
 import { Request } from "../app/request";
 
-export const get = () => Request.get("/api/settings");
+export const get = () => Request.get("/settings");
 
-export const update = ({ update }) => Request.patch("/api/settings").send(update);
+export const update = ({ update }) => Request.patch("/settings").send(update);

--- a/src/js/administration/hooks.ts
+++ b/src/js/administration/hooks.ts
@@ -2,7 +2,7 @@ import { useQuery } from "react-query";
 import { Request } from "../app/request";
 
 function fetchSettings() {
-    return Request.get("/api/settings").then(response => {
+    return Request.get("/settings").then(response => {
         return response.body;
     });
 }

--- a/src/js/analyses/api.js
+++ b/src/js/analyses/api.js
@@ -1,18 +1,18 @@
 import { Request } from "../app/request";
 
 export const find = ({ sampleId, term, page = 1 }) =>
-    Request.get(`/api/samples/${sampleId}/analyses`).query({ find: term, page });
+    Request.get(`/samples/${sampleId}/analyses`).query({ find: term, page });
 
-export const get = ({ analysisId }) => Request.get(`/api/analyses/${analysisId}`);
+export const get = ({ analysisId }) => Request.get(`/analyses/${analysisId}`);
 
 export const analyze = ({ sampleId, refId, subtractionIds, workflow }) =>
-    Request.post(`/api/samples/${sampleId}/analyses`).send({
+    Request.post(`/samples/${sampleId}/analyses`).send({
         workflow,
         ref_id: refId,
-        subtractions: subtractionIds
+        subtractions: subtractionIds,
     });
 
 export const blastNuvs = ({ analysisId, sequenceIndex }) =>
-    Request.put(`/api/analyses/${analysisId}/${sequenceIndex}/blast`, {});
+    Request.put(`/analyses/${analysisId}/${sequenceIndex}/blast`, {});
 
-export const remove = ({ analysisId }) => Request.delete(`/api/analyses/${analysisId}`);
+export const remove = ({ analysisId }) => Request.delete(`/analyses/${analysisId}`);

--- a/src/js/app/request.js
+++ b/src/js/app/request.js
@@ -1,7 +1,7 @@
 import Superagent from "superagent";
 
-const createRequest = method => url => {
-    return Superagent[method](url).set("Accept", "application/json");
+const createRequest = method => slug => {
+    return Superagent[method](`/api${slug}`).set("Accept", "application/json");
 };
 
 export const Request = {
@@ -9,5 +9,5 @@ export const Request = {
     post: createRequest("post"),
     patch: createRequest("patch"),
     put: createRequest("put"),
-    delete: createRequest("delete")
+    delete: createRequest("delete"),
 };

--- a/src/js/caches/api.js
+++ b/src/js/caches/api.js
@@ -7,4 +7,4 @@ import { Request } from "../app/request";
  * @param cacheId {string} the id of the cache to get
  * @returns {promise}
  */
-export const get = ({ cacheId }) => Request.get(`/api/caches/${cacheId}`);
+export const get = ({ cacheId }) => Request.get(`/caches/${cacheId}`);

--- a/src/js/dev/api.js
+++ b/src/js/dev/api.js
@@ -1,3 +1,3 @@
 import { Request } from "../app/request";
 
-export const post = ({ command }) => Request.post(`/api/dev`).send({ command });
+export const post = ({ command }) => Request.post(`/dev`).send({ command });

--- a/src/js/files/api.js
+++ b/src/js/files/api.js
@@ -14,11 +14,11 @@ import { Request } from "../app/request";
  * @returns {promise}
  */
 export const list = ({ fileType, paginate, page }) =>
-    Request.get("/api/uploads").query({
+    Request.get("/uploads").query({
         upload_type: fileType,
         ready: true,
         paginate,
-        page
+        page,
     });
 
 /**
@@ -28,7 +28,7 @@ export const list = ({ fileType, paginate, page }) =>
  * @param fileId {string} the fileId to handleRemove
  * @returns {promise}
  */
-export const remove = ({ fileId }) => Request.delete(`/api/uploads/${fileId}`);
+export const remove = ({ fileId }) => Request.delete(`/uploads/${fileId}`);
 
 /**
  * Upload a ``file`` with the given ``fileType``. Pass progress events to ``onProgress``.
@@ -42,7 +42,7 @@ export const remove = ({ fileId }) => Request.delete(`/api/uploads/${fileId}`);
  * @returns {promise}
  */
 export function upload({ file, fileType, onProgress, onSuccess, onFailure }) {
-    return Request.post("/api/uploads")
+    return Request.post("/uploads")
         .query({ name: file.name, type: fileType })
         .attach("file", file)
         .on("progress", onProgress)

--- a/src/js/groups/api.js
+++ b/src/js/groups/api.js
@@ -1,22 +1,22 @@
 import { Request } from "../app/request";
 
-export const list = () => Request.get("/api/groups");
+export const list = () => Request.get("/groups");
 
-export const create = ({ name }) => Request.post("/api/groups").send({ name });
+export const create = ({ name }) => Request.post("/groups").send({ name });
 
 export function setName({ groupId, name }) {
-    return Request.patch(`/api/groups/${groupId}`).send({
-        name
+    return Request.patch(`/groups/${groupId}`).send({
+        name,
     });
 }
 
 export const setPermission = ({ groupId, permission, value }) =>
-    Request.patch(`/api/groups/${groupId}`).send({
+    Request.patch(`/groups/${groupId}`).send({
         permissions: {
-            [permission]: value
-        }
+            [permission]: value,
+        },
     });
 
-export const remove = ({ groupId }) => Request.delete(`/api/groups/${groupId}`);
+export const remove = ({ groupId }) => Request.delete(`/groups/${groupId}`);
 
-export const get = ({ groupId }) => Request.get(`/api/groups/${groupId}`);
+export const get = ({ groupId }) => Request.get(`/groups/${groupId}`);

--- a/src/js/hmm/api.js
+++ b/src/js/hmm/api.js
@@ -1,11 +1,11 @@
 import { Request } from "../app/request";
 
-export const find = ({ term, page }) => Request.get("/api/hmms").query({ find: term, page });
+export const find = ({ term, page }) => Request.get("/hmms").query({ find: term, page });
 
-export const list = ({ page }) => Request.get("/api/hmms").query({ page });
+export const list = ({ page }) => Request.get("/hmms").query({ page });
 
-export const install = () => Request.post("/api/hmms/status/updates");
+export const install = () => Request.post("/hmms/status/updates");
 
-export const get = ({ hmmId }) => Request.get(`/api/hmms/${hmmId}`);
+export const get = ({ hmmId }) => Request.get(`/hmms/${hmmId}`);
 
-export const purge = () => Request.delete("/api/hmms");
+export const purge = () => Request.delete("/hmms");

--- a/src/js/indexes/api.js
+++ b/src/js/indexes/api.js
@@ -1,13 +1,13 @@
 import { Request } from "../app/request";
 
-export const find = ({ refId, term, page }) => Request.get(`/api/refs/${refId}/indexes`).query({ find: term, page });
+export const find = ({ refId, term, page }) => Request.get(`/refs/${refId}/indexes`).query({ find: term, page });
 
-export const get = ({ indexId }) => Request.get(`/api/indexes/${indexId}`);
+export const get = ({ indexId }) => Request.get(`/indexes/${indexId}`);
 
-export const listReady = () => Request.get("/api/indexes").query({ ready: true });
+export const listReady = () => Request.get("/indexes").query({ ready: true });
 
-export const getUnbuilt = ({ refId }) => Request.get(`/api/refs/${refId}/history?unbuilt=true`);
+export const getUnbuilt = ({ refId }) => Request.get(`/refs/${refId}/history?unbuilt=true`);
 
-export const create = ({ refId }) => Request.post(`/api/refs/${refId}/indexes`);
+export const create = ({ refId }) => Request.post(`/refs/${refId}/indexes`);
 
-export const getHistory = ({ indexId, page = 1 }) => Request.get(`/api/indexes/${indexId}/history?page=${page}`);
+export const getHistory = ({ indexId, page = 1 }) => Request.get(`/indexes/${indexId}/history?page=${page}`);

--- a/src/js/jobs/api.js
+++ b/src/js/jobs/api.js
@@ -2,11 +2,11 @@ import { forEach } from "lodash-es";
 import { Request } from "../app/request";
 
 export const find = ({ archived, states, page }) => {
-    const request = Request.get("/api/jobs").query({ archived, page });
+    const request = Request.get("/jobs").query({ archived, page });
     forEach(states, state => request.query({ state }));
     return request;
 };
 
-export const get = ({ jobId }) => Request.get(`/api/jobs/${jobId}`);
-export const cancel = ({ jobId }) => Request.put(`/api/jobs/${jobId}/cancel`);
-export const archive = ({ jobId }) => Request.patch(`/api/jobs/${jobId}/archive`);
+export const get = ({ jobId }) => Request.get(`/jobs/${jobId}`);
+export const cancel = ({ jobId }) => Request.put(`/jobs/${jobId}/cancel`);
+export const archive = ({ jobId }) => Request.patch(`/jobs/${jobId}/archive`);

--- a/src/js/labels/api.ts
+++ b/src/js/labels/api.ts
@@ -1,19 +1,19 @@
 import { Request } from "../app/request";
 
-export const listLabels = () => Request.get("/api/labels");
+export const listLabels = () => Request.get("/labels");
 
 export const create = ({ name, description, color }) =>
-    Request.post("/api/labels").send({
+    Request.post("/labels").send({
         name,
         description,
-        color
+        color,
     });
 
-export const remove = ({ labelId }) => Request.delete(`/api/labels/${labelId}`);
+export const remove = ({ labelId }) => Request.delete(`/labels/${labelId}`);
 
 export const update = ({ labelId, name, description, color }) =>
-    Request.patch(`/api/labels/${labelId}`).send({
+    Request.patch(`/labels/${labelId}`).send({
         name,
         description,
-        color
+        color,
     });

--- a/src/js/labels/components/Create.tsx
+++ b/src/js/labels/components/Create.tsx
@@ -21,7 +21,7 @@ export function CreateLabel() {
 
     const mutation = useMutation(
         (newLabel: NewLabel) => {
-            return Request.post("/api/labels").send(newLabel);
+            return Request.post("/labels").send(newLabel);
         },
         {
             onSuccess: () => {
@@ -30,8 +30,8 @@ export function CreateLabel() {
             },
             onError: (error: ResponseError) => {
                 setError(error.response.body.message);
-            }
-        }
+            },
+        },
     );
 
     const handleSubmit = ({ color, name, description }: NewLabel) => {

--- a/src/js/labels/components/Edit.tsx
+++ b/src/js/labels/components/Edit.tsx
@@ -19,7 +19,7 @@ export function EditLabel({ id, color, name, description }: EditLabelProps) {
     const queryClient = useQueryClient();
 
     const mutation = useMutation(data => {
-        return Request.patch(`/api/labels/${id}`)
+        return Request.patch(`/labels/${id}`)
             .send(data)
             .then(response => {
                 return response.body;
@@ -31,7 +31,7 @@ export function EditLabel({ id, color, name, description }: EditLabelProps) {
             onSuccess: () => {
                 setShow(false);
                 queryClient.invalidateQueries("labels");
-            }
+            },
         });
     };
 

--- a/src/js/labels/components/Remove.tsx
+++ b/src/js/labels/components/Remove.tsx
@@ -28,14 +28,14 @@ export function RemoveLabel({ id, name }: RemoveLabelProps) {
 
     const mutation = useMutation(
         () => {
-            return Request.delete(`/api/labels/${id}`);
+            return Request.delete(`/labels/${id}`);
         },
         {
             onSuccess: () => {
                 setOpen(false);
                 queryClient.invalidateQueries("labels");
-            }
-        }
+            },
+        },
     );
 
     return (

--- a/src/js/labels/hooks.ts
+++ b/src/js/labels/hooks.ts
@@ -2,7 +2,7 @@ import { useQuery } from "react-query";
 import { Request } from "../app/request";
 
 function fetchLabels() {
-    return Request.get("/api/labels").then(response => {
+    return Request.get("/labels").then(response => {
         return response.body;
     });
 }

--- a/src/js/message/api.ts
+++ b/src/js/message/api.ts
@@ -1,6 +1,5 @@
 import { Request } from "../app/request";
 
-export const get = () => Request.get("/api/instance_message");
+export const get = () => Request.get("/instance_message");
 
-export const set = ({ message }) =>
-    Request.put("/api/instance_message").send({ color: "red", message });
+export const set = ({ message }) => Request.put("/instance_message").send({ color: "red", message });

--- a/src/js/otus/api.js
+++ b/src/js/otus/api.js
@@ -1,56 +1,56 @@
 import { Request } from "../app/request";
 
 export const find = ({ refId, term, verified, page }) =>
-    Request.get(`/api/refs/${refId}/otus`).query({ find: term, page, verified: verified || undefined });
+    Request.get(`/refs/${refId}/otus`).query({ find: term, page, verified: verified || undefined });
 
-export const listNames = ({ refId }) => Request.get(`/api/refs/${refId}/otus?names=true`);
+export const listNames = ({ refId }) => Request.get(`/refs/${refId}/otus?names=true`);
 
-export const get = ({ otuId }) => Request.get(`/api/otus/${otuId}`);
+export const get = ({ otuId }) => Request.get(`/otus/${otuId}`);
 
-export const getHistory = ({ otuId }) => Request.get(`/api/otus/${otuId}/history`);
+export const getHistory = ({ otuId }) => Request.get(`/otus/${otuId}/history`);
 
-export const getGenbank = accession => Request.get(`/api/genbank/${accession}`);
+export const getGenbank = accession => Request.get(`/genbank/${accession}`);
 
 export const create = ({ refId, name, abbreviation }) =>
-    Request.post(`/api/refs/${refId}/otus`).send({
+    Request.post(`/refs/${refId}/otus`).send({
         name,
-        abbreviation
+        abbreviation,
     });
 
 export const edit = ({ otuId, name, abbreviation, schema }) =>
-    Request.patch(`/api/otus/${otuId}`).send({
+    Request.patch(`/otus/${otuId}`).send({
         name,
         abbreviation,
-        schema
+        schema,
     });
 
-export const remove = ({ otuId }) => Request.delete(`/api/otus/${otuId}`);
+export const remove = ({ otuId }) => Request.delete(`/otus/${otuId}`);
 
 export const addIsolate = ({ otuId, sourceType, sourceName }) =>
-    Request.post(`/api/otus/${otuId}/isolates`).send({
+    Request.post(`/otus/${otuId}/isolates`).send({
         source_type: sourceType,
-        source_name: sourceName
+        source_name: sourceName,
     });
 
 export const editIsolate = ({ otuId, isolateId, sourceType, sourceName }) =>
-    Request.patch(`/api/otus/${otuId}/isolates/${isolateId}`).send({
+    Request.patch(`/otus/${otuId}/isolates/${isolateId}`).send({
         source_type: sourceType,
-        source_name: sourceName
+        source_name: sourceName,
     });
 
 export const setIsolateAsDefault = ({ otuId, isolateId }) =>
-    Request.put(`/api/otus/${otuId}/isolates/${isolateId}/default`);
+    Request.put(`/otus/${otuId}/isolates/${isolateId}/default`);
 
-export const removeIsolate = ({ otuId, isolateId }) => Request.delete(`/api/otus/${otuId}/isolates/${isolateId}`);
+export const removeIsolate = ({ otuId, isolateId }) => Request.delete(`/otus/${otuId}/isolates/${isolateId}`);
 
 export const addSequence = ({ otuId, isolateId, accession, definition, host, sequence, segment, target }) =>
-    Request.post(`/api/otus/${otuId}/isolates/${isolateId}/sequences`).send({
+    Request.post(`/otus/${otuId}/isolates/${isolateId}/sequences`).send({
         accession,
         definition,
         host,
         sequence,
         segment,
-        target
+        target,
     });
 
 export const editSequence = ({
@@ -62,18 +62,18 @@ export const editSequence = ({
     host,
     sequence,
     segment,
-    target
+    target,
 }) =>
-    Request.patch(`/api/otus/${otuId}/isolates/${isolateId}/sequences/${sequenceId}`).send({
+    Request.patch(`/otus/${otuId}/isolates/${isolateId}/sequences/${sequenceId}`).send({
         accession,
         definition,
         host,
         sequence,
         segment,
-        target
+        target,
     });
 
 export const removeSequence = ({ otuId, isolateId, sequenceId }) =>
-    Request.delete(`/api/otus/${otuId}/isolates/${isolateId}/sequences/${sequenceId}`);
+    Request.delete(`/otus/${otuId}/isolates/${isolateId}/sequences/${sequenceId}`);
 
-export const revert = ({ change_id }) => Request.delete(`/api/history/${change_id}`);
+export const revert = ({ change_id }) => Request.delete(`/history/${change_id}`);

--- a/src/js/references/api.js
+++ b/src/js/references/api.js
@@ -1,78 +1,78 @@
 import { Request } from "../app/request";
 
 export function find({ term, page }) {
-    return Request.get("/api/refs").query({ find: term, page });
+    return Request.get("/refs").query({ find: term, page });
 }
 
 export function get({ refId }) {
-    return Request.get(`/api/refs/${refId}`);
+    return Request.get(`/refs/${refId}`);
 }
 
 export function create({ name, description, dataType, organism }) {
-    return Request.post("/api/refs").send({
+    return Request.post("/refs").send({
         name,
         description,
         data_type: dataType,
-        organism
+        organism,
     });
 }
 
 export function edit({ refId, update }) {
-    return Request.patch(`/api/refs/${refId}`).send(update);
+    return Request.patch(`/refs/${refId}`).send(update);
 }
 
 export function importReference({ name, description, fileId }) {
-    return Request.post("/api/refs").send({
+    return Request.post("/refs").send({
         name,
         description,
-        import_from: fileId
+        import_from: fileId,
     });
 }
 
 export function cloneReference({ name, description, refId }) {
-    return Request.post("/api/refs").send({
+    return Request.post("/refs").send({
         name,
         description,
-        clone_from: refId
+        clone_from: refId,
     });
 }
 
 export function remoteReference({ remote_from }) {
-    return Request.post("/api/refs").send({ remote_from });
+    return Request.post("/refs").send({ remote_from });
 }
 
 export function remove({ refId }) {
-    return Request.delete(`/api/refs/${refId}`);
+    return Request.delete(`/refs/${refId}`);
 }
 
 export function addUser({ refId, user }) {
-    return Request.post(`/api/refs/${refId}/users`).send({ user_id: user });
+    return Request.post(`/refs/${refId}/users`).send({ user_id: user });
 }
 
 export function editUser({ refId, userId, update }) {
-    return Request.patch(`/api/refs/${refId}/users/${userId}`).send(update);
+    return Request.patch(`/refs/${refId}/users/${userId}`).send(update);
 }
 
 export function removeUser({ refId, userId }) {
-    return Request.delete(`/api/refs/${refId}/users/${userId}`);
+    return Request.delete(`/refs/${refId}/users/${userId}`);
 }
 
 export function addGroup({ refId, group }) {
-    return Request.post(`/api/refs/${refId}/groups`).send({ group_id: group });
+    return Request.post(`/refs/${refId}/groups`).send({ group_id: group });
 }
 
 export function editGroup({ refId, groupId, update }) {
-    return Request.patch(`/api/refs/${refId}/groups/${groupId}`).send(update);
+    return Request.patch(`/refs/${refId}/groups/${groupId}`).send(update);
 }
 
 export function removeGroup({ refId, groupId }) {
-    return Request.delete(`/api/refs/${refId}/groups/${groupId}`);
+    return Request.delete(`/refs/${refId}/groups/${groupId}`);
 }
 
 export function checkUpdates({ refId }) {
-    return Request.get(`/api/refs/${refId}/release`);
+    return Request.get(`/refs/${refId}/release`);
 }
 
 export function updateRemote({ refId }) {
-    return Request.post(`/api/refs/${refId}/updates`).send({});
+    return Request.post(`/refs/${refId}/updates`).send({});
 }

--- a/src/js/references/components/ImportReference.tsx
+++ b/src/js/references/components/ImportReference.tsx
@@ -13,7 +13,7 @@ import {
     InputSimple,
     ProgressBarAffixed,
     SaveButton,
-    UploadBar
+    UploadBar,
 } from "../../base";
 
 const ImportReferenceUpload = styled.div`
@@ -38,10 +38,10 @@ interface ImportReferenceValues {
  * @param importFrom - the ID of the file to import from
  */
 function importReference({ name, description, importFrom }: ImportReferenceValues) {
-    return Request.post("/api/refs").send({
+    return Request.post("/refs").send({
         name,
         description,
-        import_from: importFrom
+        import_from: importFrom,
     });
 }
 
@@ -58,7 +58,7 @@ export function ImportReference() {
         const formData = new FormData();
         formData.append("file", file);
 
-        return Request.post("/api/uploads")
+        return Request.post("/uploads")
             .query({ name: file.name, type: "reference" })
             .send(formData)
             .on("progress", event => {
@@ -74,13 +74,13 @@ export function ImportReference() {
         control,
         formState: { errors },
         handleSubmit,
-        register
+        register,
     } = useForm({
         defaultValues: {
             name: "",
             description: "",
-            upload: ""
-        }
+            upload: "",
+        },
     });
 
     function handleDrop(acceptedFiles: File[]) {

--- a/src/js/references/components/SourceTypes/GlobalSourceTypes.tsx
+++ b/src/js/references/components/SourceTypes/GlobalSourceTypes.tsx
@@ -12,7 +12,7 @@ import {
     InputLabel,
     InputLevel,
     InputSimple,
-    SectionHeader
+    SectionHeader,
 } from "../../../base";
 import { useUpdateSourceTypes } from "../../hooks";
 import { SourceTypeList } from "./SourceTypeList";
@@ -61,9 +61,9 @@ interface GlobalSourceTypesProps {
 export function GlobalSourceTypes({ sourceTypes }: GlobalSourceTypesProps) {
     const { error, lastRemoved, handleRemove, handleSubmit, handleUndo, register } = useUpdateSourceTypes(
         "default_source_types",
-        "/api/settings",
+        "/settings",
         "settings",
-        sourceTypes
+        sourceTypes,
     );
 
     return (

--- a/src/js/references/components/SourceTypes/LocalSourceTypes.tsx
+++ b/src/js/references/components/SourceTypes/LocalSourceTypes.tsx
@@ -15,7 +15,7 @@ import {
     InputError,
     InputSimple,
     LoadingPlaceholder,
-    SectionHeader
+    SectionHeader,
 } from "../../../base";
 import { useGetReference, useUpdateReference, useUpdateSourceTypes } from "../../hooks";
 import { SourceTypeList } from "./SourceTypeList";
@@ -73,9 +73,9 @@ export function LocalSourceTypes() {
 
     const { error, lastRemoved, handleRemove, handleSubmit, handleUndo, register } = useUpdateSourceTypes(
         "source_types",
-        `/api/refs/${refId}`,
+        `/refs/${refId}`,
         ["reference", refId],
-        sourceTypes
+        sourceTypes,
     );
 
     if (isLoading) {

--- a/src/js/references/hooks.ts
+++ b/src/js/references/hooks.ts
@@ -8,7 +8,7 @@ import { Request } from "../app/request";
 import { Reference } from "./types";
 
 function getReference(refId: string): Reference {
-    return Request.get(`/api/refs/${refId}`).then(response => {
+    return Request.get(`/refs/${refId}`).then(response => {
         return new Reference(response.body);
     });
 }
@@ -22,13 +22,13 @@ export function useUpdateReference(refId: string, onSuccess?: () => void) {
 
     const mutation = useMutation(
         (data: { restrict_source_types: boolean }) => {
-            return Request.patch(`/api/refs/${refId}`).send(data);
+            return Request.patch(`/refs/${refId}`).send(data);
         },
         {
             onSuccess: () => {
                 queryClient.invalidateQueries(["reference", refId]).then(() => onSuccess && onSuccess());
-            }
-        }
+            },
+        },
     );
 
     return { mutation };
@@ -40,7 +40,7 @@ export function getValidationSchema(sourceTypes: string[]) {
             .lowercase()
             .notOneOf(sourceTypes, "Source type already exists")
             .test("containsNoSpaces", "Source types may not contain spaces", value => !value.includes(" "))
-            .trim()
+            .trim(),
     });
 }
 
@@ -49,10 +49,10 @@ export function useSourceTypesForm(sourceTypes: string[]) {
         formState: { errors },
         handleSubmit,
         register,
-        reset
+        reset,
     } = useForm({
         defaultValues: { sourceType: "" },
-        resolver: yupResolver(getValidationSchema(sourceTypes))
+        resolver: yupResolver(getValidationSchema(sourceTypes)),
     });
 
     return { errors, handleSubmit, register, reset };
@@ -62,7 +62,7 @@ export function useUpdateSourceTypes(
     key: "default_source_types" | "source_types",
     path: string,
     queryKey: string | string[],
-    sourceTypes: string[]
+    sourceTypes: string[],
 ) {
     const queryClient = useQueryClient();
 
@@ -83,8 +83,8 @@ export function useUpdateSourceTypes(
                 }
 
                 queryClient.invalidateQueries(queryKey);
-            }
-        }
+            },
+        },
     );
 
     const { errors, handleSubmit, register, reset } = useSourceTypesForm(sourceTypes);
@@ -95,7 +95,7 @@ export function useUpdateSourceTypes(
                 onSuccess: () => {
                     reset();
                     setLastRemoved("");
-                }
+                },
             });
         }
     }
@@ -106,8 +106,8 @@ export function useUpdateSourceTypes(
             {
                 onSuccess: () => {
                     setLastRemoved(sourceType);
-                }
-            }
+                },
+            },
         );
     }
 
@@ -116,7 +116,7 @@ export function useUpdateSourceTypes(
             mutation.mutate(union(sourceTypes, [lastRemoved]), {
                 onSuccess: () => {
                     setLastRemoved("");
-                }
+                },
             });
         }
     }
@@ -128,6 +128,6 @@ export function useUpdateSourceTypes(
         handleRemove,
         handleSubmit: handleSubmit(handleAdd),
         handleUndo,
-        register
+        register,
     };
 }

--- a/src/js/samples/api.js
+++ b/src/js/samples/api.js
@@ -1,8 +1,8 @@
 import { Request } from "../app/request";
 
 export const find = ({ term, labels, workflows, page = 1 }) => {
-    const request = Request.get("/api/samples").query({
-        page
+    const request = Request.get("/samples").query({
+        page,
     });
 
     if (term) {
@@ -22,13 +22,13 @@ export const find = ({ term, labels, workflows, page = 1 }) => {
     return request;
 };
 
-export const filter = ({ term }) => Request.get(`/api/samples?find=${term}`);
+export const filter = ({ term }) => Request.get(`/samples?find=${term}`);
 
-export const get = ({ sampleId }) => Request.get(`/api/samples/${sampleId}`);
+export const get = ({ sampleId }) => Request.get(`/samples/${sampleId}`);
 
 export const create = action => {
     const { name, isolate, host, locale, libraryType, subtractions, files, labels, group } = action;
-    return Request.post("/api/samples").send({
+    return Request.post("/samples").send({
         name,
         isolate,
         host,
@@ -37,12 +37,12 @@ export const create = action => {
         files,
         library_type: libraryType,
         labels,
-        group
+        group,
     });
 };
 
-export const update = ({ sampleId, update }) => Request.patch(`/api/samples/${sampleId}`).send(update);
+export const update = ({ sampleId, update }) => Request.patch(`/samples/${sampleId}`).send(update);
 
-export const updateRights = ({ sampleId, update }) => Request.patch(`/api/samples/${sampleId}/rights`).send(update);
+export const updateRights = ({ sampleId, update }) => Request.patch(`/samples/${sampleId}/rights`).send(update);
 
-export const remove = ({ sampleId }) => Request.delete(`/api/samples/${sampleId}`);
+export const remove = ({ sampleId }) => Request.delete(`/samples/${sampleId}`);

--- a/src/js/subtraction/api.js
+++ b/src/js/subtraction/api.js
@@ -1,19 +1,19 @@
 import { Request } from "../app/request";
 
-export const find = ({ term, page }) => Request.get("/api/subtractions").query({ find: term, page });
+export const find = ({ term, page }) => Request.get("/subtractions").query({ find: term, page });
 
-export const shortlist = () => Request.get("/api/subtractions?short=true");
+export const shortlist = () => Request.get("/subtractions?short=true");
 
-export const get = ({ subtractionId }) => Request.get(`/api/subtractions/${subtractionId}`);
+export const get = ({ subtractionId }) => Request.get(`/subtractions/${subtractionId}`);
 
 export const create = ({ name, nickname, uploadId }) =>
-    Request.post("/api/subtractions").send({
+    Request.post("/subtractions").send({
         name,
         nickname,
-        upload_id: uploadId
+        upload_id: uploadId,
     });
 
 export const edit = ({ subtractionId, name, nickname }) =>
-    Request.patch(`/api/subtractions/${subtractionId}`).send({ name, nickname });
+    Request.patch(`/subtractions/${subtractionId}`).send({ name, nickname });
 
-export const remove = ({ subtractionId }) => Request.delete(`/api/subtractions/${subtractionId}`);
+export const remove = ({ subtractionId }) => Request.delete(`/subtractions/${subtractionId}`);

--- a/src/js/tasks/api.js
+++ b/src/js/tasks/api.js
@@ -1,5 +1,5 @@
 import { Request } from "../app/request";
 
-export const list = () => Request.get("/api/tasks");
+export const list = () => Request.get("/tasks");
 
-export const get = ({ taskId }) => Request.get(`/api/tasks/${taskId}`);
+export const get = ({ taskId }) => Request.get(`/tasks/${taskId}`);

--- a/src/js/users/api.js
+++ b/src/js/users/api.js
@@ -1,20 +1,20 @@
 import { Request } from "../app/request";
 
-export const find = ({ term, page }) => Request.get("/api/users").query({ find: term, page });
+export const find = ({ term, page }) => Request.get("/users").query({ find: term, page });
 
-export const get = ({ userId }) => Request.get(`/api/users/${userId}`);
+export const get = ({ userId }) => Request.get(`/users/${userId}`);
 
 export const create = ({ handle, password, forceReset }) =>
-    Request.post("/api/users").send({
+    Request.post("/users").send({
         handle,
         password,
-        force_reset: forceReset
+        force_reset: forceReset,
     });
 
 export const createFirst = ({ handle, password }) =>
-    Request.put("/api/users/first").send({
+    Request.put("/users/first").send({
         handle,
-        password
+        password,
     });
 
-export const edit = ({ userId, update }) => Request.patch(`/api/users/${userId}`).send(update);
+export const edit = ({ userId, update }) => Request.patch(`/users/${userId}`).send(update);


### PR DESCRIPTION
Changes:
 - removes /api from all api requests made using the `Requests` module
 - appends `/api` onto the front of all slugs passed to the `Requests` module
 - formatting changes made by prettier while modifying the files