### PR TITLE
Complete conversion to using administrator roles

### DIFF
--- a/src/js/account/components/API/CreateInfo.jsx
+++ b/src/js/account/components/API/CreateInfo.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
+import { AdministratorRoles } from "../../../administration/types";
+import { hasSufficientAdminRole } from "../../../administration/utils";
 import { AlertOuter } from "../../../base";
 import { getAccountAdministratorRole } from "../../selectors";
 
@@ -15,8 +17,8 @@ const StyledAPIKeyAdministratorInfo = styled(AlertOuter)`
     }
 `;
 
-export const APIKeyAdministratorInfo = ({ administrator }) => {
-    if (administrator) {
+export const APIKeyAdministratorInfo = ({ administratorRole }) => {
+    if (hasSufficientAdminRole(AdministratorRoles.BASE, administratorRole)) {
         return (
             <StyledAPIKeyAdministratorInfo color="purple">
                 <div>
@@ -38,7 +40,7 @@ export const APIKeyAdministratorInfo = ({ administrator }) => {
 };
 
 export const mapStateToProps = state => ({
-    administrator: getAccountAdministratorRole(state) !== null,
+    administratorRole: getAccountAdministratorRole(state),
 });
 
 export default connect(mapStateToProps)(APIKeyAdministratorInfo);

--- a/src/js/account/components/API/__tests__/API.test.jsx
+++ b/src/js/account/components/API/__tests__/API.test.jsx
@@ -130,8 +130,8 @@ describe("<API />", () => {
             expect(screen.getByText("Provide a name for the key")).toBeInTheDocument();
         });
 
-        describe("APIKeyAdiminstratorInfo", () => {
-            it("should render correctly when newKey is empty and state.administrator = true", () => {
+        describe("APIKeyAdministratorInfo", () => {
+            it("should render correctly when newKey is empty and state.administratorRole = AdministratorRoles.FULL", () => {
                 state.account.administrator_role = AdministratorRoles.FULL;
 
                 renderWithRouter(<APIKeys {...props} />, state, history, createReducer);
@@ -142,7 +142,7 @@ describe("<API />", () => {
                 ).toBeInTheDocument();
             });
 
-            it("should render correctly when newKey is empty and state.administrator = false", () => {
+            it("should render correctly when newKey is empty and state.administratorRole = null", () => {
                 renderWithRouter(<APIKeys {...props} />, state, history, createReducer);
 
                 expect(screen.queryByText(/You are an administrator/)).not.toBeInTheDocument();

--- a/src/js/account/selectors.js
+++ b/src/js/account/selectors.js
@@ -1,7 +1,7 @@
 import { get } from "lodash-es";
 
 export const getAccount = state => state.account;
-export const getAccountAdministratorRole = state => get(state, "account.administrator_role", false);
+export const getAccountAdministratorRole = state => get(state, "account.administrator_role", null);
 
 export const getAccountId = state => state.account.id;
 export const getAccountHandle = state => state.account.handle;

--- a/src/js/base/stories/Pagination.stories.js
+++ b/src/js/base/stories/Pagination.stories.js
@@ -50,5 +50,4 @@ const fakeUserListFactory = (seed, numItems) => {
 const fakeUserFactory = () => ({
     id: faker.random.alphaNumeric(6),
     handle: `${faker.name.firstName()}${faker.name.lastName()}`,
-    administrator: false,
 });

--- a/src/js/groups/components/__tests__/Groups.test.jsx
+++ b/src/js/groups/components/__tests__/Groups.test.jsx
@@ -126,7 +126,7 @@ describe("Groups", () => {
     });
 
     it("should render correctly when active group has a group member", async () => {
-        const group = createFakeGroup({ users: [{ handle: "testUser1", administrator: false, id: "test_id" }] });
+        const group = createFakeGroup({ users: [{ handle: "testUser1", id: "test_id" }] });
         mockApiListGroups([group]);
         mockApiGetGroup(group);
 
@@ -139,12 +139,12 @@ describe("Groups", () => {
 
     it("should render correctly when more than one group exists", async () => {
         const group_1 = createFakeGroup({
-            users: [{ handle: "testUser1", administrator: false, id: "test_id" }],
+            users: [{ handle: "testUser1", id: "test_id" }],
             permissions: { create_sample: true, modify_hmm: true },
             name: "testName",
         });
         const group_2 = createFakeGroup({
-            users: [{ handle: "testUser2", administrator: false, id: "test_id2" }],
+            users: [{ handle: "testUser2", id: "test_id2" }],
             permissions: { create_sample: true, modify_hmm: true, remove_job: true },
             name: "testName2",
         });

--- a/src/js/indexes/components/__tests__/Indexes.test.tsx
+++ b/src/js/indexes/components/__tests__/Indexes.test.tsx
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { createFakeIndexMinimal, mockApiFindIndexes } from "../../../../tests/fake/indexes";
 import { createFakeReferenceNested } from "../../../../tests/fake/references";
 import { createGenericReducer, renderWithRouter } from "../../../../tests/setupTests";
+import { AdministratorRoles } from "../../../administration/types";
 import { Indexes } from "../Indexes";
 
 function createReducer(state, history) {
@@ -26,7 +27,7 @@ describe("<Indexes />", () => {
     beforeEach(() => {
         state = {
             references: { detail: { id: defaultReference.id } },
-            account: { administrator: true },
+            account: { administrator_role: AdministratorRoles.FULL },
             indexes: { unbuilt: [] },
         };
     });

--- a/src/js/jobs/components/__tests__/List.test.jsx
+++ b/src/js/jobs/components/__tests__/List.test.jsx
@@ -4,6 +4,7 @@ import React from "react";
 import { BrowserRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "../../../../tests/setupTests";
+import { AdministratorRoles } from "../../../administration/types";
 import * as utils from "../../../administration/utils";
 import { JobsList, mapDispatchToProps, mapStateToProps } from "../List";
 
@@ -35,7 +36,6 @@ describe("<JobsList />", () => {
                     user: {
                         id: "test_user_id",
                         handle: "user_handle",
-                        administrator: true,
                     },
                     workflow: "create_sample",
                 },
@@ -53,7 +53,7 @@ describe("<JobsList />", () => {
                 },
             },
             account: {
-                administrator: true,
+                administrator_role: AdministratorRoles.FULL,
             },
             router: { location: new window.URL("https://www.virtool.ca") },
         };

--- a/src/js/jobs/stories/JobItem.stories.jsx
+++ b/src/js/jobs/stories/JobItem.stories.jsx
@@ -7,7 +7,6 @@ export default {
 };
 
 const user = {
-    administrator: false,
     id: "foo",
     handle: "Foo Bar",
 };

--- a/src/js/references/__tests__/selectors.test.js
+++ b/src/js/references/__tests__/selectors.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { AdministratorRoles } from "../../administration/types";
 import { checkReferenceRight, getCanModifyReferenceOTU } from "../selectors";
 
 const rights = ["build", "modify", "modify_otu", "remove"];
@@ -9,7 +10,7 @@ describe("checkReferenceRight()", () => {
     beforeEach(() => {
         state = {
             account: {
-                administrator: false,
+                administrator_role: null,
                 groups: ["leads"],
                 id: "bob",
             },
@@ -23,7 +24,7 @@ describe("checkReferenceRight()", () => {
     });
 
     it("should return true when account is administrator", () => {
-        state.account.administrator = true;
+        state.account.administrator_role = AdministratorRoles.FULL;
         rights.forEach(rightToCheck => {
             expect(checkReferenceRight(state, rightToCheck)).toBe(true);
         });
@@ -81,7 +82,7 @@ describe("getCanModifyReferenceOTU()", () => {
     beforeEach(() => {
         state = {
             account: {
-                administrator: false,
+                administrator_role: null,
                 groups: ["leads"],
                 id: "bob",
             },
@@ -102,7 +103,7 @@ describe("getCanModifyReferenceOTU()", () => {
     });
 
     it("should return true when administrator", () => {
-        state.account.administrator = true;
+        state.account.administrator_role = AdministratorRoles.FULL;
         expect(getCanModifyReferenceOTU(state)).toBe(true);
     });
 

--- a/src/js/references/components/Detail/__tests__/Header.test.jsx
+++ b/src/js/references/components/Detail/__tests__/Header.test.jsx
@@ -1,6 +1,7 @@
 import { shallow } from "enzyme";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AdministratorRoles } from "../../../../administration/types";
 import { mapDispatchToProps, mapStateToProps, ReferenceDetailHeader, ReferenceDetailHeaderIcon } from "../Header";
 
 describe("<ReferenceDetailHeaderIcon />", () => {
@@ -92,7 +93,7 @@ describe("mapStateToProps()", () => {
                 },
             },
             account: {
-                administrator: true,
+                administrator_role: AdministratorRoles.FULL,
             },
             router: {
                 location: {

--- a/src/js/references/selectors.ts
+++ b/src/js/references/selectors.ts
@@ -2,6 +2,7 @@ import { filter, find, get, includes, some } from "lodash-es";
 import createCachedSelector from "re-reselect";
 import { createSelector } from "reselect";
 import { getAccount } from "../account/selectors";
+import { AdministratorRoles } from "../administration/types";
 import { getTermSelectorFactory } from "../utils/selectors";
 
 const getStateTerm = state => state.references.term;
@@ -52,7 +53,7 @@ export const getReferenceItemProgress = createSelector([getReferenceItemTaskId, 
 export const checkReferenceRight = createCachedSelector(
     [getAccount, getReferenceDetail, (state, right) => right],
     (account, detail, right) => {
-        if (account.administrator) {
+        if (account.administrator_role === AdministratorRoles.FULL) {
             return true;
         }
 

--- a/src/js/references/types.ts
+++ b/src/js/references/types.ts
@@ -7,11 +7,8 @@ export type ReferenceClonedFrom = {
     name: string;
 };
 
-export type ReferenceContributor = {
-    administrator: boolean;
+export type ReferenceContributor = UserNested & {
     count: number;
-    handle: string;
-    id: string;
 };
 
 export type ReferenceDataType = "barcode" | "genome";

--- a/src/js/samples/components/Detail/__tests__/Rights.test.jsx
+++ b/src/js/samples/components/Detail/__tests__/Rights.test.jsx
@@ -1,8 +1,8 @@
 import { shallow } from "enzyme";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AdministratorRoles } from "../../../../administration/types";
 import { InputSelect } from "../../../../base";
-import { getCanModifyRights } from "../../../selectors";
 import { mapDispatchToProps, mapStateToProps, SampleRights } from "../Rights";
 
 vi.mock("../../../selectors.ts");
@@ -68,26 +68,29 @@ describe("<SampleRights />", () => {
     });
 });
 
+vi.unmock("../../../selectors.ts");
+
 describe("mapStateToProps()", () => {
-    const state = {
-        samples: {
-            detail: {
-                all_read: true,
-                all_write: false,
-                group: "baz",
-                group_read: true,
-                group_write: false,
-                user: { id: "Baz" },
-                id: "Boo",
+    let state;
+    beforeEach(() => {
+        state = {
+            samples: {
+                detail: {
+                    all_read: true,
+                    all_write: false,
+                    group: "baz",
+                    group_read: true,
+                    group_write: false,
+                    user: { id: "Baz" },
+                    id: "Boo",
+                },
             },
-        },
-        account: { id: "foo", administrator: true },
-        groups: { documents: "bar" },
-    };
+            account: { id: "foo", administrator_role: null },
+            groups: { documents: "bar" },
+        };
+    });
 
     it("should return props when getCanModifyRights returns false", () => {
-        getCanModifyRights.mockReturnValue(false);
-
         const props = mapStateToProps(state);
         expect(props).toEqual({
             accountId: "foo",
@@ -104,8 +107,7 @@ describe("mapStateToProps()", () => {
     });
 
     it("should return props when getCanModifyRights returns true", () => {
-        getCanModifyRights.mockReturnValue(true);
-
+        state.account.administrator_role = AdministratorRoles.FULL;
         const props = mapStateToProps(state);
         expect(props).toEqual({
             accountId: "foo",

--- a/src/js/subtraction/components/__tests__/SubtractionFileManager.test.tsx
+++ b/src/js/subtraction/components/__tests__/SubtractionFileManager.test.tsx
@@ -39,7 +39,7 @@ describe("<SubtractionFileManager />", () => {
                     size: 1024,
                     type: "subtraction",
                     uploaded_at: "2022-04-13T20:22:25.000000Z",
-                    user: { handle: "test_handle", id: "n91xt5wq", administrator: true },
+                    user: { handle: "test_handle", id: "n91xt5wq" },
                 },
             ],
         },

--- a/src/js/users/components/__tests__/UserDetail.test.tsx
+++ b/src/js/users/components/__tests__/UserDetail.test.tsx
@@ -33,7 +33,7 @@ describe("<UserDetail />", () => {
     afterEach(() => nock.cleanAll());
 
     describe("<UserDetail />", () => {
-        it("should render correctly when administrator=true, canModifyUser=true and 5 groups exist", async () => {
+        it("should render correctly when administrator_role = AdministratorRoles.FULL, canModifyUser=true and 5 groups exist", async () => {
             mockApiListGroups(groups);
             mockGetAccountAPI(account);
 
@@ -80,7 +80,7 @@ describe("<UserDetail />", () => {
             expect(screen.queryByText("bob")).not.toBeInTheDocument();
         });
 
-        it("should render correctly when [administrator=false] and canModifyUser=false", async () => {
+        it("should render correctly when [administrator_role=null] and canModifyUser=false", async () => {
             mockApiListGroups(groups);
             mockGetAccountAPI(account);
             const scope = mockApiGetUser(props.match.params.userId, userDetail);

--- a/src/js/users/types.ts
+++ b/src/js/users/types.ts
@@ -16,8 +16,6 @@ type UserB2C = {
 
 /** A user with the essential information */
 export type UserNested = {
-    /** Indicates if the user is an administrator */
-    administrator: boolean;
     /** The unique identifier */
     id: string;
     /** The user's handle or username */
@@ -26,6 +24,8 @@ export type UserNested = {
 
 /** A Virtool user */
 export type User = UserNested & {
+    /** Their administrator role defining what resources they can modify */
+    administrator_role: AdministratorRoles;
     /** Indicates if user is active */
     active: boolean;
     /** Their B2C specific information */
@@ -48,8 +48,6 @@ export type User = UserNested & {
     permissions: Permissions;
     /** Their primary group */
     primary_group: GroupMinimal;
-    /** Their administrator role defining what resources they can modify */
-    administrator_role: AdministratorRoles;
 };
 
 /** User search results from the API */

--- a/src/tests/fake/user.tsx
+++ b/src/tests/fake/user.tsx
@@ -10,7 +10,6 @@ import { createFakePermissions } from "./permissions";
 type CreateFakeUserNestedProps = {
     handle?: string;
     id?: string;
-    administrator?: boolean;
 };
 
 /**
@@ -20,11 +19,10 @@ type CreateFakeUserNestedProps = {
  * @returns a UserNested object with fake data
  */
 export function createFakeUserNested(props?: CreateFakeUserNestedProps): UserNested {
-    let { handle, id, administrator } = props || {};
+    let { handle, id } = props || {};
 
     return {
         id: id || faker.random.alphaNumeric(8),
-        administrator: administrator || false,
         handle: handle || faker.internet.userName(),
     };
 }
@@ -76,7 +74,7 @@ export function createFakeUsers(count: number): Array<User> {
     return times(count || 1, () => createFakeUser());
 }
 
-type Query = {
+type FindUsersQuery = {
     page: number;
     per_page: number;
     term: string;
@@ -90,7 +88,7 @@ type Query = {
  * @param query - the query parameters to match
  * @returns - a nock Scope for the mocked API call
  */
-export function mockApiFindUsers(users: Array<User>, query?: Query) {
+export function mockApiFindUsers(users: Array<User>, query?: FindUsersQuery) {
     return nock("http://localhost")
         .get("/api/admin/users")
         .query(query || true)


### PR DESCRIPTION
Changes:
 - Now checks if `account,administrator_role === AdministratorRoles.FULL` when checking reference and otu permissions instead of checking `account.administrator` 
 - APIInfo now checks if `account,administrator_role === AdministratorRoles.BASE` instead of `account.administrator` to determine whether to warn the user about admin privileges
 - removes mocking of `administrator` in testing