### PR TITLE
fix: enable vertical scrolling in analysis creation dialog

### DIFF
--- a/src/js/analyses/components/Create/CreateAnalysisDialogContent.tsx
+++ b/src/js/analyses/components/Create/CreateAnalysisDialogContent.tsx
@@ -1,5 +1,5 @@
+import { DialogContent } from "@base";
 import styled, { keyframes } from "styled-components";
-import { DialogContent } from "../../../base";
 
 const createAnalysisOpen = keyframes`
   from {
@@ -14,8 +14,8 @@ const createAnalysisOpen = keyframes`
 
 export const CreateAnalysisDialogContent = styled(DialogContent)`
     animation: ${createAnalysisOpen} 150ms cubic-bezier(0.16, 1, 0.3, 1);
-    display: flex;
-    flex-direction: column;
+    max-height: 90vh;
+    overflow: auto;
     position: fixed;
     top: 5%;
     transform: translate(-50%, 0%);


### PR DESCRIPTION
Changes:
 - Sets a max height for the dialog based on viewport size (90% of current viewport)
 - enables vertical scrolling if the dialog height requirements exceed the set maximum

When scrolling is enabled: (no visual changes when scrolling is not required)
![image](https://github.com/virtool/virtool-ui/assets/59776400/6179346c-d186-48b5-8180-1a634b68e6bb)
