### PR TITLE
fix: prevent jumping effect in references page

### DIFF
--- a/src/js/indexes/components/RebuildIndex.tsx
+++ b/src/js/indexes/components/RebuildIndex.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, DialogContent, DialogFooter, DialogOverlay, DialogTitle, LoadingPlaceholder } from "@base";
+import { Button, Dialog, DialogContent, DialogFooter, DialogOverlay, DialogTitle } from "@base";
 import { useCreateIndex, useFetchUnbuiltChanges } from "@indexes/queries";
 import { DialogPortal } from "@radix-ui/react-dialog";
 import React from "react";
@@ -20,7 +20,7 @@ export default function RebuildIndex({ refId }: RebuildIndexProps) {
     const mutation = useCreateIndex();
 
     if (isLoading) {
-        return <LoadingPlaceholder />;
+        return null;
     }
 
     function handleSubmit(e) {


### PR DESCRIPTION
## Changes
<!--- Provide the broad strokes of the changes made in a bulleted list --->

## Compatiblity

Any changes that require a newer version of the API are considered breaking
changes.

Common breaking changes:
 - Making a request to a new API endpoint that will return `403` or `404` in older versions of the API.
 - No longer sending request fields required by previous versions of the API 
 - Requiring new fields from an API endpoint that will not be present in
   responses from older versions of the API
 - Breaking backwards compatibility with old response data shapes


Choose one:
 - [x] The changes do not break compatibility
 - [ ] The changes potentially break compatibility


## Pre-Review Checklist
 - [x] All changes are tested
 - [x] All touched code documentation is updated
 - [x] All tests pass in your local environment
 - [x] Deepsource issues have been reviewed and addressed
 - [x] Debugging logging and commented out code has been removed

 
## Screenshots:
_Only required for visual changes_.

