### PR TITLE
fix: prevent crushed install button for reference installation

### DIFF
--- a/src/js/references/components/Official.tsx
+++ b/src/js/references/components/Official.tsx
@@ -41,7 +41,6 @@ export const ReferenceOfficial = ({ officialInstalled, onRemote }: ReferenceOffi
                             plant virus reference
                         </ExternalLink>
                         <span>
-                            {" "}
                             that can be installed automatically. Once installed, it can easily be kept up-to-date.
                         </span>
                     </p>

--- a/src/js/references/components/Official.tsx
+++ b/src/js/references/components/Official.tsx
@@ -17,11 +17,8 @@ const StyledReferenceOfficial = styled(Box)`
 
     button {
         margin-left: auto;
+        min-width: 83px;
     }
-`;
-
-const StyledButton = styled(Button)`
-    min-width: 83px;
 `;
 
 type ReferenceOfficialProps = {
@@ -49,9 +46,9 @@ export const ReferenceOfficial = ({ officialInstalled, onRemote }: ReferenceOffi
                         </span>
                     </p>
                 </div>
-                <StyledButton color="blue" icon="cloud-download-alt" onClick={onRemote}>
+                <Button color="blue" icon="cloud-download-alt" onClick={onRemote}>
                     Install
-                </StyledButton>
+                </Button>
             </StyledReferenceOfficial>
         );
     }

--- a/src/js/references/components/Official.tsx
+++ b/src/js/references/components/Official.tsx
@@ -20,6 +20,10 @@ const StyledReferenceOfficial = styled(Box)`
     }
 `;
 
+const StyledButton = styled(Button)`
+    min-width: 83px;
+`;
+
 type ReferenceOfficialProps = {
     officialInstalled: boolean;
     onRemote: () => void;
@@ -45,9 +49,9 @@ export const ReferenceOfficial = ({ officialInstalled, onRemote }: ReferenceOffi
                         </span>
                     </p>
                 </div>
-                <Button color="blue" icon="cloud-download-alt" onClick={onRemote}>
+                <StyledButton color="blue" icon="cloud-download-alt" onClick={onRemote}>
                     Install
-                </Button>
+                </StyledButton>
             </StyledReferenceOfficial>
         );
     }


### PR DESCRIPTION
![Screenshot from 2024-03-04 12-40-44](https://github.com/virtool/virtool-ui/assets/125520621/d5516c34-fde6-4bd4-9a0c-fc1d6da10179)
