### PR TITLE
fix: prevent crash when closing barcode sequence editing dialog

### DIFF
--- a/src/js/sequences/components/Barcode/EditBarcodeSequence.tsx
+++ b/src/js/sequences/components/Barcode/EditBarcodeSequence.tsx
@@ -1,26 +1,25 @@
 import { Dialog, DialogContent, DialogOverlay, DialogTitle } from "@base";
 import { useEditSequence } from "@otus/queries";
-import { OTUSequence } from "@otus/types";
 import { DialogPortal } from "@radix-ui/react-dialog";
-import { ReferenceTarget } from "@references/types";
 import BarcodeSequenceForm from "@sequences/components/Barcode/BarcodeSequenceForm";
 import { useUrlSearchParam } from "@utils/hooks";
 import React from "react";
+import { useGetActiveSequence, useGetSelectableTargets } from "@sequences/hooks";
 
 type EditBarcodeSequence = {
-    activeSequence: OTUSequence;
     isolateId: string;
     otuId: string;
-    /** A list of unreferenced targets */
-    targets: ReferenceTarget[];
 };
 
 /**
  * Displays dialog to edit a barcode sequence
  */
-export default function EditBarcodeSequence({ activeSequence, isolateId, otuId, targets }: EditBarcodeSequence) {
+export default function EditBarcodeSequence({ isolateId, otuId }: EditBarcodeSequence) {
     const [openEditSequence, setOpenEditSequence] = useUrlSearchParam("openEditSequence");
     const mutation = useEditSequence(otuId);
+
+    const targets = useGetSelectableTargets();
+    const activeSequence = useGetActiveSequence();
 
     function onSubmit({ accession, definition, host, sequence, target }) {
         mutation.mutate(

--- a/src/js/sequences/components/Barcode/TargetField.tsx
+++ b/src/js/sequences/components/Barcode/TargetField.tsx
@@ -67,7 +67,7 @@ export default function TargetField({ targets }: TargetFieldProps) {
                     render={({ field: { onChange, value } }) => {
                         const targetExists = targets.some(target => target.name === value);
 
-                        if (value && !targetExists) {
+                        if (value && !targetExists && !disabled) {
                             setValue("target", targets[0]?.name);
                         }
 

--- a/src/js/sequences/components/EditSequence.tsx
+++ b/src/js/sequences/components/EditSequence.tsx
@@ -1,5 +1,4 @@
 import { useCurrentOTUContext } from "@otus/queries";
-import { useGetActiveSequence, useGetUnreferencedSegments, useGetUnreferencedTargets } from "@sequences/hooks";
 import { useUrlSearchParam } from "@utils/hooks";
 import React from "react";
 import EditBarcodeSequence from "./Barcode/EditBarcodeSequence";
@@ -13,25 +12,14 @@ export default function EditSequence() {
     const { otu, reference } = useCurrentOTUContext();
     const { data_type } = reference;
 
-    const targets = useGetUnreferencedTargets();
-    const segments = useGetUnreferencedSegments();
-    const activeSequence = useGetActiveSequence();
-
     return data_type === "barcode" ? (
-        <EditBarcodeSequence
-            activeSequence={activeSequence}
-            isolateId={activeIsolate}
-            otuId={otu.id}
-            targets={targets}
-        />
+        <EditBarcodeSequence isolateId={activeIsolate} otuId={otu.id} />
     ) : (
         <EditGenomeSequence
-            activeSequence={activeSequence}
             hasSchema={Boolean(otu.schema.length)}
             isolateId={activeIsolate}
             otuId={otu.id}
             refId={reference.id}
-            segments={segments}
         />
     );
 }

--- a/src/js/sequences/components/Genome/EditGenomeSequence.tsx
+++ b/src/js/sequences/components/Genome/EditGenomeSequence.tsx
@@ -1,34 +1,27 @@
 import { Dialog, DialogContent, DialogOverlay, DialogTitle } from "@base";
 import { useEditSequence } from "@otus/queries";
-import { OTUSegment, OTUSequence } from "@otus/types";
 import { DialogPortal } from "@radix-ui/react-dialog";
 import GenomeSequenceForm from "@sequences/components/Genome/GenomeSequenceForm";
 import { useUrlSearchParam } from "@utils/hooks";
 import React from "react";
+import { useGetActiveSequence, useGetUnreferencedSegments } from "@sequences/hooks";
 
 type EditGenomeSequenceProps = {
-    activeSequence: OTUSequence;
     hasSchema: boolean;
     isolateId: string;
     otuId: string;
     refId: string;
-    /** A list of unreferenced segments */
-    segments: OTUSegment[];
 };
 
 /**
  * Displays dialog to edit a genome sequence
  */
-export default function EditGenomeSequence({
-    activeSequence,
-    hasSchema,
-    isolateId,
-    otuId,
-    refId,
-    segments,
-}: EditGenomeSequenceProps) {
+export default function EditGenomeSequence({ hasSchema, isolateId, otuId, refId }: EditGenomeSequenceProps) {
     const [openEditSequence, setOpenEditSequence] = useUrlSearchParam("openEditSequence");
     const mutation = useEditSequence(otuId);
+
+    const segments = useGetUnreferencedSegments();
+    const activeSequence = useGetActiveSequence();
 
     function onSubmit({ accession, definition, host, sequence, segment }) {
         mutation.mutate(

--- a/src/js/sequences/hooks.ts
+++ b/src/js/sequences/hooks.ts
@@ -87,7 +87,7 @@ export function useGetUnreferencedTargets() {
 }
 
 /**
- * Get a list of targets that have not already been assigned to a sequence
+ * Get a list of targets that are valid selections for the active sequence
  *
  * @returns A list of unreferenced targets
  */

--- a/src/js/sequences/hooks.ts
+++ b/src/js/sequences/hooks.ts
@@ -75,6 +75,23 @@ export function useGetInactiveSequences() {
  * @returns A list of unreferenced targets
  */
 export function useGetUnreferencedTargets() {
+    const {
+        otu,
+        reference: { targets },
+    } = useCurrentOTUContext();
+
+    const { sequences } = useGetActiveIsolate(otu);
+    const referencedTargetNames = map(sequences, sequence => sequence.target);
+
+    return filter(targets, target => !referencedTargetNames.includes(target.name));
+}
+
+/**
+ * Get a list of targets that have not already been assigned to a sequence
+ *
+ * @returns A list of unreferenced targets
+ */
+export function useGetSelectableTargets() {
     const { reference } = useCurrentOTUContext();
     const { targets } = reference;
 


### PR DESCRIPTION
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->
**Note:** This PR has existing testing issues that should be automagically resolved once rebased onto the testing changes made in the most recent wouter PR

Changes:
- Mild rework of existing OTU hooks to prevent a small UI issues where components would mistakenly think that unreferenced targets exist when they do not
- Prevent a crash that could occur when closing the `editBarcodeSequence` dialogue when there were no unreferenced targets


## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] All tests pass in my local environment
* [ ] Deepsource issues have been reviewed and addressed.
* [x] Commented code and `console` usages have been removed.
 
## Screenshots
_Only required for visual changes_
