### PR TITLE
refactor: move reference creation to a dialog

### DIFF
--- a/src/js/app/Main.jsx
+++ b/src/js/app/Main.jsx
@@ -20,7 +20,7 @@ const Administration = lazy(() => import("../administration/components/Settings"
 const Account = lazy(() => import("@account/components/Account"));
 const HMM = lazy(() => import("../hmm/components/HMM"));
 const Jobs = lazy(() => import("../jobs/components/Jobs"));
-const References = lazy(() => import("../references/components/References"));
+const References = lazy(() => import("@references/components/References"));
 const Samples = lazy(() => import("../samples/components/Samples"));
 const Subtraction = lazy(() => import("../subtraction/components/Subtraction"));
 const ML = lazy(() => import("../ml/components/ML"));

--- a/src/js/references/components/CreateReference.tsx
+++ b/src/js/references/components/CreateReference.tsx
@@ -1,35 +1,40 @@
+import { Dialog, DialogContent, DialogOverlay, DialogTitle, Tabs, TabsLink } from "@base";
+import { DialogPortal } from "@radix-ui/react-dialog";
+import { useLocationState } from "@utils/hooks";
 import React from "react";
-import { useLocation } from "react-router-dom";
-import { ContainerNarrow, Tabs, TabsLink, ViewHeader, ViewHeaderTitle } from "../../base";
 import EmptyReference from "./EmptyReference";
 import { ImportReference } from "./ImportReference";
-
-type LocationState = {
-    emptyReference: boolean;
-    importReference: boolean;
-};
 
 /**
  * The create reference view with options to create an empty reference or import a reference
  */
 export function CreateReference() {
-    const location = useLocation<LocationState>();
+    const [locationState, setLocationState] = useLocationState();
 
     return (
-        <ContainerNarrow>
-            <ViewHeader title="Create Reference">
-                <ViewHeaderTitle>Create Reference</ViewHeaderTitle>
-            </ViewHeader>
-            <Tabs>
-                <TabsLink to={{ state: { emptyReference: true } }} isActive={() => location.state.emptyReference}>
-                    Empty
-                </TabsLink>
-                <TabsLink to={{ state: { importReference: true } }} isActive={() => location.state.importReference}>
-                    Import
-                </TabsLink>
-            </Tabs>
+        <Dialog open={locationState?.createReference} onOpenChange={() => setLocationState({ createReference: false })}>
+            <DialogPortal>
+                <DialogOverlay />
+                <DialogContent size="lg">
+                    <DialogTitle>Create Reference</DialogTitle>
+                    <Tabs>
+                        <TabsLink
+                            to={{ state: { createReference: true, emptyReference: true } }}
+                            isActive={() => locationState?.emptyReference}
+                        >
+                            Empty
+                        </TabsLink>
+                        <TabsLink
+                            to={{ state: { createReference: true, importReference: true } }}
+                            isActive={() => locationState?.importReference}
+                        >
+                            Import
+                        </TabsLink>
+                    </Tabs>
 
-            {location.state.importReference ? <ImportReference /> : <EmptyReference />}
-        </ContainerNarrow>
+                    {locationState?.importReference ? <ImportReference /> : <EmptyReference />}
+                </DialogContent>
+            </DialogPortal>
+        </Dialog>
     );
 }

--- a/src/js/references/components/EmptyReference.tsx
+++ b/src/js/references/components/EmptyReference.tsx
@@ -1,6 +1,6 @@
+import { Button, DialogFooter } from "@base";
 import React from "react";
 import { Controller, useForm } from "react-hook-form";
-import { Alert, Button } from "../../base";
 import { useCreateReference } from "../queries";
 import { ReferenceDataType } from "../types";
 import { DataTypeSelection } from "./DataTypeSelection";
@@ -28,9 +28,6 @@ export default function EmptyReference() {
 
     return (
         <form onSubmit={handleSubmit(values => mutation.mutate({ ...values }))}>
-            <Alert>
-                <strong>Create an empty reference.</strong>
-            </Alert>
             <ReferenceForm errors={errors} mode={ReferenceFormMode.empty} register={register} />
             <Controller
                 name="dataType"
@@ -38,9 +35,11 @@ export default function EmptyReference() {
                 rules={{ required: "Required Field" }}
                 render={({ field: { onChange, value } }) => <DataTypeSelection onSelect={onChange} dataType={value} />}
             />
-            <Button type="submit" icon="save" color="blue">
-                Save
-            </Button>
+            <DialogFooter>
+                <Button type="submit" icon="save" color="blue">
+                    Save
+                </Button>
+            </DialogFooter>
         </form>
     );
 }

--- a/src/js/references/components/ImportReference.tsx
+++ b/src/js/references/components/ImportReference.tsx
@@ -1,12 +1,7 @@
-import { useMutation } from "@tanstack/react-query";
-import React, { useState } from "react";
-import { Controller, useForm } from "react-hook-form";
-import { useHistory } from "react-router-dom";
-import styled from "styled-components";
-import { Request } from "../../app/request";
+import { Request } from "@app/request";
 import {
     Alert,
-    Box,
+    DialogFooter,
     InputError,
     InputGroup,
     InputLabel,
@@ -14,15 +9,15 @@ import {
     ProgressBarAffixed,
     SaveButton,
     UploadBar,
-} from "../../base";
+} from "@base";
+import { useMutation } from "@tanstack/react-query";
+import React, { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { useHistory } from "react-router-dom";
+import styled from "styled-components";
 
 const ImportReferenceUpload = styled.div`
     margin-bottom: 15px;
-`;
-
-const ImportReferenceUploadBarContainer = styled(Box)`
-    border-radius: ${props => props.theme.borderRadius.sm};
-    padding: 15px 15px 0;
 `;
 
 interface ImportReferenceValues {
@@ -101,17 +96,15 @@ export function ImportReference() {
                 rules={{ required: true }}
                 render={({ field: { onChange } }) => (
                     <ImportReferenceUpload>
-                        <ImportReferenceUploadBarContainer>
-                            <ProgressBarAffixed color="green" now={progress} />
-                            <UploadBar
-                                message={uploadBarMessage}
-                                onDrop={acceptedFiles => {
-                                    handleDrop(acceptedFiles);
-                                    onChange(acceptedFiles[0].name);
-                                }}
-                                multiple={false}
-                            />
-                        </ImportReferenceUploadBarContainer>
+                        <ProgressBarAffixed color="green" now={progress} />
+                        <UploadBar
+                            message={uploadBarMessage}
+                            onDrop={acceptedFiles => {
+                                handleDrop(acceptedFiles);
+                                onChange(acceptedFiles[0].name);
+                            }}
+                            multiple={false}
+                        />
 
                         <InputError>
                             {errors.upload?.type === "required" && "A reference file must be uploaded"}
@@ -135,7 +128,9 @@ export function ImportReference() {
                     <InputSimple as="textarea" id="description" {...register("description")} />
                 </InputGroup>
 
-                <SaveButton disabled={progress !== 100 && progress !== 0} altText="Import" />
+                <DialogFooter>
+                    <SaveButton disabled={progress !== 100 && progress !== 0} altText="Import" />
+                </DialogFooter>
             </form>
         </>
     );

--- a/src/js/references/components/ReferenceList.tsx
+++ b/src/js/references/components/ReferenceList.tsx
@@ -1,3 +1,4 @@
+import { CreateReference } from "@references/components/CreateReference";
 import { useUrlSearchParams } from "@utils/hooks";
 import { flatMap } from "lodash-es";
 import React from "react";
@@ -43,6 +44,7 @@ export default function ReferenceList() {
                     </ViewHeaderTitle>
                 </ViewHeader>
                 <ReferenceToolbar />
+                <CreateReference />
                 <ReferenceOfficial officialInstalled={official_installed} />
                 {total_count !== 0 && (
                     <BoxGroup>

--- a/src/js/references/components/ReferenceToolbar.tsx
+++ b/src/js/references/components/ReferenceToolbar.tsx
@@ -1,8 +1,8 @@
+import { useCheckAdminRoleOrPermission } from "@administration/hooks";
+import { InputSearch, LinkButton, Toolbar } from "@base";
+import { Permission } from "@groups/types";
 import { useUrlSearchParams } from "@utils/hooks";
 import React from "react";
-import { useCheckAdminRoleOrPermission } from "../../administration/hooks";
-import { InputSearch, LinkButton, Toolbar } from "../../base";
-import { Permission } from "../../groups/types";
 
 /**
  * A toolbar which allows the references to be filtered by name
@@ -13,7 +13,7 @@ export default function ReferenceToolbar() {
 
     const createButton = canCreate ? (
         <LinkButton
-            to={{ pathname: "/refs/add", state: { newReference: true, emptyReference: true } }}
+            to={{ state: { createReference: true, emptyReference: true } }}
             color="blue"
             tip="Create"
             icon="plus-square fa-fw"

--- a/src/js/references/components/References.tsx
+++ b/src/js/references/components/References.tsx
@@ -1,13 +1,15 @@
+import { useFetchSettings } from "@administration/queries";
+import { Container, LoadingPlaceholder } from "@base";
 import React from "react";
 import { Redirect, Route, Switch } from "react-router-dom";
-import { useFetchSettings } from "../../administration/queries";
-import { Container, LoadingPlaceholder } from "../../base";
-import { CreateReference } from "./CreateReference";
 import ReferenceDetail from "./Detail/ReferenceDetail";
 import ReferenceList from "./ReferenceList";
 import { ReferenceSettings } from "./ReferenceSettings";
 
-export function References() {
+/**
+ * The references view with routes to reference-related components
+ */
+export default function References() {
     const { isLoading } = useFetchSettings();
 
     if (isLoading) {
@@ -20,11 +22,8 @@ export function References() {
                 <Route path="/refs" component={ReferenceList} exact />
                 <Redirect from="/refs/settings/*" to="/refs/settings" />
                 <Route path="/refs/settings" component={ReferenceSettings} />
-                <Route path="/refs/add" component={CreateReference} />
                 <Route path="/refs/:refId" component={ReferenceDetail} />
             </Switch>
         </Container>
     );
 }
-
-export default References;

--- a/src/js/types/types.d.ts
+++ b/src/js/types/types.d.ts
@@ -14,11 +14,14 @@ export type LocationType = {
     addSequence?: boolean;
     activeHitId?: number;
     cloneReference?: string;
+    createReference?: boolean;
     editIsolate?: boolean;
     editReference?: boolean;
     editSequence?: boolean;
+    emptyReference?: boolean;
     export?: boolean;
     devCommands?: boolean;
+    importReference?: boolean;
     removeIsolate?: boolean;
     removeSequence?: string;
 };


### PR DESCRIPTION
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->
## Changes
- Added `createReference` location state for dialog
- Removed path to `refs/add`
- Removed `Create an empty reference` alert since it added no value
- Moved reference creation into dialog

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] All tests pass in my local environment
* [x] Deepsource issues have been reviewed and addressed.
* [x] Commented code and `console` usages have been removed.
 
## Screenshots
_Only required for visual changes_
![Screenshot from 2024-07-22 15-02-46](https://github.com/user-attachments/assets/ffe2ac46-7e0c-4cc7-8adb-3136be80dc4a)
![Screenshot from 2024-07-22 15-02-49](https://github.com/user-attachments/assets/f354554a-6086-446b-9d7b-c4a36a641398)


