### PR TITLE
Mark untrustworthy ranges in iimi graphs

### DIFF
--- a/src/js/analyses/components/Iimi/IimiCoverage.tsx
+++ b/src/js/analyses/components/Iimi/IimiCoverage.tsx
@@ -2,9 +2,25 @@ import { axisBottom, axisLeft } from "d3-axis";
 import { format } from "d3-format";
 import { scaleLinear } from "d3-scale";
 import { select } from "d3-selection";
-import { area, line } from "d3-shape";
+import { area } from "d3-shape";
 import React, { useEffect, useRef } from "react";
 import styled, { DefaultTheme } from "styled-components";
+import { theme } from "../../../app/theme";
+
+function deriveTrustworthyRegions(untrustWorthyRanges, length: number) {
+    const trustworthyRanges = [];
+    let start = 1;
+    let end;
+
+    untrustWorthyRanges.forEach(range => {
+        end = range[0];
+        trustworthyRanges.push([start, end]);
+        start = range[1];
+    });
+
+    trustworthyRanges.push([start, length]);
+    return trustworthyRanges;
+}
 
 function draw(element, data, length, yMax, untrustworthyRanges) {
     select(element).append("svg");
@@ -47,17 +63,29 @@ function draw(element, data, length, yMax, untrustworthyRanges) {
         svg.append("g").attr("transform", `translate(0,${height})`).call(xAxis).attr("class", "axis");
     }
 
+    const trustworthyRanges = deriveTrustworthyRegions(untrustworthyRanges, length);
+
+    if (trustworthyRanges.length) {
+        trustworthyRanges.forEach(range => {
+            svg.append("rect")
+                .attr("x", x(range[0]))
+                .attr("y", 0)
+                .attr("width", x(range[1] - range[0]))
+                .attr("height", height)
+                .attr("fill", theme.color.blue)
+                .attr("opacity", 0.2);
+        });
+    }
+
     if (untrustworthyRanges.length) {
         untrustworthyRanges.forEach(range => {
-            const lineGenerator = line()
-                .x(d => x(d))
-                .y(0);
-
-            svg.append("path")
-                .datum(range)
-                .attr("class", "untrustworthy-range")
-                .attr("d", lineGenerator)
-                .attr("transform", `translate(0,${-4})`);
+            svg.append("rect")
+                .attr("x", x(range[0]))
+                .attr("y", 0)
+                .attr("width", x(range[1] - range[0]))
+                .attr("height", height)
+                .attr("fill", theme.color.red)
+                .attr("opacity", 0.5);
         });
     }
 }

--- a/src/js/analyses/components/Iimi/IimiCoverage.tsx
+++ b/src/js/analyses/components/Iimi/IimiCoverage.tsx
@@ -2,16 +2,16 @@ import { axisBottom, axisLeft } from "d3-axis";
 import { format } from "d3-format";
 import { scaleLinear } from "d3-scale";
 import { select } from "d3-selection";
-import { area } from "d3-shape";
+import { area, line } from "d3-shape";
 import React, { useEffect, useRef } from "react";
 import styled, { DefaultTheme } from "styled-components";
 
-function draw(element, data, length, yMax) {
+function draw(element, data, length, yMax, untrustworthyRanges) {
     select(element).append("svg");
 
     const margin = {
         top: 5,
-        left: 30,
+        left: 35,
         bottom: 20,
         right: 0,
     };
@@ -43,8 +43,22 @@ function draw(element, data, length, yMax) {
 
         svg.append("path").datum(data).attr("class", "depth-area").attr("d", areaDrawer);
 
-        svg.append("g").attr("transform", `translate(0,0)`).call(yAxis);
-        svg.append("g").attr("transform", `translate(0,${height})`).call(xAxis);
+        svg.append("g").attr("transform", `translate(0,0)`).call(yAxis).attr("class", "axis");
+        svg.append("g").attr("transform", `translate(0,${height})`).call(xAxis).attr("class", "axis");
+    }
+
+    if (untrustworthyRanges.length) {
+        untrustworthyRanges.forEach(range => {
+            const lineGenerator = line()
+                .x(d => x(d))
+                .y(0);
+
+            svg.append("path")
+                .datum(range)
+                .attr("class", "untrustworthy-range")
+                .attr("d", lineGenerator)
+                .attr("transform", `translate(0,${-4})`);
+        });
     }
 }
 
@@ -56,6 +70,11 @@ const StyledIimiCoverageChart = styled.div<StyledIimiCoverageChartProps>`
     display: inline-block;
     margin-top: 5px;
 
+    path.untrustworthy-range {
+        stroke: ${props => props.theme.color.red};
+        stroke-width: 1;
+    }
+
     path.depth-area {
         fill: ${props => props.theme.color.blue};
     }
@@ -65,14 +84,15 @@ interface IimiCoverageChartProps {
     data: any;
     id: string;
     yMax: number;
+    untrustworthyRanges: any;
 }
 
-export function IimiCoverageChart({ data, id, yMax }: IimiCoverageChartProps) {
+export function IimiCoverageChart({ data, id, yMax, untrustworthyRanges }: IimiCoverageChartProps) {
     const chartEl = useRef(null);
 
     useEffect(() => {
         const length = data.length;
-        draw(chartEl.current, data, length, yMax);
+        draw(chartEl.current, data, length, yMax, untrustworthyRanges);
     }, [data, id, yMax]);
 
     return <StyledIimiCoverageChart ref={chartEl} />;

--- a/src/js/analyses/components/Iimi/IimiCoverage.tsx
+++ b/src/js/analyses/components/Iimi/IimiCoverage.tsx
@@ -73,7 +73,7 @@ function draw(element, data, length, yMax, untrustworthyRanges) {
                 .attr("width", x(range[1] - range[0]))
                 .attr("height", height)
                 .attr("fill", theme.color.blue)
-                .attr("opacity", 0.2);
+                .attr("opacity", 0.15);
         });
     }
 
@@ -85,7 +85,7 @@ function draw(element, data, length, yMax, untrustworthyRanges) {
                 .attr("width", x(range[1] - range[0]))
                 .attr("height", height)
                 .attr("fill", theme.color.red)
-                .attr("opacity", 0.5);
+                .attr("opacity", 0.4);
         });
     }
 }

--- a/src/js/analyses/components/Iimi/IimiIsolate.tsx
+++ b/src/js/analyses/components/Iimi/IimiIsolate.tsx
@@ -1,4 +1,4 @@
-import { max, sortBy } from "lodash-es";
+import { sortBy } from "lodash-es";
 import React from "react";
 import styled from "styled-components";
 import { Box, Label } from "../../../base";
@@ -46,7 +46,8 @@ export function IimiIsolate({ name, sequences }) {
                         <IimiCoverageChart
                             data={convertRleToCoverage(sequence.coverage.lengths, sequence.coverage.values)}
                             id={sequence.id}
-                            yMax={max(sequence.coverage.values)}
+                            yMax={Math.max(...sequence.coverage.values, 10)}
+                            untrustworthyRanges={sequence.untrustworthy_ranges}
                         />
                     </Box>
                 ))}


### PR DESCRIPTION
Changes: 

- Adjust left margin to prevent some cases where y axis text was getting clipped
- enforce minimum y axis height of 10 to prevent graphing of milli-reads

Screenshots:

Extreme untrustworthy regions:
![image](https://github.com/virtool/virtool-ui/assets/59776400/3f84e425-ed3a-4e73-8606-b2764237e1a7)

Minimal untrustworthy regions
![image](https://github.com/virtool/virtool-ui/assets/59776400/a37d22dd-25a6-46e7-85cd-25c795f2a8d8)

Regular graph:
![image](https://github.com/virtool/virtool-ui/assets/59776400/f59d85c3-e77b-48de-961d-65aa0408f876)

