### PR TITLE
Remove password visibility icon in first user form

### DIFF
--- a/src/js/wall/components/FirstUser.tsx
+++ b/src/js/wall/components/FirstUser.tsx
@@ -2,7 +2,6 @@ import Button from "@base/Button";
 import InputError from "@base/InputError";
 import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
-import InputPassword from "@base/InputPassword";
 import InputSimple from "@base/InputSimple";
 import { useCreateFirstUser } from "@users/queries";
 import React from "react";

--- a/src/js/wall/components/FirstUser.tsx
+++ b/src/js/wall/components/FirstUser.tsx
@@ -49,9 +49,10 @@ export default function FirstUser() {
                 </InputGroup>
                 <InputGroup>
                     <InputLabel htmlFor="password">Password</InputLabel>
-                    <InputPassword
+                    <InputSimple
                         aria-label="password"
                         id="password"
+                        type="password"
                         {...register("password", {
                             required:
                                 "Password does not meet minimum length requirement (8)",


### PR DESCRIPTION
* Remove the password visibility icon in the first user form.
* Resolves the misalignment of the icon. It was at the beginning of the input instead of the end.

## Checklist

Think before checking the following items:

- [x] I have considered backwards and forwards compatibility.
- [x] All changes are tested.
- [x] All touched code documentation is updated.

## Screenshots

_Only required for visual changes_
