### PR TITLE
feat: use sample names in fastq downloads

### DIFF
--- a/src/samples/components/Files/ReadItem.tsx
+++ b/src/samples/components/Files/ReadItem.tsx
@@ -15,9 +15,19 @@ const StyledReadItem = styled(BoxGroupSection)`
     justify-content: space-between;
 `;
 
+/**
+ * Sanitize a string for use as a filename by replacing invalid characters
+ * with underscores.
+ */
+function sanitizeFileName(name: string): string {
+    return name.replace(/[/\\:*?"<>|\s]/g, "_");
+}
+
 type ReadItemProps = {
-    name: string;
     download_url: string;
+    name: string;
+    sampleName: string;
+    side: number;
     /** The size of the read file in bytes */
     size: number;
 };
@@ -25,12 +35,20 @@ type ReadItemProps = {
 /**
  * A condensed read item for use in a list of reads
  */
-export default function ReadItem({ name, download_url, size }: ReadItemProps) {
+export default function ReadItem({
+    download_url,
+    name,
+    sampleName,
+    side,
+    size,
+}: ReadItemProps) {
+    const downloadName = `${sanitizeFileName(sampleName)}_${side}.fq.gz`;
+
     return (
         <StyledReadItem>
             <ReadItemMain>
                 <div>
-                    <a href={`/api/${download_url}`} download>
+                    <a href={`/api/${download_url}`} download={downloadName}>
                         {name}
                     </a>
                 </div>

--- a/src/samples/components/Files/SampleDetailFiles.tsx
+++ b/src/samples/components/Files/SampleDetailFiles.tsx
@@ -21,7 +21,7 @@ export default function SampleDetailFiles() {
         <ContainerNarrow>
             <SampleFileSizeWarning reads={data.reads} sampleId={data.id} />
             <SampleFilesMessage showLegacy={data.is_legacy} />
-            <SampleReads reads={data.reads} />
+            <SampleReads reads={data.reads} sampleName={data.name} />
         </ContainerNarrow>
     );
 }

--- a/src/samples/components/Files/SampleReads.tsx
+++ b/src/samples/components/Files/SampleReads.tsx
@@ -16,17 +16,29 @@ const SampleReadsTitle = styled.h2`
 type SampleReadsProps = {
     /** A list of reads used to create the sample */
     reads: Read[];
+    /** The name of the sample */
+    sampleName: string;
 };
+
+/**
+ * Extract the read side (1 or 2) from a read filename like "reads_1.fq.gz"
+ */
+function extractReadSide(name: string): number {
+    const match = name.match(/reads_(\d+)/);
+    return match ? parseInt(match[1], 10) : 1;
+}
 
 /**
  * Displays a list of reads used to create the sample
  */
-export default function SampleReads({ reads }: SampleReadsProps) {
+export default function SampleReads({ reads, sampleName }: SampleReadsProps) {
     const fileComponents = reads.map((file) => (
         <ReadItem
             key={file.name}
-            name={file.name}
             download_url={file.download_url}
+            name={file.name}
+            sampleName={sampleName}
+            side={extractReadSide(file.name)}
             size={file.size}
         />
     ));


### PR DESCRIPTION
## Summary
- FASTQ downloads now use `<sample_name>_<side>.fq.gz` instead of generic `reads_1.fq.gz`
- Sample names are sanitized to replace invalid filename characters with underscores
- Side number is extracted from the original read filename to handle unordered arrays

Closes VIR-2185