### PR TITLE
fix: prevent crash when loading nuvs analysis pages

### DIFF
--- a/src/analyses/components/Nuvs/NuvsItem.tsx
+++ b/src/analyses/components/Nuvs/NuvsItem.tsx
@@ -20,10 +20,12 @@ export default function NuvsItem({ hit }: NuVsItemProps) {
 
     const { annotatedOrfCount, e, id, index, sequence } = hit;
 
+    const isActive = activeHit !== null && Number(activeHit) === id;
+
     return (
         <Box
             className={cn(
-                { "bg-slate-100": activeHit.toString() === hit.id.toString() },
+                { "bg-slate-100": isActive },
                 "border-none",
                 "nuvs-item",
                 "rounded-none",

--- a/src/analyses/components/Nuvs/NuvsList.tsx
+++ b/src/analyses/components/Nuvs/NuvsList.tsx
@@ -19,8 +19,9 @@ type NuVsListProps = {
 export default function NuvsList({ detail }: NuVsListProps) {
     const sortedHits = useSortAndFilterNuVsHits(detail);
 
+    const firstHitId = sortedHits[0]?.id ? String(sortedHits[0].id) : undefined;
     const { value: activeHit, setValue: setActiveHit } =
-        useUrlSearchParam<string>("activeHit");
+        useUrlSearchParam<string>("activeHit", firstHitId);
 
     let nextId: string;
     let nextIndex: number;
@@ -28,7 +29,7 @@ export default function NuvsList({ detail }: NuVsListProps) {
     let previousIndex: number;
 
     if (activeHit) {
-        const windowIndex = findIndex(sortedHits, { id: activeHit });
+        const windowIndex = findIndex(sortedHits, { id: Number(activeHit) });
 
         if (windowIndex > 0) {
             previousIndex = windowIndex - 1;

--- a/src/analyses/hooks.ts
+++ b/src/analyses/hooks.ts
@@ -71,19 +71,13 @@ export function useSortAndFilterNuVsHits(detail) {
 }
 
 export function useGetActiveHit(matches) {
-    const { value: activeHit, setValue: setActiveHit } =
-        useUrlSearchParam<string>("activeHit");
+    const { value: activeHit } = useUrlSearchParam<string>("activeHit");
 
     if (activeHit !== null) {
-        const hit = find(matches, { id: Number(activeHit) });
-
-        if (hit) {
-            return hit;
-        }
+        return find(matches, { id: Number(activeHit) }) || null;
     }
 
-    setActiveHit(matches[0].id);
-    return matches[0] || null;
+    return null;
 }
 
 type UseCompatibleIndexesResult = {


### PR DESCRIPTION
## Summary
Fixes a TypeError crash that prevented users from viewing nuvs analysis results when navigating to analysis pages.

## Problem
Users encountered `TypeError: Cannot read properties of undefined (reading 'toString')` when loading nuvs analysis pages. The crash occurred during initial page load when no sequence was selected yet (no `activeHit` URL parameter).

**Impact:**
- 31 occurrences since May 2025
- 4 users affected
- Prevented users from viewing analysis results

## Solution
- Initialize `activeHit` synchronously using `defaultValue` parameter instead of `useEffect` to eliminate race condition
- Remove initialization side effect from `useGetActiveHit`, making it a pure lookup function
- Fix type comparison bug in `findIndex` (string vs number)
- Simplify active state check in `NuvsItem`

## Testing
- All existing tests pass
- Handles null case correctly without defensive guards throughout code

Fixes [CLOUD-UI-22](https://cfia-virtool.sentry.io/issues/6596129310)
Resolves VIR-2187