### PR TITLE
fix: attribution time bug

### DIFF
--- a/src/js/base/RelativeTime.tsx
+++ b/src/js/base/RelativeTime.tsx
@@ -15,12 +15,12 @@ import React, { useEffect, useState } from "react";
 function createTimeString(time) {
     const now = Date.now();
     const timeString = formatDistanceStrict(new Date(time), now, { addSuffix: true });
-    return includes(timeString, "in a") || includes(timeString, "a few") ? "just now" : timeString;
+    return includes(timeString, "in a") || includes(timeString, "seconds") ? "just now" : timeString;
 }
 
 function useRelativeTime(time) {
     const [timeString, setTimeString] = useState(createTimeString(time));
-
+    console.log(timeString);
     useEffect(() => {
         function updateTimeString() {
             const newTimeString = createTimeString(time);

--- a/src/js/base/RelativeTime.tsx
+++ b/src/js/base/RelativeTime.tsx
@@ -1,4 +1,4 @@
-import { formatDistanceStrict } from "date-fns";
+import { formatDistanceStrict, isAfter } from "date-fns";
 import { includes } from "lodash-es";
 import React, { useEffect, useState } from "react";
 
@@ -14,8 +14,9 @@ import React, { useEffect, useState } from "react";
  */
 function createTimeString(time) {
     const now = Date.now();
-    const timeString = formatDistanceStrict(new Date(time), now, { addSuffix: true });
-    return includes(timeString, "1 minute") || includes(timeString, "seconds") ? "just now" : timeString;
+    const currentTime = isAfter(new Date(time), new Date()) ? now : time;
+    const timeString = formatDistanceStrict(new Date(currentTime), now, { addSuffix: true });
+    return includes(timeString, "in a") || includes(timeString, "a few") ? "just now" : timeString;
 }
 
 function useRelativeTime(time) {

--- a/src/js/base/RelativeTime.tsx
+++ b/src/js/base/RelativeTime.tsx
@@ -15,12 +15,12 @@ import React, { useEffect, useState } from "react";
 function createTimeString(time) {
     const now = Date.now();
     const timeString = formatDistanceStrict(new Date(time), now, { addSuffix: true });
-    return includes(timeString, "in a") || includes(timeString, "seconds") ? "just now" : timeString;
+    return includes(timeString, "1 minute") || includes(timeString, "seconds") ? "just now" : timeString;
 }
 
 function useRelativeTime(time) {
     const [timeString, setTimeString] = useState(createTimeString(time));
-    console.log(timeString);
+
     useEffect(() => {
         function updateTimeString() {
             const newTimeString = createTimeString(time);

--- a/src/js/base/RelativeTime.tsx
+++ b/src/js/base/RelativeTime.tsx
@@ -14,8 +14,11 @@ import React, { useEffect, useState } from "react";
  */
 function createTimeString(time) {
     const now = Date.now();
-    const currentTime = isAfter(new Date(time), new Date()) ? now : time;
-    const timeString = formatDistanceStrict(new Date(currentTime), now, { addSuffix: true });
+    const serverDate = new Date(time);
+    const clientDate = new Date();
+
+    const currentTime = isAfter(serverDate, clientDate) ? clientDate : serverDate;
+    const timeString = formatDistanceStrict(currentTime, now, { addSuffix: true });
     return includes(timeString, "in a") || includes(timeString, "a few") ? "just now" : timeString;
 }
 

--- a/src/js/base/__tests__/RelativeTime.test.jsx
+++ b/src/js/base/__tests__/RelativeTime.test.jsx
@@ -34,14 +34,14 @@ describe("<RelativeTime />", () => {
 
         // Render with time that is only 10 seconds before the current (mocked) time.
         renderWithProviders(<RelativeTime time="2019-04-22T10:20:20Z" />);
-        expect(await screen.getByText("just now")).toBeInTheDocument();
+        expect(await screen.getByText("10 seconds ago")).toBeInTheDocument();
 
         act(() => {
             vi.setSystemTime(new Date("2019-04-22T10:20:32Z"));
             vi.advanceTimersByTime(8000);
         });
 
-        expect(await screen.findByText("just now")).toBeInTheDocument();
+        expect(await screen.findByText("20 seconds ago")).toBeInTheDocument();
     });
 
     afterAll(() => {

--- a/src/js/base/__tests__/RelativeTime.test.jsx
+++ b/src/js/base/__tests__/RelativeTime.test.jsx
@@ -34,14 +34,14 @@ describe("<RelativeTime />", () => {
 
         // Render with time that is only 10 seconds before the current (mocked) time.
         renderWithProviders(<RelativeTime time="2019-04-22T10:20:20Z" />);
-        expect(await screen.getByText("10 seconds ago")).toBeInTheDocument();
+        expect(await screen.getByText("just now")).toBeInTheDocument();
 
         act(() => {
             vi.setSystemTime(new Date("2019-04-22T10:20:32Z"));
             vi.advanceTimersByTime(8000);
         });
 
-        expect(await screen.findByText("20 seconds ago")).toBeInTheDocument();
+        expect(await screen.findByText("just now")).toBeInTheDocument();
     });
 
     afterAll(() => {


### PR DESCRIPTION
## Changes
<!--- Provide the broad strokes of the changes made in a bulleted list --->

## Compatiblity

Any changes that require a newer version of the API are considered breaking
changes.

Common breaking changes:
 - Making a request to a new API endpoint that will return `403` or `404` in older versions of the API.
 - No longer sending request fields required by previous versions of the API 
 - Requiring new fields from an API endpoint that will not be present in
   responses from older versions of the API
 - Breaking backwards compatibility with old response data shapes


Choose one:
 - [x] The changes do not break compatibility
 - [ ] The changes potentially break compatibility


## Pre-Review Checklist
 - [x] All changes are tested
 - [x] All touched code documentation is updated
 - [x] All tests pass in your local environment
 - [x] Deepsource issues have been reviewed and addressed
 - [x] Debugging logging and commented out code has been removed

 
## Screenshots:
_Only required for visual changes_.
![Screenshot from 2024-05-01 11-46-32](https://github.com/virtool/virtool-ui/assets/125520621/5d4d5728-72ae-4d0b-b9fd-fbc25d5dbee1)
