### PR TITLE
Restore support for older subtractions in list view

### DIFF
--- a/src/js/subtraction/components/Item.tsx
+++ b/src/js/subtraction/components/Item.tsx
@@ -40,15 +40,15 @@ type SubtractionItemProps = {
 /**
  * Condensed subtraction item for use in a list of subtractions
  *
- * @param id - The unique subtraction id
- * @param user - The user who created the subtraction
- * @param name - The name of the subtraction
  * @param created_at - The date the subtraction was created
+ * @param id - The unique subtraction id
  * @param job - The job associated with the subtraction
+ * @param name - The name of the subtraction
  * @param ready - Whether the associated job is complete
+ * @param user - The user who created the subtraction
  * @returns A condensed subtraction item
  */
-export function SubtractionItem({ created_at, id, job, user, name, ready }: SubtractionItemProps) {
+export function SubtractionItem({ created_at, id, job, name, ready, user }: SubtractionItemProps) {
     return (
         <BoxLink key={id} to={`/subtractions/${id}`}>
             <StyledSubtractionItemHeader>

--- a/src/js/subtraction/components/Item.tsx
+++ b/src/js/subtraction/components/Item.tsx
@@ -33,7 +33,7 @@ type SubtractionItemProps = {
     user: UserNested;
     name: string;
     created_at: string;
-    job: JobMinimal;
+    job?: JobMinimal;
     ready: boolean;
 };
 
@@ -58,8 +58,8 @@ export function SubtractionItem({ created_at, id, job, name, ready, user }: Subt
                         <>
                             <ProgressCircle
                                 size={sizes.md}
-                                progress={job?.progress || 0}
-                                state={job?.state || "waiting"}
+                                progress={job?.progress ?? 0}
+                                state={job?.state ?? "waiting"}
                             />
                             {getStateTitle(job?.state)}
                         </>

--- a/src/js/subtraction/components/Item.tsx
+++ b/src/js/subtraction/components/Item.tsx
@@ -34,6 +34,7 @@ type SubtractionItemProps = {
     name: string;
     created_at: string;
     job: JobMinimal;
+    ready: boolean;
 };
 
 /**
@@ -44,18 +45,23 @@ type SubtractionItemProps = {
  * @param name - The name of the subtraction
  * @param created_at - The date the subtraction was created
  * @param job - The job associated with the subtraction
+ * @param ready - Whether the associated job is complete
  * @returns A condensed subtraction item
  */
-export function SubtractionItem({ id, user, name, created_at, job }: SubtractionItemProps) {
+export function SubtractionItem({ created_at, id, job, user, name, ready }: SubtractionItemProps) {
     return (
         <BoxLink key={id} to={`/subtractions/${id}`}>
             <StyledSubtractionItemHeader>
                 <span>{name}</span>
                 <ProgressTag>
-                    {job.state === "complete" || (
+                    {ready || (
                         <>
-                            <ProgressCircle size={sizes.md} progress={job.progress} state={job.state} />
-                            {getStateTitle(job.state)}
+                            <ProgressCircle
+                                size={sizes.md}
+                                progress={job?.progress || 0}
+                                state={job?.state || "waiting"}
+                            />
+                            {getStateTitle(job?.state)}
                         </>
                     )}
                 </ProgressTag>
@@ -73,13 +79,14 @@ export function SubtractionItem({ id, user, name, created_at, job }: Subtraction
  * @returns The props derived from redux state
  */
 export function mapStateToProps(state, props) {
-    const { id, user, name, created_at, job } = state.subtraction.documents[props.index];
+    const { id, user, name, created_at, job, ready } = state.subtraction.documents[props.index];
     return {
         id,
         user,
         created_at,
         name,
         job,
+        ready,
     };
 }
 

--- a/src/js/subtraction/components/__tests__/Item.test.tsx
+++ b/src/js/subtraction/components/__tests__/Item.test.tsx
@@ -17,6 +17,7 @@ describe("<SubtractionItem />", () => {
             user: { handle: "user_handle" },
             job: { progress: 50, state: "running" },
             created_at: new Date().setFullYear(new Date().getFullYear() - 1),
+            ready: false,
         };
         history = createBrowserHistory();
     });
@@ -36,11 +37,16 @@ describe("<SubtractionItem />", () => {
         expect(screen.getByText(getStateTitle(state))).toBeInTheDocument();
     });
 
-    it("should not render progress bar if job is complete", () => {
-        props.job.state = "complete";
+    it("should not render progress bar if job is ready", () => {
+        props.ready = true;
         renderWithRouter(<SubtractionItem {...props} />, {}, history);
         expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
         expect(screen.queryByText("Complete")).not.toBeInTheDocument();
+    });
+    it("should correctly render subtractions where jobs=null", () => {
+        props.job = null;
+        props.ready = false;
+        renderWithRouter(<SubtractionItem {...props} />, {}, history);
     });
 });
 
@@ -79,6 +85,7 @@ describe("mapStateToProps()", () => {
             name: "Bar",
             job: { id: "job_id_2", progress: 50, state: "failed" },
             user: { id: "user_id_2", handle: "user_handle_2" },
+            ready: true,
         });
     });
 });


### PR DESCRIPTION
Example view: Final subtraction in the list is how a subtraction with `{ready: false, job: null}` is visually represented with this patch
![image](https://github.com/virtool/virtool-ui/assets/59776400/67324cd6-9b63-4a43-9839-447411f7b6bb)

