### PR TITLE
fix: ensure label buttons render correctly

### DIFF
--- a/src/js/labels/components/Item.tsx
+++ b/src/js/labels/components/Item.tsx
@@ -28,7 +28,6 @@ const LabelItemIcons = styled.div`
     top: 0;
     right: 0;
     bottom: 0;
-    z-index: 20;
 
     *:not(:first-child) {
         margin-left: 5px;


### PR DESCRIPTION
Changes:

 - Removes z-index from label buttons. Inspect visually no obvious reason for z-index to have been specified