### PR TITLE
ci: update gha with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,11 @@ updates:
       directory: "/"
       schedule:
           interval: "weekly"
-          day: "monday"
-          time: "09:00"
       open-pull-requests-limit: 10
-      reviewers:
-          - "igboyes"
-      assignees:
-          - "igboyes"
       commit-message:
           prefix: "chore"
           include: "scope"
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "monthly"


### PR DESCRIPTION
Removed reviewer and assignee fields from npm updates. Added GitHub Actions updates with a monthly schedule.