### PR TITLE
fix: increase max renderable read count

### DIFF
--- a/src/js/analyses/components/Iimi/IimiCoverage.tsx
+++ b/src/js/analyses/components/Iimi/IimiCoverage.tsx
@@ -50,7 +50,6 @@ const StyledIimiCoverageChart = styled.div<StyledIimiCoverageChartProps>`
 
     path.depth-area {
         fill: ${props => props.theme.color.blue};
-        stroke: ${props => props.theme.color.blue};
     }
 `;
 

--- a/src/js/analyses/components/Iimi/IimiIsolate.tsx
+++ b/src/js/analyses/components/Iimi/IimiIsolate.tsx
@@ -46,7 +46,7 @@ export function IimiIsolate({ name, sequences }) {
                         <IimiCoverageChart
                             data={convertRleToCoverage(sequence.coverage.lengths, sequence.coverage.values)}
                             id={sequence.id}
-                            yMax={100}
+                            yMax={1000}
                         />
                     </Box>
                 ))}

--- a/src/js/analyses/components/Iimi/IimiViewer.tsx
+++ b/src/js/analyses/components/Iimi/IimiViewer.tsx
@@ -26,8 +26,8 @@ export function IimiViewer({ detail }) {
                     <li>We do not guarantee the accuracy of the results.</li>
                     <li>This analysis could become inaccessbile at any time as the workflow changes.</li>
                     <li>
-                        This analysis viewer is a work in progress. If you think something is missing, we probably know.
-                        We will solicit feedback when the viewer is stable.
+                        This analysis viewer is a work in progress. Some features may not be present as we continue to
+                        improve the viewer.
                     </li>
                 </ImportantList>
             </Box>


### PR DESCRIPTION
Changes: 
 - removes stroke colour preventing display of 0 depth sections
 - increase max renderable read depth to 1000
 - tweak iimi analysis view disclaimer

Low read examples:
![image](https://github.com/virtool/virtool-ui/assets/59776400/192c7b36-d3bf-4560-9116-a16f035ccab6)

Extreme read count:
![image](https://github.com/virtool/virtool-ui/assets/59776400/f55d963e-bc6b-4afb-a91b-d9a99a0077f2)

Good detection:
![image](https://github.com/virtool/virtool-ui/assets/59776400/4253336b-a8dd-41e4-a490-6075dedea9da)


