### PR TITLE
refactor: replace date-fns with browser APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "clsx": "^2.1.1",
         "commander": "^12.1.0",
         "d3": "^7.9.0",
-        "date-fns": "^3.6.0",
         "downshift": "^9.0.13",
         "es-toolkit": "^1.43.0",
         "express": "^5.1.0",
@@ -6993,16 +6992,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "clsx": "^2.1.1",
     "commander": "^12.1.0",
     "d3": "^7.9.0",
-    "date-fns": "^3.6.0",
     "downshift": "^9.0.13",
     "es-toolkit": "^1.43.0",
     "express": "^5.1.0",

--- a/src/analyses/components/Nuvs/BlastInProgress.tsx
+++ b/src/analyses/components/Nuvs/BlastInProgress.tsx
@@ -1,9 +1,9 @@
+import { addSeconds, formatDistanceStrict } from "@/app/date";
 import Box from "@base/Box";
 import ExternalLink from "@base/ExternalLink";
 import Icon from "@base/Icon";
 import Loader from "@base/Loader";
 import RelativeTime from "@base/RelativeTime";
-import { addSeconds, formatDistanceStrict } from "date-fns";
 import styled from "styled-components";
 
 const ridRoot =

--- a/src/analyses/components/Nuvs/NuvsBlastPending.tsx
+++ b/src/analyses/components/Nuvs/NuvsBlastPending.tsx
@@ -1,9 +1,9 @@
+import { addSeconds, formatDistanceStrict } from "@/app/date";
 import Box from "@base/Box";
 import ExternalLink from "@base/ExternalLink";
 import Icon from "@base/Icon";
 import Loader from "@base/Loader";
 import RelativeTime from "@base/RelativeTime";
-import { addSeconds, formatDistanceStrict } from "date-fns";
 import styled from "styled-components";
 
 const ridRoot =

--- a/src/app/date.ts
+++ b/src/app/date.ts
@@ -1,0 +1,117 @@
+/**
+ * Date utilities using browser APIs to replace date-fns.
+ */
+
+const TIME_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+    ["year", 31536000],
+    ["month", 2592000],
+    ["week", 604800],
+    ["day", 86400],
+    ["hour", 3600],
+    ["minute", 60],
+    ["second", 1],
+];
+
+const relativeTimeFormatter = new Intl.RelativeTimeFormat("en", {
+    numeric: "always",
+    style: "long",
+});
+
+/**
+ * Format the distance between two dates as a human-readable string.
+ *
+ * @param date - the date to compare
+ * @param baseDate - the base date to compare against (defaults to now)
+ * @param options - formatting options
+ * @returns a string like "3 days ago" or "in 5 minutes"
+ */
+export function formatDistanceStrict(
+    date: Date,
+    baseDate: Date | number = Date.now(),
+    options: { addSuffix?: boolean } = {},
+): string {
+    const { addSuffix = false } = options;
+    const baseDateObj =
+        typeof baseDate === "number" ? new Date(baseDate) : baseDate;
+    const diffInSeconds = Math.round(
+        (date.getTime() - baseDateObj.getTime()) / 1000,
+    );
+    const absoluteDiff = Math.abs(diffInSeconds);
+
+    for (const [unit, secondsInUnit] of TIME_UNITS) {
+        if (absoluteDiff >= secondsInUnit || unit === "second") {
+            const value = Math.round(absoluteDiff / secondsInUnit);
+            const signedValue = diffInSeconds < 0 ? -value : value;
+
+            if (addSuffix) {
+                return relativeTimeFormatter.format(signedValue, unit);
+            }
+
+            return `${value} ${unit}${value !== 1 ? "s" : ""}`;
+        }
+    }
+
+    return addSuffix ? "just now" : "0 seconds";
+}
+
+/**
+ * Format a duration in seconds as a human-readable string.
+ *
+ * Returns the largest non-zero unit (e.g., "3 hours", "2 days").
+ *
+ * @param seconds - the duration in seconds
+ * @returns a human-readable duration string
+ */
+export function formatRoundedDuration(seconds: number): string {
+    if (seconds < 1) {
+        return "less than a second";
+    }
+
+    for (const [unit, secondsInUnit] of TIME_UNITS) {
+        const value = Math.floor(seconds / secondsInUnit);
+        if (value >= 1) {
+            return `${value} ${unit}${value !== 1 ? "s" : ""}`;
+        }
+    }
+
+    return "less than a second";
+}
+
+/**
+ * Add seconds to a date.
+ *
+ * @param date - the base date
+ * @param seconds - the number of seconds to add
+ * @returns a new Date with the seconds added
+ */
+export function addSeconds(date: Date, seconds: number): Date {
+    return new Date(date.getTime() + seconds * 1000);
+}
+
+/**
+ * Format a date as a time string (HH:mm:ss).
+ *
+ * @param date - the date to format
+ * @returns a time string in 24-hour format
+ */
+export function formatTime(date: Date): string {
+    return date.toLocaleTimeString("en-GB", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: false,
+    });
+}
+
+/**
+ * Format a date as an ISO date string (yyyy-MM-dd).
+ *
+ * @param date - the date to format
+ * @returns a date string in ISO format
+ */
+export function formatDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+}

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -2,11 +2,11 @@
  * General utility constants and functions.
  */
 import clsx, { ClassValue } from "clsx";
-import { formatDuration, intervalToDuration } from "date-fns";
 import { get, sampleSize, startCase } from "es-toolkit/compat";
 import numbro from "numbro";
 import { twMerge } from "tailwind-merge";
 import { capitalize } from "./common";
+export { formatRoundedDuration } from "./date";
 
 /**
  * A string containing all alphanumeric digits in both cases.
@@ -71,31 +71,6 @@ export function formatIsolateName(isolate: object): string {
     return sourceType === "unknown"
         ? "Unnamed"
         : `${capitalize(sourceType)} ${sourceName}`;
-}
-
-/**
- * Return an English string describing a duration given a number of seconds.
- */
-export function formatRoundedDuration(seconds: number) {
-    const duration = intervalToDuration({ start: 0, end: seconds * 1000 });
-
-    const units = [
-        "years",
-        "months",
-        "weeks",
-        "days",
-        "hours",
-        "minutes",
-        "seconds",
-    ];
-
-    for (const unit of units) {
-        if (duration[unit]) {
-            return formatDuration({ [unit]: duration[unit] }, { zero: false });
-        }
-    }
-
-    return "less than a second";
 }
 
 /**

--- a/src/base/RelativeTime.tsx
+++ b/src/base/RelativeTime.tsx
@@ -1,4 +1,4 @@
-import { formatDistanceStrict, isAfter } from "date-fns";
+import { formatDistanceStrict } from "@/app/date";
 import { useEffect, useState } from "react";
 
 type RelativeTimeOptions = {
@@ -9,12 +9,12 @@ type RelativeTimeOptions = {
  * Create a human-readable relative time.
  *
  * It is possible that the relative time could be in the future if the browser time lags behind the server time. If this
- * is the case the string will contain the substring 'in a'. If this substring is present, return the alternative time
+ * is the case the string will contain the substring 'in'. If this substring is present, return the alternative time
  * string 'just now'.
  *
- * @param time {string} the ISO formatted time
- * @param options.addSuffix whether to add "ago" suffix (default: true)
- * @returns {string}
+ * @param time - the ISO formatted time
+ * @param options.addSuffix - whether to add "ago" suffix (default: true)
+ * @returns a human-readable relative time string
  */
 function createTimeString(
     time: string | Date,
@@ -24,17 +24,13 @@ function createTimeString(
     const serverDate = new Date(time);
     const clientDate = new Date();
 
-    const currentTime = isAfter(serverDate, clientDate)
-        ? clientDate
-        : serverDate;
+    const currentTime = serverDate > clientDate ? clientDate : serverDate;
 
     const timeString = formatDistanceStrict(currentTime, now, {
         addSuffix,
     });
 
-    return timeString.includes("in a") || timeString.includes("a few")
-        ? "just now"
-        : timeString;
+    return timeString.startsWith("in ") ? "just now" : timeString;
 }
 
 export function useRelativeTime(

--- a/src/jobs/components/JobStep.tsx
+++ b/src/jobs/components/JobStep.tsx
@@ -1,6 +1,6 @@
+import { formatDate, formatTime } from "@/app/date";
 import Badge from "@/base/Badge";
 import BoxGroupSection from "@base/BoxGroupSection";
-import { format } from "date-fns";
 import { Calendar, Clock } from "lucide-react";
 import { marked } from "marked";
 import type { JobState, JobStep } from "../types";
@@ -32,11 +32,11 @@ export default function JobStepItem({ step, state }: JobStepProps) {
                 <div className="flex gap-4">
                     <Badge className="flex gap-1.5 items-center">
                         <Clock size={16} />
-                        {format(new Date(step.startedAt), "HH:mm:ss")}
+                        {formatTime(new Date(step.startedAt))}
                     </Badge>
                     <Badge className="flex gap-1.5 items-center">
                         <Calendar size={16} />
-                        {format(new Date(step.startedAt), "yyyy-MM-dd")}
+                        {formatDate(new Date(step.startedAt))}
                     </Badge>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- Replace date-fns with native browser APIs using `Intl.RelativeTimeFormat`
- Add new `src/app/date.ts` with utilities: `formatDistanceStrict`, `formatRoundedDuration`, `addSeconds`, `formatTime`, `formatDate`
- Remove date-fns dependency (~75KB minified)