### PR TITLE
chore: upgrade references to the v6 api

### DIFF
--- a/src/js/app/Main.tsx
+++ b/src/js/app/Main.tsx
@@ -83,7 +83,7 @@ export default function Main() {
                         <Redirect from="/" to="/samples" exact />
                         <Route path="/jobs" component={Jobs} />
                         <CompatRoute path="/samples" component={Samples} />
-                        <Route path="/refs" component={References} />
+                        <CompatRoute path="/refs" component={References} />
                         <CompatRoute path="/hmm" component={HMM} />
                         <CompatRoute path="/subtractions" component={Subtraction} />
                         <Route path="/administration" component={Administration} />

--- a/src/js/indexes/components/IndexDetail.tsx
+++ b/src/js/indexes/components/IndexDetail.tsx
@@ -14,7 +14,7 @@ import { useFetchIndex } from "@indexes/queries";
 import { DownloadLink } from "@references/components/Detail/DownloadLink";
 import { useGetReference } from "@references/queries";
 import React from "react";
-import { match } from "react-router-dom";
+import { useParams } from "react-router-dom-v5-compat";
 import styled from "styled-components";
 
 const IndexDetailSubtitle = styled.div`
@@ -26,16 +26,11 @@ const IndexDetailSubtitle = styled.div`
     }
 `;
 
-type IndexDetailProps = {
-    /** Match object containing path information */
-    match: match<{ indexId: string; refId: string }>;
-};
-
 /**
  * The index detailed view
  */
-export default function IndexDetail({ match }: IndexDetailProps) {
-    const { indexId, refId } = match.params;
+export default function IndexDetail() {
+    const { indexId, refId } = useParams();
     const { data: index, isPending: isPendingIndex, isError } = useFetchIndex(indexId);
     const { data: reference, isPending: isPendingReference } = useGetReference(refId);
 

--- a/src/js/indexes/components/IndexOTU.tsx
+++ b/src/js/indexes/components/IndexOTU.tsx
@@ -1,6 +1,6 @@
 import { Badge, BoxGroupSection } from "@base";
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 import styled from "styled-components";
 
 const StyledIndexOTU = styled(BoxGroupSection)`

--- a/src/js/indexes/components/Indexes.tsx
+++ b/src/js/indexes/components/Indexes.tsx
@@ -4,21 +4,16 @@ import { useUrlSearchParams } from "@utils/hooks";
 import { map } from "lodash";
 import { find, get } from "lodash-es/lodash";
 import React from "react";
-import { match } from "react-router-dom";
+import { useParams } from "react-router-dom-v5-compat";
 import { useFindIndexes } from "../queries";
 import RebuildAlert from "./RebuildAlert";
 import RebuildIndex from "./RebuildIndex";
 
-type IndexesProps = {
-    /** Match object containing path information */
-    match: match<{ refId: string }>;
-};
-
 /**
  * Displays a list of reference indexes
  */
-export default function Indexes({ match }: IndexesProps) {
-    const { refId } = match.params;
+export default function Indexes() {
+    const { refId } = useParams();
     const [urlPage] = useUrlSearchParams<number>("page");
     const { data, isPending } = useFindIndexes(Number(urlPage) || 1, 25, refId);
 

--- a/src/js/indexes/components/Indexes.tsx
+++ b/src/js/indexes/components/Indexes.tsx
@@ -38,7 +38,6 @@ export default function Indexes() {
                         {map(documents, document => (
                             <IndexItem
                                 index={document}
-                                refId={refId}
                                 activeId={get(find(documents, { ready: true, has_files: true }), "id")}
                             />
                         ))}

--- a/src/js/indexes/components/Item/IndexItem.tsx
+++ b/src/js/indexes/components/Item/IndexItem.tsx
@@ -1,6 +1,6 @@
+import { Attribution, BoxGroupSection } from "@base";
 import React from "react";
-import { Link } from "react-router-dom";
-import { Attribution, BoxGroupSection } from "../../../base";
+import { Link } from "react-router-dom-v5-compat";
 import { IndexMinimal } from "../../types";
 import { IndexItemDescription } from "./IndexItemDescription";
 import { IndexItemIcon } from "./IndexItemIcon";
@@ -8,7 +8,6 @@ import { IndexItemIcon } from "./IndexItemIcon";
 type IndexItemProps = {
     activeId: string;
     index: IndexMinimal;
-    refId: string;
 };
 
 /**
@@ -20,11 +19,11 @@ type IndexItemProps = {
  * @return The index item
  */
 
-export function IndexItem({ activeId, index, refId }: IndexItemProps) {
+export function IndexItem({ activeId, index }: IndexItemProps) {
     return (
         <BoxGroupSection>
             <h3 className="grid grid-cols-3 mb-2 text-lg">
-                <Link className="font-medium" to={`/refs/${refId}/indexes/${index.id}`}>
+                <Link className="font-medium" to={index.id}>
                     Version {index.version}
                 </Link>
                 <IndexItemDescription changeCount={index.change_count} modifiedCount={index.modified_otu_count} />

--- a/src/js/indexes/components/RebuildAlert.tsx
+++ b/src/js/indexes/components/RebuildAlert.tsx
@@ -2,7 +2,7 @@ import { Alert, Icon } from "@base";
 import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
 import { useUrlSearchParams } from "@utils/hooks";
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 import { useFindIndexes } from "../queries";
 
 type RebuildAlertProps = {
@@ -33,17 +33,14 @@ export default function RebuildAlert({ refId }: RebuildAlertProps) {
     }
 
     if (change_count && hasRights) {
-        const to = {
-            pathname: `/refs/${refId}/indexes`,
-            state: { rebuild: true },
-        };
-
         return (
             <Alert color="orange" level>
                 <Icon name="info-circle" />
                 <span>
                     <span>There are unbuilt changes. </span>
-                    <Link to={to}>Rebuild the index</Link>
+                    <Link to="" state={{ rebuild: true }}>
+                        Rebuild the index
+                    </Link>
                     <span> to use the changes in future analyses.</span>
                 </span>
             </Alert>

--- a/src/js/indexes/components/RebuildIndex.tsx
+++ b/src/js/indexes/components/RebuildIndex.tsx
@@ -2,7 +2,7 @@ import { Button, Dialog, DialogContent, DialogFooter, DialogOverlay, DialogTitle
 import { useCreateIndex, useFetchUnbuiltChanges } from "@indexes/queries";
 import { DialogPortal } from "@radix-ui/react-dialog";
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 import RebuildHistory from "./History";
 import RebuildIndexError from "./RebuildIndexError";
 
@@ -14,8 +14,8 @@ type RebuildIndexProps = {
  * Displays a dialog to rebuild an index
  */
 export default function RebuildIndex({ refId }: RebuildIndexProps) {
-    const history = useHistory();
-    const location = useLocation<{ rebuild: boolean }>();
+    const navigate = useNavigate();
+    const location = useLocation();
     const { data, isPending } = useFetchUnbuiltChanges(refId);
     const mutation = useCreateIndex();
 
@@ -29,14 +29,17 @@ export default function RebuildIndex({ refId }: RebuildIndexProps) {
             { refId },
             {
                 onSuccess: () => {
-                    history.push({ state: { rebuild: false } });
+                    navigate(".", { replace: true, state: { rebuild: false } });
                 },
             }
         );
     }
 
     return (
-        <Dialog open={location.state?.rebuild} onOpenChange={() => history.push({ state: { rebuild: false } })}>
+        <Dialog
+            open={location.state?.rebuild}
+            onOpenChange={() => navigate(".", { replace: true, state: { rebuild: false } })}
+        >
             <DialogPortal>
                 <DialogOverlay />
                 <DialogContent>

--- a/src/js/indexes/components/__tests__/Indexes.test.tsx
+++ b/src/js/indexes/components/__tests__/Indexes.test.tsx
@@ -1,30 +1,28 @@
 import { AdministratorRoles } from "@administration/types";
+import References from "@references/components/References";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { createFakeAccount, mockApiGetAccount } from "@tests/fake/account";
+import { createFakeSettings, mockApiGetSettings } from "@tests/fake/admin";
+import { createFakeIndexMinimal, mockApiFindIndexes, mockApiGetUnbuiltChanges } from "@tests/fake/indexes";
+import { createFakeReference, mockApiGetReferenceDetail } from "@tests/fake/references";
+import { renderWithMemoryRouter } from "@tests/setupTests";
 import nock from "nock";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
-import { createFakeAccount, mockApiGetAccount } from "../../../../tests/fake/account";
-import { createFakeIndexMinimal, mockApiFindIndexes, mockApiGetUnbuiltChanges } from "../../../../tests/fake/indexes";
-import { createFakeReference, mockApiGetReferenceDetail } from "../../../../tests/fake/references";
-import { renderWithMemoryRouter } from "../../../../tests/setupTests";
-import Indexes from "../Indexes";
 
 describe("<Indexes />", () => {
-    let props;
     let reference;
 
     beforeEach(() => {
         reference = createFakeReference();
+        mockApiGetSettings(createFakeSettings());
         mockApiGetReferenceDetail(reference);
         mockApiGetAccount(
             createFakeAccount({
                 administrator_role: AdministratorRoles.FULL,
             })
         );
-        props = {
-            match: { params: { refId: reference.id } },
-        };
     });
 
     afterEach(() => nock.cleanAll());
@@ -37,7 +35,7 @@ describe("<Indexes />", () => {
             total_otu_count: 1,
             change_count: 1,
         });
-        renderWithMemoryRouter(<Indexes {...props} />);
+        renderWithMemoryRouter(<References />, [`/${reference.id}/indexes`]);
 
         await waitFor(() => findIndexesScope.done());
         expect(await screen.findByText(`Version ${index.version}`)).toBeInTheDocument();
@@ -48,7 +46,7 @@ describe("<Indexes />", () => {
         expect(await screen.findByText("There are unbuilt changes.")).toBeInTheDocument();
         expect(await screen.findByRole("link", { name: "Rebuild the index" })).toHaveAttribute(
             "href",
-            `/refs/${reference.id}/indexes`
+            `/${reference.id}/indexes`
         );
     });
 
@@ -61,7 +59,7 @@ describe("<Indexes />", () => {
             total_otu_count: 1,
             change_count: 1,
         });
-        renderWithMemoryRouter(<Indexes {...props} />);
+        renderWithMemoryRouter(<References />, [`/${reference.id}/indexes`]);
 
         await userEvent.click(await screen.findByRole("link", { name: "Rebuild the index" }));
 

--- a/src/js/otus/components/CreateOTU.tsx
+++ b/src/js/otus/components/CreateOTU.tsx
@@ -1,7 +1,7 @@
 import { Dialog, DialogContent, DialogOverlay, DialogTitle } from "@base";
 import { DialogPortal } from "@radix-ui/react-dialog";
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 import { useCreateOTU } from "../queries";
 import { OTUForm } from "./OTUForm";
 
@@ -13,8 +13,8 @@ type CreateOTUProps = {
  * Displays a dialog to create an OTU
  */
 export default function CreateOTU({ refId }: CreateOTUProps) {
-    const history = useHistory();
-    const location = useLocation<{ createOTU: boolean }>();
+    const navigate = useNavigate();
+    const location = useLocation();
 
     const mutation = useCreateOTU(refId);
 
@@ -23,14 +23,14 @@ export default function CreateOTU({ refId }: CreateOTUProps) {
             { name, abbreviation },
             {
                 onSuccess: () => {
-                    history.replace({ state: { createOTU: false } });
+                    navigate(".", { replace: true, state: { createOTU: false } });
                 },
             }
         );
     }
 
     function onHide() {
-        history.replace({ state: { createOTU: false } });
+        navigate(".", { replace: true, state: { createOTU: false } });
         mutation.reset();
     }
 

--- a/src/js/otus/components/Detail/EditOTU.tsx
+++ b/src/js/otus/components/Detail/EditOTU.tsx
@@ -1,8 +1,8 @@
+import { Dialog, DialogContent, DialogOverlay, DialogTitle } from "@base";
 import { useUpdateOTU } from "@otus/queries";
 import { DialogPortal } from "@radix-ui/react-dialog";
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
-import { Dialog, DialogContent, DialogOverlay, DialogTitle } from "../../../base";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 import { OTUForm } from "../OTUForm";
 
 type EditOTUProps = {
@@ -15,8 +15,8 @@ type EditOTUProps = {
  * Displays a dialog for editing an OTU
  */
 export default function EditOTU({ abbreviation, name, otuId }: EditOTUProps) {
-    const location = useLocation<{ editOTU: boolean }>();
-    const history = useHistory();
+    const location = useLocation();
+    const navigate = useNavigate();
     const mutation = useUpdateOTU(otuId);
 
     function handleSubmit({ name, abbreviation }) {
@@ -24,14 +24,14 @@ export default function EditOTU({ abbreviation, name, otuId }: EditOTUProps) {
             { otuId, name, abbreviation },
             {
                 onSuccess: () => {
-                    history.replace({ state: { editOTU: false } });
+                    navigate(".", { replace: true, state: { editOTU: false } });
                 },
             }
         );
     }
 
     function onHide() {
-        history.replace({ state: { editOTU: false } });
+        navigate(".", { replace: true, state: { editOTU: false } });
         mutation.reset();
     }
 

--- a/src/js/otus/components/Detail/History/OTUHistory.tsx
+++ b/src/js/otus/components/Detail/History/OTUHistory.tsx
@@ -3,18 +3,13 @@ import HistoryList from "@otus/components/Detail/History/HistoryList";
 import { useFetchOTUHistory } from "@otus/queries";
 import { groupBy } from "lodash-es";
 import React from "react";
-import { match } from "react-router-dom";
-
-type OTUHistoryProps = {
-    /** Match object containing path information */
-    match: match<{ otuId: string }>;
-};
+import { useParams } from "react-router-dom-v5-compat";
 
 /**
  * Display and manage the history for the OTU
  */
-export default function OTUHistory({ match }: OTUHistoryProps) {
-    const { otuId } = match.params;
+export default function OTUHistory() {
+    const { otuId } = useParams();
     const { data, isPending } = useFetchOTUHistory(otuId);
 
     if (isPending) {

--- a/src/js/otus/components/Detail/OTUDetail.tsx
+++ b/src/js/otus/components/Detail/OTUDetail.tsx
@@ -3,7 +3,7 @@ import { LoadingPlaceholder, NotFound, Tabs, TabsLink, ViewHeader, ViewHeaderIco
 import { useFetchOTU } from "@otus/queries";
 import { useGetReference } from "@references/queries";
 import React from "react";
-import { Link, Redirect, Route, Switch } from "react-router-dom";
+import { Link, Navigate, Route, Routes, useParams } from "react-router-dom-v5-compat";
 import styled from "styled-components";
 import History from "./History/OTUHistory";
 import { OTUHeaderEndIcons } from "./OTUHeaderEndIcons";
@@ -37,8 +37,8 @@ const OTUDetailSubtitle = styled.p`
 /**
  * Displays detailed otu view allowing users to manage otus
  */
-export default function OTUDetail({ match }) {
-    const { otuId, refId } = match.params;
+export default function OTUDetail() {
+    const { otuId, refId } = useParams();
     const { data: otu, isPending: isPendingOTU, isError } = useFetchOTU(otuId);
     const { data: reference, isPending: isPendingReference } = useGetReference(refId);
 
@@ -78,12 +78,12 @@ export default function OTUDetail({ match }) {
                 <TabsLink to={`/refs/${refId}/otus/${id}/history`}>History</TabsLink>
             </Tabs>
 
-            <Switch>
-                <Redirect from="/refs/:refId/otus/:otuId" to={`/refs/${refId}/otus/${id}/otu`} exact />
-                <Route path="/refs/:refId/otus/:otuId/otu" component={OTUSection} />
-                <Route path="/refs/:refId/otus/:otuId/history" component={History} />
-                <Route path="/refs/:refId/otus/:otuId/schema" component={Schema} />
-            </Switch>
+            <Routes>
+                <Route path="/" element={<Navigate replace to={`/refs/${refId}/otus/${id}/otu`} />} />
+                <Route path="/otu" element={<OTUSection />} />
+                <Route path="/history" element={<History />} />
+                <Route path="/schema" element={<Schema />} />
+            </Routes>
         </>
     );
 }

--- a/src/js/otus/components/Detail/OTUSection.tsx
+++ b/src/js/otus/components/Detail/OTUSection.tsx
@@ -1,8 +1,7 @@
 import { LoadingPlaceholder } from "@base";
 import { useGetReference } from "@references/queries";
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
-import { useParams } from "react-router-dom-v5-compat";
+import { useLocation, useNavigate, useParams } from "react-router-dom-v5-compat";
 import { CurrentOTUContextProvider, useFetchOTU } from "../../queries";
 import AddIsolate from "./Isolates/AddIsolate";
 import IsolateEditor from "./Isolates/IsolateEditor";
@@ -14,8 +13,8 @@ import General from "./OTUGeneral";
 export default function OTUSection() {
     const { otuId, refId } = useParams();
 
-    const history = useHistory();
-    const location = useLocation<{ addIsolate: boolean }>();
+    const navigate = useNavigate();
+    const location = useLocation();
     const { data: reference, isPending: isPendingReference } = useGetReference(refId);
     const { data: otu, isPending: isPendingOTU } = useFetchOTU(otuId);
 
@@ -32,7 +31,7 @@ export default function OTUSection() {
                 otuId={otuId}
                 restrictSourceTypes={reference.restrict_source_types}
                 show={location.state?.addIsolate}
-                onHide={() => history.replace({ state: { addIsolate: false } })}
+                onHide={() => navigate(".", { replace: true, state: { addIsolate: false } })}
             />
         </CurrentOTUContextProvider>
     );

--- a/src/js/otus/components/Detail/OTUSection.tsx
+++ b/src/js/otus/components/Detail/OTUSection.tsx
@@ -1,22 +1,18 @@
 import { LoadingPlaceholder } from "@base";
 import { useGetReference } from "@references/queries";
 import React from "react";
-import { match, useHistory, useLocation } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
+import { useParams } from "react-router-dom-v5-compat";
 import { CurrentOTUContextProvider, useFetchOTU } from "../../queries";
 import AddIsolate from "./Isolates/AddIsolate";
 import IsolateEditor from "./Isolates/IsolateEditor";
 import General from "./OTUGeneral";
 
-type OTUSectionProps = {
-    /** Match object containing path information */
-    match: match<{ otuId: string; refId: string }>;
-};
-
 /**
  * Displays a component for managing the OTU
  */
-export default function OTUSection({ match }: OTUSectionProps) {
-    const { otuId, refId } = match.params;
+export default function OTUSection() {
+    const { otuId, refId } = useParams();
 
     const history = useHistory();
     const location = useLocation<{ addIsolate: boolean }>();

--- a/src/js/otus/components/Detail/RemoveOTU.tsx
+++ b/src/js/otus/components/Detail/RemoveOTU.tsx
@@ -1,6 +1,6 @@
+import { RemoveDialog } from "@base/RemoveDialog";
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
-import { RemoveDialog } from "../../../base/RemoveDialog";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 import { useRemoveOTU } from "../../queries";
 
 type RemoveOTUProps = {
@@ -13,8 +13,8 @@ type RemoveOTUProps = {
  * Displays a dialog for removing an OTU
  */
 export default function RemoveOTU({ id, name, refId }: RemoveOTUProps) {
-    const history = useHistory();
-    const location = useLocation<{ removeOTU: boolean }>();
+    const navigate = useNavigate();
+    const location = useLocation();
     const mutation = useRemoveOTU();
 
     function handleConfirm() {
@@ -22,8 +22,8 @@ export default function RemoveOTU({ id, name, refId }: RemoveOTUProps) {
             { otuId: id },
             {
                 onSuccess: () => {
-                    history.push(`/refs/${refId}/otus/`);
-                    history.replace({ state: { removeOTU: false } });
+                    navigate(`/refs/${refId}/otus/`);
+                    navigate(".", { replace: true, state: { removeOTU: false } });
                 },
             }
         );
@@ -34,7 +34,7 @@ export default function RemoveOTU({ id, name, refId }: RemoveOTUProps) {
             name={name}
             noun="OTU"
             onConfirm={handleConfirm}
-            onHide={() => history.replace({ state: { removeOTU: false } })}
+            onHide={() => navigate(".", { replace: true, state: { removeOTU: false } })}
             show={location.state?.removeOTU}
         />
     );

--- a/src/js/otus/components/Detail/Schema/AddSegment.tsx
+++ b/src/js/otus/components/Detail/Schema/AddSegment.tsx
@@ -3,7 +3,7 @@ import { useUpdateOTU } from "@otus/queries";
 import { Molecule, OTUSegment } from "@otus/types";
 import { DialogPortal } from "@radix-ui/react-dialog";
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 import SegmentForm from "./SegmentForm";
 
 type FormValues = {
@@ -24,8 +24,8 @@ type AddSegmentProps = {
  * Displays a dialog for adding a segment
  */
 export default function AddSegment({ otuId, name, abbreviation, schema }: AddSegmentProps) {
-    const history = useHistory();
-    const location = useLocation<{ addSegment: boolean }>();
+    const navigate = useNavigate();
+    const location = useLocation();
     const mutation = useUpdateOTU(otuId);
 
     function handleSubmit({ segmentName, molecule, required }: FormValues) {
@@ -33,7 +33,7 @@ export default function AddSegment({ otuId, name, abbreviation, schema }: AddSeg
             { otuId, name, abbreviation, schema: [...schema, { name: segmentName, molecule, required }] },
             {
                 onSuccess: () => {
-                    history.replace({ state: { addSegment: false } });
+                    navigate(".", { replace: true, state: { addSegment: false } });
                 },
             }
         );
@@ -42,7 +42,7 @@ export default function AddSegment({ otuId, name, abbreviation, schema }: AddSeg
     return (
         <Dialog
             open={location.state?.addSegment}
-            onOpenChange={() => history.replace({ state: { addSegment: false } })}
+            onOpenChange={() => navigate(".", { replace: true, state: { addSegment: false } })}
         >
             <DialogPortal>
                 <DialogOverlay />

--- a/src/js/otus/components/Detail/Schema/EditSegment.tsx
+++ b/src/js/otus/components/Detail/Schema/EditSegment.tsx
@@ -6,7 +6,7 @@ import { DialogPortal } from "@radix-ui/react-dialog";
 import { map } from "lodash";
 import { find } from "lodash-es";
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 
 type FormValues = {
     segmentName: string;
@@ -26,8 +26,8 @@ type EditSegmentProps = {
  * Displays a dialog to edit a segment
  */
 export default function EditSegment({ abbreviation, otuId, name, schema }: EditSegmentProps) {
-    const history = useHistory();
-    const location = useLocation<{ editSegment: "" }>();
+    const navigate = useNavigate();
+    const location = useLocation();
     const mutation = useUpdateOTU(otuId);
 
     const initialName = location.state?.editSegment;
@@ -42,7 +42,7 @@ export default function EditSegment({ abbreviation, otuId, name, schema }: EditS
             { otuId, name, abbreviation, schema: newArray },
             {
                 onSuccess: () => {
-                    history.replace({ state: { editSegment: "" } });
+                    navigate(".", { replace: true, state: { editSegment: "" } });
                 },
             }
         );
@@ -51,7 +51,7 @@ export default function EditSegment({ abbreviation, otuId, name, schema }: EditS
     return (
         <Dialog
             open={Boolean(location.state?.editSegment)}
-            onOpenChange={() => history.replace({ state: { editSegment: "" } })}
+            onOpenChange={() => navigate(".", { replace: true, state: { editSegment: "" } })}
         >
             <DialogPortal>
                 <DialogOverlay />

--- a/src/js/otus/components/Detail/Schema/RemoveSegment.tsx
+++ b/src/js/otus/components/Detail/Schema/RemoveSegment.tsx
@@ -3,7 +3,7 @@ import { useUpdateOTU } from "@otus/queries";
 import { OTUSegment } from "@otus/types";
 import { reject } from "lodash-es";
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 
 type RemoveSegmentProps = {
     abbreviation: string;
@@ -17,8 +17,8 @@ type RemoveSegmentProps = {
  * Displays a dialog for removing a segment
  */
 export default function RemoveSegment({ abbreviation, name, otuId, schema }: RemoveSegmentProps) {
-    const history = useHistory();
-    const location = useLocation<{ removeSegment: string }>();
+    const navigate = useNavigate();
+    const location = useLocation();
     const mutation = useUpdateOTU(otuId);
 
     const activeName = location.state?.removeSegment;
@@ -28,7 +28,7 @@ export default function RemoveSegment({ abbreviation, name, otuId, schema }: Rem
             { otuId, name, abbreviation, schema: reject(schema, { name: activeName }) },
             {
                 onSuccess: () => {
-                    history.replace({ state: { removeSegment: "" } });
+                    navigate(".", { replace: true, state: { removeSegment: "" } });
                 },
             }
         );
@@ -39,7 +39,7 @@ export default function RemoveSegment({ abbreviation, name, otuId, schema }: Rem
             name={activeName}
             noun="Segment"
             onConfirm={handleSubmit}
-            onHide={() => history.replace({ state: { removeSegment: "" } })}
+            onHide={() => navigate(".", { replace: true, state: { removeSegment: "" } })}
             show={Boolean(location.state?.removeSegment)}
         />
     );

--- a/src/js/otus/components/Detail/Schema/Schema.tsx
+++ b/src/js/otus/components/Detail/Schema/Schema.tsx
@@ -5,7 +5,8 @@ import { OTUSegment } from "@otus/types";
 import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
 import { map } from "lodash";
 import React from "react";
-import { match, useHistory } from "react-router-dom";
+import { useHistory } from "react-router-dom";
+import { useParams } from "react-router-dom-v5-compat";
 import styled from "styled-components";
 import AddSegment from "./AddSegment";
 import RemoveSegment from "./RemoveSegment";
@@ -16,16 +17,11 @@ const AddButton = styled(Button)`
     width: 100%;
 `;
 
-type SchemaProps = {
-    /** Match object containing path information */
-    match: match<{ otuId: string; refId: string }>;
-};
-
 /**
  * Displays a component allowing users to manage the otu schema
  */
-export default function Schema({ match }: SchemaProps) {
-    const { refId, otuId } = match.params;
+export default function Schema() {
+    const { refId, otuId } = useParams();
     const { hasPermission: canModify, isPending: isPendingPermission } = useCheckReferenceRight(
         refId,
         ReferenceRight.modify_otu

--- a/src/js/otus/components/Detail/Schema/Schema.tsx
+++ b/src/js/otus/components/Detail/Schema/Schema.tsx
@@ -5,8 +5,7 @@ import { OTUSegment } from "@otus/types";
 import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
 import { map } from "lodash";
 import React from "react";
-import { useHistory } from "react-router-dom";
-import { useParams } from "react-router-dom-v5-compat";
+import { useNavigate, useParams } from "react-router-dom-v5-compat";
 import styled from "styled-components";
 import AddSegment from "./AddSegment";
 import RemoveSegment from "./RemoveSegment";
@@ -26,7 +25,7 @@ export default function Schema() {
         refId,
         ReferenceRight.modify_otu
     );
-    const history = useHistory();
+    const navigate = useNavigate();
     const { data, isPending } = useFetchOTU(otuId);
     const mutation = useUpdateOTU(otuId);
 
@@ -55,7 +54,7 @@ export default function Schema() {
     return (
         <div>
             {canModify && (
-                <AddButton color="blue" onClick={() => history.push({ state: { addSegment: true } })}>
+                <AddButton color="blue" onClick={() => navigate(".", { state: { addSegment: true } })}>
                     Add Segment
                 </AddButton>
             )}

--- a/src/js/otus/components/Detail/Schema/Segment.tsx
+++ b/src/js/otus/components/Detail/Schema/Segment.tsx
@@ -3,7 +3,7 @@ import { IconButton } from "@base/IconButton";
 import { OTUSegment } from "@otus/types";
 import { cn } from "@utils/utils";
 import React from "react";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 import styled from "styled-components";
 
 const StyledSegment = styled(BoxGroupSection)`
@@ -33,7 +33,7 @@ type SegmentProps = {
  * A condensed segment item for use in a list of segments
  */
 export default function Segment({ canModify, first, last, onMoveUp, onMoveDown, segment }: SegmentProps) {
-    const history = useHistory();
+    const navigate = useNavigate();
 
     return (
         <StyledSegment>
@@ -46,13 +46,13 @@ export default function Segment({ canModify, first, last, onMoveUp, onMoveDown, 
                         name="trash"
                         color="red"
                         tip="remove segment"
-                        onClick={() => history.push({ state: { removeSegment: segment.name } })}
+                        onClick={() => navigate(".", { state: { removeSegment: segment.name } })}
                     />
                     <IconButton
                         name="pen"
                         color="grayDark"
                         tip="edit segment"
-                        onClick={() => history.push({ state: { editSegment: segment.name } })}
+                        onClick={() => navigate(".", { state: { editSegment: segment.name } })}
                     />
                 </div>
             )}

--- a/src/js/otus/components/OTUItem.tsx
+++ b/src/js/otus/components/OTUItem.tsx
@@ -1,8 +1,8 @@
+import { getFontSize, getFontWeight } from "@app/theme";
+import { BoxGroupSection } from "@base";
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 import styled from "styled-components";
-import { getFontSize, getFontWeight } from "../../app/theme";
-import { BoxGroupSection } from "../../base";
 
 const OTUItemName = styled(Link)`
     font-size: ${getFontSize("lg")};
@@ -29,17 +29,16 @@ type OTUItemProps = {
     abbreviation: string;
     id: string;
     name: string;
-    refId: string;
     verified: boolean;
 };
 
 /**
  * A condensed OTU item for use in a list of OTUs
  */
-export default function OTUItem({ abbreviation, id, name, refId, verified }: OTUItemProps) {
+export default function OTUItem({ abbreviation, id, name, verified }: OTUItemProps) {
     return (
         <StyledOTUItem key={id}>
-            <OTUItemName to={`/refs/${refId}/otus/${id}`}>{name}</OTUItemName>
+            <OTUItemName to={id}>{name}</OTUItemName>
             <OTUItemAbbreviation>{abbreviation}</OTUItemAbbreviation>
             {verified || <OTUItemUnverified>Unverified</OTUItemUnverified>}
         </StyledOTUItem>

--- a/src/js/otus/components/OTUList.tsx
+++ b/src/js/otus/components/OTUList.tsx
@@ -46,7 +46,7 @@ export default function OTUList() {
                 >
                     <BoxGroup>
                         {map(documents, document => (
-                            <OTUItem key={document.id} {...document} refId={refId} />
+                            <OTUItem key={document.id} {...document} />
                         ))}
                     </BoxGroup>
                 </Pagination>

--- a/src/js/otus/components/OTUList.tsx
+++ b/src/js/otus/components/OTUList.tsx
@@ -3,23 +3,18 @@ import { useGetReference } from "@references/queries";
 import { useUrlSearchParams } from "@utils/hooks";
 import { map } from "lodash";
 import React from "react";
-import { match } from "react-router-dom";
+import { useParams } from "react-router-dom-v5-compat";
 import RebuildAlert from "../../indexes/components/RebuildAlert";
 import { useListOTUs } from "../queries";
 import CreateOTU from "./CreateOTU";
 import OTUItem from "./OTUItem";
 import OTUToolbar from "./OTUToolbar";
 
-type OTUListProps = {
-    /** Match object containing path information */
-    match: match<{ refId: string }>;
-};
-
 /**
  * A list of OTUs with filtering
  */
-export default function OTUList({ match }: OTUListProps) {
-    const { refId } = match.params;
+export default function OTUList() {
+    const { refId } = useParams();
     const [term, setTerm] = useUrlSearchParams<string>("find");
     const [urlPage] = useUrlSearchParams<number>("page");
     const { data: reference, isPending: isPendingReference } = useGetReference(refId);

--- a/src/js/otus/components/__tests__/OTUList.test.tsx
+++ b/src/js/otus/components/__tests__/OTUList.test.tsx
@@ -1,31 +1,27 @@
 import { AdministratorRoles } from "@administration/types";
+import References from "@references/components/References";
 import { screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { createFakeAccount, mockApiGetAccount } from "@tests/fake/account";
+import { createFakeSettings, mockApiGetSettings } from "@tests/fake/admin";
 import { createFakeOTUMinimal, mockApiGetOTUs } from "@tests/fake/otus";
 import { createFakeReference, mockApiGetReferenceDetail } from "@tests/fake/references";
-import { renderWithRouter } from "@tests/setupTests";
+import { renderWithMemoryRouter } from "@tests/setupTests";
 import { createBrowserHistory } from "history";
 import nock from "nock";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
-import OTUList from "../OTUList";
 
 describe("<OTUsList />", () => {
     let history;
     let reference;
     let OTUs;
-    let props;
 
     beforeEach(() => {
+        mockApiGetSettings(createFakeSettings());
         reference = createFakeReference();
         OTUs = [createFakeOTUMinimal(), createFakeOTUMinimal()];
         history = createBrowserHistory();
         mockApiGetReferenceDetail(reference);
-
-        props = {
-            match: { params: { refId: reference.id } },
-        };
     });
 
     afterEach(() => nock.cleanAll());
@@ -33,7 +29,7 @@ describe("<OTUsList />", () => {
     describe("<OTUList />", () => {
         it("should render correctly", async () => {
             const scope = mockApiGetOTUs(OTUs, reference.id);
-            renderWithRouter(<OTUList {...props} />, history);
+            renderWithMemoryRouter(<References />, [`/${reference.id}/otus`]);
 
             expect(await screen.findByText(OTUs[0].name)).toBeInTheDocument();
             expect(screen.getByText(OTUs[0].abbreviation)).toBeInTheDocument();
@@ -46,7 +42,7 @@ describe("<OTUsList />", () => {
 
         it("should render when no documents are found", async () => {
             const scope = mockApiGetOTUs([], reference.id);
-            renderWithRouter(<OTUList {...props} />, history);
+            renderWithMemoryRouter(<References />, [`/${reference.id}/otus`]);
 
             expect(await screen.findByText("No OTUs found.")).toBeInTheDocument();
             expect(screen.queryByText(OTUs[0].name)).toBeNull();
@@ -59,7 +55,7 @@ describe("<OTUsList />", () => {
     describe("<OTUToolbar />", () => {
         it("should render properly", async () => {
             const scope = mockApiGetOTUs(OTUs, reference.id);
-            renderWithRouter(<OTUList {...props} />, history);
+            renderWithMemoryRouter(<References />, [`/${reference.id}/otus`]);
 
             expect(await screen.findByRole("textbox")).toBeInTheDocument();
 
@@ -72,7 +68,7 @@ describe("<OTUsList />", () => {
                 administrator_role: AdministratorRoles.FULL,
             });
             mockApiGetAccount(account);
-            renderWithRouter(<OTUList {...props} />, history);
+            renderWithMemoryRouter(<References />, [`/${reference.id}/otus`]);
 
             expect(await screen.findByText("Create")).toBeInTheDocument();
 
@@ -85,26 +81,10 @@ describe("<OTUsList />", () => {
                 administrator_role: null,
             });
             mockApiGetAccount(account);
-            renderWithRouter(<OTUList {...props} />, history);
+            renderWithMemoryRouter(<References />, [`/${reference.id}/otus`]);
 
             expect(await screen.findByRole("textbox")).toBeInTheDocument();
             expect(screen.queryByText("Create")).toBeNull();
-
-            scope.done();
-        });
-
-        it("should handle toolbar updates correctly", async () => {
-            const scope = mockApiGetOTUs(OTUs, reference.id);
-            renderWithRouter(<OTUList {...props} />, history);
-
-            expect(await screen.findByRole("textbox")).toBeInTheDocument();
-            const inputElement = screen.getByPlaceholderText("Name or abbreviation");
-            expect(inputElement).toHaveValue("");
-
-            await userEvent.type(inputElement, "Foobar");
-            expect(inputElement).toHaveValue("Foobar");
-
-            expect(history.location.search).toEqual("?find=Foobar");
 
             scope.done();
         });
@@ -113,7 +93,7 @@ describe("<OTUsList />", () => {
     describe("<OTUItem />", () => {
         it("should render when [verified=true]", async () => {
             const scope = mockApiGetOTUs(OTUs, reference.id);
-            renderWithRouter(<OTUList {...props} />, history);
+            renderWithMemoryRouter(<References />, [`/${reference.id}/otus`]);
 
             expect(await screen.findByText(OTUs[0].name)).toBeInTheDocument();
             expect(screen.queryByText("Unverified")).toBeNull();
@@ -123,7 +103,7 @@ describe("<OTUsList />", () => {
 
         it("should render when [verified=false]", async () => {
             const scope = mockApiGetOTUs([createFakeOTUMinimal({ verified: false })], reference.id);
-            renderWithRouter(<OTUList {...props} />, history);
+            renderWithMemoryRouter(<References />, [`/${reference.id}/otus`]);
 
             expect(await screen.findByText("Unverified")).toBeInTheDocument();
             scope.done();

--- a/src/js/otus/components/__tests__/OTUList.test.tsx
+++ b/src/js/otus/components/__tests__/OTUList.test.tsx
@@ -6,13 +6,11 @@ import { createFakeSettings, mockApiGetSettings } from "@tests/fake/admin";
 import { createFakeOTUMinimal, mockApiGetOTUs } from "@tests/fake/otus";
 import { createFakeReference, mockApiGetReferenceDetail } from "@tests/fake/references";
 import { renderWithMemoryRouter } from "@tests/setupTests";
-import { createBrowserHistory } from "history";
 import nock from "nock";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 
 describe("<OTUsList />", () => {
-    let history;
     let reference;
     let OTUs;
 
@@ -20,7 +18,6 @@ describe("<OTUsList />", () => {
         mockApiGetSettings(createFakeSettings());
         reference = createFakeReference();
         OTUs = [createFakeOTUMinimal(), createFakeOTUMinimal()];
-        history = createBrowserHistory();
         mockApiGetReferenceDetail(reference);
     });
 

--- a/src/js/otus/hooks.ts
+++ b/src/js/otus/hooks.ts
@@ -1,7 +1,6 @@
-import { LocationType } from "@/types/types";
 import { OTU } from "@otus/types";
 import { find } from "lodash-es";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom-v5-compat";
 
 /**
  * A hook to get the active isolate
@@ -10,7 +9,7 @@ import { useLocation } from "react-router-dom";
  * @returns The active isolate
  */
 export function useGetActiveIsolate(otu: OTU) {
-    const location = useLocation<LocationType>();
+    const location = useLocation();
 
     const activeIsolateId = location.state?.activeIsolateId || otu.isolates[0]?.id;
     return otu.isolates.length ? find(otu.isolates, { id: activeIsolateId }) : null;
@@ -23,7 +22,7 @@ export function useGetActiveIsolate(otu: OTU) {
  * @returns The unique identifier of the active isolate
  */
 export function useGetActiveIsolateId(otu: OTU) {
-    const location = useLocation<LocationType>();
+    const location = useLocation();
 
     return location.state?.activeIsolateId || otu.isolates[0]?.id;
 }

--- a/src/js/references/components/Detail/EditMember.tsx
+++ b/src/js/references/components/Detail/EditMember.tsx
@@ -5,7 +5,7 @@ import { ReferenceGroup, ReferenceUser } from "@references/types";
 import { useQueryClient } from "@tanstack/react-query";
 import { map } from "lodash-es";
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 import { MemberRight } from "./MemberRight";
 
 const rights = ["modify_otu", "build", "modify", "remove"];
@@ -20,7 +20,7 @@ type EditReferenceMemberProps = {
  * Displays a dialog to modify rights for a member
  */
 export default function EditReferenceMember({ noun, refId, member }: EditReferenceMemberProps) {
-    const history = useHistory();
+    const navigate = useNavigate();
     const location = useLocation();
     const mutation = useUpdateReferenceMember(noun);
     const queryClient = useQueryClient();
@@ -49,7 +49,7 @@ export default function EditReferenceMember({ noun, refId, member }: EditReferen
     return (
         <Dialog
             open={location.state?.[`edit${noun}`]}
-            onOpenChange={() => history.push({ state: { [`edit${noun}`]: false } })}
+            onOpenChange={() => navigate(".", { replace: true, state: { [`edit${noun}`]: false } })}
         >
             <DialogPortal>
                 <DialogOverlay />

--- a/src/js/references/components/Detail/LatestBuild.tsx
+++ b/src/js/references/components/Detail/LatestBuild.tsx
@@ -1,7 +1,7 @@
 import { BoxGroupSection, NoneFoundSection, RelativeTime } from "@base";
 import { ReferenceBuild } from "@references/types";
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 import styled from "styled-components";
 
 const StyledLatestBuild = styled(BoxGroupSection)`

--- a/src/js/references/components/Detail/ReferenceDetail.tsx
+++ b/src/js/references/components/Detail/ReferenceDetail.tsx
@@ -2,7 +2,7 @@ import { ContainerNarrow, LoadingPlaceholder, NotFound } from "@base";
 import IndexDetail from "@indexes/components/IndexDetail";
 import { useGetReference } from "@references/queries";
 import React from "react";
-import { match, Redirect, Route, Switch } from "react-router-dom";
+import { Navigate, Route, Routes, useParams } from "react-router-dom-v5-compat";
 import Indexes from "../../../indexes/components/Indexes";
 import OTUDetail from "../../../otus/components/Detail/OTUDetail";
 import OTUList from "../../../otus/components/OTUList";
@@ -12,16 +12,11 @@ import ReferenceDetailTabs from "./ReferenceDetailTabs";
 import ReferenceManager from "./ReferenceManager";
 import ReferenceSettings from "./ReferenceSettings";
 
-type ReferenceDetailProps = {
-    /** Match object containing path information */
-    match: match<{ refId: string }>;
-};
-
 /**
  * The detailed view for a reference
  */
-export default function ReferenceDetail({ match }: ReferenceDetailProps) {
-    const { refId } = match.params;
+export default function ReferenceDetail() {
+    const { refId } = useParams();
     const { data, isPending, isError } = useGetReference(refId);
 
     if (isError) {
@@ -34,30 +29,35 @@ export default function ReferenceDetail({ match }: ReferenceDetailProps) {
 
     return (
         <>
-            <Switch>
-                <Route path="/refs/:refId/otus/:otuId" />
-                <Route path="/refs">
-                    <ReferenceDetailHeader
-                        createdAt={data.created_at}
-                        isRemote={Boolean(data.remotes_from)}
-                        name={data.name}
-                        userHandle={data.user.handle}
-                        refId={refId}
-                    />
-                    <ReferenceDetailTabs id={refId} otuCount={data.otu_count} />
-                </Route>
-            </Switch>
+            <Routes>
+                <Route path="/otus/:otuId/*" />
+                <Route
+                    path="/*"
+                    element={
+                        <>
+                            <ReferenceDetailHeader
+                                createdAt={data.created_at}
+                                isRemote={Boolean(data.remotes_from)}
+                                name={data.name}
+                                userHandle={data.user.handle}
+                                refId={refId}
+                            />
+                            <ReferenceDetailTabs id={refId} otuCount={data.otu_count} />
+                        </>
+                    }
+                />
+            </Routes>
 
             <ContainerNarrow>
-                <Switch>
-                    <Redirect from="/refs/:refId" to={`/refs/${refId}/manage`} exact />
-                    <Route path="/refs/:refId/manage" component={ReferenceManager} />
-                    <Route path="/refs/:refId/otus" component={OTUList} exact />
-                    <Route path="/refs/:refId/otus/:otuId" component={OTUDetail} />
-                    <Route path="/refs/:refId/indexes" component={Indexes} exact />
-                    <Route path="/refs/:refId/indexes/:indexId" component={IndexDetail} />
-                    <Route path="/refs/:refId/settings" component={ReferenceSettings} />
-                </Switch>
+                <Routes>
+                    <Route path="/" element={<Navigate replace to={`/refs/${refId}/manage`} />} />
+                    <Route path="/manage" element={<ReferenceManager />} />
+                    <Route path="/otus" element={<OTUList />} />
+                    <Route path="/otus/:otuId/*" element={<OTUDetail />} />
+                    <Route path="/indexes" element={<Indexes />} />
+                    <Route path="/indexes/:indexId/*" element={<IndexDetail />} />
+                    <Route path="/settings" element={<ReferenceSettings />} />
+                </Routes>
             </ContainerNarrow>
 
             <EditReference detail={data} />

--- a/src/js/references/components/Detail/ReferenceDetailHeader.tsx
+++ b/src/js/references/components/Detail/ReferenceDetailHeader.tsx
@@ -1,8 +1,8 @@
+import { Icon, ViewHeader, ViewHeaderAttribution, ViewHeaderIcons, ViewHeaderTitle } from "@base";
 import { IconButton } from "@base/IconButton";
 import { endsWith } from "lodash-es";
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
-import { Icon, ViewHeader, ViewHeaderAttribution, ViewHeaderIcons, ViewHeaderTitle } from "../../../base";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 import { ReferenceRight, useCheckReferenceRight } from "../../hooks";
 
 type ReferenceDetailHeaderProps = {
@@ -25,7 +25,7 @@ export default function ReferenceDetailHeader({
     userHandle,
 }: ReferenceDetailHeaderProps) {
     const location = useLocation();
-    const history = useHistory();
+    const navigate = useNavigate();
     const { hasPermission: canModify } = useCheckReferenceRight(refId, ReferenceRight.modify);
 
     const showIcons = endsWith(location.pathname, "/manage");
@@ -42,7 +42,7 @@ export default function ReferenceDetailHeader({
                                 color="grayDark"
                                 name="pen"
                                 tip="modify"
-                                onClick={() => history.push({ state: { editReference: true } })}
+                                onClick={() => navigate(".", { state: { editReference: true } })}
                             />
                         )}
                     </ViewHeaderIcons>

--- a/src/js/references/components/Detail/ReferenceManager.tsx
+++ b/src/js/references/components/Detail/ReferenceManager.tsx
@@ -2,23 +2,18 @@ import { cn } from "@/utils/utils";
 import { BoxGroup, BoxGroupHeader, BoxGroupTable, ContainerNarrow, LoadingPlaceholder } from "@base";
 import Contributors from "@indexes/components/Contributors";
 import React from "react";
-import { match } from "react-router-dom";
+import { useParams } from "react-router-dom-v5-compat";
 import { useGetReference } from "../../queries";
 import { Clone } from "./Clone";
 import { LatestBuild } from "./LatestBuild";
 import RemoteReference from "./Remote";
 import Targets from "./Targets/Targets";
 
-type ReferenceManageProps = {
-    /** Match object containing path information */
-    match: match<{ refId: string }>;
-};
-
 /**
  * Display and edit information for a reference
  */
-export default function ReferenceManager({ match }: ReferenceManageProps) {
-    const { refId } = match.params;
+export default function ReferenceManager() {
+    const { refId } = useParams();
     const { data: reference, isPending } = useGetReference(refId);
 
     if (isPending) {

--- a/src/js/references/components/Detail/ReferenceMembers.tsx
+++ b/src/js/references/components/Detail/ReferenceMembers.tsx
@@ -1,8 +1,8 @@
+import { BoxGroup, BoxGroupHeader, BoxGroupSection, Icon } from "@base";
 import { find, map } from "lodash-es";
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 import styled from "styled-components";
-import { BoxGroup, BoxGroupHeader, BoxGroupSection, Icon } from "../../../base";
 import { ReferenceRight, useCheckReferenceRight } from "../../hooks";
 import { useRemoveReferenceUser } from "../../queries";
 import { ReferenceGroup, ReferenceUser } from "../../types";
@@ -46,15 +46,15 @@ type ReferenceMembersProps = {
  * Displays a component for managing who can access a reference by users or groups
  */
 export default function ReferenceMembers({ members, noun, refId }: ReferenceMembersProps) {
-    const history = useHistory();
-    const location = useLocation<{ addgroup: boolean; adduser: boolean }>();
+    const navigate = useNavigate();
+    const location = useLocation();
 
     const mutation = useRemoveReferenceUser(refId, noun);
     const { hasPermission: canModify } = useCheckReferenceRight(refId, ReferenceRight.modify);
 
     function handleHide() {
-        history.replace({ state: { [`add${noun}`]: false } });
-        history.replace({ state: { [`edit${noun}`]: false } });
+        navigate(".", { replace: true, state: { [`add${noun}`]: false } });
+        navigate(".", { replace: true, state: { [`edit${noun}`]: false } });
     }
 
     const plural = `${noun}s`;
@@ -66,7 +66,7 @@ export default function ReferenceMembers({ members, noun, refId }: ReferenceMemb
                     <h2>
                         {plural}
                         {canModify && (
-                            <NewMemberLink onClick={() => history.push({ state: { [`add${noun}`]: true } })}>
+                            <NewMemberLink onClick={() => navigate(".", { state: { [`add${noun}`]: true } })}>
                                 Add {noun}
                             </NewMemberLink>
                         )}
@@ -79,7 +79,7 @@ export default function ReferenceMembers({ members, noun, refId }: ReferenceMemb
                             key={member.id}
                             {...member}
                             canModify={canModify}
-                            onEdit={id => history.push({ state: { [`edit${noun}`]: id } })}
+                            onEdit={id => navigate(".", { state: { [`edit${noun}`]: id } })}
                             onRemove={id => mutation.mutate({ id })}
                         />
                     ))

--- a/src/js/references/components/Detail/ReferenceSettings.tsx
+++ b/src/js/references/components/Detail/ReferenceSettings.tsx
@@ -1,22 +1,17 @@
 import { LoadingPlaceholder, SectionHeader } from "@base";
 import { sortBy } from "lodash-es";
 import React from "react";
-import { match } from "react-router-dom";
+import { useParams } from "react-router-dom-v5-compat";
 import { useGetReference } from "../../queries";
 import { LocalSourceTypes } from "../SourceTypes/LocalSourceTypes";
 import ReferenceMembers from "./ReferenceMembers";
 import RemoveReference from "./RemoveReference";
 
-type ReferenceSettingsProps = {
-    /** Match object containing path information */
-    match: match<{ refId: string }>;
-};
-
 /**
  * The reference settings view allowing users to manage the reference
  */
-export default function ReferenceSettings({ match }: ReferenceSettingsProps) {
-    const { refId } = match.params;
+export default function ReferenceSettings() {
+    const { refId } = useParams();
     const { data, isPending } = useGetReference(refId);
 
     if (isPending) {

--- a/src/js/references/components/Detail/RemoveReference.tsx
+++ b/src/js/references/components/Detail/RemoveReference.tsx
@@ -1,7 +1,7 @@
+import { RemoveBanner } from "@base";
+import { RemoveDialog } from "@base/RemoveDialog";
 import React, { useCallback } from "react";
-import { useHistory, useLocation } from "react-router-dom";
-import { RemoveBanner } from "../../../base";
-import { RemoveDialog } from "../../../base/RemoveDialog";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 import { ReferenceRight, useCheckReferenceRight } from "../../hooks";
 import { useRemoveReference } from "../../queries";
 
@@ -16,8 +16,8 @@ type RemoveReferenceProps = {
  * Displays a banner for removing a reference
  */
 export default function RemoveReference({ id, name }: RemoveReferenceProps) {
-    const history = useHistory();
-    const location = useLocation<{ removeRef: boolean }>();
+    const navigate = useNavigate();
+    const location = useLocation();
 
     const { hasPermission: canRemove } = useCheckReferenceRight(id, ReferenceRight.remove);
     const mutation = useRemoveReference();
@@ -28,7 +28,7 @@ export default function RemoveReference({ id, name }: RemoveReferenceProps) {
                 { refId: id },
                 {
                     onSuccess: () => {
-                        history.push("/refs");
+                        navigate("/refs");
                     },
                 }
             ),
@@ -41,14 +41,14 @@ export default function RemoveReference({ id, name }: RemoveReferenceProps) {
                 <RemoveBanner
                     message="Permanently delete this reference"
                     buttonText="Delete"
-                    onClick={() => history.push({ state: { removeRef: true } })}
+                    onClick={() => navigate(".", { state: { removeRef: true } })}
                 />
                 <RemoveDialog
                     name={name}
                     noun="Reference"
                     show={location.state?.removeRef}
                     onConfirm={handleClick}
-                    onHide={() => history.push({ state: { removeRef: false } })}
+                    onHide={() => navigate(".", { replace: true, state: { removeRef: false } })}
                 />
             </>
         )

--- a/src/js/references/components/Detail/Targets/Targets.tsx
+++ b/src/js/references/components/Detail/Targets/Targets.tsx
@@ -1,9 +1,9 @@
+import { BoxGroup, BoxGroupHeader, NoneFoundSection } from "@base";
 import { useUpdateReference } from "@references/queries";
 import { find, map, reject } from "lodash-es";
 import React from "react";
-import { Link, useHistory, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom-v5-compat";
 import styled from "styled-components";
-import { BoxGroup, BoxGroupHeader, NoneFoundSection } from "../../../../base";
 import { ReferenceRight, useCheckReferenceRight } from "../../../hooks";
 import { Reference } from "../../../types";
 import AddTarget from "./AddTarget";
@@ -28,8 +28,8 @@ type TargetsProps = {
 export default function Targets({ reference }: TargetsProps) {
     const { data_type, targets, id } = reference;
 
-    const history = useHistory();
-    const location = useLocation<{ addTarget: boolean; editTarget: boolean }>();
+    const navigate = useNavigate();
+    const location = useLocation();
     const { hasPermission: canModify } = useCheckReferenceRight(reference.id, ReferenceRight.modify);
     const { mutation } = useUpdateReference(id);
 
@@ -42,7 +42,7 @@ export default function Targets({ reference }: TargetsProps) {
             key={target.name}
             {...target}
             canModify={canModify}
-            onEdit={name => history.push({ state: { editTarget: name } })}
+            onEdit={name => navigate(".", { state: { editTarget: name } })}
             onRemove={name => mutation.mutate({ targets: reject(targets, { name }) })}
         />
     ));
@@ -52,7 +52,11 @@ export default function Targets({ reference }: TargetsProps) {
             <TargetsHeader>
                 <h2>
                     <span>Targets</span>
-                    {canModify && <Link to={{ state: { addTarget: true } }}>Add Target</Link>}
+                    {canModify && (
+                        <Link to="" state={{ addTarget: true }}>
+                            Add Target
+                        </Link>
+                    )}
                 </h2>
                 <p>Manage the allowable sequence targets for this barcode reference.</p>
             </TargetsHeader>
@@ -65,14 +69,14 @@ export default function Targets({ reference }: TargetsProps) {
                         refId={id}
                         targets={targets}
                         show={location.state?.addTarget}
-                        onHide={() => history.replace({ state: { addTarget: false } })}
+                        onHide={() => navigate(".", { replace: true, state: { addTarget: false } })}
                     />
                     <EditTarget
                         targets={targets}
                         refId={id}
                         target={location.state?.editTarget && find(targets, { name: location.state.editTarget })}
                         show={location.state?.editTarget}
-                        onHide={() => history.replace({ state: { editTarget: false } })}
+                        onHide={() => navigate(".", { replace: true, state: { editTarget: false } })}
                     />
                 </>
             )}

--- a/src/js/references/components/Detail/__tests__/ReferenceManager.test.tsx
+++ b/src/js/references/components/Detail/__tests__/ReferenceManager.test.tsx
@@ -1,24 +1,22 @@
+import References from "@references/components/References";
 import { screen } from "@testing-library/react";
+import { createFakeSettings, mockApiGetSettings } from "@tests/fake/admin";
+import { createFakeReference, mockApiGetReferenceDetail } from "@tests/fake/references";
+import { renderWithMemoryRouter } from "@tests/setupTests";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
-import { createFakeReference, mockApiGetReferenceDetail } from "../../../../../tests/fake/references";
-import { renderWithMemoryRouter } from "../../../../../tests/setupTests";
-import ReferenceManager from "../ReferenceManager";
 
 describe("<ReferenceManager />", () => {
-    let props;
     let reference;
 
     beforeEach(() => {
+        mockApiGetSettings(createFakeSettings());
         reference = createFakeReference();
         mockApiGetReferenceDetail(reference);
-        props = {
-            match: { params: { refId: reference.id } },
-        };
     });
 
     it("should render properly", async () => {
-        renderWithMemoryRouter(<ReferenceManager {...props} />);
+        renderWithMemoryRouter(<References />, [`/${reference.id}/manage`]);
 
         expect(await screen.findByText("General")).toBeInTheDocument();
         expect(screen.getByText("Description")).toBeInTheDocument();
@@ -31,14 +29,14 @@ describe("<ReferenceManager />", () => {
     });
 
     it("should render when [remotes_from=null]", async () => {
-        renderWithMemoryRouter(<ReferenceManager {...props} />);
+        renderWithMemoryRouter(<References />, [`/${reference.id}/manage`]);
 
         expect(await screen.findByText("General")).toBeInTheDocument();
         expect(screen.queryByText("Remote Reference")).toBeNull();
     });
 
     it("should render when [cloned_from={ Bar: 'Bee' }]", async () => {
-        renderWithMemoryRouter(<ReferenceManager {...props} />);
+        renderWithMemoryRouter(<References />, [`/${reference.id}/manage`]);
 
         expect(await screen.findByText("Clone Reference")).toBeInTheDocument();
         expect(screen.getByText("Source Reference"));

--- a/src/js/references/components/Item/ReferenceItem.tsx
+++ b/src/js/references/components/Item/ReferenceItem.tsx
@@ -1,13 +1,12 @@
 import { useCheckAdminRoleOrPermission } from "@/administration/hooks";
 import { Permission } from "@/groups/types";
+import { getFontSize, getFontWeight } from "@app/theme";
+import { Attribution, BoxGroupSection, Icon, ProgressCircle } from "@base";
 import { IconButton } from "@base/IconButton";
 import { JobState } from "@jobs/types";
 import React from "react";
-import { Link, useHistory } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom-v5-compat";
 import styled from "styled-components";
-import { getFontSize, getFontWeight } from "../../../app/theme";
-import { Attribution, BoxGroupSection, Icon } from "../../../base";
-import { ProgressCircle } from "../../../base/ProgressCircle";
 import { ReferenceMinimal } from "../../types";
 
 const StyledReferenceItem = styled(BoxGroupSection)`
@@ -51,7 +50,7 @@ type ReferenceItemProps = {
  * A condensed reference item for use in a list of references
  */
 export function ReferenceItem({ reference }: ReferenceItemProps) {
-    const history = useHistory();
+    const navigate = useNavigate();
     const { id, data_type, name, organism, user, created_at, task } = reference;
     const { hasPermission: canCreate } = useCheckAdminRoleOrPermission(Permission.create_ref);
 
@@ -60,13 +59,13 @@ export function ReferenceItem({ reference }: ReferenceItemProps) {
             name="clone"
             tip="clone"
             color="blue"
-            onClick={() => history.push({ state: { cloneReference: id } })}
+            onClick={() => navigate(".", { state: { cloneReference: id } })}
         />
     ) : null;
 
     return (
         <StyledReferenceItem>
-            <ReferenceLink to={`/refs/${id}`}>{name}</ReferenceLink>
+            <ReferenceLink to={id}>{name}</ReferenceLink>
             <ReferenceItemDataDescriptor>
                 <Icon name={data_type === "genome" ? "dna" : "barcode"} />
                 {organism || "unknown"} {data_type || "genome"}s

--- a/src/js/references/components/References.tsx
+++ b/src/js/references/components/References.tsx
@@ -1,7 +1,7 @@
 import { useFetchSettings } from "@administration/queries";
 import { Container, LoadingPlaceholder } from "@base";
 import React from "react";
-import { Redirect, Route, Switch } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom-v5-compat";
 import ReferenceDetail from "./Detail/ReferenceDetail";
 import ReferenceList from "./ReferenceList";
 import { ReferenceSettings } from "./ReferenceSettings";
@@ -18,12 +18,12 @@ export default function References() {
 
     return (
         <Container>
-            <Switch>
-                <Route path="/refs" component={ReferenceList} exact />
-                <Redirect from="/refs/settings/*" to="/refs/settings" />
-                <Route path="/refs/settings" component={ReferenceSettings} />
-                <Route path="/refs/:refId" component={ReferenceDetail} />
-            </Switch>
+            <Routes>
+                <Route path="/" element={<ReferenceList />} />
+                <Route path="/settings/*" element={<Navigate replace to="/refs/settings" />} />
+                <Route path="/settings" element={<ReferenceSettings />} />
+                <Route path="/:refId/*" element={<ReferenceDetail />} />
+            </Routes>
         </Container>
     );
 }

--- a/src/js/references/components/SourceTypes/LocalSourceTypes.tsx
+++ b/src/js/references/components/SourceTypes/LocalSourceTypes.tsx
@@ -15,7 +15,7 @@ import {
 import { IconButton } from "@base/IconButton";
 import { get } from "lodash-es";
 import React from "react";
-import { useRouteMatch } from "react-router-dom";
+import { useParams } from "react-router-dom-v5-compat";
 import styled from "styled-components";
 import { useUpdateSourceTypes } from "../../hooks";
 import { referenceQueryKeys, useGetReference, useUpdateReference } from "../../queries";
@@ -61,15 +61,8 @@ const SourceTypesUndo = styled(BoxGroupSection)`
     }
 `;
 
-interface MatchTypes {
-    /** The reference id */
-    refId: string;
-}
-
 export function LocalSourceTypes() {
-    const match = useRouteMatch<MatchTypes>();
-    const refId = match.params.refId;
-
+    const { refId } = useParams();
     const { data, isPending } = useGetReference(refId);
 
     const { mutation: updateReferenceMutation } = useUpdateReference(refId);

--- a/src/js/references/components/__tests__/EmptyReference.test.tsx
+++ b/src/js/references/components/__tests__/EmptyReference.test.tsx
@@ -1,14 +1,14 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { mockApiCreateReference } from "@tests/fake/references";
+import { renderWithMemoryRouter } from "@tests/setupTests";
 import React from "react";
 import { describe, expect, it } from "vitest";
-import { mockApiCreateReference } from "../../../../tests/fake/references";
-import { renderWithProviders } from "../../../../tests/setupTests";
 import EmptyReference from "../EmptyReference";
 
 describe("<EmptyReference />", () => {
     it("should display error and block submission when name textbox is empty", async () => {
-        renderWithProviders(<EmptyReference />);
+        renderWithMemoryRouter(<EmptyReference />);
 
         await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
@@ -17,7 +17,7 @@ describe("<EmptyReference />", () => {
 
     it("handleSubmit should call onSubmit when [name.length!=0] and [dataType.length!=0]", async () => {
         const scope = mockApiCreateReference("test_name", "", "genome", "");
-        renderWithProviders(<EmptyReference />);
+        renderWithMemoryRouter(<EmptyReference />);
 
         await userEvent.type(screen.getByRole("textbox", { name: "Name" }), "test_name");
         await userEvent.click(screen.getByRole("button", { name: "Save" }));
@@ -27,7 +27,7 @@ describe("<EmptyReference />", () => {
 
     it("handleSubmit should submit correct dataType when changed", async () => {
         const scope = mockApiCreateReference("test_name", "", "barcode", "");
-        renderWithProviders(<EmptyReference />);
+        renderWithMemoryRouter(<EmptyReference />);
 
         await userEvent.type(screen.getByRole("textbox", { name: "Name" }), "test_name");
         await userEvent.click(screen.getByRole("button", { name: "Barcode Target sequences for barcode analysis" }));
@@ -43,7 +43,7 @@ describe("<EmptyReference />", () => {
         const description = "test_description";
 
         const scope = mockApiCreateReference(name, description, dataType, organism);
-        renderWithProviders(<EmptyReference />);
+        renderWithMemoryRouter(<EmptyReference />);
 
         await userEvent.type(screen.getByRole("textbox", { name: "Name" }), name);
         await userEvent.type(screen.getByRole("textbox", { name: "Organism" }), organism);

--- a/src/js/references/components/__tests__/ImportReference.test.tsx
+++ b/src/js/references/components/__tests__/ImportReference.test.tsx
@@ -1,9 +1,9 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { renderWithMemoryRouter } from "@tests/setupTests";
 import nock from "nock";
 import React from "react";
 import { describe, expect, it } from "vitest";
-import { renderWithProviders } from "../../../../tests/setupTests";
 import { ImportReference } from "../ImportReference";
 
 describe("<ImportReference />", () => {
@@ -22,7 +22,7 @@ describe("<ImportReference />", () => {
             })
             .reply(201, { id: "foo", name: "External", description: "External reference" });
 
-        renderWithProviders(<ImportReference />);
+        renderWithMemoryRouter(<ImportReference />);
 
         await userEvent.upload(
             screen.getByLabelText("Upload file"),
@@ -36,7 +36,7 @@ describe("<ImportReference />", () => {
     });
 
     it("should display errors when file or name missing", async () => {
-        renderWithProviders(<ImportReference />);
+        renderWithMemoryRouter(<ImportReference />);
 
         expect(screen.queryByText("A reference file must be uploaded")).not.toBeInTheDocument();
         expect(screen.queryByText("A name is required.")).not.toBeInTheDocument();

--- a/src/js/references/queries.ts
+++ b/src/js/references/queries.ts
@@ -2,7 +2,7 @@ import { ErrorResponse } from "@/types/types";
 import { Request } from "@app/request";
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 import {
     addReferenceGroup,
     addReferenceUser,
@@ -92,7 +92,7 @@ export function useRemoteReference() {
  * @returns A mutator for importing a reference
  */
 export function useImportReference() {
-    const history = useHistory();
+    const navigate = useNavigate();
 
     return useMutation<
         unknown,
@@ -104,7 +104,7 @@ export function useImportReference() {
         }
     >({
         mutationFn: ({ name, description, importFrom }) => importReference(name, description, importFrom),
-        onSuccess: () => history.push("/refs"),
+        onSuccess: () => navigate("/refs"),
     });
 }
 
@@ -145,7 +145,7 @@ export function useUploadReference() {
  * @returns A mutator for creating an empty reference
  */
 export function useCreateReference() {
-    const history = useHistory();
+    const navigate = useNavigate();
 
     return useMutation<
         Reference,
@@ -155,7 +155,7 @@ export function useCreateReference() {
         mutationFn: ({ name, description, dataType, organism }) =>
             createReference(name, description, dataType, organism),
         onSuccess: () => {
-            history.push("/refs", { emptyReference: false });
+            navigate("/refs", { replace: true, state: { emptyReference: false } });
         },
     });
 }

--- a/src/js/sequences/components/EditSequence.tsx
+++ b/src/js/sequences/components/EditSequence.tsx
@@ -1,8 +1,7 @@
-import { LocationType } from "@/types/types";
 import { useCurrentOTUContext } from "@otus/queries";
 import { useGetActiveSequence, useGetUnreferencedSegments, useGetUnreferencedTargets } from "@sequences/hooks";
 import React from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom-v5-compat";
 import EditBarcodeSequence from "./Barcode/EditBarcodeSequence";
 import EditGenomeSequence from "./Genome/EditGenomeSequence";
 
@@ -10,7 +9,7 @@ import EditGenomeSequence from "./Genome/EditGenomeSequence";
  * A component to manage the editing of sequences
  */
 export default function EditSequence() {
-    const location = useLocation<LocationType>();
+    const location = useLocation();
     const { otu, reference } = useCurrentOTUContext();
     const { data_type } = reference;
 

--- a/src/js/sequences/components/Genome/SequenceSegmentField.tsx
+++ b/src/js/sequences/components/Genome/SequenceSegmentField.tsx
@@ -4,7 +4,7 @@ import { OTUSegment } from "@otus/types";
 import { map } from "lodash-es";
 import React from "react";
 import { Controller, useFormContext } from "react-hook-form";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 import styled from "styled-components";
 import { SequenceSegment } from "./SequenceSegment";
 

--- a/src/js/sequences/components/IsolateSequences.tsx
+++ b/src/js/sequences/components/IsolateSequences.tsx
@@ -7,7 +7,7 @@ import RemoveSequence from "@sequences/components/RemoveSequence";
 import { useGetUnreferencedTargets } from "@sequences/hooks";
 import { map } from "lodash";
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router-dom-v5-compat";
 import styled from "styled-components";
 import AddSequenceLink from "./AddSequenceLink";
 import AddBarcodeSequence from "./Barcode/AddBarcodeSequence";

--- a/src/js/sequences/hooks.ts
+++ b/src/js/sequences/hooks.ts
@@ -1,10 +1,9 @@
-import { LocationType } from "@/types/types";
 import { useGetActiveIsolate } from "@otus/hooks";
 import { useCurrentOTUContext } from "@otus/queries";
 import sortSequencesBySegment from "@otus/utils";
 import { compact, filter, find, map, reject } from "lodash-es";
 import { useCallback, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom-v5-compat";
 
 /**
  * A hook for managing sequence detail visibility.
@@ -36,7 +35,7 @@ export function useExpanded() {
  * @returns The active sequence
  */
 export function useGetActiveSequence() {
-    const location = useLocation<LocationType>();
+    const location = useLocation();
     const { otu } = useCurrentOTUContext();
 
     const activeIsolate = useGetActiveIsolate(otu);
@@ -60,7 +59,7 @@ export function useGetActiveSequence() {
  * @returns A list of inactive sequences
  */
 export function useGetInactiveSequences() {
-    const location = useLocation<LocationType>();
+    const location = useLocation();
     const { otu } = useCurrentOTUContext();
 
     const activeIsolate = useGetActiveIsolate(otu);


### PR DESCRIPTION
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->
## Changes
- Updated all components under `References` which used `react-router-dom` to `react-router-dom-v5-compat`
- Updated all `Link` imports accordingly
- Updated all `match` props accordingly
- Updated all `useHistory` to `useNavigate`
- Updated all imports of `useLocation` from `react-router-dom` to `react-router-dom-v5-compat`
- Updated tests to ensure they pass
- Updated `OTUList` test to remove handling of toolbar since the toolbar is tested in other components and I wasn't able to find out how to do URL testing using `MemoryRouter` seamlessly. What I found was that it might work using `createMemoryRouter` and checking the route path to see if it changes. 

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] All tests pass in my local environment
* [x] Deepsource issues have been reviewed and addressed.
* [x] Commented code and `console` usages have been removed.
 
## Screenshots
_Only required for visual changes_
