### PR TITLE
Reduce load times when sorting and filtering iimi results

### DIFF
--- a/src/analyses/components/Iimi/IimiCondensedCoverage.tsx
+++ b/src/analyses/components/Iimi/IimiCondensedCoverage.tsx
@@ -1,7 +1,6 @@
 import { FormattedIimiIsolate } from "@analyses/types";
-import { combineUntrustworthyRegions, maxSequences } from "@analyses/utils";
-import { filter, map, sortBy, unzip } from "lodash-es";
-import React from "react";
+import { map, sortBy, unzip } from "lodash-es";
+import React, { useMemo } from "react";
 import { SummaryChart } from "../Charts/SummaryChart";
 
 /** A graph of maximum Iimi analysis sequence coverage */
@@ -10,32 +9,17 @@ export function IimiCondensedCoverage({
 }: {
     isolates: FormattedIimiIsolate[];
 }) {
-    const sequences = sortBy(
-        unzip(map(isolates, "sequences")),
-        (seqs) => seqs[0]?.length,
+    const sequences = useMemo(
+        () =>
+            sortBy(
+                unzip(map(isolates, "sequences")),
+                (seqs) => seqs[0]?.length,
+            ),
+        [isolates],
     );
 
     const charts = map(sequences, (seqs) => {
-        const filteredSeqs = filter(seqs);
-        const avgSeq = maxSequences(
-            map(filteredSeqs, (seq) => {
-                return seq.coverage;
-            }),
-        );
-
-        return (
-            <SummaryChart
-                key={filteredSeqs[0].id}
-                data={avgSeq}
-                id={isolates[0].id}
-                yMax={Math.max(...avgSeq, 10)}
-                untrustworthyRanges={combineUntrustworthyRegions(
-                    map(seqs, (sequence) =>
-                        sequence ? sequence.untrustworthy_ranges : [],
-                    ),
-                )}
-            />
-        );
+        return <SummaryChart key={seqs[0].id} seqs={seqs} />;
     });
 
     return <div>{charts}</div>;

--- a/src/analyses/components/Iimi/IimiViewer.tsx
+++ b/src/analyses/components/Iimi/IimiViewer.tsx
@@ -51,7 +51,7 @@ export function IimiViewer({ detail }: { detail: FormattedIimiAnalysis }) {
                 <ul className="list-disc list-inside pl-4">
                     <li>We do not guarantee the accuracy of the results.</li>
                     <li>
-                        This analysis could become inaccessbile at any time as
+                        This analysis could become inaccessible at any time as
                         the workflow changes.
                     </li>
                 </ul>

--- a/src/analyses/components/Iimi/__tests__/IimiViewer.test.tsx
+++ b/src/analyses/components/Iimi/__tests__/IimiViewer.test.tsx
@@ -60,7 +60,7 @@ describe("<IimiViewer />", () => {
         ).toBeInTheDocument();
         expect(
             screen.getByText(
-                /This analysis could become inaccessbile at any time/,
+                /This analysis could become inaccessible at any time/,
             ),
         ).toBeInTheDocument();
     });


### PR DESCRIPTION
<!---
* Describe your changes in a bulleted list.
* Identify and justify breaking changes.
--->

- Prevent unnecessary re-rendering of Iimi overview graphs
  - Reduces initial load time by preventing complete rerenders of the graphs during load
  - Greatly reduces time for sorting graphs by eliminating the need to re-render the graphs
  - Improve performance when changing filtering criteria by only needing to render newly displayed graphs
- fix small type

## Checklist

Think before checking the following items:

- [x] I have considered backwards and forwards compatibility.
- [x] All changes are tested.
- [x] All touched code documentation is updated.

## Screenshots

_Only required for visual changes_
