### PR TITLE
docs: simplify `pull_request_template.md`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,16 @@
-## Changes
-<!--- Provide the broad strokes of the changes made in a bulleted list --->
+<!---
+Describe your changes in a bulleted list.
 
-## Compatiblity
-
-Any changes that require a newer version of the API are considered breaking
-changes.
-
-Common breaking changes:
- - Making a request to a new API endpoint that will return `403` or `404` in older versions of the API.
- - No longer sending request fields required by previous versions of the API 
- - Requiring new fields from an API endpoint that will not be present in
-   responses from older versions of the API
- - Breaking backwards compatibility with old response data shapes
-
-
-Choose one:
- - [ ] The changes do not break compatibility
- - [ ] The changes potentially break compatibility
-
+Be sure to identify and justify breaking changes.
+--->
 
 ## Pre-Review Checklist
- - [ ] All changes are tested
- - [ ] All touched code documentation is updated
- - [ ] All tests pass in your local environment
- - [ ] Deepsource issues have been reviewed and addressed
- - [ ] Debugging logging and commented out code has been removed
-
+* [ ] I have considered backwards and forwards compatibility.
+* [ ] All changes are tested.
+* [ ] All touched code documentation is updated.
+* [ ] All tests pass in my local environment
+* [ ] Deepsource issues have been reviewed and addressed.
+* [ ] Commented code and `console` usages have been removed.
  
-## Screenshots:
-_Only required for visual changes_.
-
+## Screenshots
+_Only required for visual changes_


### PR DESCRIPTION
## Changes
<!--- Provide the broad strokes of the changes made in a bulleted list --->

## Compatiblity

Any changes that require a newer version of the API are considered breaking
changes.

Common breaking changes:
 - Making a request to a new API endpoint that will return `403` or `404` in older versions of the API.
 - No longer sending request fields required by previous versions of the API 
 - Requiring new fields from an API endpoint that will not be present in
   responses from older versions of the API
 - Breaking backwards compatibility with old response data shapes


Choose one:
 - [x] The changes do not break compatibility
 - [ ] The changes potentially break compatibility


## Pre-Review Checklist
 - [x] All changes are tested
 - [x] All touched code documentation is updated
 - [x] All tests pass in your local environment
 - [x] Deepsource issues have been reviewed and addressed
 - [x] Debugging logging and commented out code has been removed

 
## Screenshots:
_Only required for visual changes_.

