### PR TITLE
fix: progress circle for reference creation/cloning

### DIFF
--- a/src/js/app/websocket/updaters.ts
+++ b/src/js/app/websocket/updaters.ts
@@ -31,7 +31,8 @@ type Document = { items: TaskObject[] } | { documents: TaskObject[] };
  */
 function infiniteListItemUpdater<T extends Document>(task: Task, selector: (cache: TaskObject) => Task) {
     return function (cache: InfiniteData<T>): InfiniteData<T> {
-        forEach(cache.pages, (page: T) => {
+        const newCache = cloneDeep(cache);
+        forEach(newCache.pages, (page: T) => {
             const items = "items" in page ? page.items : page.documents;
             forEach(items, (item: { task: Task }) => {
                 const previousTask = selector(item);
@@ -41,7 +42,7 @@ function infiniteListItemUpdater<T extends Document>(task: Task, selector: (cach
             });
         });
 
-        return cache;
+        return newCache;
     };
 }
 


### PR DESCRIPTION
## Changes
<!--- Provide the broad strokes of the changes made in a bulleted list --->

## Compatiblity

Any changes that require a newer version of the API are considered breaking
changes.

Common breaking changes:
 - Making a request to a new API endpoint that will return `403` or `404` in older versions of the API.
 - No longer sending request fields required by previous versions of the API 
 - Requiring new fields from an API endpoint that will not be present in
   responses from older versions of the API
 - Breaking backwards compatibility with old response data shapes


Choose one:
 - [x] The changes do not break compatibility
 - [ ] The changes potentially break compatibility


## Pre-Review Checklist
 - [x] All changes are tested
 - [x] All touched code documentation is updated
 - [x] All tests pass in your local environment
 - [x] Deepsource issues have been reviewed and addressed
 - [x] Debugging logging and commented out code has been removed

 
## Screenshots:
_Only required for visual changes_.

