### PR TITLE
Resolve Markdown typing error

### DIFF
--- a/src/js/base/Markdown.tsx
+++ b/src/js/base/Markdown.tsx
@@ -17,11 +17,11 @@ type MarkdownProps = {
 export function Markdown({ markdown = "" }: MarkdownProps) {
     marked.use({
         gfm: true,
+        async: false,
     });
-    console.log(marked.parse(markdown));
 
     if (markdown) {
-        return <StyledMarkdown dangerouslySetInnerHTML={{ __html: marked.parse(markdown) }} />;
+        return <StyledMarkdown dangerouslySetInnerHTML={{ __html: marked.parse(markdown) as string }} />;
     }
 
     return (


### PR DESCRIPTION
Resolves a typing error in`Markdown.tsc` present in main that is causing other PR's CI to fail