### PR TITLE
Provide source maps for deminification

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
   root: "src",
   build: {
     outDir: "../dist",
+    sourcemap: true,
   },
   plugins: [
     createHtmlPlugin({}),


### PR DESCRIPTION
One line change to `vite.config.js`. Built the image locally in docker and confirmed that map files were included for all minified JS files