### PR TITLE
Improve password manager compatibility

### DIFF
--- a/src/account/components/AccountPassword.tsx
+++ b/src/account/components/AccountPassword.tsx
@@ -54,6 +54,7 @@ export default function AccountPassword({
                         <InputContainer>
                             <InputPassword
                                 id="oldPassword"
+                                autoComplete="current-password"
                                 {...register("oldPassword", {
                                     required:
                                         "Please provide your old password",
@@ -78,6 +79,7 @@ export default function AccountPassword({
                         <InputContainer>
                             <InputPassword
                                 id="newPassword"
+                                autoComplete="new-password"
                                 {...register("newPassword", {
                                     required: "Please provide a new password",
                                     minLength: {

--- a/src/base/InputPassword.tsx
+++ b/src/base/InputPassword.tsx
@@ -6,6 +6,7 @@ import InputIconButton from "./InputIconButton";
 type InputPasswordProps = {
     id: string;
     name: string;
+    autoComplete?: string;
 };
 
 const InputPassword = forwardRef<HTMLInputElement, InputPasswordProps>(

--- a/src/users/components/CreateUserForm.tsx
+++ b/src/users/components/CreateUserForm.tsx
@@ -51,7 +51,7 @@ export function CreateUserForm({
                 <InputLabel htmlFor="handle">Username</InputLabel>
                 <InputSimple
                     id="handle"
-                    autoComplete="username"
+                    autoComplete="off"
                     {...register("handle", {
                         required: "Please specify a username",
                     })}
@@ -63,7 +63,7 @@ export function CreateUserForm({
                 <InputSimple
                     id="password"
                     type="password"
-                    autoComplete="new-password"
+                    autoComplete="off"
                     {...register("password", {
                         required:
                             "Password does not meet minimum length requirement (8)",

--- a/src/users/components/Password.tsx
+++ b/src/users/components/Password.tsx
@@ -78,6 +78,7 @@ export default function Password({
                                 aria-label="password"
                                 id="password"
                                 type="password"
+                                autoComplete="off"
                                 {...register("password", {
                                     required:
                                         "Password does not meet minimum length requirement (8)",

--- a/src/wall/components/FirstUser.tsx
+++ b/src/wall/components/FirstUser.tsx
@@ -42,6 +42,7 @@ export default function FirstUser() {
                     <InputSimple
                         aria-label="username"
                         id="username"
+                        autoComplete="username"
                         {...register("username", { required: true })}
                     />
                 </InputGroup>
@@ -51,6 +52,7 @@ export default function FirstUser() {
                         aria-label="password"
                         id="password"
                         type="password"
+                        autoComplete="new-password"
                         {...register("password", {
                             required:
                                 "Password does not meet minimum length requirement (8)",

--- a/src/wall/components/LoginForm.tsx
+++ b/src/wall/components/LoginForm.tsx
@@ -44,6 +44,7 @@ export default function LoginForm({ setResetCode }: LoginFormProps) {
                     <InputLabel htmlFor="handle">Username</InputLabel>
                     <InputSimple
                         id="handle"
+                        autoComplete="username"
                         {...register("handle", { required: true })}
                         autoFocus
                     />
@@ -53,6 +54,7 @@ export default function LoginForm({ setResetCode }: LoginFormProps) {
                     <InputSimple
                         id="password"
                         type="password"
+                        autoComplete="current-password"
                         {...register("password", { required: true })}
                     />
                 </InputGroup>

--- a/src/wall/components/ResetForm.tsx
+++ b/src/wall/components/ResetForm.tsx
@@ -37,6 +37,7 @@ export default function ResetForm({ resetCode }: ResetFormProps) {
                     <InputSimple
                         id="password"
                         type="password"
+                        autoComplete="new-password"
                         {...register("password")}
                     />
                     {isError && (


### PR DESCRIPTION
## Summary
- Added autocomplete attributes to user-facing login and password forms
- Disabled autofill on admin forms that manage other users' credentials

## Test plan
- [x] TypeScript type checking passes
- [x] Prettier formatting passes
- [x] ESLint passes
- [x] Manually verify password managers correctly recognize login form
- [x] Manually verify password managers correctly recognize password change forms
- [x] Manually verify admin user creation form does not trigger autofill