### PR TITLE
feat: display sample names in read file names

### DIFF
--- a/src/samples/components/Files/ReadItem.tsx
+++ b/src/samples/components/Files/ReadItem.tsx
@@ -25,7 +25,6 @@ function sanitizeFileName(name: string): string {
 
 type ReadItemProps = {
     download_url: string;
-    name: string;
     sampleName: string;
     side: number;
     /** The size of the read file in bytes */
@@ -37,7 +36,6 @@ type ReadItemProps = {
  */
 export default function ReadItem({
     download_url,
-    name,
     sampleName,
     side,
     size,
@@ -49,7 +47,7 @@ export default function ReadItem({
             <ReadItemMain>
                 <div>
                     <a href={`/api/${download_url}`} download={downloadName}>
-                        {name}
+                        {downloadName}
                     </a>
                 </div>
             </ReadItemMain>

--- a/src/samples/components/Files/SampleReads.tsx
+++ b/src/samples/components/Files/SampleReads.tsx
@@ -36,7 +36,6 @@ export default function SampleReads({ reads, sampleName }: SampleReadsProps) {
         <ReadItem
             key={file.name}
             download_url={file.download_url}
-            name={file.name}
             sampleName={sampleName}
             side={extractReadSide(file.name)}
             size={file.size}


### PR DESCRIPTION
## Summary

- Display sample names in read file names instead of generic read names
- Removes unused `name` prop from ReadItem component
- Consistent with recent changes to use sample names in FASTQ downloads