### PR TITLE
feat: use radix scroll area in isolates list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@radix-ui/react-dropdown-menu": "^2.0.6",
                 "@radix-ui/react-popover": "^1.0.7",
                 "@radix-ui/react-progress": "^1.0.3",
+                "@radix-ui/react-scroll-area": "^1.1.0",
                 "@radix-ui/react-select": "^2.1.1",
                 "@radix-ui/react-toggle": "^1.1.0",
                 "@radix-ui/react-toggle-group": "^1.1.0",
@@ -5386,6 +5387,183 @@
             "peerDependencies": {
                 "@types/react": "*",
                 "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-scroll-area": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.1.0.tgz",
+            "integrity": "sha512-9ArIZ9HWhsrfqS765h+GZuLoxaRHD/j0ZWOWilsCvYTpYJp8XwCqNG7Dt9Nu/TItKOdgLGkOPCodQvDc+UMwYg==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/number": "1.1.0",
+                "@radix-ui/primitive": "1.1.0",
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-context": "1.1.0",
+                "@radix-ui/react-direction": "1.1.0",
+                "@radix-ui/react-presence": "1.1.0",
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-use-callback-ref": "1.1.0",
+                "@radix-ui/react-use-layout-effect": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/primitive": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+            "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==",
+            "license": "MIT"
+        },
+        "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-compose-refs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+            "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-context": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+            "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-direction": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
+            "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-presence": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.0.tgz",
+            "integrity": "sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-use-layout-effect": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+            "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-slot": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+            "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-use-callback-ref": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+            "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-use-layout-effect": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+            "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
             },
             "peerDependenciesMeta": {
                 "@types/react": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-popover": "^1.0.7",
         "@radix-ui/react-progress": "^1.0.3",
+        "@radix-ui/react-scroll-area": "^1.1.0",
         "@radix-ui/react-select": "^2.1.1",
         "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-toggle-group": "^1.1.0",

--- a/src/js/base/ScrollArea.tsx
+++ b/src/js/base/ScrollArea.tsx
@@ -1,0 +1,107 @@
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+import { cn } from "@utils/utils";
+import React from "react";
+
+type ScrollAreaProps = {
+    children: React.ReactNode;
+    className?: string;
+};
+
+/**
+ * A styled scrollable area compatible with horizontal and vertical scrolling
+ */
+export function ScrollArea({ children, className }: ScrollAreaProps) {
+    return (
+        <ScrollAreaPrimitive.Root
+            className={cn(
+                "w-[240px]",
+                "h-[420px]",
+                "rounded",
+                "overflow-hidden",
+                "p-0",
+                "flex-none",
+                "mr-[15px]",
+                "border",
+                "border-gray-300",
+                className
+            )}
+        >
+            <ScrollAreaPrimitive.Viewport className={cn("w-full", "h-full rounded")}>
+                {children}
+            </ScrollAreaPrimitive.Viewport>
+            <ScrollAreaPrimitive.Scrollbar
+                className={cn(
+                    "flex",
+                    "select-none",
+                    "touch-none",
+                    "p-0.5",
+                    "bg-gray-100",
+                    "transition-colors",
+                    "duration-[160ms]",
+                    "ease-out",
+                    "hover:bg-gray-200",
+                    "data-[orientation=vertical]:w-2.5",
+                    "data-[orientation=horizontal]:flex-col",
+                    "data-[orientation=horizontal]:h-2.5"
+                )}
+                orientation="vertical"
+            >
+                <ScrollAreaPrimitive.Thumb
+                    className={cn(
+                        "flex-1",
+                        "bg-gray-400",
+                        "rounded-[10px]",
+                        "relative",
+                        "before:content-['']",
+                        "before:absolute",
+                        "before:top-1/2",
+                        "before:left-1/2",
+                        "before:-translate-x-1/2",
+                        "before:-translate-y-1/2",
+                        "before:w-full",
+                        "before:h-full",
+                        "before:min-w-[44px]",
+                        "before:min-h-[44px]"
+                    )}
+                />
+            </ScrollAreaPrimitive.Scrollbar>
+            <ScrollAreaPrimitive.Scrollbar
+                className={cn(
+                    "flex",
+                    "select-none",
+                    "touch-none",
+                    "p-0.5",
+                    "bg-gray-100",
+                    "transition-colors",
+                    "duration-[160ms]",
+                    "ease-out",
+                    "hover:bg-gray-200",
+                    "data-[orientation=vertical]:w-2.5",
+                    "data-[orientation=horizontal]:flex-col",
+                    "data-[orientation=horizontal]:h-2.5"
+                )}
+                orientation="horizontal"
+            >
+                <ScrollAreaPrimitive.Thumb
+                    className={cn(
+                        "flex-1",
+                        "bg-gray-400",
+                        "rounded-[10px]",
+                        "relative",
+                        "before:content-['']",
+                        "before:absolute",
+                        "before:top-1/2",
+                        "before:left-1/2",
+                        "before:-translate-x-1/2",
+                        "before:-translate-y-1/2",
+                        "before:w-full",
+                        "before:h-full",
+                        "before:min-w-[44px]",
+                        "before:min-h-[44px]"
+                    )}
+                />
+            </ScrollAreaPrimitive.Scrollbar>
+            <ScrollAreaPrimitive.Corner className="bg-gray-200" />
+        </ScrollAreaPrimitive.Root>
+    );
+}

--- a/src/js/base/stories/ScrollArea.stories.tsx
+++ b/src/js/base/stories/ScrollArea.stories.tsx
@@ -1,0 +1,33 @@
+import { BoxGroupSection } from "@base";
+import { ScrollArea } from "@base/ScrollArea";
+import type { Meta, StoryObj } from "@storybook/react";
+import { map } from "lodash";
+import React from "react";
+
+const meta: Meta<typeof ScrollArea> = {
+    title: "base/ScrollArea",
+    component: ScrollArea,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function Template(args) {
+    const items = Array.from({ length: 10 }, (_, i) => `Item ${i + 1}`);
+
+    return (
+        <ScrollArea className={args.className}>
+            {map(items, (item, index) => (
+                <BoxGroupSection key={index}>{item}</BoxGroupSection>
+            ))}
+        </ScrollArea>
+    );
+}
+
+export const scrollArea: Story = {
+    render: Template,
+    args: {
+        className: "h-52",
+    },
+};

--- a/src/js/otus/components/Detail/Isolates/IsolateEditor.tsx
+++ b/src/js/otus/components/Detail/Isolates/IsolateEditor.tsx
@@ -1,5 +1,6 @@
-import { Box, BoxGroup, NoneFoundBox, SubviewHeader, SubviewHeaderTitle } from "@/base";
+import { NoneFoundBox, SubviewHeader, SubviewHeaderTitle } from "@/base";
 import { getFontSize, getFontWeight } from "@app/theme";
+import { ScrollArea } from "@base/ScrollArea";
 import { ViewHeaderTitleBadge } from "@base/ViewHeaderTitleBadge";
 import { useCurrentOTUContext } from "@otus/queries";
 import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
@@ -29,21 +30,6 @@ const IsolateEditorTitle = styled(SubviewHeaderTitle)`
         font-weight: ${getFontWeight("thick")};
         margin-left: auto;
     }
-`;
-
-const IsolateEditorListContainer = styled(Box)`
-    flex: 0 0 auto;
-    height: 420px;
-    margin: 0 15px 0 0;
-    padding: 0;
-    overflow-y: scroll;
-    width: 240px;
-`;
-
-const IsolateEditorList = styled(BoxGroup)`
-    border: none;
-    box-shadow: ${props => props.theme.boxShadow.inset};
-    width: 100%;
 `;
 
 const AddIsolateLink = styled.a`
@@ -77,9 +63,7 @@ export default function IsolateEditor() {
 
     const body = isolateComponents.length ? (
         <IsolateEditorContainer>
-            <IsolateEditorListContainer>
-                <IsolateEditorList>{isolateComponents}</IsolateEditorList>
-            </IsolateEditorListContainer>
+            <ScrollArea>{isolateComponents}</ScrollArea>
             <IsolateDetail
                 canModify={canModify}
                 otuId={otu.id}


### PR DESCRIPTION
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->
## Changes
- Installed `ScrollArea` from Radix and styled it using `Tailwind`
- Added it to storybook
- Updated `IsolateEditor` to use new `ScrollArea` component


## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] All tests pass in my local environment
* [x] Deepsource issues have been reviewed and addressed.
* [x] Commented code and `console` usages have been removed.
 
## Screenshots
_Only required for visual changes_

**Cursor in the scroll area**
![Screenshot from 2024-08-06 15-46-22](https://github.com/user-attachments/assets/51e741cb-c276-4ce0-bae9-b4a06398d633)

**Hovering over the scroll bar:**
![Screenshot from 2024-08-06 15-46-50](https://github.com/user-attachments/assets/e59734e4-83b0-4dcb-8a10-7e2fe10fee13)

**Cursor out of the scroll area**
![Screenshot from 2024-08-06 15-46-52](https://github.com/user-attachments/assets/a8b01c25-5401-437b-a113-8f7a592d6719)

