### PR TITLE
fix: restore missing dot colors in job status filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "virtool-ui",
       "dependencies": {
         "@azure/msal-browser": "^2.33.0",
         "@azure/msal-react": "^1.5.3",

--- a/src/base/Dot.tsx
+++ b/src/base/Dot.tsx
@@ -1,8 +1,10 @@
 import { cn } from "@app/utils";
 import React from "react";
 
+export type DotColor = "blue" | "green" | "gray" | "red";
+
 type DotProps = {
-    color: "blue" | "green" | "gray" | "red";
+    color: DotColor;
 };
 
 export default function Dot({ color }: DotProps) {

--- a/src/base/Dot.tsx
+++ b/src/base/Dot.tsx
@@ -2,7 +2,7 @@ import { cn } from "@app/utils";
 import React from "react";
 
 type DotProps = {
-    color: string;
+    color: "blue" | "green" | "gray" | "red";
 };
 
 export default function Dot({ color }: DotProps) {
@@ -12,7 +12,7 @@ export default function Dot({ color }: DotProps) {
                 {
                     "bg-blue-500": color === "blue",
                     "bg-green-600": color === "green",
-                    "bg-gray-600": color === "gray",
+                    "bg-gray-400": color === "gray",
                     "bg-red-600": color === "red",
                 },
                 "margin-full",

--- a/src/jobs/components/Filters/StateButton.tsx
+++ b/src/jobs/components/Filters/StateButton.tsx
@@ -2,7 +2,7 @@ import { cn } from "@app/utils";
 import Badge from "@base/Badge";
 import BoxGroupSection from "@base/BoxGroupSection";
 import Checkbox from "@base/Checkbox";
-import Dot from "@base/Dot";
+import Dot, { DotColor } from "@base/Dot";
 import React from "react";
 
 type StateButtonProps = {
@@ -13,7 +13,7 @@ type StateButtonProps = {
     count: number;
 
     /** The state color */
-    color: string;
+    color: DotColor;
 
     /** The name of the state */
     label: string;

--- a/src/jobs/components/Filters/StateFilter.tsx
+++ b/src/jobs/components/Filters/StateFilter.tsx
@@ -63,7 +63,7 @@ export default function StateFilter({ counts }: StateFilterProps) {
                 states={[
                     {
                         active: states.includes("waiting"),
-                        color: "grey",
+                        color: "gray",
                         count: availableCounts.waiting,
                         state: "waiting",
                         label: "waiting",
@@ -73,7 +73,7 @@ export default function StateFilter({ counts }: StateFilterProps) {
                         count: availableCounts.preparing,
                         state: "preparing",
                         label: "preparing",
-                        color: "grey",
+                        color: "gray",
                     },
                     {
                         active: states.includes("running"),


### PR DESCRIPTION
* Use "gray" over "grey" consistently to prevent missing dot colors.
* Running `npm i` removed `name` from `package.json`.
* Resolves #648.

## Checklist

Think before checking the following items:

- [x] I have considered backwards and forwards compatibility.
- [x] All changes are tested.
- [x] All touched code documentation is updated.

## Screenshots

_Only required for visual changes_
