### PR TITLE
fix: clear cached data on logout

### DIFF
--- a/src/js/account/actions.js
+++ b/src/js/account/actions.js
@@ -3,21 +3,21 @@
  *
  * @module account/actions
  */
+import { createAction } from "@reduxjs/toolkit";
 import {
-    GET_ACCOUNT,
-    UPDATE_ACCOUNT,
-    UPDATE_ACCOUNT_SETTINGS,
     CHANGE_ACCOUNT_PASSWORD,
-    GET_API_KEYS,
+    CLEAR_API_KEY,
     CREATE_API_KEY,
-    UPDATE_API_KEY,
-    REMOVE_API_KEY,
+    GET_ACCOUNT,
+    GET_API_KEYS,
     LOGIN,
     LOGOUT,
-    CLEAR_API_KEY,
-    RESET_PASSWORD
+    REMOVE_API_KEY,
+    RESET_PASSWORD,
+    UPDATE_ACCOUNT,
+    UPDATE_ACCOUNT_SETTINGS,
+    UPDATE_API_KEY,
 } from "../app/actionTypes";
-import { createAction } from "@reduxjs/toolkit";
 
 /**
  * Returns action that can trigger an API call for getting the current account data.
@@ -35,7 +35,7 @@ export const getAccount = createAction(GET_ACCOUNT.REQUESTED);
  * @returns {object}
  */
 export const updateAccount = createAction(UPDATE_ACCOUNT.REQUESTED, update => ({
-    payload: { update }
+    payload: { update },
 }));
 
 /**
@@ -46,7 +46,7 @@ export const updateAccount = createAction(UPDATE_ACCOUNT.REQUESTED, update => ({
  * @returns {object}
  */
 export const updateAccountSettings = createAction(UPDATE_ACCOUNT_SETTINGS.REQUESTED, update => ({
-    payload: { update }
+    payload: { update },
 }));
 
 /**
@@ -58,7 +58,7 @@ export const updateAccountSettings = createAction(UPDATE_ACCOUNT_SETTINGS.REQUES
  * @returns {object}
  */
 export const changePassword = createAction(CHANGE_ACCOUNT_PASSWORD.REQUESTED, (oldPassword, newPassword) => ({
-    payload: { old_password: oldPassword, password: newPassword }
+    payload: { old_password: oldPassword, password: newPassword },
 }));
 
 /**
@@ -78,7 +78,7 @@ export const getAPIKeys = createAction(GET_API_KEYS.REQUESTED);
  * @returns {object}
  */
 export const createAPIKey = createAction(CREATE_API_KEY.REQUESTED, (name, permissions) => ({
-    payload: { name, permissions }
+    payload: { name, permissions },
 }));
 
 /**
@@ -98,7 +98,7 @@ export const clearAPIKey = createAction(CLEAR_API_KEY);
  * @returns {object}
  */
 export const updateAPIKey = createAction(UPDATE_API_KEY.REQUESTED, (keyId, permissions) => ({
-    payload: { keyId, permissions }
+    payload: { keyId, permissions },
 }));
 
 /**
@@ -109,7 +109,7 @@ export const updateAPIKey = createAction(UPDATE_API_KEY.REQUESTED, (keyId, permi
  * @returns {object}
  */
 export const removeAPIKey = createAction(REMOVE_API_KEY.REQUESTED, keyId => ({
-    payload: { keyId }
+    payload: { keyId },
 }));
 
 /**
@@ -119,7 +119,7 @@ export const removeAPIKey = createAction(REMOVE_API_KEY.REQUESTED, keyId => ({
  * @returns {object}
  */
 export const login = createAction(LOGIN.REQUESTED, (username, password, remember) => ({
-    payload: { username, password, remember }
+    payload: { username, password, remember },
 }));
 
 /**
@@ -130,8 +130,8 @@ export const login = createAction(LOGIN.REQUESTED, (username, password, remember
  */
 export const loginSucceeded = createAction(LOGIN.SUCCEEDED, () => ({
     payload: {
-        reset: false
-    }
+        reset: false,
+    },
 }));
 
 /**
@@ -150,5 +150,5 @@ export const logout = createAction(LOGOUT.REQUESTED);
  * @returns {object}
  */
 export const resetPassword = createAction(RESET_PASSWORD.REQUESTED, (password, resetCode) => ({
-    payload: { password, resetCode }
+    payload: { password, resetCode },
 }));

--- a/src/js/account/querys.ts
+++ b/src/js/account/querys.ts
@@ -4,9 +4,7 @@ import { Request } from "../app/request";
 const getAccount = () =>
     Request.get("/account")
         .query()
-        .then(response => {
-            return response.body;
-        });
+        .then(response => response.body);
 
 export const useGetAccount = () => {
     return useQuery("account", () => getAccount());

--- a/src/js/account/reducer.js
+++ b/src/js/account/reducer.js
@@ -9,9 +9,8 @@ import {
     CREATE_API_KEY,
     GET_ACCOUNT,
     GET_API_KEYS,
-    LOGOUT,
     UPDATE_ACCOUNT,
-    UPDATE_ACCOUNT_SETTINGS
+    UPDATE_ACCOUNT_SETTINGS,
 } from "../app/actionTypes";
 
 /**
@@ -23,7 +22,7 @@ import {
 export const initialState = {
     apiKeys: null,
     newKey: null,
-    ready: false
+    ready: false,
 };
 
 /**
@@ -55,9 +54,6 @@ export const accountReducer = createReducer(initialState, builder => {
         })
         .addCase(UPDATE_ACCOUNT_SETTINGS.SUCCEEDED, (state, action) => {
             state.settings = action.payload;
-        })
-        .addCase(LOGOUT.SUCCEEDED, () => {
-            return { ...initialState };
         });
 });
 

--- a/src/js/account/sagas.js
+++ b/src/js/account/sagas.js
@@ -11,9 +11,10 @@ import {
     RESET_PASSWORD,
     UPDATE_ACCOUNT,
     UPDATE_ACCOUNT_SETTINGS,
-    UPDATE_API_KEY
+    UPDATE_API_KEY,
 } from "../app/actionTypes";
 import { apiCall } from "../utils/sagas";
+import { resetClient } from "../utils/utils";
 import * as accountAPI from "./api";
 
 export function* watchAccount() {
@@ -76,7 +77,11 @@ export function* login(action) {
 }
 
 export function* logout() {
-    yield apiCall(accountAPI.logout, {}, LOGOUT);
+    const response = yield apiCall(accountAPI.logout, {}, LOGOUT);
+
+    if (response.ok) {
+        resetClient();
+    }
 }
 
 export function* resetPassword(action) {

--- a/src/js/app/__tests__/appReducer.test.js
+++ b/src/js/app/__tests__/appReducer.test.js
@@ -1,4 +1,4 @@
-import { CREATE_FIRST_USER, LOGIN, LOGOUT, RESET_PASSWORD } from "../actionTypes";
+import { CREATE_FIRST_USER, LOGIN, RESET_PASSWORD } from "../actionTypes";
 import { appReducer } from "../reducer";
 
 describe("App Reducer", () => {
@@ -10,13 +10,13 @@ describe("App Reducer", () => {
             first: "bar",
             login: true,
             reset: false,
-            resetCode: true
+            resetCode: true,
         };
     });
 
     it("should return existing state for unhandled action", () => {
         const action = {
-            type: "UNHANDLED"
+            type: "UNHANDLED",
         };
         const result = appReducer(state, action);
         expect(result).toEqual(state);
@@ -25,24 +25,12 @@ describe("App Reducer", () => {
     it.each([
         [
             { type: LOGIN.SUCCEEDED, payload: { reset: true, reset_code: false } },
-            { dev: "foo", first: "bar", login: false, reset: true, resetCode: false }
+            { dev: "foo", first: "bar", login: false, reset: true, resetCode: false },
         ],
-        [{ type: LOGIN.FAILED }, { dev: "foo", first: "bar", reset: false, resetCode: true, login: true }]
+        [{ type: LOGIN.FAILED }, { dev: "foo", first: "bar", reset: false, resetCode: true, login: true }],
     ])(".match(%o, %o)", (action, expected) => {
         const result = appReducer(state, action);
         expect(result).toEqual(expected);
-    });
-
-    it("should return login false, reset true, resetCode false", () => {
-        state.login = false;
-        const action = {
-            type: LOGOUT.SUCCEEDED
-        };
-        const result = appReducer(state, action);
-        expect(result).toEqual({
-            ...state,
-            login: true
-        });
     });
 
     it.each([
@@ -54,8 +42,8 @@ describe("App Reducer", () => {
                 login: false,
                 reset: false,
                 resetCode: null,
-                resetError: null
-            }
+                resetError: null,
+            },
         ],
         [
             RESET_PASSWORD.FAILED,
@@ -65,15 +53,15 @@ describe("App Reducer", () => {
                 login: false,
                 reset: true,
                 resetCode: true,
-                resetError: true
-            }
-        ]
+                resetError: true,
+            },
+        ],
     ])(".match(%o, %o)", (type, expected) => {
         const action = {
             type,
             resetCode: false,
             resetError: false,
-            payload: { reset_code: true, error: true }
+            payload: { reset_code: true, error: true },
         };
         const result = appReducer(state, action);
 
@@ -84,13 +72,13 @@ describe("App Reducer", () => {
         state.login = true;
         state.first = true;
         const action = {
-            type: CREATE_FIRST_USER.SUCCEEDED
+            type: CREATE_FIRST_USER.SUCCEEDED,
         };
         const result = appReducer(state, action);
         expect(result).toEqual({
             ...state,
             login: false,
-            first: false
+            first: false,
         });
     });
 });

--- a/src/js/app/actionTypes.js
+++ b/src/js/app/actionTypes.js
@@ -13,13 +13,13 @@
 const createRequestActionType = root => ({
     REQUESTED: `${root}_REQUESTED`,
     SUCCEEDED: `${root}_SUCCEEDED`,
-    FAILED: `${root}_FAILED`
+    FAILED: `${root}_FAILED`,
 });
 
 // App
 export const PUSH_STATE = "PUSH_STATE";
 export const UPDATE_SEARCH = "UPDATE_SEARCH";
-export const SET_INITIAL_STATE = "SET_INITIAL_STATE";
+export const GET_INITIAL_STATE = createRequestActionType("GET_INITIAL_STATE");
 
 // Dev
 export const POST_DEV_COMMAND = createRequestActionType("POST_DEV_COMMAND");

--- a/src/js/app/actions.js
+++ b/src/js/app/actions.js
@@ -1,10 +1,14 @@
-import { PUSH_STATE, SET_INITIAL_STATE } from "./actionTypes";
 import { createAction } from "@reduxjs/toolkit";
+import { GET_INITIAL_STATE, PUSH_STATE } from "./actionTypes";
 
 export const pushState = createAction(PUSH_STATE, state => ({
-    payload: { state }
+    payload: { state },
 }));
 
-export const setInitialState = createAction(SET_INITIAL_STATE, ({ dev, first_user }) => ({
-    payload: { dev, first: first_user }
-}));
+/**
+ * Returns action that can trigger an API calls to get the initial state of the application
+ *
+ * @func
+ * @returns {object}
+ */
+export const getInitialState = createAction(GET_INITIAL_STATE.REQUESTED);

--- a/src/js/app/api.ts
+++ b/src/js/app/api.ts
@@ -1,0 +1,3 @@
+import { Request } from "./request";
+
+export const root = () => Request.get("/");

--- a/src/js/app/reducer.js
+++ b/src/js/app/reducer.js
@@ -22,12 +22,14 @@ import samplesReducer from "../samples/reducer";
 import subtractionsReducer from "../subtraction/reducer";
 import tasksReducer from "../tasks/reducer";
 import usersReducer from "../users/reducer";
-import { CREATE_FIRST_USER, LOGIN, LOGOUT, RESET_PASSWORD, SET_INITIAL_STATE } from "./actionTypes";
+import { CREATE_FIRST_USER, GET_INITIAL_STATE, LOGIN, RESET_PASSWORD } from "./actionTypes";
 import rootSaga from "./sagas";
 
 const initialState = {
-    login: false,
-    reset: false
+    login: true,
+    reset: false,
+    ready: false,
+    first: false,
 };
 
 export const appReducer = createReducer(initialState, builder => {
@@ -42,9 +44,6 @@ export const appReducer = createReducer(initialState, builder => {
             }
         })
         .addCase(LOGIN.FAILED, state => {
-            state.login = true;
-        })
-        .addCase(LOGOUT.SUCCEEDED, state => {
             state.login = true;
         })
         .addCase(RESET_PASSWORD.SUCCEEDED, state => {
@@ -63,9 +62,11 @@ export const appReducer = createReducer(initialState, builder => {
             state.login = false;
             state.first = false;
         })
-        .addCase(SET_INITIAL_STATE, (state, action) => {
+        .addCase(GET_INITIAL_STATE.SUCCEEDED, (state, action) => {
             state.dev = action.payload.dev;
-            state.first = action.payload.first;
+            state.first = action.payload.first_user;
+            state.login = action.payload.login;
+            state.ready = true;
         });
 });
 
@@ -96,9 +97,9 @@ export const createAppStore = history => {
             settings: settingsReducer,
             subtraction: subtractionsReducer,
             tasks: tasksReducer,
-            users: usersReducer
+            users: usersReducer,
         }),
-        compose(applyMiddleware(sagaMiddleware, routerMiddleware(history)), sentryReduxEnhancer)
+        compose(applyMiddleware(sagaMiddleware, routerMiddleware(history)), sentryReduxEnhancer),
     );
 
     sagaMiddleware.run(rootSaga);

--- a/src/js/app/websocket.js
+++ b/src/js/app/websocket.js
@@ -11,7 +11,7 @@ import { wsUpdateStatus } from "../status/actions";
 import { wsInsertSubtraction, wsRemoveSubtraction, wsUpdateSubtraction } from "../subtraction/actions";
 import { wsInsertTask, wsUpdateTask } from "../tasks/actions";
 import { wsInsertUser, wsRemoveUser, wsUpdateUser } from "../users/actions";
-import { LOGOUT } from "./actionTypes";
+import { resetClient } from "../utils/utils";
 
 const actionCreatorWrapper = actionCreator => {
     return (state, message) => actionCreator(message.data);
@@ -35,7 +35,7 @@ const inserters = {
     subtraction: actionCreatorWrapper(wsInsertSubtraction),
     tasks: actionCreatorWrapper(wsInsertTask),
     uploads: actionCreatorWrapper(wsInsertFile),
-    users: actionCreatorWrapper(wsInsertUser)
+    users: actionCreatorWrapper(wsInsertUser),
 };
 
 const updaters = {
@@ -56,7 +56,7 @@ const updaters = {
     subtraction: actionCreatorWrapper(wsUpdateSubtraction),
     tasks: actionCreatorWrapper(wsUpdateTask),
     uploads: actionCreatorWrapper(wsUpdateFile),
-    users: actionCreatorWrapper(wsUpdateUser)
+    users: actionCreatorWrapper(wsUpdateUser),
 };
 
 const removers = {
@@ -68,13 +68,13 @@ const removers = {
     samples: actionCreatorWrapper(wsRemoveSample),
     subtraction: actionCreatorWrapper(wsRemoveSubtraction),
     uploads: actionCreatorWrapper(wsRemoveFile),
-    users: actionCreatorWrapper(wsRemoveUser)
+    users: actionCreatorWrapper(wsRemoveUser),
 };
 
 const modifiers = {
     insert: inserters,
     update: updaters,
-    delete: removers
+    delete: removers,
 };
 
 export const INITIALIZING = "initializing";
@@ -133,9 +133,7 @@ export default function WSConnection({ getState, dispatch }) {
             }
 
             if (e.code === 4000) {
-                this.dispatch({ type: LOGOUT.SUCCEEDED });
-                this.connectionStatus = ABANDONED;
-                return;
+                resetClient();
             }
 
             setTimeout(() => {

--- a/src/js/index.jsx
+++ b/src/js/index.jsx
@@ -4,10 +4,8 @@ import { createBrowserHistory } from "history";
 import "normalize.css";
 import React from "react";
 import ReactDOM from "react-dom";
-import { setInitialState } from "./app/actions";
 import App from "./app/App";
 import { createAppStore } from "./app/reducer";
-import { Request } from "./app/request";
 import "./nonce";
 
 if (window.virtool.sentryDsn !== "SENTRY_DSN") {
@@ -26,10 +24,6 @@ const history = createBrowserHistory();
 
 window.b2c = { use: false };
 window.store = createAppStore(history);
-
-Request.get("/").then(({ body }) => {
-    window.store.dispatch(setInitialState(body));
-});
 
 const AppWithProfiler = withProfiler(App);
 

--- a/src/js/utils/sagas.js
+++ b/src/js/utils/sagas.js
@@ -8,7 +8,7 @@ import { replace } from "connected-react-router";
 import { get, includes } from "lodash-es";
 import { put } from "redux-saga/effects";
 import { getProtectedResources } from "../app/authConfig";
-import { createFindURL } from "./utils";
+import { createFindURL, resetClient } from "./utils";
 
 /**
  * Gets access token for b2c authentication
@@ -76,7 +76,7 @@ export function* apiCall(apiMethod, action, actionType, context = {}) {
         const statusCode = get(error, "response.statusCode");
 
         if (statusCode === 401) {
-            resetAndClearStorage();
+            resetClient();
         }
 
         if (get(error, "response.body")) {

--- a/src/js/utils/sagas.js
+++ b/src/js/utils/sagas.js
@@ -7,7 +7,6 @@ import { InteractionRequiredAuthError } from "@azure/msal-browser";
 import { replace } from "connected-react-router";
 import { get, includes } from "lodash-es";
 import { put } from "redux-saga/effects";
-import { LOGOUT } from "../app/actionTypes";
 import { getProtectedResources } from "../app/authConfig";
 import { createFindURL } from "./utils";
 
@@ -21,7 +20,7 @@ export function getAccessToken() {
     return window.msalInstance
         .acquireTokenSilent({
             scopes: protectedResources.backendApi.scopes,
-            account
+            account,
         })
         .then(response => {
             return response.accessToken;
@@ -30,7 +29,7 @@ export function getAccessToken() {
             if (error instanceof InteractionRequiredAuthError) {
                 window.msalInstance
                     .acquireTokenPopup({
-                        scopes: protectedResources.backendApi.scopes
+                        scopes: protectedResources.backendApi.scopes,
                     })
                     .then(response => {
                         return response.accessToken;
@@ -77,10 +76,7 @@ export function* apiCall(apiMethod, action, actionType, context = {}) {
         const statusCode = get(error, "response.statusCode");
 
         if (statusCode === 401) {
-            yield put({
-                type: LOGOUT.SUCCEEDED
-            });
-            return error.response;
+            resetAndClearStorage();
         }
 
         if (get(error, "response.body")) {
@@ -115,6 +111,6 @@ export function* putGenericError(actionType, error) {
     const message = body ? body.message : null;
     yield put({
         type: actionType.FAILED,
-        payload: { message, error, status }
+        payload: { message, error, status },
     });
 }

--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -168,6 +168,19 @@ export const toScientificNotation = number => {
 };
 
 /**
+ *  Clears session storage and reloads the page.
+ *
+ *  This is used to clear the session storage when the user logs out or the token expires.
+ *
+ *  @func
+ *  @returns {undefined}
+ */
+export const resetClient = () => {
+    window.sessionStorage.clear();
+    window.location.reload();
+};
+
+/**
  * Stores the passed object in local storage at key given
  *
  * @func


### PR DESCRIPTION
Replaces existing logout logic with wiping sessionStorage and refreshing the page.

Changes:
  - Changes default sagas 401 behaviour to reset the client
  - Changes default 401 react-query logic to reset the client
  - Changes default websocket 400 code to reset the client
  - Changes logout behaviour to reset the client on successful logout
  - Removes previous logout logic
  - Changes initialisation logic to determine if user is logged in via a  request to `/account`