### PR TITLE
refactor: continue lodash to es-toolkit migration

### DIFF
--- a/src/analyses/components/Charts/SummaryChart.tsx
+++ b/src/analyses/components/Charts/SummaryChart.tsx
@@ -6,7 +6,6 @@ import {
 } from "@analyses/utils";
 import { theme } from "@app/theme";
 import { area, scaleLinear, select } from "d3";
-import { filter, map, max } from "lodash-es";
 import { useEffect, useRef } from "react";
 import styled, { DefaultTheme } from "styled-components";
 
@@ -111,15 +110,11 @@ export function SummaryChart({ seqs }: IimiCoverageChartProps) {
     const chartEl = useRef(null);
 
     useEffect(() => {
-        const filteredSeqs = filter(seqs);
-        const avgSeq = maxSequences(
-            map(filteredSeqs, (seq) => {
-                return seq.coverage;
-            }),
-        );
+        const filteredSeqs = seqs.filter(Boolean);
+        const avgSeq = maxSequences(filteredSeqs.map((seq) => seq.coverage));
 
         const untrustworthyRanges = combineUntrustworthyRegions(
-            map(seqs, (sequence) =>
+            seqs.map((sequence) =>
                 sequence ? sequence.untrustworthy_ranges : [],
             ),
         );
@@ -128,7 +123,7 @@ export function SummaryChart({ seqs }: IimiCoverageChartProps) {
             chartEl.current,
             avgSeq,
             avgSeq.length,
-            max([...avgSeq, 10]),
+            Math.max(...avgSeq, 10),
             untrustworthyRanges,
         );
     }, [seqs]);

--- a/src/analyses/components/Iimi/IimiCondensedCoverage.tsx
+++ b/src/analyses/components/Iimi/IimiCondensedCoverage.tsx
@@ -1,5 +1,5 @@
 import { FormattedIimiIsolate } from "@analyses/types";
-import { map, sortBy, unzip } from "lodash-es";
+import { sortBy, unzip } from "es-toolkit";
 import { useMemo } from "react";
 import { SummaryChart } from "../Charts/SummaryChart";
 
@@ -11,14 +11,13 @@ export function IimiCondensedCoverage({
 }) {
     const sequences = useMemo(
         () =>
-            sortBy(
-                unzip(map(isolates, "sequences")),
+            sortBy(unzip(isolates.map((isolate) => isolate.sequences)), [
                 (seqs) => seqs[0]?.length,
-            ),
+            ]),
         [isolates],
     );
 
-    const charts = map(sequences, (seqs) => {
+    const charts = sequences.map((seqs) => {
         return <SummaryChart key={seqs[0].id} seqs={seqs} />;
     });
 

--- a/src/analyses/components/Iimi/IimiIsolate.tsx
+++ b/src/analyses/components/Iimi/IimiIsolate.tsx
@@ -1,3 +1,4 @@
+import { FormattedIimiSequence } from "@analyses/types";
 import Box from "@base/Box";
 import { sortBy } from "es-toolkit";
 import styled from "styled-components";
@@ -11,10 +12,15 @@ const CoveragePanel = styled.div`
     overflow-x: scroll;
 `;
 
+type IimiIsolateProps = {
+    name: string;
+    sequences: FormattedIimiSequence[];
+};
+
 /**
  * a single iimi isolate item
  */
-export function IimiIsolate({ name, sequences }) {
+export function IimiIsolate({ name, sequences }: IimiIsolateProps) {
     const sorted = sortBy(sequences, [(sequence) => sequence.length]);
 
     return (

--- a/src/analyses/components/Iimi/IimiIsolate.tsx
+++ b/src/analyses/components/Iimi/IimiIsolate.tsx
@@ -1,5 +1,5 @@
 import Box from "@base/Box";
-import { sortBy } from "lodash-es";
+import { sortBy } from "es-toolkit";
 import styled from "styled-components";
 import { CoverageChart } from "../Charts/CoverageChart";
 import { IimiDetection } from "./IimiDetection";
@@ -15,7 +15,7 @@ const CoveragePanel = styled.div`
  * a single iimi isolate item
  */
 export function IimiIsolate({ name, sequences }) {
-    const sorted = sortBy(sequences, (sequence) => sequence.length);
+    const sorted = sortBy(sequences, [(sequence) => sequence.length]);
 
     return (
         <div>

--- a/src/analyses/components/Iimi/IimiOtu.tsx
+++ b/src/analyses/components/Iimi/IimiOtu.tsx
@@ -7,7 +7,6 @@ import { formatIsolateName } from "@app/utils";
 import AccordionContent from "@base/AccordionContent";
 import AccordionScrollingItem from "@base/AccordionScrollingItem";
 import AccordionTrigger from "@base/AccordionTrigger";
-import { map } from "lodash-es";
 import styled from "styled-components";
 import { IimiCondensedCoverage } from "./IimiCondensedCoverage";
 import { IimiDetection } from "./IimiDetection";
@@ -56,7 +55,7 @@ export function IimiOtu({
                 <IimiCondensedCoverage isolates={isolates} />
             </IimiAccordionTrigger>
             <AccordionContent>
-                {map(isolates, (isolate: IimiIsolateData) => (
+                {isolates.map((isolate: IimiIsolateData) => (
                     <IimiIsolate
                         name={formatIsolateName(isolate)}
                         sequences={isolate.sequences}

--- a/src/analyses/components/Iimi/IimiOtu.tsx
+++ b/src/analyses/components/Iimi/IimiOtu.tsx
@@ -1,8 +1,5 @@
 import AnalysisValue from "@analyses/components/AnalysisValue";
-import {
-    FormattedIimiHit,
-    IimiIsolate as IimiIsolateData,
-} from "@analyses/types";
+import { FormattedIimiHit, FormattedIimiIsolate } from "@analyses/types";
 import { formatIsolateName } from "@app/utils";
 import AccordionContent from "@base/AccordionContent";
 import AccordionScrollingItem from "@base/AccordionScrollingItem";
@@ -55,7 +52,7 @@ export function IimiOtu({
                 <IimiCondensedCoverage isolates={isolates} />
             </IimiAccordionTrigger>
             <AccordionContent>
-                {isolates.map((isolate: IimiIsolateData) => (
+                {isolates.map((isolate: FormattedIimiIsolate) => (
                     <IimiIsolate
                         name={formatIsolateName(isolate)}
                         sequences={isolate.sequences}

--- a/src/analyses/components/Iimi/IimiViewer.tsx
+++ b/src/analyses/components/Iimi/IimiViewer.tsx
@@ -9,15 +9,15 @@ import { useState } from "react";
 import { IimiOtu } from "./IimiOtu";
 import IimiToolbar from "./IimiToolbar";
 
-type sortKey = {
-    key: string;
+type SortConfig = {
+    getValue: (item: FormattedIimiHit) => unknown;
     order: "desc" | "asc";
 };
 
-const sortKeys: { [key: string]: sortKey } = {
-    probability: { key: "probability", order: "desc" },
-    coverage: { key: "coverage", order: "desc" },
-    name: { key: "name", order: "asc" },
+const sortConfigs: Record<string, SortConfig> = {
+    probability: { getValue: (item) => item.probability, order: "desc" },
+    coverage: { getValue: (item) => item.coverage, order: "desc" },
+    name: { getValue: (item) => item.name, order: "asc" },
 };
 
 /**
@@ -39,8 +39,8 @@ export function IimiViewer({ detail }: { detail: FormattedIimiAnalysis }) {
 
     const sortedHits = orderBy(
         hits,
-        [sortKeys[sort].key],
-        [sortKeys[sort].order],
+        [sortConfigs[sort].getValue],
+        [sortConfigs[sort].order],
     );
 
     return (

--- a/src/analyses/components/Iimi/IimiViewer.tsx
+++ b/src/analyses/components/Iimi/IimiViewer.tsx
@@ -3,7 +3,7 @@ import { useFuse } from "@app/fuse";
 import { useUrlSearchParam } from "@app/hooks";
 import Accordion from "@base/Accordion";
 import Box from "@base/Box";
-import { orderBy } from "lodash-es";
+import { orderBy } from "es-toolkit";
 import { CircleAlert } from "lucide-react";
 import { useState } from "react";
 import { IimiOtu } from "./IimiOtu";
@@ -37,7 +37,11 @@ export function IimiViewer({ detail }: { detail: FormattedIimiAnalysis }) {
         (item) => item.probability && item.probability >= minimumProbability,
     );
 
-    const sortedHits = orderBy(hits, sortKeys[sort].key, sortKeys[sort].order);
+    const sortedHits = orderBy(
+        hits,
+        [sortKeys[sort].key],
+        [sortKeys[sort].order],
+    );
 
     return (
         <>

--- a/src/analyses/components/Nuvs/ExportPreview.tsx
+++ b/src/analyses/components/Nuvs/ExportPreview.tsx
@@ -1,6 +1,5 @@
 import { getBorder } from "@app/theme";
 import Table from "@base/Table";
-import { replace } from "lodash-es";
 import styled from "styled-components";
 
 const ExportPreviewCode = styled.div`
@@ -46,7 +45,7 @@ export default function NuvsExportPreview({ mode }: NuVsExportPreviewProps) {
         barName = "best annotation";
         barExample = "RNA Polymerase";
 
-        previewHeader = replace(previewHeader, "sequence_1", "orf_1_1");
+        previewHeader = previewHeader.replace("sequence_1", "orf_1_1");
         previewSequence =
             "ELREECRSLRSRCDQLEERVSAMEDEMNEMKREGKFREKRIKRNEQSLQEIWDYVKRPNLRLIGVPESDGENGTKLENTFREKSAME";
     }

--- a/src/analyses/components/Nuvs/NuvsBlastResults.tsx
+++ b/src/analyses/components/Nuvs/NuvsBlastResults.tsx
@@ -5,7 +5,6 @@ import BoxGroupTable from "@base/BoxGroupTable";
 import Button from "@base/Button";
 import ExternalLink from "@base/ExternalLink";
 import Icon from "@base/Icon";
-import { map } from "lodash-es";
 import numbro from "numbro";
 import styled from "styled-components";
 
@@ -32,7 +31,7 @@ type BLASTResultsProps = {
  * Displays the results of the blast installed for the sequence
  */
 export default function NuvsBlastResults({ hits, onBlast }: BLASTResultsProps) {
-    const components = map(hits, (hit, index) => (
+    const components = hits.map((hit, index) => (
         <tr key={index}>
             <td>
                 <ExternalLink

--- a/src/analyses/components/Nuvs/NuvsDetail.tsx
+++ b/src/analyses/components/Nuvs/NuvsDetail.tsx
@@ -1,5 +1,5 @@
 import { useGetActiveHit } from "@analyses/hooks";
-import { FormattedNuvsHit } from "@analyses/types";
+import { FormattedNuvsHit, NuvsOrf as NuvsOrfType } from "@analyses/types";
 import { calculateAnnotatedOrfCount } from "@analyses/utils";
 import { useUrlSearchParam } from "@app/hooks";
 import { getBorder } from "@app/theme";
@@ -95,13 +95,13 @@ export default function NuvsDetail({
 
     const { e, families, orfs, sequence, index } = hit;
 
-    let filtered;
+    let filtered: NuvsOrfType[] = orfs;
 
     if (filterORFs) {
         filtered = orfs.filter((orf) => orf.hits.length);
     }
 
-    filtered = sortBy(filtered || orfs, [(orf) => orf.hits.length]).reverse();
+    filtered = sortBy(filtered, [(orf) => orf.hits.length]).reverse();
 
     const orfComponents = filtered.map((orf, index) => (
         <NuvsOrf

--- a/src/analyses/components/Nuvs/NuvsDetail.tsx
+++ b/src/analyses/components/Nuvs/NuvsDetail.tsx
@@ -4,7 +4,7 @@ import { calculateAnnotatedOrfCount } from "@analyses/utils";
 import { useUrlSearchParam } from "@app/hooks";
 import { getBorder } from "@app/theme";
 import Badge from "@base/Badge";
-import { filter, map, sortBy } from "lodash-es";
+import { sortBy } from "es-toolkit";
 import styled from "styled-components";
 import NuvsBlast from "./NuvsBlast";
 import NuvsOrf from "./NuvsOrf";
@@ -98,12 +98,12 @@ export default function NuvsDetail({
     let filtered;
 
     if (filterORFs) {
-        filtered = filter(orfs, (orf) => orf.hits.length);
+        filtered = orfs.filter((orf) => orf.hits.length);
     }
 
-    filtered = sortBy(filtered || orfs, (orf) => orf.hits.length).reverse();
+    filtered = sortBy(filtered || orfs, [(orf) => orf.hits.length]).reverse();
 
-    const orfComponents = map(filtered, (orf, index) => (
+    const orfComponents = filtered.map((orf, index) => (
         <NuvsOrf
             key={index}
             index={index}

--- a/src/analyses/components/Nuvs/NuvsExport.tsx
+++ b/src/analyses/components/Nuvs/NuvsExport.tsx
@@ -11,13 +11,11 @@ import PseudoLabel from "@base/PseudoLabel";
 import ToggleGroup from "@base/ToggleGroup";
 import ToggleGroupItem from "@base/ToggleGroupItem";
 import { DialogPortal, DialogTrigger } from "@radix-ui/react-dialog";
-import { forEach, map, reduce, replace } from "lodash-es";
 import { useState } from "react";
 import NuvsExportPreview from "./NuvsExportPreview";
 
 function getBestHit(items) {
-    return reduce(
-        items,
+    return items.reduce(
         (best, hit) => {
             if (hit.full_e < best.e) {
                 best.e = hit.full_e;
@@ -31,48 +29,40 @@ function getBestHit(items) {
 }
 
 function exportContigData(hits: FormattedNuvsHit[], sampleName: string) {
-    return map(hits, (result) => {
-        const orfNames = reduce(
-            result.orfs,
-            (names, orf) => {
-                // Get the best hit for the current ORF.
-                if (orf.hits.length) {
-                    const bestHit = getBestHit(orf.hits);
+    return hits.map((result) => {
+        const orfNames = result.orfs.reduce((names, orf) => {
+            // Get the best hit for the current ORF.
+            if (orf.hits.length) {
+                const bestHit = getBestHit(orf.hits);
 
-                    if (bestHit.name) {
-                        names.push(bestHit.name);
-                    }
+                if (bestHit.name) {
+                    names.push(bestHit.name);
                 }
+            }
 
-                return names;
-            },
-            [],
-        );
+            return names;
+        }, []);
         return `>sequence_${result.index}|${sampleName}|${orfNames.join("|")}\n${result.sequence}`;
     });
 }
 
 function exportOrfData(hits: FormattedNuvsHit[], sampleName: string) {
-    return reduce(
-        hits,
-        (lines, result) => {
-            forEach(result.orfs, (orf) => {
-                // Get the best hit for the current ORF.
-                if (orf.hits.length) {
-                    const bestHit = getBestHit(orf.hits);
+    return hits.reduce((lines, result) => {
+        result.orfs.forEach((orf) => {
+            // Get the best hit for the current ORF.
+            if (orf.hits.length) {
+                const bestHit = getBestHit(orf.hits);
 
-                    if (bestHit.name) {
-                        lines.push(
-                            `>orf_${result.index}_${orf.index}|${sampleName}|${bestHit.name}\n${orf.pro}`,
-                        );
-                    }
+                if (bestHit.name) {
+                    lines.push(
+                        `>orf_${result.index}_${orf.index}|${sampleName}|${bestHit.name}\n${orf.pro}`,
+                    );
                 }
-            });
+            }
+        });
 
-            return lines;
-        },
-        [],
-    );
+        return lines;
+    }, []);
 }
 
 function downloadData(
@@ -82,7 +72,7 @@ function downloadData(
     suffix: string,
 ) {
     return followDynamicDownload(
-        `nuvs.${replace(sampleName, " ", "_")}.${analysisId}.${suffix}.fa`,
+        `nuvs.${sampleName.replace(" ", "_")}.${analysisId}.${suffix}.fa`,
         content.join("\n"),
     );
 }

--- a/src/analyses/components/Nuvs/NuvsExportPreview.tsx
+++ b/src/analyses/components/Nuvs/NuvsExportPreview.tsx
@@ -1,6 +1,5 @@
 import { getBorder } from "@app/theme";
 import Table from "@base/Table";
-import { replace } from "lodash-es";
 import styled from "styled-components";
 
 const ExportPreviewCode = styled.div`
@@ -46,7 +45,7 @@ export default function NuvsExportPreview({ mode }: NuVsExportPreviewProps) {
         barName = "best annotation";
         barExample = "RNA Polymerase";
 
-        previewHeader = replace(previewHeader, "sequence_1", "orf_1_1");
+        previewHeader = previewHeader.replace("sequence_1", "orf_1_1");
         previewSequence =
             "ELREECRSLRSRCDQLEERVSAMEDEMNEMKREGKFREKRIKRNEQSLQEIWDYVKRPNLRLIGVPESDGENGTKLENTFREKSAME";
     }

--- a/src/analyses/components/Nuvs/NuvsList.tsx
+++ b/src/analyses/components/Nuvs/NuvsList.tsx
@@ -5,7 +5,6 @@ import { useSortAndFilterNuVsHits } from "@analyses/hooks";
 import { FormattedNuvsAnalysis } from "@analyses/types";
 import { useUrlSearchParam } from "@app/hooks";
 import Key from "@base/Key";
-import { findIndex } from "lodash-es";
 import { FixedSizeList } from "react-window";
 
 type NuVsListProps = {
@@ -29,7 +28,9 @@ export default function NuvsList({ detail }: NuVsListProps) {
     let previousIndex: number;
 
     if (activeHit) {
-        const windowIndex = findIndex(sortedHits, { id: Number(activeHit) });
+        const windowIndex = sortedHits.findIndex(
+            (hit) => hit.id === Number(activeHit),
+        );
 
         if (windowIndex > 0) {
             previousIndex = windowIndex - 1;

--- a/src/analyses/components/Pathoscope/PathoscopeDetail.tsx
+++ b/src/analyses/components/Pathoscope/PathoscopeDetail.tsx
@@ -26,7 +26,7 @@ export default function PathoscopeDetail({
         (isolate) => !filterIsolates || isolate.pi >= 0.03 * pi,
     );
 
-    const maxGenomeLength = maxBy(filtered, [(item) => item.filled.length])
+    const maxGenomeLength = maxBy(filtered, (item) => item.filled.length)!
         .filled.length;
 
     const isolateComponents = filtered.map((isolate) => {

--- a/src/analyses/components/Pathoscope/PathoscopeDetail.tsx
+++ b/src/analyses/components/Pathoscope/PathoscopeDetail.tsx
@@ -1,7 +1,7 @@
 import { FormattedPathoscopeHit } from "@analyses/types";
 import { useUrlSearchParam } from "@app/hooks";
 import ScrollSyncContainer from "@base/ScrollSyncContainer";
-import { filter, maxBy } from "lodash-es";
+import { maxBy } from "es-toolkit";
 import PathoscopeIsolate from "./PathoscopeIsolate";
 
 type PathoscopeDetailProps = {
@@ -22,13 +22,12 @@ export default function PathoscopeDetail({
 
     const { isolates, pi } = hit;
 
-    const filtered = filter(
-        isolates,
+    const filtered = isolates.filter(
         (isolate) => !filterIsolates || isolate.pi >= 0.03 * pi,
     );
 
-    const maxGenomeLength = maxBy(filtered, (item) => item.filled.length).filled
-        .length;
+    const maxGenomeLength = maxBy(filtered, [(item) => item.filled.length])
+        .filled.length;
 
     const isolateComponents = filtered.map((isolate) => {
         return (

--- a/src/analyses/components/Pathoscope/PathoscopeList.tsx
+++ b/src/analyses/components/Pathoscope/PathoscopeList.tsx
@@ -1,25 +1,21 @@
 import { useSortAndFilterPathoscopeHits } from "@analyses/hooks";
 import Accordion from "@base/Accordion";
-import { map } from "lodash-es";
 import { PathoscopeItem } from "./PathoscopeItem";
 
 /** A list of Pathoscope analysis results*/
 export function PathoscopeList({ detail, sample }) {
     return (
         <Accordion type="single" collapsible>
-            {map(
-                useSortAndFilterPathoscopeHits(
-                    detail,
-                    sample.quality.length[1],
-                ),
-                (hit) => (
-                    <PathoscopeItem
-                        key={hit.id}
-                        hit={hit}
-                        mappedCount={detail.results.readCount}
-                    />
-                ),
-            )}
+            {useSortAndFilterPathoscopeHits(
+                detail,
+                sample.quality.length[1],
+            ).map((hit) => (
+                <PathoscopeItem
+                    key={hit.id}
+                    hit={hit}
+                    mappedCount={detail.results.readCount}
+                />
+            ))}
         </Accordion>
     );
 }

--- a/src/analyses/components/Pathoscope/PathoscopeMapping.tsx
+++ b/src/analyses/components/Pathoscope/PathoscopeMapping.tsx
@@ -2,7 +2,6 @@ import { toThousand } from "@app/utils";
 import Box from "@base/Box";
 import Label from "@base/Label";
 import Link from "@base/Link";
-import { map } from "lodash-es";
 import numbro from "numbro";
 import styled from "styled-components";
 import { Bars } from "../Viewer/Bars";
@@ -26,12 +25,12 @@ export function AnalysisMappingReferenceTitle({ index, reference }) {
 }
 
 export function AnalysisMappingSubtractionTitle({ subtractions }) {
-    return map(subtractions, (subtraction, index) => (
+    return subtractions.map((subtraction, index) => (
         <span key={subtraction.id}>
             <Link to={`/subtractions/${subtraction.id}`}>
                 {subtraction.name}
             </Link>
-            {Number(index) !== subtractions.length - 1 ? ", " : ""}
+            {index !== subtractions.length - 1 ? ", " : ""}
         </span>
     ));
 }

--- a/src/base/Attribution.tsx
+++ b/src/base/Attribution.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@app/utils";
-import { capitalize } from "lodash-es";
+import { capitalize } from "es-toolkit";
 import InitialIcon from "./InitialIcon";
 import RelativeTime from "./RelativeTime";
 

--- a/src/base/AttributionWithName.tsx
+++ b/src/base/AttributionWithName.tsx
@@ -1,4 +1,4 @@
-import { capitalize } from "lodash-es";
+import { capitalize } from "es-toolkit";
 import styled from "styled-components";
 import InitialIcon from "./InitialIcon";
 

--- a/src/base/CompactScrollList.tsx
+++ b/src/base/CompactScrollList.tsx
@@ -3,7 +3,6 @@ import {
     FetchNextPageOptions,
     InfiniteQueryObserverResult,
 } from "@tanstack/react-query/";
-import { map } from "lodash-es";
 import { ReactElement } from "react";
 import LoadingPlaceholder from "./LoadingPlaceholder";
 
@@ -54,7 +53,7 @@ export default function CompactScrollList({
         }
     }
 
-    const entries = map(items, (item) => renderRow(item));
+    const entries = items.map((item) => renderRow(item));
 
     return (
         <div

--- a/src/base/InitialIcon.tsx
+++ b/src/base/InitialIcon.tsx
@@ -1,5 +1,4 @@
 import { getColor, getFontWeight, theme } from "@app/theme";
-import { reduce } from "lodash-es";
 import { useMemo } from "react";
 import styled from "styled-components";
 
@@ -64,7 +63,7 @@ type InitialIconProps = {
 
 export default function InitialIcon({ handle, size }: InitialIconProps) {
     const hash = useMemo(
-        () => reduce(handle.split(""), hashColor, 0) % 360,
+        () => handle.split("").reduce(hashColor, 0) % 360,
         [handle],
     );
 

--- a/src/hmm/components/HMMInstaller.tsx
+++ b/src/hmm/components/HMMInstaller.tsx
@@ -4,7 +4,6 @@ import Icon from "@base/Icon";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import ProgressBarAffixed from "@base/ProgressBarAffixed";
 import { useQueryClient } from "@tanstack/react-query";
-import { replace } from "lodash-es";
 import styled from "styled-components";
 import { hmmQueryKeys, useListHmms } from "../queries";
 import InstallOption from "./InstallOption";
@@ -61,7 +60,7 @@ export function HMMInstaller() {
 
     if (task && !installed) {
         const progress = task.progress;
-        const step = replace(task.step, "_", " ");
+        const step = task.step.replace("_", " ");
 
         return (
             <HMMInstalling>

--- a/src/hmm/components/HMMItem.tsx
+++ b/src/hmm/components/HMMItem.tsx
@@ -2,7 +2,6 @@ import { getFontSize, getFontWeight } from "@app/theme";
 import BoxGroupSection from "@base/BoxGroupSection";
 import Label from "@base/Label";
 import Link from "@base/Link";
-import { keys, map, reject } from "lodash-es";
 import styled from "styled-components";
 import { HMMMinimal } from "../types";
 
@@ -37,14 +36,13 @@ type HMMItemProps = {
  * A condensed hmm item for use in a list of hmms
  */
 export default function HMMItem({ hmm }: HMMItemProps) {
-    const filteredFamilies = reject(
-        keys(hmm.families),
-        (family) => family === "None",
+    const filteredFamilies = Object.keys(hmm.families).filter(
+        (family) => family !== "None",
     );
 
-    const labelComponents = map(filteredFamilies.slice(0, 3), (family, i) => (
-        <Label key={i}>{family}</Label>
-    ));
+    const labelComponents = filteredFamilies
+        .slice(0, 3)
+        .map((family, i) => <Label key={i}>{family}</Label>);
 
     return (
         <StyledHMMItem>

--- a/src/hmm/components/HMMList.tsx
+++ b/src/hmm/components/HMMList.tsx
@@ -6,7 +6,6 @@ import Pagination from "@base/Pagination";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
-import { map } from "lodash-es";
 import { useListHmms } from "../queries";
 import { HMMInstaller } from "./HMMInstaller";
 import HMMItem from "./HMMItem";
@@ -61,7 +60,7 @@ export default function HMMList() {
                             pageCount={page_count}
                         >
                             <BoxGroup>
-                                {map(documents, (document) => (
+                                {documents.map((document) => (
                                     <HMMItem key={document.id} hmm={document} />
                                 ))}
                             </BoxGroup>

--- a/src/hmm/components/HmmDetail.tsx
+++ b/src/hmm/components/HmmDetail.tsx
@@ -10,7 +10,6 @@ import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NotFound from "@base/NotFound";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
-import { map } from "lodash-es";
 import styled from "styled-components";
 import { useFetchHmm } from "../queries";
 import { ClusterMember } from "./ClusterMember";
@@ -41,8 +40,7 @@ export default function HmmDetail() {
         return <LoadingPlaceholder className="mt-32" />;
     }
 
-    const clusterMembers = map(
-        data.entries,
+    const clusterMembers = data.entries.map(
         ({ name, accession, organism }, index) => (
             <ClusterMember
                 name={name}
@@ -54,7 +52,7 @@ export default function HmmDetail() {
         ),
     );
 
-    const names = map(data.names, (name, index) => (
+    const names = data.names.map((name, index) => (
         <Label className="mr-1" key={index}>
             {name}
         </Label>

--- a/src/hmm/components/HmmTaxonomy.tsx
+++ b/src/hmm/components/HmmTaxonomy.tsx
@@ -2,7 +2,7 @@ import Badge from "@base/Badge";
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupHeader from "@base/BoxGroupHeader";
 import BoxGroupSection from "@base/BoxGroupSection";
-import { map, sortBy } from "lodash-es";
+import { sortBy } from "es-toolkit";
 import styled from "styled-components";
 
 const HmmTaxonomyItem = styled(BoxGroupSection)`
@@ -28,11 +28,11 @@ type HmmTaxonomyProps = {
  */
 export function HmmTaxonomy({ counts, title }: HmmTaxonomyProps) {
     const sorted = sortBy(
-        map(counts, (count, name) => ({ name, count })),
-        "name",
+        Object.entries(counts).map(([name, count]) => ({ name, count })),
+        ["name"],
     );
 
-    const components = map(sorted, ({ name, count }) => (
+    const components = sorted.map(({ name, count }) => (
         <HmmTaxonomyItem key={name}>
             {name} <Badge>{count}</Badge>
         </HmmTaxonomyItem>

--- a/src/jobs/components/Filters/StateFilter.tsx
+++ b/src/jobs/components/Filters/StateFilter.tsx
@@ -3,8 +3,7 @@ import BoxGroup from "@base/BoxGroup";
 import SidebarHeader from "@base/SidebarHeader";
 import SideBarSection from "@base/SideBarSection";
 import { JobCounts, JobState, jobStateToLegacy } from "@jobs/types";
-import { xor } from "lodash-es";
-import { reduce } from "lodash-es/lodash";
+import { xor } from "es-toolkit";
 import { StateButton } from "./StateButton";
 
 function getCount(counts: JobCounts, state: JobState): number {
@@ -20,8 +19,7 @@ function getCount(counts: JobCounts, state: JobState): number {
         if (workflowCounts) {
             return (
                 sum +
-                reduce(
-                    workflowCounts,
+                Object.values(workflowCounts).reduce(
                     (result, value) => result + (value ?? 0),
                     0,
                 )

--- a/src/jobs/components/JobArgs.tsx
+++ b/src/jobs/components/JobArgs.tsx
@@ -2,7 +2,6 @@ import BoxGroup from "@base/BoxGroup";
 import BoxGroupHeader from "@base/BoxGroupHeader";
 import BoxGroupTable from "@base/BoxGroupTable";
 import Link from "@base/Link";
-import { map } from "lodash-es";
 import { ReactNode } from "react";
 
 type JobArgsRowProps = {
@@ -111,7 +110,7 @@ type UnknownJobRows = {
 function UnknownJobRows({ args }: UnknownJobRows) {
     return (
         <>
-            {map(args, (value, key): ReactNode => {
+            {Object.entries(args).map(([key, value]): ReactNode => {
                 if (typeof value === "string" || typeof value === "number") {
                     return (
                         <JobArgsRow

--- a/src/jobs/components/JobList.tsx
+++ b/src/jobs/components/JobList.tsx
@@ -7,7 +7,6 @@ import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Pagination from "@base/Pagination";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
-import { map } from "lodash-es";
 import { ReactElement } from "react";
 import styled from "styled-components";
 import { useFindJobs } from "../queries";
@@ -79,7 +78,7 @@ export default function JobsList() {
                 pageCount={page_count}
             >
                 <BoxGroup>
-                    {map(documents, (document) => (
+                    {documents.map((document) => (
                         <JobItem key={document.id} {...document} />
                     ))}
                 </BoxGroup>

--- a/src/jobs/types.ts
+++ b/src/jobs/types.ts
@@ -144,7 +144,7 @@ export type ServerJob = z.input<typeof Job>;
 export type Job = z.infer<typeof Job>;
 
 export type JobCounts = {
-    [state in JobState]?: { [key: string]: number | null };
+    [state in ServerJobState]?: { [key: string]: number | null };
 };
 
 export type JobSearchResult = SearchResult & {

--- a/src/otus/components/Detail/Isolates/EditIsolate.tsx
+++ b/src/otus/components/Detail/Isolates/EditIsolate.tsx
@@ -4,7 +4,7 @@ import DialogOverlay from "@base/DialogOverlay";
 import DialogTitle from "@base/DialogTitle";
 import { useUpdateIsolate } from "@otus/queries";
 import { DialogPortal } from "@radix-ui/react-dialog";
-import { capitalize } from "lodash-es";
+import { capitalize } from "es-toolkit";
 import IsolateForm from "./IsolateForm";
 
 type EditIsolateProps = {

--- a/src/otus/components/Detail/Isolates/SourceType.tsx
+++ b/src/otus/components/Detail/Isolates/SourceType.tsx
@@ -2,7 +2,7 @@ import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import InputSelect from "@base/InputSelect";
 import InputSimple from "@base/InputSimple";
-import { capitalize, map } from "lodash-es";
+import { capitalize } from "es-toolkit";
 import { UseFormRegister, UseFormWatch } from "react-hook-form";
 
 type IsolateFormValues = {
@@ -30,7 +30,7 @@ export function SourceType({
     watch,
 }: SourceTypeProps) {
     if (restrictSourceTypes) {
-        const optionComponents = map(allowedSourceTypes, (sourceType) => (
+        const optionComponents = allowedSourceTypes.map((sourceType) => (
             <option key={sourceType} value={capitalize(sourceType)}>
                 {capitalize(sourceType)}
             </option>

--- a/src/otus/hooks.ts
+++ b/src/otus/hooks.ts
@@ -1,5 +1,4 @@
 import { useNaiveUrlSearchParam, useUrlSearchParam } from "@app/hooks";
-import { find } from "lodash-es";
 import { Otu, OtuIsolate } from "./types";
 
 /**
@@ -10,7 +9,9 @@ import { Otu, OtuIsolate } from "./types";
  */
 export function useActiveIsolate(otu: Otu): OtuIsolate | undefined {
     const { value: activeIsolate } = useNaiveUrlSearchParam("activeIsolate");
-    return find(otu.isolates, { id: activeIsolate || otu.isolates[0]?.id });
+    return otu.isolates.find(
+        (isolate) => isolate.id === (activeIsolate || otu.isolates[0]?.id),
+    );
 }
 
 /**

--- a/src/references/components/Detail/ReferenceSettings.tsx
+++ b/src/references/components/Detail/ReferenceSettings.tsx
@@ -2,7 +2,7 @@ import { usePathParams } from "@app/hooks";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import SectionHeader from "@base/SectionHeader";
 import { useFetchReference } from "@references/queries";
-import { sortBy } from "lodash-es";
+import { sortBy } from "es-toolkit";
 import { LocalSourceTypes } from "../SourceTypes/LocalSourceTypes";
 import ReferenceMembers from "./ReferenceMembers";
 import RemoveReference from "./RemoveReference";
@@ -27,12 +27,12 @@ export default function ReferenceSettings() {
             </SectionHeader>
             <ReferenceMembers
                 noun="user"
-                members={sortBy(data.users, "id")}
+                members={sortBy(data.users, ["id"])}
                 refId={refId}
             />
             <ReferenceMembers
                 noun="group"
-                members={sortBy(data.groups, "id")}
+                members={sortBy(data.groups, ["id"])}
                 refId={refId}
             />
             <RemoveReference id={data.id} name={data.name} />

--- a/src/references/components/ReferenceList.tsx
+++ b/src/references/components/ReferenceList.tsx
@@ -6,7 +6,6 @@ import Pagination from "@base/Pagination";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
-import { map } from "lodash-es";
 import { useFindReferences } from "../queries";
 import Clone from "./CloneReference";
 import { CreateReference } from "./CreateReference";
@@ -56,7 +55,7 @@ export default function ReferenceList() {
                         pageCount={page_count}
                     >
                         <BoxGroup>
-                            {map(documents, (document) => (
+                            {documents.map((document) => (
                                 <ReferenceItem
                                     key={document.id}
                                     reference={document}

--- a/src/samples/components/Files/SampleReads.tsx
+++ b/src/samples/components/Files/SampleReads.tsx
@@ -1,7 +1,6 @@
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupHeader from "@base/BoxGroupHeader";
 import { Read } from "@samples/types";
-import { map } from "lodash-es";
 import styled from "styled-components";
 import ReadItem from "./ReadItem";
 
@@ -23,7 +22,7 @@ type SampleReadsProps = {
  * Displays a list of reads used to create the sample
  */
 export default function SampleReads({ reads }: SampleReadsProps) {
-    const fileComponents = map(reads, (file) => (
+    const fileComponents = reads.map((file) => (
         <ReadItem
             key={file.name}
             name={file.name}

--- a/src/samples/components/Sidebar/SampleSidebarMultiselectList.tsx
+++ b/src/samples/components/Sidebar/SampleSidebarMultiselectList.tsx
@@ -1,5 +1,4 @@
 import { SampleLabel } from "@samples/queries";
-import { map } from "lodash-es";
 import styled from "styled-components";
 import SampleMultiSelectLabel from "../Label/SampleMultiSelectLabel";
 
@@ -29,8 +28,7 @@ type SampleSidebarMultiselectList = {
 export default function SampleSidebarMultiselectList({
     items,
 }: SampleSidebarMultiselectList) {
-    const sampleItemComponents = map(
-        items,
+    const sampleItemComponents = items.map(
         ({ id, color, name, allLabeled }) => (
             <SampleSidebarMultiSelectListItem
                 key={id}

--- a/src/sequences/components/CreateSequence.tsx
+++ b/src/sequences/components/CreateSequence.tsx
@@ -6,7 +6,7 @@ import DialogTitle from "@base/DialogTitle";
 import { useCreateSequence } from "@otus/queries";
 import { OtuSegment, OtuSequence } from "@otus/types";
 import { DialogPortal } from "@radix-ui/react-dialog";
-import { compact, map } from "lodash-es";
+import { compact } from "es-toolkit";
 import SequenceForm from "./SequenceForm";
 
 type CreateSequenceProps = {
@@ -33,7 +33,10 @@ export default function CreateSequence({
     const mutation = useCreateSequence(otuId);
 
     const segments = schema.filter(
-        (segment) => !compact(map(sequences, "segment")).includes(segment.name),
+        (segment) =>
+            !compact(sequences.map((seq) => seq.segment)).includes(
+                segment.name,
+            ),
     );
 
     function onSubmit({ accession, definition, host, sequence, segment }) {

--- a/src/sequences/components/RemoveSequence.tsx
+++ b/src/sequences/components/RemoveSequence.tsx
@@ -2,7 +2,6 @@ import { useUrlSearchParam } from "@app/hooks";
 import RemoveDialog from "@base/RemoveDialog";
 import { useRemoveSequence } from "@otus/queries";
 import { OtuSequence } from "@otus/types";
-import { find } from "lodash-es";
 
 type RemoveSequenceProps = {
     isolateName: string;
@@ -25,7 +24,7 @@ export default function RemoveSequence({
 
     const mutation = useRemoveSequence(otuId);
 
-    const sequence = find(sequences, { id: removeSequenceId });
+    const sequence = sequences.find((seq) => seq.id === removeSequenceId);
 
     function handleConfirm() {
         mutation.mutate(

--- a/src/sequences/components/Sequences.tsx
+++ b/src/sequences/components/Sequences.tsx
@@ -5,7 +5,6 @@ import NoneFoundSection from "@base/NoneFoundSection";
 import { useCurrentOtuContext } from "@otus/queries";
 import { OtuIsolate } from "@otus/types";
 import sortSequencesBySegment from "@otus/utils";
-import { map } from "lodash-es";
 import styled from "styled-components";
 import CreateSequence from "./CreateSequence";
 import CreateSequenceLink from "./CreateSequenceLink";
@@ -44,7 +43,7 @@ export default function Sequences({
         otu.schema,
     );
 
-    let sequenceComponents = map(sequences, (sequence) => (
+    let sequenceComponents = sequences.map((sequence) => (
         <Sequence key={sequence.id} {...sequence} />
     ));
 

--- a/src/sequences/hooks.ts
+++ b/src/sequences/hooks.ts
@@ -3,7 +3,7 @@ import { useActiveIsolate } from "@otus/hooks";
 import { useCurrentOtuContext } from "@otus/queries";
 import { OtuSegment, OtuSequence } from "@otus/types";
 import sortSequencesBySegment from "@otus/utils";
-import { compact, find, map, reject } from "lodash-es";
+import { compact } from "es-toolkit";
 import { useCallback, useState } from "react";
 
 type UseExpandedResult = {
@@ -50,7 +50,7 @@ export function useActiveSequence(): OtuSequence | undefined {
     );
 
     if (editSequenceId) {
-        return find(sequences, { id: editSequenceId });
+        return sequences.find((seq) => seq.id === editSequenceId);
     }
 }
 
@@ -73,7 +73,9 @@ export function useGetUnreferencedSegments() {
     );
 
     const referencedSegmentNames = compact(
-        map(reject(sequences, { id: activeSequenceId }), "segment"),
+        sequences
+            .filter((seq) => seq.id !== activeSequenceId)
+            .map((seq) => seq.segment),
     );
 
     return otu.schema.filter(

--- a/src/subtraction/components/Detail/SubtractionFiles.tsx
+++ b/src/subtraction/components/Detail/SubtractionFiles.tsx
@@ -9,7 +9,7 @@ export type SubtractionFilesProps = {
     files: SubtractionFile[];
 };
 
-export default function SubtractionFiles({ files }) {
+export default function SubtractionFiles({ files }: SubtractionFilesProps) {
     return (
         <BoxGroup>
             <BoxGroupHeader>

--- a/src/subtraction/components/Detail/SubtractionFiles.tsx
+++ b/src/subtraction/components/Detail/SubtractionFiles.tsx
@@ -2,7 +2,7 @@ import BoxGroup from "@base/BoxGroup";
 import BoxGroupHeader from "@base/BoxGroupHeader";
 import NoneFound from "@base/NoneFound";
 import { SubtractionFile } from "@subtraction/types";
-import { sortBy } from "lodash-es";
+import { sortBy } from "es-toolkit";
 import { SubtractionFileItem } from "./SubtractionFileItem";
 
 export type SubtractionFilesProps = {
@@ -17,7 +17,7 @@ export default function SubtractionFiles({ files }) {
                 <p>Data files available to workflows using this subtraction.</p>
             </BoxGroupHeader>
             {files.length ? (
-                sortBy(files).map((file: SubtractionFile) => (
+                sortBy(files, [(f) => f.name]).map((file: SubtractionFile) => (
                     <SubtractionFileItem
                         downloadUrl={file.download_url}
                         name={file.name}

--- a/src/subtraction/components/SubtractionFileSelector.tsx
+++ b/src/subtraction/components/SubtractionFileSelector.tsx
@@ -9,7 +9,6 @@ import {
     FetchNextPageOptions,
     InfiniteQueryObserverResult,
 } from "@tanstack/react-query/";
-import { flatMap } from "lodash-es";
 import styled from "styled-components";
 import { SubtractionFileItem } from "./SubtractionFileItem";
 
@@ -60,7 +59,7 @@ export function SubtractionFileSelector({
 }: SubtractionFileSelectorProps) {
     useValidateFiles(UploadType.subtraction, selected, onClick);
 
-    const items = flatMap(files.pages, (page) => page.items);
+    const items = files.pages.flatMap((page) => page.items);
 
     function renderRow(item: Upload) {
         return (

--- a/src/subtraction/components/SubtractionList.tsx
+++ b/src/subtraction/components/SubtractionList.tsx
@@ -6,7 +6,6 @@ import Pagination from "@base/Pagination";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
-import { map } from "lodash-es";
 import { useFindSubtractions } from "../queries";
 import { SubtractionItem } from "./SubtractionItem";
 import SubtractionToolbar from "./SubtractionToolbar";
@@ -52,7 +51,7 @@ export default function SubtractionList() {
                     pageCount={page_count}
                 >
                     <BoxGroup>
-                        {map(documents, (document) => (
+                        {documents.map((document) => (
                             <SubtractionItem key={document.id} {...document} />
                         ))}
                     </BoxGroup>

--- a/src/uploads/components/FileManager.tsx
+++ b/src/uploads/components/FileManager.tsx
@@ -11,7 +11,7 @@ import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
 import { Permission } from "@groups/types";
-import { capitalize, map } from "lodash-es";
+import { capitalize } from "es-toolkit";
 import { ReactNode } from "react";
 import { Accept } from "react-dropzone";
 import { useListFiles } from "../queries";
@@ -107,7 +107,7 @@ export function FileManager({
                     pageCount={files.page_count}
                 >
                     <BoxGroup>
-                        {map(files.items, (item) => (
+                        {files.items.map((item) => (
                             <UploadItem
                                 {...item}
                                 canDelete={canDelete}

--- a/src/users/components/__tests__/ManageUsers.test.tsx
+++ b/src/users/components/__tests__/ManageUsers.test.tsx
@@ -3,7 +3,6 @@ import { screen } from "@testing-library/react";
 import { createFakeAccount, mockApiGetAccount } from "@tests/fake/account";
 import { createFakeUsers, mockApiFindUsers } from "@tests/fake/user";
 import { renderWithRouter } from "@tests/setup";
-import { forEach } from "lodash-es";
 import { describe, expect, it } from "vitest";
 import { ManageUsers } from "../ManageUsers";
 
@@ -24,7 +23,7 @@ describe("<ManageUsers />", () => {
             screen.getByRole("button", { name: "Create" }),
         ).toBeInTheDocument();
         expect(await screen.findByText(/Administrator/)).toBeInTheDocument();
-        forEach(users, (user) => {
+        users.forEach((user) => {
             expect(screen.getByText(user.handle)).toBeInTheDocument();
         });
     });


### PR DESCRIPTION
## Summary
- Continue migration from lodash-es to es-toolkit and native JS methods
- Convert ~30 more files from lodash to es-toolkit or native equivalents
- Reduces lodash usage from ~80+ files to ~53 files

## Changes
**Converted to native JS:**
- `map` → `Array.prototype.map()`
- `filter` → `Array.prototype.filter()`
- `forEach` → `Array.prototype.forEach()`
- `find` → `Array.prototype.find()`
- `findIndex` → `Array.prototype.findIndex()`
- `reduce` → `Array.prototype.reduce()`
- `flatMap` → `Array.prototype.flatMap()`
- `replace` → `String.prototype.replace()`
- `keys` → `Object.keys()`
- `reject` → `filter()` with negated condition

**Converted to es-toolkit:**
- `sortBy`, `orderBy`, `maxBy`, `unzip`, `xor`, `compact`, `capitalize`

## Test plan
- All 336 tests pass
- Build succeeds