### PR TITLE
chore: update group testing to remove connected-react-router imports

### DIFF
--- a/src/js/administration/components/Settings.tsx
+++ b/src/js/administration/components/Settings.tsx
@@ -1,10 +1,9 @@
+import { useFetchAccount } from "@account/queries";
+import { ContainerNarrow, ContainerWide, LoadingPlaceholder, ViewHeader, ViewHeaderTitle } from "@base";
+import { ManageUsers } from "@users/components/ManageUsers";
 import React from "react";
 import { Redirect, Route, Switch } from "react-router-dom";
-import { ContainerNarrow, ContainerWide, LoadingPlaceholder, ViewHeader, ViewHeaderTitle } from "../../base";
-
-import { useFetchAccount } from "../../account/queries";
-import { Groups } from "../../groups/components/Groups";
-import { ManageUsers } from "../../users/components/ManageUsers";
+import Groups from "../../groups/components/Groups";
 import UserDetail from "../../users/components/UserDetail";
 import { AdministratorRoles } from "../types";
 import { hasSufficientAdminRole } from "../utils";

--- a/src/js/groups/components/Groups.tsx
+++ b/src/js/groups/components/Groups.tsx
@@ -1,9 +1,9 @@
+import { getColor } from "@app/theme";
+import { BoxGroup, LinkButton, LoadingPlaceholder, RemoveBanner } from "@base";
+import { InputHeader } from "@base/InputHeader";
 import { find, sortBy } from "lodash-es";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
-import { getColor } from "../../app/theme";
-import { BoxGroup, LinkButton, LoadingPlaceholder, RemoveBanner } from "../../base";
-import { InputHeader } from "../../base/InputHeader";
 import { useFetchGroup, useListGroups, useRemoveGroup, useUpdateGroup } from "../queries";
 import Create from "./CreateGroup";
 import { GroupSelector } from "./GroupSelector";
@@ -39,7 +39,7 @@ export const NoneSelected = styled.div`
     transform: translate(-50%, -50%);
 `;
 
-export const Groups = () => {
+export default function Groups() {
     const updateGroupMutation = useUpdateGroup();
     const removeMutation = useRemoveGroup();
 
@@ -101,4 +101,4 @@ export const Groups = () => {
             <Create />
         </>
     );
-};
+}


### PR DESCRIPTION
## Changes
<!--- Provide the broad strokes of the changes made in a bulleted list --->

## Compatiblity

Any changes that require a newer version of the API are considered breaking
changes.

Common breaking changes:
 - Making a request to a new API endpoint that will return `403` or `404` in older versions of the API.
 - No longer sending request fields required by previous versions of the API 
 - Requiring new fields from an API endpoint that will not be present in
   responses from older versions of the API
 - Breaking backwards compatibility with old response data shapes


Choose one:
 - [x] The changes do not break compatibility
 - [ ] The changes potentially break compatibility


## Pre-Review Checklist
 - [x] All changes are tested
 - [x] All touched code documentation is updated
 - [x] All tests pass in your local environment
 - [x] Deepsource issues have been reviewed and addressed
 - [x] Debugging logging and commented out code has been removed

 
## Screenshots:
_Only required for visual changes_.

