### PR TITLE
fix: ensure group remains selected in groups list view

### DIFF
--- a/src/js/groups/components/Groups.tsx
+++ b/src/js/groups/components/Groups.tsx
@@ -1,4 +1,4 @@
-import { find } from "lodash-es";
+import { find, sortBy } from "lodash-es";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { getColor } from "../../app/theme";
@@ -52,10 +52,10 @@ export const Groups = () => {
     });
 
     useEffect(() => {
-        if (groups && !find(groups, { id: selectedGroup })) {
-            setSelectedGroupId(groups[0]?.id);
+        if (groups && !find(groups, { id: selectedGroupId })) {
+            setSelectedGroupId(sortBy(groups, "name")[0]?.id);
         }
-    }, [groups]);
+    }, [groups, selectedGroupId]);
 
     if (isLoadingGroups || (groups.length && !selectedGroup)) {
         return <LoadingPlaceholder margin="130px" />;


### PR DESCRIPTION
Changes:

 - Ensure that the detailed view doesn't switch to the default group when changing the current group
 - Ensure that the first item in the list is always the default