### PR TITLE
fix: restore quick analysis function beyond the first page

### DIFF
--- a/src/js/analyses/components/Create/QuickAnalyze.tsx
+++ b/src/js/analyses/components/Create/QuickAnalyze.tsx
@@ -1,4 +1,5 @@
 import { DialogPortal } from "@radix-ui/react-dialog";
+import { merge } from "lodash";
 import { filter, forEach, uniqBy } from "lodash-es";
 import React, { useEffect } from "react";
 import { useHistory, useLocation } from "react-router-dom";
@@ -144,7 +145,7 @@ export default function QuickAnalyze({
     const compatibleWorkflows = getCompatibleWorkflows(mode ?? "genome", Boolean(hmms.total_count));
 
     function onChangeWorkflow(workflow: Workflows) {
-        history.push({ state: { ...location.state, workflow } });
+        history.push(merge(location, { state: { workflow } }));
     }
 
     return (


### PR DESCRIPTION
## Changes
- Restores quick analysis function on later pages by preventing overwriting the url search params

## Compatiblity

Any changes that require a newer version of the API are considered breaking
changes.

Common breaking changes:
 - Making a request to a new API endpoint that will return `403` or `404` in older versions of the API.
 - No longer sending request fields required by previous versions of the API 
 - Requiring new fields from an API endpoint that will not be present in
   responses from older versions of the API
 - Breaking backwards compatibility with old response data shapes


Choose one:
 - [x] The changes do not break compatibility
 - [ ] The changes potentially break compatibility


## Pre-Review Checklist
 - [x] All changes are tested
 - [x] All touched code documentation is updated
 - [x] All tests pass in your local environment
 - [x] Deepsource issues have been reviewed and addressed
 - [x] Debugging logging and commented out code has been removed

 
## Screenshots:
N/A no visual changes

