### PR TITLE
fix: prevent crash when local client is outdated

### DIFF
--- a/src/js/app/App.tsx
+++ b/src/js/app/App.tsx
@@ -9,6 +9,7 @@ import { GlobalStyles } from "./GlobalStyles";
 import Main from "./Main";
 import { theme } from "./theme";
 import { resetClient } from "@utils/utils";
+import { ErrorBoundary } from "@app/ErrorBoundary";
 
 // Lazy load components
 const LazyFirstUser = React.lazy(() => import("@wall/components/FirstUser"));
@@ -64,12 +65,14 @@ const queryClient = new QueryClient({
 export default function App(): React.ReactElement {
     return (
         <ThemeProvider theme={theme}>
-            <QueryClientProvider client={queryClient}>
-                <Router hook={useBrowserLocation}>
-                    <GlobalStyles />
-                    <ConnectedApp />
-                </Router>
-            </QueryClientProvider>
+            <ErrorBoundary>
+                <QueryClientProvider client={queryClient}>
+                    <Router hook={useBrowserLocation}>
+                        <GlobalStyles />
+                        <ConnectedApp />
+                    </Router>
+                </QueryClientProvider>
+            </ErrorBoundary>
         </ThemeProvider>
     );
 }

--- a/src/js/app/ErrorBoundary.tsx
+++ b/src/js/app/ErrorBoundary.tsx
@@ -1,14 +1,20 @@
 import React from "react";
 
 type ErrorBoundryState = {
+    /* Indicates if any error has occured */
     hasError: boolean;
+    /* the most recent error detected */
     error: Error;
 };
 
 type ErrorBoundryProps = {
+    /* UI to render when no error is detected */
     children: React.ReactNode;
 };
 
+/**
+ * Error handling that refreshes the website when an old client version is detected
+ */
 export class ErrorBoundary extends React.Component<ErrorBoundryProps, ErrorBoundryState> {
     constructor(props) {
         super(props);

--- a/src/js/app/ErrorBoundary.tsx
+++ b/src/js/app/ErrorBoundary.tsx
@@ -13,7 +13,7 @@ type ErrorBoundryProps = {
 };
 
 /**
- * Error handling that refreshes the website when an old client version is detected
+ * Error handling component that refreshes the website when an old client version is detected
  */
 export class ErrorBoundary extends React.Component<ErrorBoundryProps, ErrorBoundryState> {
     constructor(props) {

--- a/src/js/app/ErrorBoundary.tsx
+++ b/src/js/app/ErrorBoundary.tsx
@@ -16,7 +16,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundryProps, ErrorBound
     }
 
     static getDerivedStateFromError(error) {
-        return { hasError: true, error: error };
+        return { hasError: true, error };
     }
 
     render() {

--- a/src/js/app/ErrorBoundary.tsx
+++ b/src/js/app/ErrorBoundary.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+type ErrorBoundryState = {
+    hasError: boolean;
+    error: Error;
+};
+
+type ErrorBoundryProps = {
+    children: React.ReactNode;
+};
+
+export class ErrorBoundary extends React.Component<ErrorBoundryProps, ErrorBoundryState> {
+    constructor(props) {
+        super(props);
+        this.state = { hasError: false, error: null };
+    }
+
+    static getDerivedStateFromError(error) {
+        return { hasError: true, error: error };
+    }
+
+    render() {
+        if (
+            this.state.hasError &&
+            this.state.error instanceof TypeError &&
+            this.state.error.message.startsWith("Failed to fetch dynamically imported module:")
+        ) {
+            window.location.reload();
+        }
+
+        return this.props.children;
+    }
+}


### PR DESCRIPTION
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->

Changes: 

  - If a dynamic page load failure is detected the page refreshes. Doing so prevents a more obvious full failure of the UI that forces the user to refresh

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] All tests pass in my local environment
* [x] Deepsource issues have been reviewed and addressed.
* [x] Commented code and `console` usages have been removed.
 
## Screenshots
_Only required for visual changes_
