### PR TITLE
fix: prevent chunk preloading errors

### DIFF
--- a/src/js/index.tsx
+++ b/src/js/index.tsx
@@ -18,6 +18,13 @@ if (window.virtool.sentryDsn !== "SENTRY_DSN") {
     window.captureException = (error) => console.error(error);
 }
 
+// Reload the page if a preload error occurs.
+// These errors occur when a new version of the app bundle is deployed and a
+// requested chunk no longer exists on the server.
+window.addEventListener("vite:preloadError", () => {
+    window.location.reload();
+});
+
 window.virtool.b2c = { use: false };
 
 const AppWithProfiler = withProfiler(App);


### PR DESCRIPTION
Prevent Vite chunk loading errors after a new bundle is deployed.

If a request chunk cannot be fetched, the page is refreshed.

* Resolves UI-401.
* Resolves UI-402.

## Checklist

Think before checking the following items:

- [x] I have considered backwards and forwards compatibility.
- [x] All changes are tested.
- [x] All touched code documentation is updated.

## Screenshots

_Only required for visual changes_
