### PR TITLE
fix: restore quick analysis opening

### DIFF
--- a/src/analyses/components/Create/QuickAnalyze.tsx
+++ b/src/analyses/components/Create/QuickAnalyze.tsx
@@ -1,4 +1,4 @@
-import { useDialogParam } from "@app/hooks";
+import { useDialogParam, useUrlSearchParam } from "@app/hooks";
 import { cn } from "@app/utils";
 import Badge from "@base/Badge";
 import BoxGroupSection from "@base/BoxGroupSection";
@@ -42,15 +42,24 @@ type QuickAnalyzeProps = {
  */
 export default function QuickAnalyze({ samples }: QuickAnalyzeProps) {
     const { open, setOpen } = useDialogParam("openQuickAnalyze");
-
+    const { unsetValue: unsetQuickAnalysisType } =
+        useUrlSearchParam("quickAnalysisType");
     const { data: hmms, isPending } = useListHmms(1, 1, "");
 
     // The dialog should close when all selected samples have been analyzed and deselected.
     useEffect(() => {
         if (samples.length === 0) {
             setOpen(false);
+            unsetQuickAnalysisType();
         }
     }, [samples, setOpen]);
+
+    function onOpenChange(open: boolean) {
+        setOpen(open);
+        if (!open) {
+            unsetQuickAnalysisType();
+        }
+    }
 
     if (isPending) {
         return null;
@@ -61,7 +70,7 @@ export default function QuickAnalyze({ samples }: QuickAnalyzeProps) {
     const sampleIds = samples.map((sample) => sample.id);
 
     return (
-        <Dialog open={open} onOpenChange={() => setOpen(!open)}>
+        <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogPortal>
                 <DialogOverlay />
                 <CreateAnalysisDialogContent>

--- a/src/samples/components/Item/SampleItem.tsx
+++ b/src/samples/components/Item/SampleItem.tsx
@@ -1,5 +1,5 @@
 import { Workflows } from "@analyses/types";
-import { useUrlSearchParam } from "@app/hooks";
+import { useDialogParam, useUrlSearchParam } from "@app/hooks";
 import { getFontSize, getFontWeight } from "@app/theme";
 import Attribution from "@base/Attribution";
 import Box from "@base/Box";
@@ -97,10 +97,12 @@ export default function SampleItem({
 }: SampleItemProps) {
     const { setValue: setQuickAnalysisType } =
         useUrlSearchParam<string>("quickAnalysisType");
+    const { setOpen } = useDialogParam("openQuickAnalyze");
 
     function onQuickAnalyze() {
         setQuickAnalysisType(Workflows.pathoscope_bowtie);
         selectOnQuickAnalyze();
+        setOpen(true);
     }
 
     return (

--- a/src/samples/components/SampleSelectionToolbar.tsx
+++ b/src/samples/components/SampleSelectionToolbar.tsx
@@ -1,8 +1,10 @@
+import { updateSearchParam } from "@app/hooks";
 import Button from "@base/Button";
 import Icon from "@base/Icon";
 import LinkButton from "@base/LinkButton";
 import React from "react";
 import styled from "styled-components";
+import { useSearch } from "wouter";
 
 const SampleSelectionToolbarTop = styled.div`
     align-items: center;
@@ -36,12 +38,16 @@ export default function SampleSelectionToolbar({
     onClear,
     selected,
 }: SampleSelectionToolbarProps) {
+    const search = useSearch();
     return (
         <SampleSelectionToolbarTop>
             <Button onClick={onClear}>
                 Clear selection of {selected.length} samples
             </Button>
-            <LinkButton color="green" to="?openQuickAnalyze=true">
+            <LinkButton
+                color="green"
+                to={updateSearchParam("openQuickAnalyze", "true", search)}
+            >
                 <Icon name="chart-area" /> Quick Analyze
             </LinkButton>
         </SampleSelectionToolbarTop>


### PR DESCRIPTION
Changes: 

- prevent navigation to first page when opening quick analysis
- open quick analysis when pressing the end icon of sample items

<!---
* Describe your changes in a bulleted list.
* Identify and justify breaking changes.
--->

## Checklist

Think before checking the following items:

- [x] I have considered backwards and forwards compatibility.
- [x] All changes are tested.
- [x] All touched code documentation is updated.

## Screenshots

_Only required for visual changes_
