### PR TITLE
refactor: start migration from lodash-es to es-toolkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "d3": "^7.9.0",
         "date-fns": "^3.6.0",
         "downshift": "^7.6.2",
+        "es-toolkit": "^1.43.0",
         "express": "^5.1.0",
         "fuse.js": "^7.1.0",
         "history": "^5.3.0",
@@ -196,7 +197,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -583,7 +583,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -630,7 +629,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4457,6 +4455,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4541,7 +4540,8 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4986,7 +4986,6 @@
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4998,7 +4997,6 @@
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5103,7 +5101,6 @@
       "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -5612,7 +5609,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6047,7 +6043,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -6855,7 +6850,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7177,7 +7171,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
@@ -7539,13 +7534,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.43.0.tgz",
+      "integrity": "sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.25.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.3.tgz",
       "integrity": "sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7628,7 +7632,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9999,6 +10002,7 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10708,7 +10712,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -10738,7 +10741,6 @@
       "integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10771,6 +10773,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10785,6 +10788,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11035,7 +11039,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11095,7 +11098,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11145,7 +11147,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.0.tgz",
       "integrity": "sha512-xXBqsWGKrY46ZqaHDo+ZUYiMUgi8suYu5kdrS20EG8KiL7VRQitEbNjm+UcrDYrNi1YLyfpmAeGjCZYXLT9YBw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -11482,7 +11483,6 @@
       "integrity": "sha512-C5VvvgCCyfyotVITIAv+4efVytl5F7wt+/I2i9q9GZcEXW9BP52YYOXC58igUi+LFZVHukErIIqQSWwv/M3WRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.7"
       },
@@ -11994,7 +11994,6 @@
       "integrity": "sha512-es7uDdEwRVVUAt7XLAZZ1hicOq9r4ov5NFeFPpa2YEyAsyHYOCr0CTlHBfslWG6D5EVNWK3kVIIuW8GHB6hEig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -12401,8 +12400,7 @@
       "version": "4.1.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
       "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -12514,7 +12512,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12668,7 +12665,6 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -12814,7 +12810,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13030,7 +13025,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -13177,7 +13171,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13191,7 +13184,6 @@
       "integrity": "sha512-gR7INfiVRwnEOkCk47faros/9McCZMp5LM+OMNWGLaDBSvJxIzwjgNFufkuePBNaesGRnLmNfW+ddbUJRZn0nQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.6",
         "@vitest/mocker": "4.0.6",
@@ -13810,7 +13802,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "d3": "^7.9.0",
     "date-fns": "^3.6.0",
     "downshift": "^7.6.2",
+    "es-toolkit": "^1.43.0",
     "express": "^5.1.0",
     "fuse.js": "^7.1.0",
     "history": "^5.3.0",

--- a/src/analyses/components/Viewer/Bars.tsx
+++ b/src/analyses/components/Viewer/Bars.tsx
@@ -1,5 +1,4 @@
 import { getBorder, getColor } from "@app/theme";
-import { map } from "lodash-es";
 import styled from "styled-components";
 import { BarsLegendItem } from "./BarsLegendItem";
 
@@ -36,7 +35,7 @@ export function Bars({ empty, items }) {
     return (
         <StyledBars>
             <Bar>
-                {map(items, ({ color, count }) => (
+                {items.map(({ color, count }) => (
                     <BarItem key={color} color={color} size={count} />
                 ))}
                 {empty && (
@@ -44,7 +43,7 @@ export function Bars({ empty, items }) {
                 )}
             </Bar>
             <div>
-                {map(items, ({ color, count, title }) => (
+                {items.map(({ color, count, title }) => (
                     <BarsLegendItem
                         key={color}
                         color={color}

--- a/src/analyses/components/Viewer/Sort.tsx
+++ b/src/analyses/components/Viewer/Sort.tsx
@@ -2,7 +2,6 @@ import Dropdown from "@base/Dropdown";
 import DropdownButton from "@base/DropdownButton";
 import DropdownMenuContent from "@base/DropdownMenuContent";
 import DropdownMenuItem from "@base/DropdownMenuItem";
-import { map } from "lodash-es";
 import { ArrowUpDown, ChevronDown } from "lucide-react";
 
 const sortKeys = {
@@ -44,7 +43,7 @@ export function AnalysisViewerSort({
                 <ChevronDown size={18} />
             </DropdownButton>
             <DropdownMenuContent>
-                {map(sortKeys[workflow], (key) => (
+                {sortKeys[workflow].map((key) => (
                     <DropdownMenuItem key={key} onSelect={() => onSelect(key)}>
                         {sortTitles[key]}
                     </DropdownMenuItem>

--- a/src/app/Main.tsx
+++ b/src/app/Main.tsx
@@ -7,7 +7,6 @@ import MessageBanner from "@message/components/MessageBanner";
 import Nav from "@nav/components/Nav";
 import Sidebar from "@nav/components/Sidebar";
 import { useQueryClient } from "@tanstack/react-query";
-import { includes } from "lodash-es";
 import { lazy, Suspense, useEffect } from "react";
 import { Helmet, HelmetProvider } from "react-helmet-async";
 import { Redirect, Route, Switch } from "wouter";
@@ -31,7 +30,7 @@ function setupWebSocket(queryClient) {
     if (!window.ws) {
         window.ws = new WsConnection(queryClient);
     }
-    if (includes([ABANDONED, INITIALIZING], window.ws.connectionStatus)) {
+    if ([ABANDONED, INITIALIZING].includes(window.ws.connectionStatus)) {
         window.ws.establishConnection();
     }
 }

--- a/src/app/hooks.tsx
+++ b/src/app/hooks.tsx
@@ -1,4 +1,3 @@
-import { forEach, map, split, trimEnd } from "lodash-es";
 import { useEffect, useRef, useState } from "react";
 import { useLocation, useParams, useSearch } from "wouter";
 
@@ -67,9 +66,9 @@ export function formatSearchParams(
 ) {
     const searchParams = new URLSearchParams();
 
-    forEach(params, (value, key) => {
+    Object.entries(params).forEach(([key, value]) => {
         if (Array.isArray(value)) {
-            forEach(value, (arrayValue) =>
+            value.forEach((arrayValue) =>
                 searchParams.append(key, String(arrayValue)),
             );
         } else {
@@ -148,7 +147,7 @@ function updateUrlSearchParamsList(
     const params = new URLSearchParams(search);
 
     params.delete(key);
-    forEach(values, (value) => params.append(key, String(value)));
+    values.forEach((value) => params.append(key, String(value)));
 
     search = `?${params.toString()}`;
     navigate(search);
@@ -333,7 +332,7 @@ function createUseUrlSearchParam(): [
         }
 
         return {
-            values: map(values, castSearchParamValue) as T[],
+            values: values.map(castSearchParamValue) as T[],
             setValues,
         };
     }
@@ -413,5 +412,5 @@ export function useMatchPartialPath(path: string, exclude?: string[]) {
         return false;
     }
 
-    return location.startsWith(trimEnd(split(path, "?")[0], "/"));
+    return location.startsWith(path.split("?")[0].replace(/\/+$/, ""));
 }

--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -3,7 +3,7 @@
  *
  * @module app/theme
  */
-import { get } from "lodash-es";
+import { get } from "es-toolkit/compat";
 import { DefaultTheme } from "styled-components";
 
 /**

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -3,7 +3,7 @@
  */
 import clsx, { ClassValue } from "clsx";
 import { formatDuration, intervalToDuration } from "date-fns";
-import { get, sampleSize, startCase } from "lodash-es";
+import { get, sampleSize, startCase } from "es-toolkit/compat";
 import numbro from "numbro";
 import { twMerge } from "tailwind-merge";
 import { capitalize } from "./common";

--- a/src/app/websocket/reactQueryHandler.ts
+++ b/src/app/websocket/reactQueryHandler.ts
@@ -9,7 +9,7 @@ import { modelQueryKeys } from "@ml/queries";
 import { referenceQueryKeys } from "@references/queries";
 import { samplesQueryKeys } from "@samples/queries";
 import { QueryClient } from "@tanstack/react-query";
-import { forEach, get } from "lodash-es";
+import { get } from "es-toolkit/compat";
 import { taskUpdaters } from "./updaters";
 
 /** Get affected resource query keys by workflow name  */
@@ -30,7 +30,7 @@ const workflowQueries = {
 function jobUpdater(queryClient, data) {
     const queryKeys = workflowQueries[data.workflow];
 
-    forEach(queryKeys, (queryKey) => {
+    queryKeys?.forEach((queryKey) => {
         queryClient.invalidateQueries({ queryKey });
     });
 }

--- a/src/app/websocket/updaters.ts
+++ b/src/app/websocket/updaters.ts
@@ -3,8 +3,9 @@ import { hmmQueryKeys } from "@hmm/queries";
 import { HmmSearchResults } from "@hmm/types";
 import { referenceQueryKeys } from "@references/queries";
 import { ReferenceSearchResult } from "@references/types";
-import { InfiniteData, QueryClient } from "@tanstack/react-query";
-import { assign, cloneDeep, forEach, get } from "lodash-es/lodash";
+import { QueryClient } from "@tanstack/react-query";
+import { get } from "es-toolkit/compat";
+import { cloneDeep } from "es-toolkit/object";
 
 interface TaskObject {
     task: Task;
@@ -33,14 +34,14 @@ function listItemUpdater<T extends Document>(
     task: Task,
     selector: (cache: TaskObject) => Task,
 ) {
-    return function (cache: InfiniteData<T>): InfiniteData<T> {
+    return function (cache: T): T {
         const newCache = cloneDeep(cache);
 
         const items = "items" in newCache ? newCache.items : newCache.documents;
-        forEach(items, (item: { task: Task }) => {
+        items.forEach((item: { task: Task }) => {
             const previousTask = selector(item);
             if (previousTask && item.task.id === task.id) {
-                assign(previousTask, task);
+                Object.assign(previousTask, task);
             }
         });
 
@@ -61,7 +62,7 @@ export function updater<T>(task: Task, selector: (cache: T) => Task) {
         const previousTask = selector(newCache);
 
         if (previousTask && previousTask.id === task.id) {
-            assign(previousTask, task);
+            Object.assign(previousTask, task);
             return newCache;
         }
     };

--- a/src/base/Pagination.tsx
+++ b/src/base/Pagination.tsx
@@ -1,5 +1,5 @@
 import { updateSearchParam, usePageParam } from "@app/hooks";
-import { map, max, min, range } from "lodash-es";
+import { range } from "es-toolkit/math";
 import { ReactElement, ReactNode, useEffect } from "react";
 import { useSearch } from "wouter";
 import PaginationContent from "./PaginationContent";
@@ -15,9 +15,9 @@ function getPageRange(
     rightButtons = 2,
 ) {
     const totalButtons = leftButtons + rightButtons;
-    let maxVal = min([pageCount, storedPage + rightButtons]);
-    const minVal = max([1, maxVal - totalButtons]);
-    maxVal = min([pageCount, minVal + totalButtons]);
+    let maxVal = Math.min(pageCount, storedPage + rightButtons);
+    const minVal = Math.max(1, maxVal - totalButtons);
+    maxVal = Math.min(pageCount, minVal + totalButtons);
 
     return range(minVal, maxVal + 1);
 }
@@ -51,10 +51,9 @@ export default function Pagination({
         }
     }, [currentPage, pageCount, setPage]);
 
-    const entries = renderRow && map(items, (item) => renderRow(item));
+    const entries = renderRow && items.map((item) => renderRow(item));
 
-    const pageButtons = map(
-        getPageRange(pageCount, storedPage),
+    const pageButtons = getPageRange(pageCount, storedPage).map(
         (pageNumber) => (
             <PaginationLink
                 key={pageNumber}

--- a/src/base/RelativeTime.tsx
+++ b/src/base/RelativeTime.tsx
@@ -1,5 +1,4 @@
 import { formatDistanceStrict, isAfter } from "date-fns";
-import { includes } from "lodash-es";
 import { useEffect, useState } from "react";
 
 type RelativeTimeOptions = {
@@ -33,7 +32,7 @@ function createTimeString(
         addSuffix,
     });
 
-    return includes(timeString, "in a") || includes(timeString, "a few")
+    return timeString.includes("in a") || timeString.includes("a few")
         ? "just now"
         : timeString;
 }

--- a/src/forms/hooks.ts
+++ b/src/forms/hooks.ts
@@ -1,5 +1,5 @@
 import { getSessionStorage, setSessionStorage } from "@app/utils";
-import { forEach, isEqual } from "lodash-es";
+import { isEqual } from "es-toolkit/predicate";
 import { Dispatch, SetStateAction, useRef, useState } from "react";
 import {
     FieldValues,
@@ -36,7 +36,7 @@ function restoreFormValues<TFieldValues extends FieldValues = FieldValues>(
         !isEqual(previousFormValues, defaultValues) &&
         !isDirty
     ) {
-        forEach(previousFormValues, (value, key) => {
+        Object.entries(previousFormValues).forEach(([key, value]) => {
             setValue(key as Path<TFieldValues>, value);
         });
 

--- a/src/groups/components/GroupMembers.tsx
+++ b/src/groups/components/GroupMembers.tsx
@@ -3,14 +3,13 @@ import BoxGroupHeader from "@base/BoxGroupHeader";
 import BoxGroupSection from "@base/BoxGroupSection";
 import InitialIcon from "@base/InitialIcon";
 import { UserNested } from "@users/types";
-import { map } from "lodash-es";
 
 type MemberProps = {
     members: UserNested[];
 };
 
 export function GroupMembers({ members }: MemberProps) {
-    const memberComponents = map(members, (member: UserNested) => (
+    const memberComponents = members.map((member: UserNested) => (
         <BoxGroupSection key={member.id}>
             <div className="flex gap-2.5">
                 <InitialIcon handle={member.handle} size="md" />

--- a/src/groups/components/GroupPermissions.tsx
+++ b/src/groups/components/GroupPermissions.tsx
@@ -1,16 +1,14 @@
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupHeader from "@base/BoxGroupHeader";
 import Checkbox from "@base/Checkbox";
-import { map } from "lodash-es";
 import { useUpdateGroup } from "../queries";
 import { Group } from "../types";
 
 export function GroupPermissions({ selectedGroup }: { selectedGroup: Group }) {
     const updateGroupMutator = useUpdateGroup();
 
-    const permissionComponents = map(
-        selectedGroup.permissions,
-        (active, permission) => (
+    const permissionComponents = Object.entries(selectedGroup.permissions).map(
+        ([permission, active]) => (
             <div key={permission} className="py-2 px-4">
                 <Checkbox
                     checked={active}

--- a/src/groups/components/GroupSelector.tsx
+++ b/src/groups/components/GroupSelector.tsx
@@ -1,7 +1,7 @@
 import { getColor } from "@app/theme";
 import BoxGroup from "@base/BoxGroup";
 import SelectBoxGroupSection from "@base/SelectBoxGroupSection";
-import { map, sortBy } from "lodash-es";
+import { sortBy } from "es-toolkit/compat";
 import styled from "styled-components";
 import { GroupMinimal } from "../types";
 
@@ -49,18 +49,16 @@ export function GroupSelector({
     setSelectedGroupId,
     groups,
 }: GroupSelectorProps) {
-    const groupComponents = map(sortBy(groups, "name"), (group) => {
-        return (
-            <GroupsSelectBoxGroupSection
-                selectable
-                active={selectedGroupId === group.id}
-                key={group.id}
-                onClick={() => setSelectedGroupId(group.id)}
-            >
-                {group.name}
-            </GroupsSelectBoxGroupSection>
-        );
-    });
+    const groupComponents = sortBy(groups, (g) => g.name).map((group) => (
+        <GroupsSelectBoxGroupSection
+            selectable
+            active={selectedGroupId === group.id}
+            key={group.id}
+            onClick={() => setSelectedGroupId(group.id)}
+        >
+            {group.name}
+        </GroupsSelectBoxGroupSection>
+    ));
 
     return (
         <GroupComponentsContainer>{groupComponents}</GroupComponentsContainer>

--- a/src/groups/components/Groups.tsx
+++ b/src/groups/components/Groups.tsx
@@ -5,7 +5,7 @@ import Button from "@base/Button";
 import InputHeader from "@base/InputHeader";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import RemoveBanner from "@base/RemoveBanner";
-import { find, sortBy } from "lodash-es";
+import { sortBy } from "es-toolkit/compat";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import {
@@ -60,8 +60,8 @@ export default function Groups() {
     const { data: selectedGroup } = useFetchGroup(selectedGroupId);
 
     useEffect(() => {
-        if (groups && !find(groups, { id: selectedGroupId })) {
-            setSelectedGroupId(sortBy(groups, "name")[0]?.id);
+        if (groups && !groups.find((g) => g.id === selectedGroupId)) {
+            setSelectedGroupId(sortBy(groups, (g) => g.name)[0]?.id);
         }
     }, [groups, selectedGroupId]);
 

--- a/src/ml/components/MLModels.tsx
+++ b/src/ml/components/MLModels.tsx
@@ -4,7 +4,6 @@ import NoneFoundBox from "@base/NoneFoundBox";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
-import { map } from "lodash-es";
 import { useFindModels } from "../queries";
 import { MLModelMinimal } from "../types";
 import { MlModel } from "./MlModel";
@@ -33,7 +32,7 @@ export function MLModels() {
     }
 
     const models = data.items.length ? (
-        map(data.items, renderRow)
+        data.items.map(renderRow)
     ) : (
         <NoneFoundBox noun={"machine learning models"} />
     );

--- a/src/references/hooks.ts
+++ b/src/references/hooks.ts
@@ -3,7 +3,7 @@ import { AdministratorRoleName } from "@administration/types";
 import { apiClient } from "@app/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { difference, filter, find, some, union } from "lodash-es";
+import { difference, union } from "es-toolkit/array";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { Response } from "superagent";
@@ -146,22 +146,21 @@ export function useCheckReferenceRight(
         return { hasPermission: true, isPending: false };
     }
 
-    const user = find(reference.users, { id: account.id });
+    const user = reference.users.find((u) => u.id === account.id);
 
     if (user?.[right]) {
         return { hasPermission: true, isPending: false };
     }
 
     // Groups in common between the user and the reference member groups.
-    const groups = filter(reference.groups, (referenceGroup) =>
-        some(
-            account.groups,
+    const groups = reference.groups.filter((referenceGroup) =>
+        account.groups.some(
             (accountGroup) => accountGroup.id === referenceGroup.id,
         ),
     );
 
     return {
-        hasPermission: groups && some(groups, { [right]: true }),
+        hasPermission: groups && groups.some((g) => g[right] === true),
         isPending: false,
     };
 }

--- a/src/samples/charting.ts
+++ b/src/samples/charting.ts
@@ -1,5 +1,4 @@
 import { select } from "d3";
-import { keysIn, map } from "lodash-es";
 
 export const QUALITY_CHART_HEIGHT = 300;
 
@@ -16,7 +15,8 @@ export function appendLegend(
     series,
     legendCircleRadius: number,
 ) {
-    map(keysIn(series), (index: number) => {
+    Object.keys(series).forEach((key) => {
+        const index = Number(key);
         svg.append("circle")
             .attr("cy", index * 25)
             .attr("r", legendCircleRadius)

--- a/src/samples/components/EditSample.tsx
+++ b/src/samples/components/EditSample.tsx
@@ -10,7 +10,7 @@ import InputSimple from "@base/InputSimple";
 import SaveButton from "@base/SaveButton";
 import TextArea from "@base/TextArea";
 import { DialogPortal } from "@radix-ui/react-dialog";
-import { pick } from "lodash-es";
+import { pick } from "es-toolkit/object";
 import { useForm } from "react-hook-form";
 import { useUpdateSample } from "../queries";
 import { Sample } from "../types";

--- a/src/samples/components/Filter/WorkflowFilter.tsx
+++ b/src/samples/components/Filter/WorkflowFilter.tsx
@@ -5,7 +5,7 @@ import Icon from "@base/Icon";
 import SidebarHeader from "@base/SidebarHeader";
 import SideBarSection from "@base/SideBarSection";
 import { WorkflowStates } from "@samples/utils";
-import { xor } from "lodash-es";
+import { xor } from "es-toolkit/array";
 import styled from "styled-components";
 
 const WorkflowFilterLabel = styled.div`

--- a/src/samples/components/SamplesList.tsx
+++ b/src/samples/components/SamplesList.tsx
@@ -14,7 +14,7 @@ import { useListIndexes } from "@indexes/queries";
 import { useFetchLabels } from "@labels/queries";
 import { useListSamples } from "@samples/queries";
 import { SampleMinimal } from "@samples/types";
-import { intersectionWith, union, xor } from "lodash-es";
+import { intersectionWith, union, xor } from "es-toolkit/array";
 import { useState } from "react";
 import styled from "styled-components";
 import SampleFilters from "./Filter/SampleFilters";

--- a/src/samples/components/Sidebar/DefaultSubtractions.tsx
+++ b/src/samples/components/Sidebar/DefaultSubtractions.tsx
@@ -4,7 +4,7 @@ import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import SidebarHeader from "@base/SidebarHeader";
 import SideBarSection from "@base/SideBarSection";
 import { useFetchSubtractionsShortlist } from "@subtraction/queries";
-import { xor } from "lodash-es";
+import { xor } from "es-toolkit/array";
 import styled from "styled-components";
 import SampleSidebarList from "./SampleSidebarList";
 import SampleSidebarSelector from "./SampleSidebarSelector";

--- a/src/samples/components/Sidebar/SampleLabels.tsx
+++ b/src/samples/components/Sidebar/SampleLabels.tsx
@@ -4,7 +4,7 @@ import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import SidebarHeader from "@base/SidebarHeader";
 import SideBarSection from "@base/SideBarSection";
 import { useFetchLabels } from "@labels/queries";
-import { xor } from "lodash-es";
+import { xor } from "es-toolkit/array";
 import styled from "styled-components";
 import SampleLabel from "../Label/SampleLabel";
 import SampleSidebarList from "./SampleSidebarList";

--- a/src/samples/hooks.ts
+++ b/src/samples/hooks.ts
@@ -1,7 +1,6 @@
 import { useFetchAccount } from "@account/queries";
 import { AdministratorRoleName } from "@administration/types";
 import { hasSufficientAdminRole } from "@administration/utils";
-import { some } from "lodash-es";
 import { useFetchSample } from "./queries";
 
 /**
@@ -26,7 +25,8 @@ export function useCheckCanEditSample(sampleId: string) {
         ) ||
         sample.all_write ||
         sample.user.id === account.id ||
-        (sample.group_write && some(account.groups, { id: sample.group }));
+        (sample.group_write &&
+            account.groups.some((g) => g.id === sample.group?.id));
 
     return { hasPermission, isPending: false };
 }

--- a/src/users/components/PrimaryGroup.tsx
+++ b/src/users/components/PrimaryGroup.tsx
@@ -3,7 +3,7 @@ import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import InputSelect from "@base/InputSelect";
 import { GroupMinimal } from "@groups/types";
-import { capitalize, map } from "lodash-es";
+import { capitalize } from "es-toolkit/string";
 import styled from "styled-components";
 
 export const PrimaryGroupOption = styled.option`
@@ -49,7 +49,7 @@ export default function PrimaryGroup({
                 <option key="none" value="none">
                     None
                 </option>
-                {map(groups, ({ id, name }) => (
+                {groups.map(({ id, name }) => (
                     <PrimaryGroupOption key={id} value={id}>
                         {capitalize(name)}
                     </PrimaryGroupOption>

--- a/src/users/components/UserGroups.tsx
+++ b/src/users/components/UserGroups.tsx
@@ -5,7 +5,7 @@ import NoneFoundSection from "@base/NoneFoundSection";
 import PseudoLabel from "@base/PseudoLabel";
 import { useListGroups } from "@groups/queries";
 import { GroupMinimal } from "@groups/types";
-import { map, some, xor } from "lodash-es";
+import { xor } from "es-toolkit/array";
 import styled from "styled-components";
 import { UserGroup } from "./UserGroup";
 
@@ -35,7 +35,12 @@ export default function UserGroups({ memberGroups, userId }: UserGroupsType) {
     function handleEdit(groupId: number) {
         mutation.mutate({
             userId,
-            update: { groups: xor(map(memberGroups, "id"), [groupId]) },
+            update: {
+                groups: xor(
+                    memberGroups.map((g) => g.id),
+                    [groupId],
+                ),
+            },
         });
     }
 
@@ -44,12 +49,12 @@ export default function UserGroups({ memberGroups, userId }: UserGroupsType) {
             <PseudoLabel>Groups</PseudoLabel>
             <UserGroupsList>
                 {data.length ? (
-                    map(data, ({ id, name }) => (
+                    data.map(({ id, name }) => (
                         <UserGroup
                             key={id}
                             id={id}
                             name={name}
-                            toggled={some(memberGroups, { id })}
+                            toggled={memberGroups.some((g) => g.id === id)}
                             onClick={handleEdit}
                         />
                     ))

--- a/src/users/components/UserPermissions.tsx
+++ b/src/users/components/UserPermissions.tsx
@@ -1,6 +1,5 @@
 import BoxGroup from "@base/BoxGroup";
 import { Permissions } from "@groups/types";
-import { transform } from "lodash-es";
 import { PermissionItem } from "./Permission";
 
 type UserPermissionsProps = {
@@ -21,18 +20,13 @@ export default function UserPermissions({ permissions }: UserPermissionsProps) {
                 </small>
             </div>
             <BoxGroup>
-                {transform(
-                    permissions,
-                    (acc, value, permission) =>
-                        acc.push(
-                            <PermissionItem
-                                key={permission}
-                                permission={permission}
-                                value={value}
-                            />,
-                        ),
-                    [],
-                )}
+                {Object.entries(permissions).map(([permission, value]) => (
+                    <PermissionItem
+                        key={permission}
+                        permission={permission}
+                        value={value}
+                    />
+                ))}
             </BoxGroup>
         </div>
     );

--- a/src/users/components/UsersList.tsx
+++ b/src/users/components/UsersList.tsx
@@ -4,7 +4,6 @@ import BoxGroup from "@base/BoxGroup";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundBox from "@base/NoneFoundBox";
 import Pagination from "@base/Pagination";
-import { map } from "lodash-es";
 import { User } from "../types";
 import { UserItem } from "./UserItem";
 
@@ -41,7 +40,7 @@ export default function UsersList({ term }: UsersListProps) {
             pageCount={page_count}
         >
             <BoxGroup>
-                {map(items, (item: User) => (
+                {items.map((item: User) => (
                     <UserItem key={item.id} {...item} />
                 ))}
             </BoxGroup>


### PR DESCRIPTION
## Summary
- Add es-toolkit package and begin migrating from lodash-es
- Migrate ~30 files from lodash-es to native JS methods and es-toolkit functions
- Both libraries coexist - remaining ~96 files still use lodash-es

## Changes
- Convert lodash `map`/`filter`/`find`/`forEach`/`reduce`/`some` to native array methods
- Convert lodash `sortBy`/`groupBy`/`cloneDeep`/`pick`/`isEqual` to es-toolkit equivalents
- Fix type issues with es-toolkit function signatures

## Test plan
- TypeScript check passes
- All 336 tests pass