### PR TITLE
fix: restore editing of non-first isolates in state

### DIFF
--- a/src/js/base/IconLink.tsx
+++ b/src/js/base/IconLink.tsx
@@ -7,14 +7,15 @@ type IconLinkProps = {
     className?: string;
     color?: VTColor;
     name: string;
+    onClick?: () => void;
     replace?: boolean;
     tip?: string;
-    to: string | object;
+    to?: string | object;
 };
 
-export function IconLink({ className, color, name, replace, tip, to, ...props }: IconLinkProps) {
+export function IconLink({ className, color, name, onClick, replace, tip, to, ...props }: IconLinkProps) {
     return (
-        <Link className={className} replace={replace} to={to} aria-label={props["aria-label"]}>
+        <Link className={className} replace={replace} to={to} onClick={onClick} aria-label={props["aria-label"]}>
             <Icon color={color} name={name} tip={tip} hoverable />
         </Link>
     );

--- a/src/js/otus/components/Detail/Isolates/IsolateEditor.tsx
+++ b/src/js/otus/components/Detail/Isolates/IsolateEditor.tsx
@@ -2,9 +2,10 @@ import { Badge, Box, BoxGroup, NoneFoundBox, SubviewHeader, SubviewHeaderTitle }
 import { getFontSize, getFontWeight } from "@app/theme";
 import { useCurrentOTUContext } from "@otus/queries";
 import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
+import { useLocationState } from "@utils/hooks";
 import { find, map } from "lodash-es";
 import React from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import styled from "styled-components";
 import IsolateDetail from "./IsolateDetail";
 import IsolateItem from "./IsolateItem";
@@ -53,15 +54,16 @@ const IsolateEditorList = styled(BoxGroup)`
  * Displays a component for managing the isolates
  */
 export default function IsolateEditor() {
-    const location = useLocation<{ activeIsolateId: string }>();
+    const [locationState] = useLocationState();
     const { otu, reference } = useCurrentOTUContext();
     const { isolates } = otu;
     const { data_type, restrict_source_types, source_types } = reference;
 
     const { hasPermission: canModify } = useCheckReferenceRight(reference.id, ReferenceRight.modify);
 
-    const activeIsolateId = location.state?.activeIsolateId || otu.isolates[0]?.id;
+    const activeIsolateId = locationState?.activeIsolateId || otu.isolates[0]?.id;
     const activeIsolate = isolates.length ? find(isolates, { id: activeIsolateId }) : null;
+    console.log(locationState?.activeIsolateId, otu.isolates[0]?.id);
 
     const isolateComponents = map(isolates, (isolate, index) => (
         <IsolateItem key={index} isolate={isolate} active={isolate.id === activeIsolate.id} dataType={data_type} />

--- a/src/js/otus/components/Detail/Isolates/IsolateEditor.tsx
+++ b/src/js/otus/components/Detail/Isolates/IsolateEditor.tsx
@@ -3,9 +3,9 @@ import { getFontSize, getFontWeight } from "@app/theme";
 import { useCurrentOTUContext } from "@otus/queries";
 import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
 import { useLocationState } from "@utils/hooks";
+import { merge } from "lodash";
 import { find, map } from "lodash-es";
 import React from "react";
-import { Link } from "react-router-dom";
 import styled from "styled-components";
 import IsolateDetail from "./IsolateDetail";
 import IsolateItem from "./IsolateItem";
@@ -50,11 +50,16 @@ const IsolateEditorList = styled(BoxGroup)`
     width: 100%;
 `;
 
+const AddIsolateLink = styled.a`
+    margin-left: auto;
+    cursor: pointer;
+`;
+
 /**
  * Displays a component for managing the isolates
  */
 export default function IsolateEditor() {
-    const [locationState] = useLocationState();
+    const [locationState, setLocationState] = useLocationState();
     const { otu, reference } = useCurrentOTUContext();
     const { isolates } = otu;
     const { data_type, restrict_source_types, source_types } = reference;
@@ -63,13 +68,16 @@ export default function IsolateEditor() {
 
     const activeIsolateId = locationState?.activeIsolateId || otu.isolates[0]?.id;
     const activeIsolate = isolates.length ? find(isolates, { id: activeIsolateId }) : null;
-    console.log(locationState?.activeIsolateId, otu.isolates[0]?.id);
 
     const isolateComponents = map(isolates, (isolate, index) => (
         <IsolateItem key={index} isolate={isolate} active={isolate.id === activeIsolate.id} dataType={data_type} />
     ));
 
-    const addIsolateLink = canModify ? <Link to={{ state: { addIsolate: true } }}>Add Isolate</Link> : null;
+    const addIsolateLink = canModify ? (
+        <AddIsolateLink onClick={() => setLocationState(merge(locationState, { addIsolate: true }))}>
+            Add Isolate
+        </AddIsolateLink>
+    ) : null;
 
     const body = isolateComponents.length ? (
         <IsolateEditorContainer>

--- a/src/js/otus/components/Detail/Isolates/IsolateItem.tsx
+++ b/src/js/otus/components/Detail/Isolates/IsolateItem.tsx
@@ -2,9 +2,10 @@ import { BoxGroupSection, Icon } from "@/base";
 import { getActiveShadow } from "@app/theme";
 import { OTUIsolate } from "@otus/types";
 import { ReferenceDataType } from "@references/types";
+import { useLocationState } from "@utils/hooks";
 import { formatIsolateName } from "@utils/utils";
+import { merge } from "lodash";
 import React from "react";
-import { useHistory } from "react-router-dom";
 import styled from "styled-components";
 
 const StyledIsolateItem = styled(BoxGroupSection)`
@@ -35,10 +36,13 @@ type IsolateItemProps = {
  * A condensed isolate item for use in a list of isolates
  */
 export default function IsolateItem({ active, dataType, isolate }: IsolateItemProps) {
-    const history = useHistory();
+    const [locationState, setLocationState] = useLocationState();
 
     return (
-        <StyledIsolateItem active={active} onClick={() => history.push({ state: { activeIsolateId: isolate.id } })}>
+        <StyledIsolateItem
+            active={active}
+            onClick={() => setLocationState(merge(locationState, { activeIsolateId: isolate.id }))}
+        >
             <span>{formatIsolateName(isolate)}</span>
             {isolate.default && dataType !== "barcode" && <Icon name="star" />}
         </StyledIsolateItem>

--- a/src/js/sequences/components/AddSequenceLink.tsx
+++ b/src/js/sequences/components/AddSequenceLink.tsx
@@ -4,6 +4,8 @@ import { useCurrentOTUContext } from "@otus/queries";
 import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
 import { ReferenceDataType } from "@references/types";
 import { useGetUnreferencedTargets } from "@sequences/hooks";
+import { useLocationState } from "@utils/hooks";
+import { merge } from "lodash";
 import React from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
@@ -26,6 +28,7 @@ type AddSequenceLinkProps = {
  * Displays a link to add a sequence
  */
 export default function AddSequenceLink({ dataType, refId }: AddSequenceLinkProps) {
+    const [locationState, setLocationState] = useLocationState();
     const { reference } = useCurrentOTUContext();
     const { hasPermission: canModify } = useCheckReferenceRight(refId, ReferenceRight.modify_otu);
     const unreferencedTargets = useGetUnreferencedTargets();
@@ -45,7 +48,11 @@ export default function AddSequenceLink({ dataType, refId }: AddSequenceLinkProp
             }
         }
 
-        return <StyledAddSequenceLink to={{ state: { addSequence: true } }}>Add Sequence</StyledAddSequenceLink>;
+        return (
+            <StyledAddSequenceLink onClick={() => setLocationState(merge(locationState, { addSequence: true }))}>
+                Add Sequence
+            </StyledAddSequenceLink>
+        );
     }
 
     return null;

--- a/src/js/sequences/components/AddSequenceLink.tsx
+++ b/src/js/sequences/components/AddSequenceLink.tsx
@@ -7,7 +7,6 @@ import { useGetUnreferencedTargets } from "@sequences/hooks";
 import { useLocationState } from "@utils/hooks";
 import { merge } from "lodash";
 import React from "react";
-import { Link } from "react-router-dom";
 import styled from "styled-components";
 
 const AddSequenceLinkMessage = styled.span`
@@ -15,8 +14,9 @@ const AddSequenceLinkMessage = styled.span`
     margin-left: auto;
 `;
 
-const StyledAddSequenceLink = styled(Link)`
+const StyledAddSequenceLink = styled.a`
     margin-left: auto;
+    cursor: pointer;
 `;
 
 type AddSequenceLinkProps = {

--- a/src/js/sequences/components/Barcode/AddBarcodeSequence.tsx
+++ b/src/js/sequences/components/Barcode/AddBarcodeSequence.tsx
@@ -5,6 +5,7 @@ import { ReferenceTarget } from "@references/types";
 import TargetField from "@sequences/components/Barcode/TargetField";
 import { useLocationState } from "@utils/hooks";
 import { Field, Form, Formik, FormikErrors, FormikTouched } from "formik";
+import { merge } from "lodash";
 import { find } from "lodash-es";
 import React from "react";
 import styled from "styled-components";
@@ -66,7 +67,7 @@ export default function AddBarcodeSequence({ isolateId, otuId, targets }: AddBar
             },
             {
                 onSuccess: () => {
-                    setLocationState({ addSequence: false });
+                    setLocationState(merge(locationState, { addSequence: false }));
                 },
             },
         );
@@ -76,7 +77,10 @@ export default function AddBarcodeSequence({ isolateId, otuId, targets }: AddBar
     const initialValues = getInitialValues(defaultTarget);
 
     return (
-        <Dialog open={locationState?.addSequence} onOpenChange={() => setLocationState({ addSequence: false })}>
+        <Dialog
+            open={locationState?.addSequence}
+            onOpenChange={() => setLocationState(merge(locationState, { addSequence: false }))}
+        >
             <DialogPortal>
                 <DialogOverlay />
                 <CenteredDialogContent>

--- a/src/js/sequences/components/Barcode/EditBarcodeSequence.tsx
+++ b/src/js/sequences/components/Barcode/EditBarcodeSequence.tsx
@@ -5,6 +5,7 @@ import { DialogPortal } from "@radix-ui/react-dialog";
 import { ReferenceTarget } from "@references/types";
 import { useLocationState } from "@utils/hooks";
 import { Field, Form, Formik, FormikErrors, FormikTouched } from "formik";
+import { merge } from "lodash";
 import { find } from "lodash-es";
 import React from "react";
 import styled from "styled-components";
@@ -62,7 +63,7 @@ export default function EditBarcodeSequence({ activeSequence, isolateId, otuId, 
             { isolateId, sequenceId: id, accession, definition, host, sequence, target: targetName },
             {
                 onSuccess: () => {
-                    setLocationState({ editSequence: false });
+                    setLocationState(merge(locationState, { editSequence: false }));
                 },
             },
         );
@@ -77,7 +78,10 @@ export default function EditBarcodeSequence({ activeSequence, isolateId, otuId, 
     });
 
     return (
-        <Dialog open={locationState?.editSequence} onOpenChange={() => setLocationState({ editSequence: false })}>
+        <Dialog
+            open={locationState?.editSequence}
+            onOpenChange={() => setLocationState(merge(locationState, { editSequence: false }))}
+        >
             <DialogPortal>
                 <DialogOverlay />
                 <CenteredDialogContent>

--- a/src/js/sequences/components/Genome/AddGenomeSequence.tsx
+++ b/src/js/sequences/components/Genome/AddGenomeSequence.tsx
@@ -4,6 +4,7 @@ import { OTUSegment, OTUSequence } from "@otus/types";
 import { DialogPortal } from "@radix-ui/react-dialog";
 import { useLocationState } from "@utils/hooks";
 import { Field, Form, Formik, FormikErrors, FormikTouched } from "formik";
+import { merge } from "lodash";
 import { find } from "lodash-es";
 import { compact, map } from "lodash-es/lodash";
 import React from "react";
@@ -56,14 +57,17 @@ export default function AddGenomeSequence({ isolateId, otuId, refId, schema, seq
             { isolateId, accession, definition, host, segment, sequence: sequence.toUpperCase() },
             {
                 onSuccess: () => {
-                    setLocationState({ addSequence: false });
+                    setLocationState(merge(locationState, { addSequence: false }));
                 },
             },
         );
     }
 
     return (
-        <Dialog open={locationState?.addSequence} onOpenChange={() => setLocationState({ addSequence: false })}>
+        <Dialog
+            open={locationState?.addSequence}
+            onOpenChange={() => setLocationState(merge(locationState, { addSequence: false }))}
+        >
             <DialogPortal>
                 <DialogOverlay />
                 <StyledContent>

--- a/src/js/sequences/components/Genome/EditGenomeSequence.tsx
+++ b/src/js/sequences/components/Genome/EditGenomeSequence.tsx
@@ -4,6 +4,7 @@ import { OTUSegment, OTUSequence } from "@otus/types";
 import { DialogPortal } from "@radix-ui/react-dialog";
 import { useLocationState } from "@utils/hooks";
 import { Field, Form, Formik, FormikErrors, FormikTouched } from "formik";
+import { merge } from "lodash";
 import { find } from "lodash-es";
 import React from "react";
 import PersistForm from "../../../forms/components/PersistForm";
@@ -62,7 +63,14 @@ export default function EditGenomeSequence({
     const { accession, definition, host, id, segment, sequence } = activeSequence;
 
     function handleSubmit({ accession, definition, host, sequence, segment }) {
-        mutation.mutate({ isolateId, sequenceId: id, accession, definition, host, segment, sequence });
+        mutation.mutate(
+            { isolateId, sequenceId: id, accession, definition, host, segment, sequence },
+            {
+                onSuccess: () => {
+                    setLocationState(merge(locationState, { editSequence: false }));
+                },
+            },
+        );
     }
 
     const initialValues = getInitialValues({
@@ -74,7 +82,10 @@ export default function EditGenomeSequence({
     });
 
     return (
-        <Dialog open={locationState?.editSequence} onOpenChange={() => setLocationState({ editSequence: false })}>
+        <Dialog
+            open={locationState?.editSequence}
+            onOpenChange={() => setLocationState(merge(locationState, { editSequence: false }))}
+        >
             <DialogPortal>
                 <DialogOverlay />
                 <StyledContent>

--- a/src/js/sequences/components/RemoveSequence.tsx
+++ b/src/js/sequences/components/RemoveSequence.tsx
@@ -1,9 +1,10 @@
 import { RemoveDialog } from "@base/RemoveDialog";
 import { useRemoveSequence } from "@otus/queries";
 import { OTUSequence } from "@otus/types";
+import { useLocationState } from "@utils/hooks";
+import { merge } from "lodash";
 import { find } from "lodash-es";
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
 
 type RemoveSequenceProps = {
     isolateName: string;
@@ -16,16 +17,15 @@ type RemoveSequenceProps = {
  * Displays a dialog for removing a sequence
  */
 export default function RemoveSequence({ isolateName, isolateId, otuId, sequences }: RemoveSequenceProps) {
-    const history = useHistory();
-    const location = useLocation<{ removeSequence: string }>();
+    const [locationState, setLocationState] = useLocationState();
     const mutation = useRemoveSequence();
 
-    const sequenceId = location.state?.removeSequence;
+    const sequenceId = locationState?.removeSequence;
     const sequence = find(sequences, { id: sequenceId });
 
     function handleConfirm() {
         mutation.mutate({ otuId, isolateId, sequenceId: sequenceId });
-        history.replace({ state: { removeSequence: false } });
+        setLocationState(merge(locationState, { removeSequence: false }));
     }
 
     const removeMessage = (
@@ -41,8 +41,8 @@ export default function RemoveSequence({ isolateName, isolateId, otuId, sequence
             name={`${sequenceId}`}
             noun="Sequence"
             onConfirm={handleConfirm}
-            onHide={() => history.replace({ state: { removeSequence: false } })}
-            show={Boolean(location.state?.removeSequence)}
+            onHide={() => setLocationState(merge(locationState, { removeSequence: false }))}
+            show={Boolean(locationState?.removeSequence)}
             message={removeMessage}
         />
     );

--- a/src/js/sequences/components/Sequence/SequenceButtons.tsx
+++ b/src/js/sequences/components/Sequence/SequenceButtons.tsx
@@ -3,6 +3,8 @@ import { useGetActiveIsolateId } from "@otus/hooks";
 import { useCurrentOTUContext } from "@otus/queries";
 import { DownloadLink } from "@references/components/Detail/DownloadLink";
 import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
+import { useLocationState } from "@utils/hooks";
+import { merge } from "lodash";
 import React from "react";
 import styled from "styled-components";
 
@@ -34,6 +36,7 @@ const StyledButton = styled(IconLink)`
  * Displays icons for the sequence item to close, edit, or remove
  */
 export default function SequenceButtons({ id, onCollapse }) {
+    const [locationState, setLocationState] = useLocationState();
     const { otu, reference } = useCurrentOTUContext();
     const { hasPermission: canModify } = useCheckReferenceRight(reference.id, ReferenceRight.modify_otu);
     const isolateId = useGetActiveIsolateId(otu);
@@ -43,10 +46,20 @@ export default function SequenceButtons({ id, onCollapse }) {
     return (
         <SequenceHeaderButtons>
             {canModify && (
-                <IconLink name="pencil-alt" color="orange" tip="Edit Sequence" to={{ state: { editSequence: id } }} />
+                <IconLink
+                    name="pencil-alt"
+                    color="orange"
+                    tip="Edit Sequence"
+                    onClick={() => setLocationState(merge(locationState, { editSequence: id }))}
+                />
             )}
             {canModify && (
-                <StyledButton name="trash" color="red" tip="Remove Sequence" to={{ state: { removeSequence: id } }} />
+                <StyledButton
+                    name="trash"
+                    color="red"
+                    tip="Remove Sequence"
+                    onClick={() => setLocationState(merge(locationState, { removeSequence: id }))}
+                />
             )}
             <DownloadLink href={href}>FASTA</DownloadLink>
             <CloseButton onClick={onCollapse} />

--- a/src/js/types/types.d.ts
+++ b/src/js/types/types.d.ts
@@ -18,4 +18,5 @@ export type LocationType = {
     editSequence?: boolean;
     export?: boolean;
     devCommands?: boolean;
+    removeSequence?: string;
 };


### PR DESCRIPTION
## Changes
<!--- Provide the broad strokes of the changes made in a bulleted list --->

## Compatiblity

Any changes that require a newer version of the API are considered breaking
changes.

Common breaking changes:
 - Making a request to a new API endpoint that will return `403` or `404` in older versions of the API.
 - No longer sending request fields required by previous versions of the API 
 - Requiring new fields from an API endpoint that will not be present in
   responses from older versions of the API
 - Breaking backwards compatibility with old response data shapes


Choose one:
 - [x] The changes do not break compatibility
 - [ ] The changes potentially break compatibility


## Pre-Review Checklist
 - [x] All changes are tested
 - [x] All touched code documentation is updated
 - [x] All tests pass in your local environment
 - [x] Deepsource issues have been reviewed and addressed
 - [x] Debugging logging and commented out code has been removed

 
## Screenshots:
_Only required for visual changes_.

