### PR TITLE
fix: correctly style focused navbar links

### DIFF
--- a/src/js/nav/components/NavBarLink.tsx
+++ b/src/js/nav/components/NavBarLink.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Link } from "@base";
 import { useMatchPartialPath } from "@utils/hooks";
 
-const navBarkLinkClassName = cn(
+const navBarLinkClassName = cn(
     "text-white",
     "cursor-pointer",
     "flex",
@@ -22,8 +22,8 @@ export function NavBarLink({ children, to }) {
             to={to}
             className={active =>
                 isActive || active
-                    ? cn(navBarkLinkClassName, "text-white", "bg-primary-dark", "hover:text-white")
-                    : navBarkLinkClassName
+                    ? cn(navBarLinkClassName, "text-white", "bg-primary-dark", "hover:text-white", "focus:text-white")
+                    : navBarLinkClassName
             }
         >
             {children}


### PR DESCRIPTION
<!---
Describe your changes in a bulleted list.

Be sure to identify and justify breaking changes.
--->

prevents navbar link text from turning blue when focused

## Pre-Review Checklist
* [x] I have considered backwards and forwards compatibility.
* [x] All changes are tested.
* [x] All touched code documentation is updated.
* [x] All tests pass in my local environment
* [x] Deepsource issues have been reviewed and addressed.
* [x] Commented code and `console` usages have been removed.
 
## Screenshots
_Only required for visual changes_
