### PR TITLE
fix: restore frontend routing after express upgrade

### DIFF
--- a/src/server/run.ts
+++ b/src/server/run.ts
@@ -25,7 +25,9 @@ async function main() {
         }),
     );
 
-    app.get("/:path*", createDefaultRouteHandler(options));
+    const defaultHandler = createDefaultRouteHandler(options);
+    app.get("/", defaultHandler);
+    app.get("/*splat", defaultHandler);
 
     app.listen(options.port, options.host, () => {
         logger.log("info", "listening for requests", {


### PR DESCRIPTION
Fixes routing broken by Express 5 upgrade.

## Summary

- Express 5 requires wildcards to have parameter names (`/*splat` instead of `*`)
- Added explicit root route handler (`/`) since wildcards don't match empty paths
- All routes (root, SPA, static files) now working correctly

## Changes

- Updated catch-all route from `/:path*` to `/*splat` for Express 5 compatibility
- Added explicit `/` route handler for root path