### PR TITLE
refactor: remove `connected-react-router`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
                 "@types/superagent": "^4.1.16",
                 "classnames": "^2.3.2",
                 "commander": "^9.4.1",
-                "connected-react-router": "^6.9.3",
                 "d3-array": "^3.2.2",
                 "d3-axis": "^3.0.0",
                 "d3-dispatch": "^3.0.1",
@@ -16780,26 +16779,6 @@
                 "node": ">=0.8"
             }
         },
-        "node_modules/connected-react-router": {
-            "version": "6.9.3",
-            "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.9.3.tgz",
-            "integrity": "sha512-4ThxysOiv/R2Dc4Cke1eJwjKwH1Y51VDwlOrOfs1LjpdYOVvCNjNkZDayo7+sx42EeGJPQUNchWkjAIJdXGIOQ==",
-            "dependencies": {
-                "lodash.isequalwith": "^4.4.0",
-                "prop-types": "^15.7.2"
-            },
-            "optionalDependencies": {
-                "immutable": "^3.8.1 || ^4.0.0",
-                "seamless-immutable": "^7.1.3"
-            },
-            "peerDependencies": {
-                "history": "^4.7.2",
-                "react": "^16.4.0 || ^17.0.0",
-                "react-redux": "^6.0.0 || ^7.1.0",
-                "react-router": "^4.3.1 || ^5.0.0",
-                "redux": "^3.6.0 || ^4.0.0"
-            }
-        },
         "node_modules/consola": {
             "version": "2.15.3",
             "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
@@ -21507,12 +21486,6 @@
                 "url": "https://opencollective.com/immer"
             }
         },
-        "node_modules/immutable": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-            "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
-            "optional": true
-        },
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -23478,11 +23451,6 @@
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
             "dev": true
-        },
-        "node_modules/lodash.isequalwith": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz",
-            "integrity": "sha512-dcZON0IalGBpRmJBmMkaoV7d3I80R2O+FrzsZyHdNSFrANq/cgDqKQNmAHE8UEj4+QYWwwhkQOVdLHiAopzlsQ=="
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -27871,12 +27839,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             }
-        },
-        "node_modules/seamless-immutable": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.4.tgz",
-            "integrity": "sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A==",
-            "optional": true
         },
         "node_modules/select-hose": {
             "version": "2.0.0",
@@ -44196,17 +44158,6 @@
             "optional": true,
             "peer": true
         },
-        "connected-react-router": {
-            "version": "6.9.3",
-            "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.9.3.tgz",
-            "integrity": "sha512-4ThxysOiv/R2Dc4Cke1eJwjKwH1Y51VDwlOrOfs1LjpdYOVvCNjNkZDayo7+sx42EeGJPQUNchWkjAIJdXGIOQ==",
-            "requires": {
-                "immutable": "^3.8.1 || ^4.0.0",
-                "lodash.isequalwith": "^4.4.0",
-                "prop-types": "^15.7.2",
-                "seamless-immutable": "^7.1.3"
-            }
-        },
         "consola": {
             "version": "2.15.3",
             "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
@@ -47867,12 +47818,6 @@
             "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.19.tgz",
             "integrity": "sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ=="
         },
-        "immutable": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-            "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
-            "optional": true
-        },
         "import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -49318,11 +49263,6 @@
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
             "dev": true
-        },
-        "lodash.isequalwith": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz",
-            "integrity": "sha512-dcZON0IalGBpRmJBmMkaoV7d3I80R2O+FrzsZyHdNSFrANq/cgDqKQNmAHE8UEj4+QYWwwhkQOVdLHiAopzlsQ=="
         },
         "lodash.merge": {
             "version": "4.6.2",
@@ -52734,12 +52674,6 @@
                 "ajv": "^6.12.5",
                 "ajv-keywords": "^3.5.2"
             }
-        },
-        "seamless-immutable": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.4.tgz",
-            "integrity": "sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A==",
-            "optional": true
         },
         "select-hose": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
         "@types/superagent": "^4.1.16",
         "classnames": "^2.3.2",
         "commander": "^9.4.1",
-        "connected-react-router": "^6.9.3",
         "d3-array": "^3.2.2",
         "d3-axis": "^3.0.0",
         "d3-dispatch": "^3.0.1",

--- a/src/js/administration/components/__tests__/Settings.test.tsx
+++ b/src/js/administration/components/__tests__/Settings.test.tsx
@@ -1,32 +1,28 @@
 import { screen, waitFor } from "@testing-library/react";
-import { createBrowserHistory } from "history";
 import nock from "nock";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createFakeAccount } from "../../../../tests/fake/account";
 import { createFakeSettings, mockApiGetSettings } from "../../../../tests/fake/admin";
 import { createFakeMessage, mockApiGetMessage } from "../../../../tests/fake/message";
-import { renderWithRouter } from "../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../tests/setupTests";
 import { AdministratorRoles } from "../../types";
 import Settings from "../Settings";
 
 describe("<Settings />", () => {
     let account;
-    let history;
     let scope;
 
     beforeEach(() => {
         account = createFakeAccount();
-        history = createBrowserHistory();
         mockApiGetMessage(createFakeMessage());
         mockApiGetSettings(createFakeSettings());
-        history.push("/administration/settings");
     });
 
     it("should render", async () => {
         account.administrator_role = AdministratorRoles.FULL;
         scope = nock("http://localhost").get("/api/account").reply(200, account);
-        renderWithRouter(<Settings />, {}, history);
+        renderWithMemoryRouter(<Settings />, [{ pathname: "/administration/settings" }]);
 
         await waitFor(() => expect(screen.getByText("Instance Message")).toBeInTheDocument());
         expect(screen.getByText("Settings")).toBeInTheDocument();
@@ -41,8 +37,7 @@ describe("<Settings />", () => {
     it("should render all options for full administrators", async () => {
         account.administrator_role = AdministratorRoles.FULL;
         scope = nock("http://localhost").get("/api/account").reply(200, account);
-
-        renderWithRouter(<Settings />, {}, history);
+        renderWithMemoryRouter(<Settings />, [{ pathname: "/administration/settings" }]);
 
         await waitFor(() => expect(screen.getByText("Users")).toBeInTheDocument());
         expect(screen.getByText("Settings")).toBeInTheDocument();
@@ -55,8 +50,7 @@ describe("<Settings />", () => {
     it("should render only groups and users for users administrators", async () => {
         account.administrator_role = AdministratorRoles.USERS;
         scope = nock("http://localhost").get("/api/account").reply(200, account);
-
-        renderWithRouter(<Settings />, {}, history);
+        renderWithMemoryRouter(<Settings />, [{ pathname: "/administration/settings" }]);
 
         await waitFor(() => expect(screen.getByText("Users")).toBeInTheDocument());
         expect(screen.queryByText("Settings")).not.toBeInTheDocument();

--- a/src/js/app/App.jsx
+++ b/src/js/app/App.jsx
@@ -2,9 +2,9 @@ import { LoadingPlaceholder } from "@/base";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { resetClient } from "@utils/utils";
 import { WallContainer } from "@wall/Container";
-import { ConnectedRouter } from "connected-react-router";
 import React, { Suspense, useEffect } from "react";
 import { connect, Provider } from "react-redux";
+import { Router } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
 import Reset from "../wall/Reset";
 import { getInitialState } from "./actions";
@@ -89,10 +89,10 @@ export default function App({ store, history }) {
         <ThemeProvider theme={theme}>
             <QueryClientProvider client={queryClient}>
                 <Provider store={store}>
-                    <ConnectedRouter history={history}>
+                    <Router history={history}>
                         <GlobalStyles />
                         <ConnectedApp />
-                    </ConnectedRouter>
+                    </Router>
                 </Provider>
             </QueryClientProvider>
         </ThemeProvider>

--- a/src/js/app/actionTypes.js
+++ b/src/js/app/actionTypes.js
@@ -17,24 +17,12 @@ const createRequestActionType = root => ({
 });
 
 // App
-export const PUSH_STATE = "PUSH_STATE";
-export const UPDATE_SEARCH = "UPDATE_SEARCH";
 export const GET_INITIAL_STATE = createRequestActionType("GET_INITIAL_STATE");
-
-// Dev
-export const POST_DEV_COMMAND = createRequestActionType("POST_DEV_COMMAND");
 
 // Account
 export const GET_ACCOUNT = createRequestActionType("GET_ACCOUNT");
 export const UPDATE_ACCOUNT = createRequestActionType("UPDATE_ACCOUNT");
-export const GET_ACCOUNT_SETTINGS = createRequestActionType("GET_ACCOUNT_SETTINGS");
-export const UPDATE_ACCOUNT_SETTINGS = createRequestActionType("UPDATE_ACCOUNT_SETTINGS");
 export const CHANGE_ACCOUNT_PASSWORD = createRequestActionType("CHANGE_ACCOUNT_PASSWORD");
-export const GET_API_KEYS = createRequestActionType("GET_API_KEYS");
-export const CREATE_API_KEY = createRequestActionType("CREATE_API_KEY");
-export const UPDATE_API_KEY = createRequestActionType("UPDATE_API_KEY");
-export const REMOVE_API_KEY = createRequestActionType("REMOVE_API_KEY");
-export const CLEAR_API_KEY = "CLEAR_API_KEY";
 export const LOGIN = createRequestActionType("LOGIN");
 export const LOGOUT = createRequestActionType("LOGOUT");
 export const RESET_PASSWORD = createRequestActionType("RESET_PASSWORD");
@@ -44,25 +32,12 @@ export const GET_SETTINGS = createRequestActionType("GET_SETTINGS");
 export const UPDATE_SETTINGS = createRequestActionType("UPDATE_SETTINGS");
 
 // Analysis
-export const WS_INSERT_ANALYSIS = "WS_INSERT_ANALYSIS";
 export const WS_UPDATE_ANALYSIS = "WS_UPDATE_ANALYSIS";
-export const WS_REMOVE_ANALYSIS = "WS_REMOVE_ANALYSIS";
-export const BLAST_NUVS = createRequestActionType("BLAST_NUVS");
-export const GET_ANALYSIS = createRequestActionType("GET_ANALYSIS");
 export const SET_ANALYSIS = "SET_ANALYSIS";
 export const SET_ANALYSIS_ACTIVE_ID = "SET_ANALYSIS_ACTIVE_ID";
 export const SET_SEARCH_IDS = "SET_SEARCH_IDS";
 export const SET_AODP_FILTER = "ADD_AODP_FILTER";
 export const SET_ANALYSIS_SORT_KEY = "SET_ANALYSIS_SORT_KEY";
-export const TOGGLE_FILTER_OTUS = "TOGGLE_FILTER_OTUS";
-export const TOGGLE_FILTER_ISOLATES = "TOGGLE_FILTER_ISOLATES";
-export const TOGGLE_FILTER_ORFS = "TOGGLE_FILTER_ORFS";
-export const TOGGLE_FILTER_SEQUENCES = "TOGGLE_FILTER_SEQUENCES";
-export const TOGGLE_ANALYSIS_SORT_DESCENDING = "TOGGLE_ANALYSIS_SORT_DESCENDING";
-export const TOGGLE_SHOW_PATHOSCOPE_READS = "TOGGLE_SHOW_PATHOSCOPE_READS";
-
-// Caches
-export const GET_CACHE = createRequestActionType("GET_CACHE");
 
 // Errors
 export const CLEAR_ERROR = "CLEAR_ERROR";
@@ -80,148 +55,42 @@ export const DELETE_PERSISTENT_FORM_STATE = "DELETE_PERSISTENT_FORM_STATE";
 export const SET_REDUX_FORM_STATE = "SET_REDUX_FORM_STATE";
 
 // Groups
-export const WS_INSERT_GROUP = "WS_INSERT_GROUP";
-export const WS_UPDATE_GROUP = "WS_UPDATE_GROUP";
-export const WS_REMOVE_GROUP = "WS_REMOVE_GROUP";
-export const REMOVE_ACTIVE_GROUP = "REMOVE_ACTIVE_GROUP";
-export const LIST_GROUPS = createRequestActionType("LIST_GROUPS");
-export const GET_GROUP = createRequestActionType("GET_GROUP");
 export const CREATE_GROUP = createRequestActionType("CREATE_GROUP");
-export const SET_GROUP_NAME = createRequestActionType("SET_GROUP_NAME");
-export const SET_GROUP_PERMISSION = createRequestActionType("SET_GROUP_PERMISSION");
-export const REMOVE_GROUP = createRequestActionType("REMOVE_GROUP");
 
 // HMMs
-export const FIND_HMMS = createRequestActionType("FIND_HMMS");
 export const GET_HMM = createRequestActionType("GET_HMM");
-export const INSTALL_HMMS = createRequestActionType("INSTALL_HMMS");
 
 // Indexes
-export const WS_INSERT_INDEX = "WS_INSERT_INDEX";
-export const WS_UPDATE_INDEX = "WS_UPDATE_INDEX";
-export const WS_REMOVE_INDEX = "WS_REMOVE_INDEX";
-export const WS_INSERT_HISTORY = "WS_INSERT_HISTORY";
-export const FIND_INDEXES = createRequestActionType("FIND_INDEXES");
 export const GET_INDEX = createRequestActionType("GET_INDEX");
-export const GET_UNBUILT = createRequestActionType("GET_UNBUILT");
 export const CREATE_INDEX = createRequestActionType("CREATE_INDEX");
-export const GET_INDEX_HISTORY = createRequestActionType("GET_INDEX_HISTORY");
-export const LIST_READY_INDEXES = createRequestActionType("LIST_READY_INDEXES");
-
-// Instance Message
-export const GET_INSTANCE_MESSAGE = createRequestActionType("GET_INSTANCE_MESSAGE");
-export const SET_INSTANCE_MESSAGE = createRequestActionType("SET_INSTANCE_MESSAGE");
-export const UPDATE_INSTANCE_MESSAGE = createRequestActionType("UPDATE_INSTANCE_MESSAGE");
 
 // Jobs
-export const WS_INSERT_JOB = "WS_INSERT_JOB";
-export const WS_UPDATE_JOB = "WS_UPDATE_JOB";
-export const WS_REMOVE_JOB = "WS_REMOVE_JOB";
-export const FIND_JOBS = createRequestActionType("FIND_JOBS");
 export const GET_JOB = createRequestActionType("GET_JOB");
-export const GET_LINKED_JOB = createRequestActionType("GET_LINKED_JOB");
-export const CANCEL_JOB = createRequestActionType("CANCEL_JOB");
-export const ARCHIVE_JOB = createRequestActionType("ARCHIVE_JOB");
 
 // OTU
-export const WS_INSERT_OTU = "WS_INSERT_OTU";
-export const WS_UPDATE_OTU = "WS_UPDATE_OTU";
-export const WS_REMOVE_OTU = "WS_REMOVE_OTU";
-export const FIND_OTUS = createRequestActionType("FIND_OTUS");
-export const REFRESH_OTUS = createRequestActionType("REFRESH_OTUS");
 export const GET_OTU = createRequestActionType("GET_OTU");
 export const CREATE_OTU = createRequestActionType("CREATE_OTU");
 export const EDIT_OTU = createRequestActionType("EDIT_OTU");
-export const REMOVE_OTU = createRequestActionType("REMOVE_OTU");
-export const GET_OTU_HISTORY = createRequestActionType("GET_OTU_HISTORY");
 export const ADD_ISOLATE = createRequestActionType("ADD_ISOLATE");
 export const EDIT_ISOLATE = createRequestActionType("EDIT_ISOLATE");
-export const SET_ISOLATE_AS_DEFAULT = createRequestActionType("SET_ISOLATE_AS_DEFAULT");
-export const REMOVE_ISOLATE = createRequestActionType("REMOVE_ISOLATE");
 export const ADD_SEQUENCE = createRequestActionType("ADD_SEQUENCE");
 export const EDIT_SEQUENCE = createRequestActionType("EDIT_SEQUENCE");
-export const REMOVE_SEQUENCE = createRequestActionType("REMOVE_SEQUENCE");
-export const REVERT = createRequestActionType("REVERT");
-export const UPLOAD_IMPORT = createRequestActionType("UPLOAD_IMPORT");
-export const SELECT_ISOLATE = "SELECT_ISOLATE";
-export const SHOW_EDIT_OTU = "SHOW_EDIT_OTU";
-export const SHOW_REMOVE_OTU = "SHOW_REMOVE_OTU";
-export const SHOW_ADD_ISOLATE = "SHOW_ADD_ISOLATE";
-export const SHOW_EDIT_ISOLATE = "SHOW_EDIT_ISOLATE";
-export const SHOW_REMOVE_ISOLATE = "SHOW_REMOVE_ISOLATE";
-export const SHOW_REMOVE_SEQUENCE = "SHOW_REMOVE_SEQUENCE";
-export const HIDE_OTU_MODAL = "HIDE_OTU_MODAL";
-
-// Tasks
-export const WS_INSERT_TASK = "WS_INSERT_TASK";
-export const WS_UPDATE_TASK = "WS_UPDATE_TASK";
-export const LIST_TASKS = createRequestActionType("LIST_TASKS");
-export const GET_TASK = createRequestActionType("GET_TASK");
 
 // Refs
-export const WS_INSERT_REFERENCE = "WS_INSERT_REFERENCE";
-export const WS_UPDATE_REFERENCE = "WS_UPDATE_REFERENCE";
-export const WS_REMOVE_REFERENCE = "WS_REMOVE_REFERENCE";
-export const FIND_REFERENCES = createRequestActionType("FIND_REFERENCES");
 export const GET_REFERENCE = createRequestActionType("GET_REFERENCE");
-export const EMPTY_REFERENCE = createRequestActionType("EMPTY_REFERENCE");
-export const EDIT_REFERENCE = createRequestActionType("EDIT_REFERENCE");
-export const REMOVE_REFERENCE = createRequestActionType("REMOVE_REFERENCE");
-export const IMPORT_REFERENCE = createRequestActionType("IMPORT_REFERENCE");
-export const CLONE_REFERENCE = createRequestActionType("CLONE_REFERENCE");
-export const REMOTE_REFERENCE = createRequestActionType("REMOTE_REFERENCE");
-export const ADD_REFERENCE_USER = createRequestActionType("ADD_REFERENCE_USER");
-export const EDIT_REFERENCE_USER = createRequestActionType("EDIT_REFERENCE_USER");
-export const REMOVE_REFERENCE_USER = createRequestActionType("REMOVE_REFERENCE_USER");
-export const ADD_REFERENCE_GROUP = createRequestActionType("ADD_REFERENCE_GROUP");
-export const EDIT_REFERENCE_GROUP = createRequestActionType("EDIT_REFERENCE_GROUP");
-export const REMOVE_REFERENCE_GROUP = createRequestActionType("REMOVE_REFERENCE_GROUP");
-export const CHECK_REMOTE_UPDATES = createRequestActionType("CHECK_REMOTE_UPDATES");
-export const UPDATE_REMOTE_REFERENCE = createRequestActionType("UPDATE_REMOTE_REFERENCE");
 
 // Samples
-export const WS_INSERT_SAMPLE = "WS_INSERT_SAMPLE";
-export const WS_UPDATE_SAMPLE = "WS_UPDATE_SAMPLE";
-export const WS_REMOVE_SAMPLE = "WS_REMOVE_SAMPLE";
-export const FIND_SAMPLES = createRequestActionType("FIND_SAMPLES");
 export const GET_SAMPLE = createRequestActionType("GET_SAMPLE");
 export const CREATE_SAMPLE = createRequestActionType("CREATE_SAMPLE");
 export const UPDATE_SAMPLE = createRequestActionType("UPDATE_SAMPLE");
-export const UPDATE_SAMPLE_RIGHTS = createRequestActionType("UPDATE_SAMPLE_RIGHTS");
-export const REMOVE_SAMPLE = createRequestActionType("REMOVE_SAMPLE");
-export const SELECT_SAMPLE = "SELECT_SAMPLE";
-export const DESELECT_SAMPLES = "DESELECT_SAMPLES";
-export const CLEAR_SAMPLE_SELECTION = "CLEAR_SAMPLE_SELECTION";
-export const SHOW_REMOVE_SAMPLE = "SHOW_REMOVE_SAMPLE";
-export const HIDE_SAMPLE_MODAL = "HIDE_SAMPLE_MODAL";
 
 // Subtraction
-export const WS_INSERT_SUBTRACTION = "WS_INSERT_SUBTRACTION";
-export const WS_UPDATE_SUBTRACTION = "WS_UPDATE_SUBTRACTION";
-export const WS_REMOVE_SUBTRACTION = "WS_REMOVE_SUBTRACTION";
-export const FIND_SUBTRACTIONS = createRequestActionType("FIND_SUBTRACTIONS");
-export const SHORTLIST_SUBTRACTIONS = createRequestActionType("LIST_SUBTRACTION_IDS");
 export const GET_SUBTRACTION = createRequestActionType("GET_SUBTRACTION");
 export const CREATE_SUBTRACTION = createRequestActionType("CREATE_SUBTRACTION");
-export const EDIT_SUBTRACTION = createRequestActionType("UPDATE_SUBTRACTION");
-export const REMOVE_SUBTRACTION = createRequestActionType("REMOVE_SUBTRACTION");
 
 // Users
-export const WS_INSERT_USER = "WS_INSERT_USER";
-export const WS_UPDATE_USER = "WS_UPDATE_USER";
-export const WS_REMOVE_USER = "WS_REMOVE_USER";
 export const FIND_USERS = createRequestActionType("FIND_USERS");
 export const GET_USER = createRequestActionType("GET_USER");
 export const CREATE_USER = createRequestActionType("CREATE_USER");
 export const CREATE_FIRST_USER = createRequestActionType("CREATE_FIRST_USER");
 export const EDIT_USER = createRequestActionType("EDIT_USER");
-export const REMOVE_USER = createRequestActionType("REMOVE_USER");
-
-//Label
-export const UPDATE_LABEL = createRequestActionType("UPDATE_LABEL");
-export const LIST_LABELS = createRequestActionType("LIST_LABELS");
-export const CREATE_LABEL = createRequestActionType("CREATE_LABEL");
-export const REMOVE_LABEL = createRequestActionType("REMOVE_LABEL");
-
-// Status
-export const WS_UPDATE_STATUS = "WS_UPDATE_STATUS";

--- a/src/js/app/actions.js
+++ b/src/js/app/actions.js
@@ -1,9 +1,5 @@
 import { createAction } from "@reduxjs/toolkit";
-import { GET_INITIAL_STATE, PUSH_STATE } from "./actionTypes";
-
-export const pushState = createAction(PUSH_STATE, state => ({
-    payload: { state },
-}));
+import { GET_INITIAL_STATE } from "./actionTypes";
 
 /**
  * Returns action that can trigger an API calls to get the initial state of the application

--- a/src/js/app/reducer.js
+++ b/src/js/app/reducer.js
@@ -1,6 +1,5 @@
 import { configureStore, createReducer } from "@reduxjs/toolkit";
 import { createReduxEnhancer } from "@sentry/react";
-import { connectRouter, routerMiddleware } from "connected-react-router";
 import createSagaMiddleware from "redux-saga";
 import accountReducer from "../account/reducer";
 import settingsReducer from "../administration/reducer";
@@ -57,7 +56,7 @@ export const appReducer = createReducer(initialState, builder => {
 
 const sentryReduxEnhancer = createReduxEnhancer();
 
-export function createAppStore(history) {
+export function createAppStore() {
     const sagaMiddleware = createSagaMiddleware();
 
     const store = configureStore({
@@ -68,10 +67,9 @@ export function createAppStore(history) {
             errors: errorsReducer,
             files: filesReducer,
             forms: formsReducer,
-            router: connectRouter(history),
             settings: settingsReducer,
         },
-        middleware: [sagaMiddleware, routerMiddleware(history)],
+        middleware: [sagaMiddleware],
         enhancers: [sentryReduxEnhancer],
     });
 

--- a/src/js/app/sagas.js
+++ b/src/js/app/sagas.js
@@ -1,19 +1,13 @@
-import { getLocation, push } from "connected-react-router";
 import { get } from "lodash-es";
-import { all, put, select, takeLatest } from "redux-saga/effects";
+import { all, put, takeLatest } from "redux-saga/effects";
 import { get as getAccountAPI } from "../account/api";
 import { watchAccount } from "../account/sagas";
 import { watchSettings } from "../administration/sagas";
 import { watchFiles } from "../files/sagas";
 import { watchForm } from "../forms/sagas";
 import { callWithAuthentication } from "../utils/sagas";
-import { GET_INITIAL_STATE, PUSH_STATE } from "./actionTypes";
+import { GET_INITIAL_STATE } from "./actionTypes";
 import { root as rootAPI } from "./api";
-
-function* pushState(action) {
-    const routerLocation = yield select(getLocation);
-    yield put(push({ ...routerLocation, state: action.payload.state }));
-}
 
 function* getInitialState() {
     let login = false;
@@ -41,7 +35,6 @@ function* getInitialState() {
 }
 
 export function* watchRouter() {
-    yield takeLatest(PUSH_STATE, pushState);
     yield takeLatest(GET_INITIAL_STATE.REQUESTED, getInitialState);
 }
 

--- a/src/js/groups/components/__tests__/Groups.test.tsx
+++ b/src/js/groups/components/__tests__/Groups.test.tsx
@@ -1,22 +1,15 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createBrowserHistory } from "history";
 import React from "react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createFakeGroup, mockApiGetGroup, mockApiListGroups } from "../../../../tests/fake/groups";
 import { createFakePermissions } from "../../../../tests/fake/permissions";
-import { renderWithRouter } from "../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../tests/setupTests";
 import Groups from "../Groups";
 
 describe("Groups", () => {
-    let history;
-
-    beforeEach(() => {
-        history = createBrowserHistory();
-    });
-
     it("should render correctly when loading = true", () => {
-        renderWithRouter(<Groups />, {}, history);
+        renderWithMemoryRouter(<Groups />);
 
         expect(screen.queryByText("No Groups Found")).not.toBeInTheDocument();
         expect(screen.queryByText("cancel_job")).not.toBeInTheDocument();
@@ -26,7 +19,7 @@ describe("Groups", () => {
 
     it("should render correctly when no groups exist", async () => {
         mockApiListGroups([]);
-        renderWithRouter(<Groups />, {}, history);
+        renderWithMemoryRouter(<Groups />);
 
         expect(await screen.findByText("No Groups Found")).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: "Delete" })).not.toBeInTheDocument();
@@ -37,7 +30,7 @@ describe("Groups", () => {
         const group = createFakeGroup();
         mockApiListGroups([group]);
         mockApiGetGroup(group);
-        renderWithRouter(<Groups />, {}, history);
+        renderWithMemoryRouter(<Groups />);
 
         expect(await screen.findByRole("button", { name: "Delete" })).toBeInTheDocument();
         expect(screen.queryByText("No groups found")).not.toBeInTheDocument();
@@ -49,7 +42,7 @@ describe("Groups", () => {
 
     it("should render create new group view correctly", async () => {
         mockApiListGroups([]);
-        renderWithRouter(<Groups />, {}, history);
+        renderWithMemoryRouter(<Groups />);
 
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
         await userEvent.click(await screen.findByText("Create"));
@@ -64,7 +57,7 @@ describe("Groups", () => {
         const group = createFakeGroup({ users: [{ handle: "testUser1", id: "test_id" }] });
         mockApiListGroups([group]);
         mockApiGetGroup(group);
-        renderWithRouter(<Groups />, {}, history);
+        renderWithMemoryRouter(<Groups />);
 
         expect(await screen.findByText("Members")).toBeInTheDocument();
         expect(screen.getByText("testUser1")).toBeInTheDocument();
@@ -85,7 +78,7 @@ describe("Groups", () => {
         mockApiListGroups([group_1, group_2]);
         mockApiGetGroup(group_1);
 
-        renderWithRouter(<Groups />, {}, history);
+        renderWithMemoryRouter(<Groups />);
 
         expect(await screen.findByText("testName")).toBeInTheDocument();
         expect(screen.getByText("testName2")).toBeInTheDocument();

--- a/src/js/hmm/components/__tests__/HMMList.test.tsx
+++ b/src/js/hmm/components/__tests__/HMMList.test.tsx
@@ -1,28 +1,25 @@
 import { AdministratorRoles } from "@administration/types";
 import { screen } from "@testing-library/react";
-import { createBrowserHistory } from "history";
 import nock from "nock";
 import React from "react";
 import { describe, expect, it } from "vitest";
 import { createFakeAccount, mockAPIGetAccount } from "../../../../tests/fake/account";
 import { createFakeHMMSearchResults, mockApiGetHmms } from "../../../../tests/fake/hmm";
-import { renderWithRouter } from "../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../tests/setupTests";
 import HMMList from "../HMMList";
 
 describe("<HMMList />", () => {
-    let history;
     let fakeHMMData;
 
     beforeEach(() => {
         fakeHMMData = createFakeHMMSearchResults();
-        history = createBrowserHistory();
     });
 
     afterEach(() => nock.cleanAll());
 
     it("should render correctly", async () => {
         const scope = mockApiGetHmms(fakeHMMData);
-        renderWithRouter(<HMMList />, {}, history);
+        renderWithMemoryRouter(<HMMList />);
 
         expect(await screen.findByText("HMMs")).toBeInTheDocument();
         expect(screen.getByPlaceholderText("Definition")).toBeInTheDocument();
@@ -36,7 +33,7 @@ describe("<HMMList />", () => {
     it("should render correctly when no documents exist", async () => {
         const fakeHMMData = createFakeHMMSearchResults({ documents: [] });
         const scope = mockApiGetHmms(fakeHMMData);
-        renderWithRouter(<HMMList />, {}, history);
+        renderWithMemoryRouter(<HMMList />);
 
         expect(await screen.findByText("HMMs")).toBeInTheDocument();
         expect(screen.getByText("No HMMs found.")).toBeInTheDocument();
@@ -50,7 +47,7 @@ describe("<HMMList />", () => {
             const scope = mockApiGetHmms(fakeHMMData);
             const account = createFakeAccount({ administrator_role: AdministratorRoles.FULL });
             mockAPIGetAccount(account);
-            renderWithRouter(<HMMList />, {}, history);
+            renderWithMemoryRouter(<HMMList />);
 
             expect(await screen.findByText("HMMs")).toBeInTheDocument();
 
@@ -70,7 +67,7 @@ describe("<HMMList />", () => {
             const scope = mockApiGetHmms(fakeHMMData);
             const account = createFakeAccount({ administrator_role: null });
             mockAPIGetAccount(account);
-            renderWithRouter(<HMMList />, {}, history);
+            renderWithMemoryRouter(<HMMList />);
 
             expect(await screen.findByText("HMMs")).toBeInTheDocument();
 
@@ -98,7 +95,7 @@ describe("<HMMList />", () => {
             const scope = mockApiGetHmms(fakeHMMData);
             const account = createFakeAccount({ administrator_role: AdministratorRoles.FULL });
             mockAPIGetAccount(account);
-            renderWithRouter(<HMMList />, {}, history);
+            renderWithMemoryRouter(<HMMList />);
 
             expect(await screen.findByText("HMMs")).toBeInTheDocument();
 

--- a/src/js/index.tsx
+++ b/src/js/index.tsx
@@ -23,7 +23,7 @@ if (window.virtool.sentryDsn !== "SENTRY_DSN") {
 const history = createBrowserHistory();
 
 window.virtool.b2c = { use: false };
-window.store = createAppStore(history);
+window.store = createAppStore();
 
 const AppWithProfiler = withProfiler(App);
 

--- a/src/js/indexes/components/__tests__/Indexes.test.tsx
+++ b/src/js/indexes/components/__tests__/Indexes.test.tsx
@@ -1,18 +1,16 @@
 import { AdministratorRoles } from "@administration/types";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createBrowserHistory } from "history";
 import nock from "nock";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createFakeAccount, mockAPIGetAccount } from "../../../../tests/fake/account";
 import { createFakeIndexMinimal, mockApiFindIndexes, mockApiGetUnbuiltChanges } from "../../../../tests/fake/indexes";
 import { createFakeReference, mockApiGetReferenceDetail } from "../../../../tests/fake/references";
-import { renderWithRouter } from "../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../tests/setupTests";
 import Indexes from "../Indexes";
 
 describe("<Indexes />", () => {
-    let history;
     let props;
     let reference;
 
@@ -27,7 +25,6 @@ describe("<Indexes />", () => {
         props = {
             match: { params: { refId: reference.id } },
         };
-        history = createBrowserHistory();
     });
 
     afterEach(() => nock.cleanAll());
@@ -40,7 +37,7 @@ describe("<Indexes />", () => {
             total_otu_count: 1,
             change_count: 1,
         });
-        renderWithRouter(<Indexes {...props} />, {}, history);
+        renderWithMemoryRouter(<Indexes {...props} />);
 
         await waitFor(() => findIndexesScope.done());
         expect(await screen.findByText(`Version ${index.version}`)).toBeInTheDocument();
@@ -64,7 +61,7 @@ describe("<Indexes />", () => {
             total_otu_count: 1,
             change_count: 1,
         });
-        renderWithRouter(<Indexes {...props} />, {}, history);
+        renderWithMemoryRouter(<Indexes {...props} />);
 
         await userEvent.click(await screen.findByRole("link", { name: "Rebuild the index" }));
 

--- a/src/js/jobs/components/__tests__/JobArgs.test.tsx
+++ b/src/js/jobs/components/__tests__/JobArgs.test.tsx
@@ -1,9 +1,8 @@
 import { screen } from "@testing-library/react";
-import CreateBrowserHistory from "history/es/createBrowserHistory";
 import { forEach } from "lodash-es";
 import React from "react";
 import { describe, expect, it } from "vitest";
-import { renderWithRouter } from "../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../tests/setupTests";
 import { JobArgs } from "../JobArgs";
 
 const sample_id = "test_sample_id";
@@ -55,22 +54,14 @@ const workflowTests = [
 
 describe("<JobArgs />", () => {
     it("Should render basics correctly", () => {
-        renderWithRouter(
-            <JobArgs workflow={"create_sample"} args={{ sample_id: "test_sample_id" }} />,
-            {},
-            CreateBrowserHistory(),
-        );
+        renderWithMemoryRouter(<JobArgs workflow={"create_sample"} args={{ sample_id: "test_sample_id" }} />);
 
         expect(screen.getByText("Arguments")).toBeInTheDocument();
         expect(screen.getByText("Run arguments that make this job unique.")).toBeInTheDocument();
     });
 
     it.each(workflowTests)("Should render $workflow jobs correctly", ({ workflow, args, urls }) => {
-        renderWithRouter(
-            <JobArgs workflow={workflow} args={{ ...args, extra_param: "extra_param" }} />,
-            {},
-            CreateBrowserHistory(),
-        );
+        renderWithMemoryRouter(<JobArgs workflow={workflow} args={{ ...args, extra_param: "extra_param" }} />);
 
         forEach(urls, ({ id, url }) => {
             expect(screen.getByRole("link", { name: id })).toHaveAttribute("href", url);
@@ -79,7 +70,7 @@ describe("<JobArgs />", () => {
     });
 
     it("Should render correctly render unknown workflows", () => {
-        renderWithRouter(
+        renderWithMemoryRouter(
             <JobArgs
                 workflow={"unknown_workflow"}
                 args={{
@@ -88,8 +79,6 @@ describe("<JobArgs />", () => {
                     excluded_param: {},
                 }}
             />,
-            {},
-            CreateBrowserHistory(),
         );
 
         expect(screen.getByText("test_sample_id")).toBeInTheDocument();

--- a/src/js/otus/components/Detail/Schema/__tests__/RemoveSegment.test.tsx
+++ b/src/js/otus/components/Detail/Schema/__tests__/RemoveSegment.test.tsx
@@ -1,17 +1,14 @@
 import { fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createBrowserHistory } from "history";
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createFakeOTU, mockApiEditOTU } from "../../../../../../tests/fake/otus";
-import { renderWithRouter } from "../../../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../../../tests/setupTests";
 import RemoveSegment from "../RemoveSegment";
 
 describe("<RemoveSegment />", () => {
     let props;
     let otu;
-    let history;
 
     beforeEach(() => {
         otu = createFakeOTU();
@@ -21,17 +18,10 @@ describe("<RemoveSegment />", () => {
             otuId: otu.id,
             schema: otu.schema,
         };
-        history = createBrowserHistory();
     });
 
     it("should render when [show=true]", () => {
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { removeSegment: props.schema[0].name } }]}>
-                <RemoveSegment {...props} />)
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<RemoveSegment {...props} />, [{ state: { removeSegment: props.schema[0].name } }]);
 
         expect(screen.getByText("Remove Segment")).toBeInTheDocument();
         expect(screen.getByText(/Are you sure you want to remove/)).toBeInTheDocument();
@@ -40,13 +30,7 @@ describe("<RemoveSegment />", () => {
     });
 
     it("should render when [show=false]", () => {
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { removeSegment: "" } }]}>
-                <RemoveSegment {...props} />)
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<RemoveSegment {...props} />, [{ state: { removeSegment: "" } }]);
 
         expect(screen.queryByText("Remove Segment")).toBeNull();
         expect(screen.queryByText(/Are you sure you want to remove/)).toBeNull();
@@ -61,13 +45,7 @@ describe("<RemoveSegment />", () => {
             otuId: otu.d,
             schema: [props.schema[1]],
         });
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { removeSegment: props.schema[0].name } }]}>
-                <RemoveSegment {...props} />)
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<RemoveSegment {...props} />, [{ state: { removeSegment: props.schema[0].name } }]);
 
         await userEvent.click(screen.getByRole("button"));
 
@@ -75,13 +53,7 @@ describe("<RemoveSegment />", () => {
     });
 
     it("should call onHide() when onHide() called on <RemoveDialog />", () => {
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { removeSegment: props.schema[0].name } }]}>
-                <RemoveSegment {...props} />)
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<RemoveSegment {...props} />, [{ state: { removeSegment: props.schema[0].name } }]);
 
         fireEvent.keyDown(document, { key: "Escape" });
 

--- a/src/js/otus/components/Detail/__tests__/RemoveOTU.test.tsx
+++ b/src/js/otus/components/Detail/__tests__/RemoveOTU.test.tsx
@@ -1,16 +1,13 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createBrowserHistory } from "history";
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it } from "vitest";
 import { mockApiRemoveOTU } from "../../../../../tests/fake/otus";
-import { renderWithRouter } from "../../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../../tests/setupTests";
 import RemoveOTU from "../RemoveOTU";
 
 describe("<RemoveOTU />", () => {
     let props;
-    let history;
 
     beforeEach(() => {
         props = {
@@ -18,17 +15,10 @@ describe("<RemoveOTU />", () => {
             name: "Foo",
             refId: "baz",
         };
-        history = createBrowserHistory();
     });
 
     it("should render when [show=true]", () => {
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { removeOTU: true } }]}>
-                <RemoveOTU {...props} />)
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<RemoveOTU {...props} />, [{ state: { removeOTU: true } }]);
 
         expect(screen.getByText("Remove OTU")).toBeInTheDocument();
         expect(screen.getByText(/Are you sure you want to remove/)).toBeInTheDocument();
@@ -37,13 +27,7 @@ describe("<RemoveOTU />", () => {
     });
 
     it("should render when [show=false]", () => {
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { removeOTU: false } }]}>
-                <RemoveOTU {...props} />)
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<RemoveOTU {...props} />, [{ state: { removeOTU: false } }]);
 
         expect(screen.queryByText("Remove OTU")).toBeNull();
         expect(screen.queryByText(/Are you sure you want to remove/)).toBeNull();
@@ -53,13 +37,7 @@ describe("<RemoveOTU />", () => {
 
     it("should handle submit when onConfirm() on RemoveDialog is called", async () => {
         const scope = mockApiRemoveOTU(props.id);
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { removeOTU: true } }]}>
-                <RemoveOTU {...props} />
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<RemoveOTU {...props} />, [{ state: { removeOTU: true } }]);
 
         await userEvent.click(screen.getByRole("button"));
 

--- a/src/js/otus/components/__tests__/CreateOTU.test.tsx
+++ b/src/js/otus/components/__tests__/CreateOTU.test.tsx
@@ -1,16 +1,13 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createBrowserHistory } from "history";
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockApiCreateOTU } from "../../../../tests/fake/otus";
-import { renderWithRouter } from "../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../tests/setupTests";
 import CreateOTU from "../CreateOTU";
 
 describe("<OTUForm />", () => {
     let props;
-    let history;
 
     beforeEach(() => {
         props = {
@@ -18,17 +15,10 @@ describe("<OTUForm />", () => {
             show: true,
             onHide: vi.fn(),
         };
-        history = createBrowserHistory();
     });
 
     it("should render", () => {
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { createOTU: true } }]}>
-                <CreateOTU {...props} />
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<CreateOTU {...props} />, [{ state: { createOTU: true } }]);
 
         expect(screen.getByText("Create OTU")).toBeInTheDocument();
         expect(screen.getByLabelText("Name")).toBeInTheDocument();
@@ -37,26 +27,16 @@ describe("<OTUForm />", () => {
     });
 
     it("should render error once submitted with no name", async () => {
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { createOTU: true } }]}>
-                <CreateOTU {...props} />
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<CreateOTU {...props} />, [{ state: { createOTU: true } }]);
+
         await userEvent.click(screen.getByRole("button"));
         expect(screen.getByText("Name required")).toBeInTheDocument();
     });
 
     it("should create OTU without abbreviation", async () => {
         const scope = mockApiCreateOTU(props.refId, "TestName", "");
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { createOTU: true } }]}>
-                <CreateOTU {...props} />
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<CreateOTU {...props} />, [{ state: { createOTU: true } }]);
+
         await userEvent.type(screen.getByLabelText("Name"), "TestName");
         await userEvent.click(screen.getByRole("button"));
 
@@ -65,13 +45,8 @@ describe("<OTUForm />", () => {
 
     it("should create OTU with abbreviation", async () => {
         const scope = mockApiCreateOTU(props.refId, "TestName", "TestAbbreviation");
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { createOTU: true } }]}>
-                <CreateOTU {...props} />
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<CreateOTU {...props} />, [{ state: { createOTU: true } }]);
+
         await userEvent.type(screen.getByLabelText("Name"), "TestName");
         await userEvent.type(screen.getByLabelText("Abbreviation"), "TestAbbreviation");
         await userEvent.click(screen.getByRole("button"));

--- a/src/js/references/components/Detail/__tests__/ReferenceDetailHeader.test.tsx
+++ b/src/js/references/components/Detail/__tests__/ReferenceDetailHeader.test.tsx
@@ -2,11 +2,10 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createBrowserHistory } from "history";
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createFakeAccount, mockAPIGetAccount } from "../../../../../tests/fake/account";
 import { createFakeReference, mockApiGetReferenceDetail } from "../../../../../tests/fake/references";
-import { renderWithRouter } from "../../../../../tests/setupTests";
+import { renderWithMemoryRouter, renderWithRouter } from "../../../../../tests/setupTests";
 import { AdministratorRoles } from "../../../../administration/types";
 import ReferenceDetailHeader from "../ReferenceDetailHeader";
 
@@ -31,26 +30,14 @@ describe("<ReferenceDetailHeaderIcon />", () => {
     });
 
     it("should render", () => {
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ pathname: `/refs/${reference.id}/manage` }]}>
-                <ReferenceDetailHeader {...props} />
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<ReferenceDetailHeader {...props} />, [{ pathname: `/refs/${reference.id}/manage` }]);
 
         expect(screen.getByText(reference.name)).toBeInTheDocument();
         expect(screen.getByText(`${reference.user.handle} created`)).toBeInTheDocument();
     });
 
     it("should render when [showIcons=false]", () => {
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ pathname: `/refs/${reference.id}/settings` }]}>
-                <ReferenceDetailHeader {...props} />
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<ReferenceDetailHeader {...props} />, [{ pathname: `/refs/${reference.id}/manage` }]);
 
         expect(screen.queryByLabelText("lock")).toBeNull();
         expect(screen.queryByRole("button")).toBeNull();
@@ -58,14 +45,14 @@ describe("<ReferenceDetailHeaderIcon />", () => {
 
     it("should render when [canModify=true]", async () => {
         mockApiGetReferenceDetail(reference);
-        renderWithRouter(<ReferenceDetailHeader {...props} />, {}, history);
+        renderWithMemoryRouter(<ReferenceDetailHeader {...props} />, [{ pathname: `/refs/${reference.id}/manage` }]);
 
         expect(await screen.findByRole("button")).toBeInTheDocument();
     });
 
     it("should render when [canModify=false]", () => {
         mockAPIGetAccount(createFakeAccount({ administrator_role: null }));
-        renderWithRouter(<ReferenceDetailHeader {...props} />, {}, history);
+        renderWithMemoryRouter(<ReferenceDetailHeader {...props} />, [{ pathname: `/refs/${reference.id}/manage` }]);
 
         expect(screen.queryByRole("button")).toBeNull();
     });
@@ -73,21 +60,21 @@ describe("<ReferenceDetailHeaderIcon />", () => {
     it("should render when [isRemote=true]", async () => {
         props.isRemote = true;
         mockAPIGetAccount(createFakeAccount({ administrator_role: AdministratorRoles.FULL }));
-        renderWithRouter(<ReferenceDetailHeader {...props} />, {}, history);
+        renderWithMemoryRouter(<ReferenceDetailHeader {...props} />, [{ pathname: `/refs/${reference.id}/manage` }]);
 
         expect(await screen.findByLabelText("lock")).toBeInTheDocument();
     });
 
     it("should render when [isRemote=false]", () => {
         mockAPIGetAccount(createFakeAccount({ administrator_role: AdministratorRoles.FULL }));
-        renderWithRouter(<ReferenceDetailHeader {...props} />, {}, history);
+        renderWithMemoryRouter(<ReferenceDetailHeader {...props} />, [{ pathname: `/refs/${reference.id}/manage` }]);
 
         expect(screen.queryByLabelText("lock")).toBeNull();
     });
 
     it("should render when [both canModify=false, isRemote=false]", () => {
         mockAPIGetAccount(createFakeAccount({ administrator_role: null }));
-        renderWithRouter(<ReferenceDetailHeader {...props} />, {}, history);
+        renderWithMemoryRouter(<ReferenceDetailHeader {...props} />, [{ pathname: `/refs/${reference.id}/manage` }]);
 
         expect(screen.queryByLabelText("lock")).toBeNull();
         expect(screen.queryByRole("button")).toBeNull();

--- a/src/js/references/components/Detail/__tests__/ReferenceManager.test.tsx
+++ b/src/js/references/components/Detail/__tests__/ReferenceManager.test.tsx
@@ -1,15 +1,13 @@
 import { screen } from "@testing-library/react";
-import { createBrowserHistory } from "history";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createFakeReference, mockApiGetReferenceDetail } from "../../../../../tests/fake/references";
-import { renderWithRouter } from "../../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../../tests/setupTests";
 import ReferenceManager from "../ReferenceManager";
 
 describe("<ReferenceManager />", () => {
     let props;
     let reference;
-    let history;
 
     beforeEach(() => {
         reference = createFakeReference();
@@ -17,11 +15,10 @@ describe("<ReferenceManager />", () => {
         props = {
             match: { params: { refId: reference.id } },
         };
-        history = createBrowserHistory();
     });
 
     it("should render properly", async () => {
-        renderWithRouter(<ReferenceManager {...props} />, {}, history);
+        renderWithMemoryRouter(<ReferenceManager {...props} />);
 
         expect(await screen.findByText("General")).toBeInTheDocument();
         expect(screen.getByText("Description")).toBeInTheDocument();
@@ -34,14 +31,14 @@ describe("<ReferenceManager />", () => {
     });
 
     it("should render when [remotes_from=null]", async () => {
-        renderWithRouter(<ReferenceManager {...props} />, {}, history);
+        renderWithMemoryRouter(<ReferenceManager {...props} />);
 
         expect(await screen.findByText("General")).toBeInTheDocument();
         expect(screen.queryByText("Remote Reference")).toBeNull();
     });
 
     it("should render when [cloned_from={ Bar: 'Bee' }]", async () => {
-        renderWithRouter(<ReferenceManager {...props} />, {}, history);
+        renderWithMemoryRouter(<ReferenceManager {...props} />);
 
         expect(await screen.findByText("Clone Reference")).toBeInTheDocument();
         expect(screen.getByText("Source Reference"));

--- a/src/js/references/components/Detail/__tests__/RemoveReference.test.tsx
+++ b/src/js/references/components/Detail/__tests__/RemoveReference.test.tsx
@@ -1,6 +1,5 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createMemoryHistory } from "history";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createFakeAccount, mockAPIGetAccount } from "../../../../../tests/fake/account";
@@ -9,14 +8,13 @@ import {
     mockApiGetReferenceDetail,
     mockApiRemoveReference,
 } from "../../../../../tests/fake/references";
-import { renderWithRouter } from "../../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../../tests/setupTests";
 import { AdministratorRoles } from "../../../../administration/types";
 import RemoveReference from "../RemoveReference";
 
 describe("<RemoveReference />", () => {
     let props;
     let reference;
-    let history;
 
     beforeEach(() => {
         reference = createFakeReference();
@@ -25,19 +23,18 @@ describe("<RemoveReference />", () => {
             id: reference.id,
             onConfirm: vi.fn(),
         };
-        history = createMemoryHistory();
     });
 
     it("should render when user has permission", async () => {
         mockAPIGetAccount(createFakeAccount({ administrator_role: AdministratorRoles.FULL }));
-        renderWithRouter(<RemoveReference {...props} />, {}, history);
+        renderWithMemoryRouter(<RemoveReference {...props} />);
 
         expect(await screen.findByText("Permanently delete this reference")).toBeInTheDocument();
     });
 
     it("should not render when user does not have permission", () => {
         mockAPIGetAccount(createFakeAccount({ administrator_role: null }));
-        renderWithRouter(<RemoveReference {...props} />, {}, history);
+        renderWithMemoryRouter(<RemoveReference {...props} />);
 
         expect(screen.queryByText("Permanently delete this reference")).toBeNull();
     });
@@ -45,7 +42,7 @@ describe("<RemoveReference />", () => {
     it("should call onConfirm() when confirmed", async () => {
         mockAPIGetAccount(createFakeAccount({ administrator_role: AdministratorRoles.FULL }));
         const scope = mockApiRemoveReference(reference.id);
-        renderWithRouter(<RemoveReference {...props} />, {}, history);
+        renderWithMemoryRouter(<RemoveReference {...props} />);
 
         expect(await screen.findByText("Permanently delete this reference")).toBeInTheDocument();
         await userEvent.click(screen.getByRole("button"));

--- a/src/js/references/components/Item/__tests__/ReferenceItem.test.tsx
+++ b/src/js/references/components/Item/__tests__/ReferenceItem.test.tsx
@@ -1,21 +1,18 @@
 import { screen } from "@testing-library/react";
-import { createBrowserHistory } from "history";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createFakeReferenceMinimal } from "../../../../../tests/fake/references";
-import { renderWithRouter } from "../../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../../tests/setupTests";
 import { ReferenceItem } from "../ReferenceItem";
 
 describe("<ReferenceItem />", () => {
     let props;
-    let history;
 
     beforeEach(() => {
         props = {
             reference: {},
             task: {},
         };
-        history = createBrowserHistory();
     });
 
     it("should render when [organism='virus'] and [progress=32]", () => {
@@ -31,7 +28,7 @@ describe("<ReferenceItem />", () => {
             },
             organism: "virus",
         });
-        renderWithRouter(<ReferenceItem {...props} />, {}, history);
+        renderWithMemoryRouter(<ReferenceItem {...props} />);
 
         expect(screen.getByText(/virus/)).toBeInTheDocument();
         expect(screen.getByRole("progressbar")).toHaveAttribute("data-value", "32");
@@ -50,7 +47,7 @@ describe("<ReferenceItem />", () => {
             },
             organism: null,
         });
-        renderWithRouter(<ReferenceItem {...props} />, {}, history);
+        renderWithMemoryRouter(<ReferenceItem {...props} />);
 
         expect(screen.getByText(/unknown/)).toBeInTheDocument();
     });
@@ -68,7 +65,7 @@ describe("<ReferenceItem />", () => {
             },
             organism: null,
         });
-        renderWithRouter(<ReferenceItem {...props} />, {}, history);
+        renderWithMemoryRouter(<ReferenceItem {...props} />);
 
         expect(screen.queryByRole("progressbar")).toBeNull();
         expect(screen.getByLabelText("clone")).toBeInTheDocument();

--- a/src/js/references/components/__tests__/ReferenceList.test.tsx
+++ b/src/js/references/components/__tests__/ReferenceList.test.tsx
@@ -17,7 +17,6 @@ import ReferenceList from "../ReferenceList";
 describe("<ReferenceList />", () => {
     let history;
     let references;
-    let state;
 
     beforeEach(() => {
         references = createFakeReferenceMinimal();
@@ -28,7 +27,7 @@ describe("<ReferenceList />", () => {
 
     it("should render correctly", async () => {
         const scope = mockApiGetReferences([references]);
-        renderWithRouter(<ReferenceList />, state, history);
+        renderWithRouter(<ReferenceList />, {}, history);
 
         expect(await screen.findByText("References")).toBeInTheDocument();
         expect(screen.getByText(references.name)).toBeInTheDocument();
@@ -42,7 +41,7 @@ describe("<ReferenceList />", () => {
     describe("<ReferenceToolbar />", () => {
         it("should render when toolbar term is changed to foo", async () => {
             const scope = mockApiGetReferences([references]);
-            renderWithRouter(<ReferenceList />, state, history);
+            renderWithRouter(<ReferenceList />, {}, history);
 
             expect(await screen.findByText("References")).toBeInTheDocument();
 
@@ -61,7 +60,7 @@ describe("<ReferenceList />", () => {
             const account = createFakeAccount({ permissions: permissions });
             mockAPIGetAccount(account);
             const scope = mockApiGetReferences([references]);
-            renderWithRouter(<ReferenceList />, state, history);
+            renderWithRouter(<ReferenceList />, {}, history);
 
             expect(await screen.findByText("References")).toBeInTheDocument();
             expect(screen.queryByLabelText("plus-square fa-fw")).toBeNull();
@@ -74,7 +73,7 @@ describe("<ReferenceList />", () => {
             const account = createFakeAccount({ permissions: permissions });
             mockAPIGetAccount(account);
             const scope = mockApiGetReferences([references]);
-            renderWithRouter(<ReferenceList />, state, history);
+            renderWithRouter(<ReferenceList />, {}, history);
 
             expect(await screen.findByLabelText("plus-square fa-fw")).toBeInTheDocument();
 
@@ -82,7 +81,7 @@ describe("<ReferenceList />", () => {
         });
         it("should handle toolbar updates correctly", async () => {
             const scope = mockApiGetReferences([references]);
-            renderWithRouter(<ReferenceList />, state, history);
+            renderWithRouter(<ReferenceList />, {}, history);
 
             expect(await screen.findByText("References")).toBeInTheDocument();
 
@@ -106,7 +105,7 @@ describe("<ReferenceList />", () => {
                 `Cloned from ${references.name}`,
                 references,
             );
-            renderWithRouter(<ReferenceList />, state, history);
+            renderWithRouter(<ReferenceList />, {}, history);
 
             expect(await screen.findByText("References")).toBeInTheDocument();
             await userEvent.click(screen.getByRole("link", { name: "clone" }));
@@ -120,7 +119,7 @@ describe("<ReferenceList />", () => {
         it("handleSubmit() should mutate with changed input", async () => {
             const getReferencesScope = mockApiGetReferences([references]);
             const cloneReferenceScope = mockApiCloneReference("newName", `Cloned from ${references.name}`, references);
-            renderWithRouter(<ReferenceList />, state, history);
+            renderWithRouter(<ReferenceList />, {}, history);
 
             expect(await screen.findByText("References")).toBeInTheDocument();
             await userEvent.click(screen.getByRole("link", { name: "clone" }));
@@ -135,7 +134,7 @@ describe("<ReferenceList />", () => {
 
         it("should display an error when name input is cleared", async () => {
             const scope = mockApiGetReferences([references]);
-            renderWithRouter(<ReferenceList />, state, history);
+            renderWithRouter(<ReferenceList />, {}, history);
 
             expect(await screen.findByText("References")).toBeInTheDocument();
             await userEvent.click(screen.getByRole("link", { name: "clone" }));

--- a/src/js/samples/components/Detail/__tests__/RemoveSample.test.tsx
+++ b/src/js/samples/components/Detail/__tests__/RemoveSample.test.tsx
@@ -1,33 +1,23 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createBrowserHistory } from "history";
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it } from "vitest";
 import { mockApiRemoveSample } from "../../../../../tests/fake/samples";
-import { renderWithRouter } from "../../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../../tests/setupTests";
 import RemoveSample from "../RemoveSample";
 
 describe("<RemoveSample />", () => {
     let props;
-    let history;
 
     beforeEach(() => {
         props = {
             id: "foo",
             name: "test",
         };
-        history = createBrowserHistory();
     });
 
     it("renders when [show=true]", () => {
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { removeSample: true } }]}>
-                <RemoveSample {...props} />
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<RemoveSample {...props} />, [{ state: { removeSample: true } }]);
 
         expect(screen.getByText("Remove Sample")).toBeInTheDocument();
         expect(screen.getByText("test")).toBeInTheDocument();
@@ -35,13 +25,7 @@ describe("<RemoveSample />", () => {
     });
 
     it("renders when [show=false]", () => {
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { removeSample: false } }]}>
-                <RemoveSample {...props} />
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<RemoveSample {...props} />, [{ state: { removeSample: false } }]);
 
         expect(screen.queryByText("Remove Sample")).toBeNull();
         expect(screen.queryByText("test")).toBeNull();
@@ -50,13 +34,7 @@ describe("<RemoveSample />", () => {
 
     it("should handle submit when onConfirm() on RemoveDialog is called", async () => {
         const scope = mockApiRemoveSample(props.id);
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { removeSample: true } }]}>
-                <RemoveSample {...props} />
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<RemoveSample {...props} />, [{ state: { removeSample: true } }]);
 
         await userEvent.click(screen.getByRole("button"));
 

--- a/src/js/samples/components/Detail/__tests__/SampleDetailGeneral.test.tsx
+++ b/src/js/samples/components/Detail/__tests__/SampleDetailGeneral.test.tsx
@@ -1,15 +1,13 @@
 import { screen } from "@testing-library/react";
-import { createBrowserHistory } from "history";
 import numbro from "numbro";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createFakeSample, mockApiGetSampleDetail } from "../../../../../tests/fake/samples";
-import { renderWithRouter } from "../../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../../tests/setupTests";
 import SampleDetailGeneral from "../SampleDetailGeneral";
 
 describe("<SampleDetailGeneral />", () => {
     let props;
-    let history;
     let sample;
 
     beforeEach(() => {
@@ -17,12 +15,11 @@ describe("<SampleDetailGeneral />", () => {
         props = {
             match: { params: { sampleId: sample.id } },
         };
-        history = createBrowserHistory();
     });
 
     it("should render properly", async () => {
         const scope = mockApiGetSampleDetail(sample);
-        renderWithRouter(<SampleDetailGeneral {...props} />, {}, history);
+        renderWithMemoryRouter(<SampleDetailGeneral {...props} />);
 
         expect(await screen.findByText("Metadata")).toBeInTheDocument();
 
@@ -55,7 +52,7 @@ describe("<SampleDetailGeneral />", () => {
 
     it("should render with [paired=true]", async () => {
         const scope = mockApiGetSampleDetail(sample);
-        renderWithRouter(<SampleDetailGeneral {...props} />, {}, history);
+        renderWithMemoryRouter(<SampleDetailGeneral {...props} />);
 
         expect(await screen.findByText("Paired")).toBeInTheDocument();
         expect(screen.getByText("Yes")).toBeInTheDocument();
@@ -67,7 +64,7 @@ describe("<SampleDetailGeneral />", () => {
         sample = createFakeSample({ paired: false });
         props.match.params.sampleId = sample.id;
         const scope = mockApiGetSampleDetail(sample);
-        renderWithRouter(<SampleDetailGeneral {...props} />, {}, history);
+        renderWithMemoryRouter(<SampleDetailGeneral {...props} />);
 
         expect(await screen.findByText("Paired")).toBeInTheDocument();
         expect(screen.getByText("No")).toBeInTheDocument();

--- a/src/js/samples/components/Detail/__tests__/SampleRights.test.tsx
+++ b/src/js/samples/components/Detail/__tests__/SampleRights.test.tsx
@@ -1,13 +1,12 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createBrowserHistory } from "history";
 import nock from "nock";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createFakeAccount, mockAPIGetAccount } from "../../../../../tests/fake/account";
 import { createFakeGroup, mockApiListGroups } from "../../../../../tests/fake/groups";
 import { createFakeSample, mockApiGetSampleDetail, mockApiUpdateSampleRights } from "../../../../../tests/fake/samples";
-import { renderWithRouter } from "../../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../../tests/setupTests";
 import { AdministratorRoles } from "../../../../administration/types";
 import SampleRights from "../SampleRights";
 
@@ -15,7 +14,6 @@ describe("<SampleRights />", () => {
     let sample;
     let group;
     let props;
-    let history;
 
     beforeEach(() => {
         sample = createFakeSample({ all_read: false, all_write: false, group_read: false, group_write: false });
@@ -25,14 +23,13 @@ describe("<SampleRights />", () => {
         props = {
             match: { params: { sampleId: sample.id } },
         };
-        history = createBrowserHistory();
     });
 
     afterEach(() => nock.cleanAll());
 
     it("should render", async () => {
         mockAPIGetAccount(createFakeAccount({ administrator_role: AdministratorRoles.FULL }));
-        renderWithRouter(<SampleRights {...props} />, {}, history);
+        renderWithMemoryRouter(<SampleRights {...props} />);
 
         expect(await screen.findByText("Sample Rights")).toBeInTheDocument();
         expect(screen.getByText("Group")).toBeInTheDocument();
@@ -42,7 +39,7 @@ describe("<SampleRights />", () => {
 
     it("should return Not allowed panel when[this.props.canModifyRights=false]", async () => {
         mockAPIGetAccount(createFakeAccount({ administrator_role: null }));
-        renderWithRouter(<SampleRights {...props} />, {}, history);
+        renderWithMemoryRouter(<SampleRights {...props} />);
 
         expect(await screen.findByText("Not allowed")).toBeInTheDocument();
     });
@@ -50,7 +47,7 @@ describe("<SampleRights />", () => {
     it("should handle group change when input is changed", async () => {
         mockAPIGetAccount(createFakeAccount({ administrator_role: AdministratorRoles.FULL }));
         const scope = mockApiUpdateSampleRights(sample, { group: group.id });
-        renderWithRouter(<SampleRights {...props} />, {}, history);
+        renderWithMemoryRouter(<SampleRights {...props} />);
 
         expect(await screen.findByText("Sample Rights")).toBeInTheDocument();
         await userEvent.selectOptions(screen.getByLabelText("Group"), group.name);
@@ -61,7 +58,7 @@ describe("<SampleRights />", () => {
     it("should handle group rights change when input is changed", async () => {
         mockAPIGetAccount(createFakeAccount({ administrator_role: AdministratorRoles.FULL }));
         const scope = mockApiUpdateSampleRights(sample, { group_read: true, group_write: true });
-        renderWithRouter(<SampleRights {...props} />, {}, history);
+        renderWithMemoryRouter(<SampleRights {...props} />);
 
         expect(await screen.findByText("Sample Rights")).toBeInTheDocument();
         await userEvent.selectOptions(screen.getByLabelText("Group Rights"), "rw");
@@ -72,7 +69,7 @@ describe("<SampleRights />", () => {
     it("should handle all users' rights change when input is changed", async () => {
         mockAPIGetAccount(createFakeAccount({ administrator_role: AdministratorRoles.FULL }));
         const scope = mockApiUpdateSampleRights(sample, { all_read: true, all_write: true });
-        renderWithRouter(<SampleRights {...props} />, {}, history);
+        renderWithMemoryRouter(<SampleRights {...props} />);
 
         expect(await screen.findByText("Sample Rights")).toBeInTheDocument();
         await userEvent.selectOptions(screen.getByLabelText("All Users' Rights"), "rw");

--- a/src/js/samples/components/Sidebar/__tests__/ManageLabels.test.tsx
+++ b/src/js/samples/components/Sidebar/__tests__/ManageLabels.test.tsx
@@ -1,16 +1,13 @@
 import { screen, waitFor } from "@testing-library/react";
-import { createBrowserHistory } from "history";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
-import { renderWithRouter } from "../../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../../tests/setupTests";
 import ManageLabels from "../ManageLabels";
 
 describe("<ManageLabels>", () => {
     let props;
-    let history;
 
     beforeEach(() => {
-        history = createBrowserHistory();
         props = {
             documents: [],
             selectedSamples: [],
@@ -24,7 +21,7 @@ describe("<ManageLabels>", () => {
 
     it("should be disabled if no labels exist", async () => {
         props.labels = [];
-        renderWithRouter(<ManageLabels {...props} />, {}, history);
+        renderWithMemoryRouter(<ManageLabels {...props} />);
         await waitFor(() => expect(screen.queryByLabelText("loading")).not.toBeInTheDocument());
 
         expect(screen.getByText("Create one")).toBeInTheDocument();
@@ -38,7 +35,7 @@ describe("<ManageLabels>", () => {
                 labels: [{ color: "#C4B5FD", description: "", id: 1, name: "test" }],
             },
         ];
-        renderWithRouter(<ManageLabels {...props} />, {}, history);
+        renderWithMemoryRouter(<ManageLabels {...props} />);
         await waitFor(() => expect(screen.queryByLabelText("loading")).not.toBeInTheDocument());
 
         expect(screen.getByText("test")).toBeInTheDocument();
@@ -57,7 +54,7 @@ describe("<ManageLabels>", () => {
                 labels: [{ color: "#FCA5A5", description: "", id: 2, name: "label" }],
             },
         ];
-        renderWithRouter(<ManageLabels {...props} />, {}, history);
+        renderWithMemoryRouter(<ManageLabels {...props} />);
         await waitFor(() => expect(screen.queryByLabelText("loading")).not.toBeInTheDocument());
 
         expect(screen.getByText(`test`)).toBeInTheDocument();

--- a/src/js/sequences/components/__tests__/RemoveSequence.test.tsx
+++ b/src/js/sequences/components/__tests__/RemoveSequence.test.tsx
@@ -1,16 +1,13 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createBrowserHistory } from "history";
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createFakeOTUSequence, mockApiRemoveSequence } from "../../../../tests/fake/otus";
-import { renderWithRouter } from "../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../tests/setupTests";
 import RemoveSequence from "../RemoveSequence";
 
 describe("<RemoveSequence />", () => {
     let props;
-    let history;
 
     beforeEach(() => {
         props = {
@@ -19,17 +16,10 @@ describe("<RemoveSequence />", () => {
             isolateName: "baz",
             sequences: [createFakeOTUSequence()],
         };
-        history = createBrowserHistory();
     });
 
     it("should render when [show=true]", () => {
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { removeSequence: props.sequences[0].id } }]}>
-                <RemoveSequence {...props} />
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<RemoveSequence {...props} />, [{ state: { removeSequence: props.sequences[0].id } }]);
 
         expect(screen.getByText("Remove Sequence")).toBeInTheDocument();
         expect(screen.getByText(/Are you sure you want to remove the sequence/)).toBeInTheDocument();
@@ -39,13 +29,7 @@ describe("<RemoveSequence />", () => {
     });
 
     it("should render when [show=false]", () => {
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { removeSequence: "" } }]}>
-                <RemoveSequence {...props} />)
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<RemoveSequence {...props} />, [{ state: { removeSequence: "" } }]);
 
         expect(screen.queryByText("Remove Sequence")).toBeNull();
         expect(screen.queryByText(/Are you sure you want to remove the sequence from/)).toBeNull();
@@ -56,13 +40,7 @@ describe("<RemoveSequence />", () => {
 
     it("should handle submit when onConfirm() on RemoveDialog is called", async () => {
         const scope = mockApiRemoveSequence(props.otuId, props.isolateId, props.sequences[0].id);
-        renderWithRouter(
-            <MemoryRouter initialEntries={[{ state: { removeSequence: props.sequences[0].id } }]}>
-                <RemoveSequence {...props} />
-            </MemoryRouter>,
-            {},
-            history,
-        );
+        renderWithMemoryRouter(<RemoveSequence {...props} />, [{ state: { removeSequence: props.sequences[0].id } }]);
 
         await userEvent.click(screen.getByRole("button"));
 

--- a/src/js/subtraction/components/__tests__/SubtractionItem.test.tsx
+++ b/src/js/subtraction/components/__tests__/SubtractionItem.test.tsx
@@ -1,13 +1,11 @@
 import { screen } from "@testing-library/react";
-import { createBrowserHistory } from "history";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
-import { renderWithRouter } from "../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../tests/setupTests";
 import { SubtractionItem } from "../SubtractionItem";
 
 describe("<SubtractionItem />", () => {
     let props;
-    let history;
 
     beforeEach(() => {
         props = {
@@ -19,11 +17,10 @@ describe("<SubtractionItem />", () => {
             created_at: new Date().setFullYear(new Date().getFullYear() - 1),
             ready: false,
         };
-        history = createBrowserHistory();
     });
 
     it("should render", () => {
-        renderWithRouter(<SubtractionItem {...props} />, {}, history);
+        renderWithMemoryRouter(<SubtractionItem {...props} />);
         expect(screen.getByText("Foo")).toBeInTheDocument();
         expect(screen.getByText("testNickname")).toBeInTheDocument();
         expect(screen.getByRole("progressbar")).toHaveAttribute("data-value", "50");
@@ -31,13 +28,13 @@ describe("<SubtractionItem />", () => {
 
     it.each(["waiting", "running", "error"])("should render progress bar for ", state => {
         props.job.state = state;
-        renderWithRouter(<SubtractionItem {...props} />, {}, history);
+        renderWithMemoryRouter(<SubtractionItem {...props} />);
         expect(screen.getByRole("progressbar")).toBeInTheDocument();
     });
 
     it("should not render progress bar if job is ready", () => {
         props.ready = true;
-        renderWithRouter(<SubtractionItem {...props} />, {}, history);
+        renderWithMemoryRouter(<SubtractionItem {...props} />);
         expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
         expect(screen.queryByText("Complete")).not.toBeInTheDocument();
         expect(screen.getByText("user_handle created")).toBeInTheDocument();
@@ -47,6 +44,6 @@ describe("<SubtractionItem />", () => {
     it("should correctly render subtractions where jobs=null", () => {
         props.job = null;
         props.ready = false;
-        renderWithRouter(<SubtractionItem {...props} />, {}, history);
+        renderWithMemoryRouter(<SubtractionItem {...props} />);
     });
 });

--- a/src/js/subtraction/components/__tests__/SubtractionList.test.tsx
+++ b/src/js/subtraction/components/__tests__/SubtractionList.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createBrowserHistory } from "history";
+import { createMemoryHistory } from "history";
 import React from "react";
 import { describe, expect, it } from "vitest";
 import { createFakeAccount, mockAPIGetAccount } from "../../../../tests/fake/account";
@@ -15,7 +15,7 @@ describe("<SubtractionList />", () => {
 
     beforeEach(() => {
         subtractions = createFakeSubtractionMinimal();
-        history = createBrowserHistory();
+        history = createMemoryHistory();
     });
 
     it("renders correctly", async () => {

--- a/src/js/users/components/__tests__/ManageUsers.test.tsx
+++ b/src/js/users/components/__tests__/ManageUsers.test.tsx
@@ -1,21 +1,14 @@
 import { AdministratorRoles } from "@administration/types";
 import { screen } from "@testing-library/react";
-import { createBrowserHistory } from "history";
 import { forEach } from "lodash-es";
 import React from "react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createFakeAccount, mockAPIGetAccount } from "../../../../tests/fake/account";
 import { createFakeUsers, mockApiFindUsers } from "../../../../tests/fake/user";
-import { renderWithRouter } from "../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../tests/setupTests";
 import { ManageUsers } from "../ManageUsers";
 
 describe("<ManageUsers />", () => {
-    let history;
-
-    beforeEach(() => {
-        history = createBrowserHistory();
-    });
-
     it("should render correctly with 3 users", async () => {
         const users = createFakeUsers(3);
         users[0].administrator_role = AdministratorRoles.FULL;
@@ -23,7 +16,7 @@ describe("<ManageUsers />", () => {
         const account = createFakeAccount({ administrator_role: AdministratorRoles.FULL });
         mockAPIGetAccount(account);
 
-        renderWithRouter(<ManageUsers />, {}, history);
+        renderWithMemoryRouter(<ManageUsers />);
 
         expect(await screen.findByLabelText("search")).toBeInTheDocument();
         expect(screen.getByRole("button", { name: "user-plus" })).toBeInTheDocument();
@@ -37,7 +30,7 @@ describe("<ManageUsers />", () => {
         const account = createFakeAccount({ administrator_role: AdministratorRoles.FULL });
         mockAPIGetAccount(account);
 
-        renderWithRouter(<ManageUsers />, {}, history);
+        renderWithMemoryRouter(<ManageUsers />);
 
         expect(await screen.findByLabelText("search")).toBeInTheDocument();
         expect(screen.getByRole("button", { name: "user-plus" })).toBeInTheDocument();
@@ -51,7 +44,7 @@ describe("<ManageUsers />", () => {
         const account = createFakeAccount({ administrator_role: null });
         mockAPIGetAccount(account);
 
-        renderWithRouter(<ManageUsers />, {}, history);
+        renderWithMemoryRouter(<ManageUsers />);
 
         expect(await screen.findByText("You do not have permission to manage users.")).toBeInTheDocument();
         expect(screen.getByText("Contact an administrator.")).toBeInTheDocument();

--- a/src/js/users/components/__tests__/UserDetail.test.tsx
+++ b/src/js/users/components/__tests__/UserDetail.test.tsx
@@ -1,6 +1,5 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createBrowserHistory } from "history";
 import { times } from "lodash-es";
 import nock from "nock";
 import React from "react";
@@ -8,12 +7,11 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { createFakeAccount, mockAPIGetAccount } from "../../../../tests/fake/account";
 import { createFakeGroupMinimal, mockApiListGroups } from "../../../../tests/fake/groups";
 import { createFakeUser, mockApiEditUser, mockApiGetUser } from "../../../../tests/fake/user";
-import { renderWithRouter } from "../../../../tests/setupTests";
+import { renderWithMemoryRouter } from "../../../../tests/setupTests";
 import { AdministratorRoles } from "../../../administration/types";
 import UserDetail from "../UserDetail";
 
 describe("<UserDetail />", () => {
-    const history = createBrowserHistory();
     const groups = times(5, index => createFakeGroupMinimal({ name: `group${index}` }));
     const userDetail = createFakeUser({ groups });
     const account = createFakeAccount({ administrator_role: AdministratorRoles.FULL });
@@ -42,7 +40,7 @@ describe("<UserDetail />", () => {
 
             const scope = mockApiGetUser(props.match.params.userId, userDetail);
 
-            renderWithRouter(<UserDetail {...props} />, {}, history);
+            renderWithMemoryRouter(<UserDetail {...props} />);
 
             expect(await screen.findByText("Change Password")).toBeInTheDocument();
 
@@ -73,7 +71,7 @@ describe("<UserDetail />", () => {
         });
 
         it("should render loading when the user details hasn't loaded", () => {
-            renderWithRouter(<UserDetail {...props} />, {}, history);
+            renderWithMemoryRouter(<UserDetail {...props} />);
 
             expect(screen.getByLabelText("loading")).toBeInTheDocument();
             expect(screen.queryByText("Groups")).not.toBeInTheDocument();
@@ -85,7 +83,7 @@ describe("<UserDetail />", () => {
             mockAPIGetAccount(account);
             const scope = mockApiGetUser(props.match.params.userId, userDetail);
 
-            renderWithRouter(<UserDetail {...props} />, {}, history);
+            renderWithMemoryRouter(<UserDetail {...props} />);
 
             expect(await screen.findByText("Change Password")).toBeInTheDocument();
 
@@ -102,7 +100,7 @@ describe("<UserDetail />", () => {
             mockAPIGetAccount(account);
             const scope = mockApiGetUser(props.match.params.userId, userDetail);
 
-            renderWithRouter(<UserDetail {...props} />, {}, history);
+            renderWithMemoryRouter(<UserDetail {...props} />);
 
             expect(await screen.findByText("You do not have permission to manage this user.")).toBeInTheDocument();
 
@@ -121,7 +119,7 @@ describe("<UserDetail />", () => {
             mockAPIGetAccount(account);
             const scope = mockApiGetUser(props.match.params.userId, userDetail);
 
-            renderWithRouter(<UserDetail {...props} />, {}, history);
+            renderWithMemoryRouter(<UserDetail {...props} />);
 
             expect(await screen.findByText("Groups")).toBeInTheDocument();
             expect(screen.getByLabelText("group1")).toBeInTheDocument();
@@ -133,7 +131,7 @@ describe("<UserDetail />", () => {
             mockAPIGetAccount(account);
             const scope = mockApiGetUser(props.match.params.userId, userDetail);
 
-            renderWithRouter(<UserDetail {...props} />, {}, history);
+            renderWithMemoryRouter(<UserDetail {...props} />);
 
             expect(await screen.findByText("Change Password")).toBeInTheDocument();
 
@@ -154,7 +152,7 @@ describe("<UserDetail />", () => {
 
             const scope = mockApiGetUser(props.match.params.userId, userDetail);
 
-            renderWithRouter(<UserDetail {...props} />, {}, history);
+            renderWithMemoryRouter(<UserDetail {...props} />);
 
             expect(await screen.findByText("Groups")).toBeInTheDocument();
             expect(screen.getByText("No groups found")).toBeInTheDocument();
@@ -172,7 +170,7 @@ describe("<UserDetail />", () => {
             mockApiListGroups(groups);
             const scope = mockApiGetUser(props.match.params.userId, userDetail);
 
-            renderWithRouter(<UserDetail {...props} />, {}, history);
+            renderWithMemoryRouter(<UserDetail {...props} />);
 
             expect(await screen.findByText("Change Password")).toBeInTheDocument();
 
@@ -194,7 +192,7 @@ describe("<UserDetail />", () => {
 
             const scope = mockApiGetUser(props.match.params.userId, userDetail);
 
-            renderWithRouter(<UserDetail {...props} />, {}, history);
+            renderWithMemoryRouter(<UserDetail {...props} />);
 
             expect(await screen.findByText("Change Password")).toBeInTheDocument();
             expect(screen.getByText("Last changed")).toBeInTheDocument();
@@ -211,7 +209,7 @@ describe("<UserDetail />", () => {
             mockApiEditUser(props.match.params.userId, 200, { password: "newPassword" }, userDetail);
             const scope = mockApiGetUser(props.match.params.userId, userDetail);
 
-            renderWithRouter(<UserDetail {...props} />, {}, history);
+            renderWithMemoryRouter(<UserDetail {...props} />);
 
             expect(await screen.findByText("Change Password")).toBeInTheDocument();
 
@@ -230,7 +228,7 @@ describe("<UserDetail />", () => {
             });
             const scope = mockApiGetUser(props.match.params.userId, userDetail);
 
-            renderWithRouter(<UserDetail {...props} />, {}, history);
+            renderWithMemoryRouter(<UserDetail {...props} />);
 
             expect(await screen.findByText("Change Password")).toBeInTheDocument();
 
@@ -265,7 +263,7 @@ describe("<UserDetail />", () => {
 
             const scope = mockApiGetUser(props.match.params.userId, userDetail);
 
-            renderWithRouter(<UserDetail {...props} />, {}, history);
+            renderWithMemoryRouter(<UserDetail {...props} />);
 
             expect(await screen.findByText("Permissions")).toBeInTheDocument();
             expect(screen.getByText("Change group membership to modify permissions")).toBeInTheDocument();

--- a/src/tests/setupTests.jsx
+++ b/src/tests/setupTests.jsx
@@ -1,19 +1,17 @@
+import { watchRouter } from "@app/sagas";
+import { theme } from "@app/theme";
 import { configureStore } from "@reduxjs/toolkit";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "@testing-library/jest-dom";
 import { fireEvent, render as rtlRender } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ConnectedRouter, connectRouter, routerMiddleware } from "connected-react-router";
 import { noop } from "lodash-es";
 import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { combineReducers } from "redux";
 import createSagaMiddleware from "redux-saga";
 import { ThemeProvider } from "styled-components";
 import { vi } from "vitest";
-import { watchRouter } from "../js/app/sagas";
-import { theme } from "../js/app/theme";
 
 process.env.TZ = "UTC";
 
@@ -58,15 +56,11 @@ export function createGenericReducer(initState) {
 }
 
 export function createAppStore(state, history, createReducer) {
-    const reducer = createReducer
-        ? createReducer(state, history)
-        : combineReducers({
-              router: connectRouter(history),
-          });
+    const reducer = createReducer && createReducer(state, history);
     const sagaMiddleware = createSagaMiddleware();
     const store = configureStore({
         reducer: reducer,
-        middleware: [sagaMiddleware, routerMiddleware(history)],
+        middleware: [sagaMiddleware],
     });
 
     sagaMiddleware.run(watchRouter);
@@ -75,11 +69,7 @@ export function createAppStore(state, history, createReducer) {
 }
 
 export function renderWithRouter(ui, state, history, createReducer) {
-    const wrappedUI = (
-        <Provider store={createAppStore(state, history, createReducer)}>
-            <ConnectedRouter history={history}> {ui} </ConnectedRouter>
-        </Provider>
-    );
+    const wrappedUI = <Provider store={createAppStore(state, history, createReducer)}>{ui}</Provider>;
     renderWithProviders(wrappedUI);
 }
 

--- a/src/tests/setupTests.jsx
+++ b/src/tests/setupTests.jsx
@@ -8,7 +8,7 @@ import userEvent from "@testing-library/user-event";
 import { noop } from "lodash-es";
 import React from "react";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Router } from "react-router-dom";
 import createSagaMiddleware from "redux-saga";
 import { ThemeProvider } from "styled-components";
 import { vi } from "vitest";
@@ -56,7 +56,7 @@ export function createGenericReducer(initState) {
 }
 
 export function createAppStore(state, history, createReducer) {
-    const reducer = createReducer && createReducer(state, history);
+    const reducer = createReducer ? createReducer(state, history) : createGenericReducer({});
     const sagaMiddleware = createSagaMiddleware();
     const store = configureStore({
         reducer: reducer,
@@ -69,7 +69,11 @@ export function createAppStore(state, history, createReducer) {
 }
 
 export function renderWithRouter(ui, state, history, createReducer) {
-    const wrappedUI = <Provider store={createAppStore(state, history, createReducer)}>{ui}</Provider>;
+    const wrappedUI = (
+        <Provider store={createAppStore(state, history, createReducer)}>
+            <Router history={history}>{ui}</Router>
+        </Provider>
+    );
     renderWithProviders(wrappedUI);
 }
 


### PR DESCRIPTION
## Changes
<!--- Provide the broad strokes of the changes made in a bulleted list --->
- Updated majority of tests to use `renderWithMemoryRouter`
- Updated `renderWithRouter` to create a generic reducer and use `Router` instead of `connected-react-router` import
- Removed unused action types
- Uninstalled `connected-react-router`
- Removed `pushState` usages

## Compatiblity

Any changes that require a newer version of the API are considered breaking
changes.

Common breaking changes:
 - Making a request to a new API endpoint that will return `403` or `404` in older versions of the API.
 - No longer sending request fields required by previous versions of the API 
 - Requiring new fields from an API endpoint that will not be present in
   responses from older versions of the API
 - Breaking backwards compatibility with old response data shapes


Choose one:
 - [x] The changes do not break compatibility
 - [ ] The changes potentially break compatibility


## Pre-Review Checklist
 - [x] All changes are tested
 - [x] All touched code documentation is updated
 - [x] All tests pass in your local environment
 - [x] Deepsource issues have been reviewed and addressed
 - [x] Debugging logging and commented out code has been removed

 
## Screenshots:
_Only required for visual changes_.

