### PR TITLE
fix: hide reference clone button if user does not have create_ref permissions

### DIFF
--- a/src/js/references/components/Item/ReferenceItem.tsx
+++ b/src/js/references/components/Item/ReferenceItem.tsx
@@ -1,3 +1,5 @@
+import { useCheckAdminRoleOrPermission } from "@/administration/hooks";
+import { Permission } from "@/groups/types";
 import React from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
@@ -48,6 +50,17 @@ type ReferenceItemProps = {
  */
 export function ReferenceItem({ reference }: ReferenceItemProps) {
     const { id, data_type, name, organism, user, created_at, task } = reference;
+    const { hasPermission: canCreate } = useCheckAdminRoleOrPermission(Permission.create_ref);
+
+    const cloneButton = canCreate ? (
+        <IconLink
+            to={{ state: { cloneReference: true, id } }}
+            name="clone"
+            tip="Clone"
+            color="blue"
+            aria-label="clone"
+        />
+    ) : null;
 
     return (
         <StyledReferenceItem>
@@ -63,13 +76,7 @@ export function ReferenceItem({ reference }: ReferenceItemProps) {
                 {task && !task.complete ? (
                     <ProgressCircle progress={task.progress || 0} state={task.complete ? "complete" : "running"} />
                 ) : (
-                    <IconLink
-                        to={{ state: { cloneReference: true, id } }}
-                        name="clone"
-                        tip="Clone"
-                        color="blue"
-                        aria-label="clone"
-                    />
+                    cloneButton
                 )}
             </ReferenceItemEndIcon>
         </StyledReferenceItem>

--- a/src/js/references/components/Item/__tests__/ReferenceItem.test.tsx
+++ b/src/js/references/components/Item/__tests__/ReferenceItem.test.tsx
@@ -71,6 +71,5 @@ describe("<ReferenceItem />", () => {
         renderWithRouter(<ReferenceItem {...props} />, {}, history);
 
         expect(screen.queryByRole("progressbar")).toBeNull();
-        expect(screen.getByLabelText("clone")).toBeInTheDocument();
     });
 });

--- a/src/js/references/components/__tests__/ReferenceList.test.tsx
+++ b/src/js/references/components/__tests__/ReferenceList.test.tsx
@@ -27,6 +27,9 @@ describe("<ReferenceList />", () => {
     afterEach(() => nock.cleanAll());
 
     it("should render correctly", async () => {
+        const permissions = createFakePermissions({ create_ref: true });
+        const account = createFakeAccount({ permissions: permissions });
+        mockAPIGetAccount(account);
         const scope = mockApiGetReferences([references]);
         renderWithRouter(<ReferenceList />, state, history);
 
@@ -34,6 +37,8 @@ describe("<ReferenceList />", () => {
         expect(screen.getByText(references.name)).toBeInTheDocument();
         expect(screen.getByText(`${references.user.handle} created`)).toBeInTheDocument();
         expect(screen.getByText(`${references.organism} ${references.data_type}s`)).toBeInTheDocument();
+
+        expect(await screen.findByRole("link", { name: "clone" })).toBeInTheDocument();
         expect(screen.getByLabelText("clone")).toBeInTheDocument();
 
         scope.done();
@@ -113,8 +118,8 @@ describe("<ReferenceList />", () => {
             renderWithRouter(<ReferenceList />, state, history);
 
             expect(await screen.findByText("References")).toBeInTheDocument();
+            expect(await screen.findByRole("link", { name: "clone" })).toBeInTheDocument();
             await userEvent.click(screen.getByRole("link", { name: "clone" }));
-
             await userEvent.click(screen.getByRole("button", { name: "Clone" }));
 
             getReferencesScope.done();
@@ -130,8 +135,8 @@ describe("<ReferenceList />", () => {
             renderWithRouter(<ReferenceList />, state, history);
 
             expect(await screen.findByText("References")).toBeInTheDocument();
+            expect(await screen.findByRole("link", { name: "clone" })).toBeInTheDocument();
             await userEvent.click(screen.getByRole("link", { name: "clone" }));
-
             await userEvent.clear(screen.getByRole("textbox"));
             await userEvent.type(screen.getByRole("textbox"), "newName");
             await userEvent.click(screen.getByRole("button", { name: "Clone" }));
@@ -148,11 +153,10 @@ describe("<ReferenceList />", () => {
             renderWithRouter(<ReferenceList />, state, history);
 
             expect(await screen.findByText("References")).toBeInTheDocument();
+            expect(await screen.findByRole("link", { name: "clone" })).toBeInTheDocument();
             await userEvent.click(screen.getByRole("link", { name: "clone" }));
-
-            await userEvent.clear(screen.getByRole("textbox"));
             await userEvent.click(screen.getByRole("button", { name: "Clone" }));
-
+            await userEvent.clear(screen.getByRole("textbox"));
             expect(screen.getByText("Required Field")).toBeInTheDocument();
 
             scope.done();

--- a/src/js/references/components/__tests__/ReferenceList.test.tsx
+++ b/src/js/references/components/__tests__/ReferenceList.test.tsx
@@ -80,6 +80,7 @@ describe("<ReferenceList />", () => {
 
             scope.done();
         });
+
         it("should handle toolbar updates correctly", async () => {
             const scope = mockApiGetReferences([references]);
             renderWithRouter(<ReferenceList />, state, history);
@@ -100,6 +101,9 @@ describe("<ReferenceList />", () => {
 
     describe("<CloneReference />", () => {
         it("handleSubmit() should mutate with correct input", async () => {
+            const permissions = createFakePermissions({ create_ref: true });
+            const account = createFakeAccount({ permissions: permissions });
+            mockAPIGetAccount(account);
             const getReferencesScope = mockApiGetReferences([references]);
             const cloneReferenceScope = mockApiCloneReference(
                 `Clone of ${references.name}`,
@@ -118,6 +122,9 @@ describe("<ReferenceList />", () => {
         });
 
         it("handleSubmit() should mutate with changed input", async () => {
+            const permissions = createFakePermissions({ create_ref: true });
+            const account = createFakeAccount({ permissions: permissions });
+            mockAPIGetAccount(account);
             const getReferencesScope = mockApiGetReferences([references]);
             const cloneReferenceScope = mockApiCloneReference("newName", `Cloned from ${references.name}`, references);
             renderWithRouter(<ReferenceList />, state, history);
@@ -134,6 +141,9 @@ describe("<ReferenceList />", () => {
         });
 
         it("should display an error when name input is cleared", async () => {
+            const permissions = createFakePermissions({ create_ref: true });
+            const account = createFakeAccount({ permissions: permissions });
+            mockAPIGetAccount(account);
             const scope = mockApiGetReferences([references]);
             renderWithRouter(<ReferenceList />, state, history);
 

--- a/src/js/references/components/__tests__/ReferenceList.test.tsx
+++ b/src/js/references/components/__tests__/ReferenceList.test.tsx
@@ -62,6 +62,9 @@ describe("<ReferenceList />", () => {
         });
 
         it("should not render creation button when [canCreate=false]", async () => {
+            const permissions = createFakePermissions({ create_ref: false });
+            const account = createFakeAccount({ permissions: permissions });
+            mockAPIGetAccount(account);
             const scope = mockApiGetReferences([references]);
             renderWithRouter(<ReferenceList />, state, history);
 

--- a/src/js/references/components/__tests__/ReferenceList.test.tsx
+++ b/src/js/references/components/__tests__/ReferenceList.test.tsx
@@ -115,8 +115,7 @@ describe("<ReferenceList />", () => {
             renderWithRouter(<ReferenceList />, state, history);
 
             expect(await screen.findByText("References")).toBeInTheDocument();
-            expect(await screen.findByRole("link", { name: "clone" })).toBeInTheDocument();
-            await userEvent.click(screen.getByRole("link", { name: "clone" }));
+            await userEvent.click(await screen.findByRole("link", { name: "clone" }));
             await userEvent.click(screen.getByRole("button", { name: "Clone" }));
 
             getReferencesScope.done();
@@ -132,8 +131,7 @@ describe("<ReferenceList />", () => {
             renderWithRouter(<ReferenceList />, state, history);
 
             expect(await screen.findByText("References")).toBeInTheDocument();
-            expect(await screen.findByRole("link", { name: "clone" })).toBeInTheDocument();
-            await userEvent.click(screen.getByRole("link", { name: "clone" }));
+            await userEvent.click(await screen.findByRole("link", { name: "clone" }));
             await userEvent.clear(screen.getByRole("textbox"));
             await userEvent.type(screen.getByRole("textbox"), "newName");
             await userEvent.click(screen.getByRole("button", { name: "Clone" }));
@@ -150,8 +148,7 @@ describe("<ReferenceList />", () => {
             renderWithRouter(<ReferenceList />, state, history);
 
             expect(await screen.findByText("References")).toBeInTheDocument();
-            expect(await screen.findByRole("link", { name: "clone" })).toBeInTheDocument();
-            await userEvent.click(screen.getByRole("link", { name: "clone" }));
+            await userEvent.click(await screen.findByRole("link", { name: "clone" }));
             await userEvent.click(screen.getByRole("button", { name: "Clone" }));
             await userEvent.clear(screen.getByRole("textbox"));
             expect(screen.getByText("Required Field")).toBeInTheDocument();

--- a/src/js/references/components/__tests__/ReferenceList.test.tsx
+++ b/src/js/references/components/__tests__/ReferenceList.test.tsx
@@ -71,18 +71,6 @@ describe("<ReferenceList />", () => {
             scope.done();
         });
 
-        it("should not render creation button when [canCreate=true]", async () => {
-            const permissions = createFakePermissions({ create_ref: true });
-            const account = createFakeAccount({ permissions: permissions });
-            mockAPIGetAccount(account);
-            const scope = mockApiGetReferences([references]);
-            renderWithRouter(<ReferenceList />, state, history);
-
-            expect(await screen.findByLabelText("plus-square fa-fw")).toBeInTheDocument();
-
-            scope.done();
-        });
-
         it("should handle toolbar updates correctly", async () => {
             const scope = mockApiGetReferences([references]);
             renderWithRouter(<ReferenceList />, state, history);

--- a/src/js/references/components/__tests__/ReferenceList.test.tsx
+++ b/src/js/references/components/__tests__/ReferenceList.test.tsx
@@ -149,8 +149,8 @@ describe("<ReferenceList />", () => {
 
             expect(await screen.findByText("References")).toBeInTheDocument();
             await userEvent.click(await screen.findByRole("link", { name: "clone" }));
-            await userEvent.click(screen.getByRole("button", { name: "Clone" }));
             await userEvent.clear(screen.getByRole("textbox"));
+            await userEvent.click(screen.getByRole("button", { name: "Clone" }));
             expect(screen.getByText("Required Field")).toBeInTheDocument();
 
             scope.done();

--- a/src/js/references/components/__tests__/ReferenceList.test.tsx
+++ b/src/js/references/components/__tests__/ReferenceList.test.tsx
@@ -62,9 +62,6 @@ describe("<ReferenceList />", () => {
         });
 
         it("should not render creation button when [canCreate=false]", async () => {
-            const permissions = createFakePermissions({ create_ref: true });
-            const account = createFakeAccount({ permissions: permissions });
-            mockAPIGetAccount(account);
             const scope = mockApiGetReferences([references]);
             renderWithRouter(<ReferenceList />, state, history);
 


### PR DESCRIPTION
## Changes
<!--- Provide the broad strokes of the changes made in a bulleted list --->

## Compatiblity

Any changes that require a newer version of the API are considered breaking
changes.

Common breaking changes:
 - Making a request to a new API endpoint that will return `403` or `404` in older versions of the API.
 - No longer sending request fields required by previous versions of the API 
 - Requiring new fields from an API endpoint that will not be present in
   responses from older versions of the API
 - Breaking backwards compatibility with old response data shapes


Choose one:
 - [ ] The changes do not break compatibility
 - [ ] The changes potentially break compatibility


## Pre-Review Checklist
 - [ ] All changes are tested
 - [ ] All touched code documentation is updated
 - [ ] All tests pass in your local environment
 - [ ] Deepsource issues have been reviewed and addressed
 - [ ] Debugging logging and commented out code has been removed

 
## Screenshots:
_Only required for visual changes_.

