### PR TITLE
refactor: convert UserDetail and Groups components to Tailwind

### DIFF
--- a/src/base/Alert.tsx
+++ b/src/base/Alert.tsx
@@ -25,7 +25,12 @@ const Alert = styled(
         outerClassName,
     }: AlertProps) => (
         <AlertOuter className={outerClassName} color={color}>
-            <AlertInner className={className} block={block} color={color} level={level}>
+            <AlertInner
+                className={className}
+                block={block}
+                color={color}
+                level={level}
+            >
                 {icon ? <Icon name={icon} /> : null}
                 {children}
             </AlertInner>

--- a/src/base/Alert.tsx
+++ b/src/base/Alert.tsx
@@ -11,17 +11,21 @@ type AlertProps = {
     color?: string;
     icon?: string;
     level?: boolean;
+    outerClassName?: string;
 };
 
 const Alert = styled(
-    ({ block, children, className, color, icon, level }: AlertProps) => (
-        <AlertOuter color={color}>
-            <AlertInner
-                className={className}
-                block={block}
-                color={color}
-                level={level}
-            >
+    ({
+        block,
+        children,
+        className,
+        color,
+        icon,
+        level,
+        outerClassName,
+    }: AlertProps) => (
+        <AlertOuter className={outerClassName} color={color}>
+            <AlertInner className={className} block={block} color={color} level={level}>
                 {icon ? <Icon name={icon} /> : null}
                 {children}
             </AlertInner>

--- a/src/base/RemoveBanner.tsx
+++ b/src/base/RemoveBanner.tsx
@@ -20,18 +20,20 @@ const StyledRemoveBanner = styled(Alert)<StyledRemoveBannerProps>`
 `;
 
 type RemoveBannerProps = {
-    message: string;
     buttonText: string;
+    message: string;
     onClick: () => void;
+    outerClassName?: string;
 };
 
 export default function RemoveBanner({
-    message,
     buttonText,
+    message,
     onClick,
+    outerClassName,
 }: RemoveBannerProps) {
     return (
-        <StyledRemoveBanner color="red">
+        <StyledRemoveBanner outerClassName={outerClassName} color="red">
             <strong>{message}</strong>
             <Button color="red" onClick={onClick}>
                 {buttonText}

--- a/src/groups/components/GroupSelector.tsx
+++ b/src/groups/components/GroupSelector.tsx
@@ -1,47 +1,13 @@
-import { getColor } from "@app/theme";
-import BoxGroup from "@base/BoxGroup";
+import { cn } from "@app/utils";
+import ScrollArea from "@base/ScrollArea";
 import SelectBoxGroupSection from "@base/SelectBoxGroupSection";
 import { sortBy } from "es-toolkit/compat";
-import styled from "styled-components";
 import { GroupMinimal } from "../types";
 
-type GroupsSelectBoxGroupSectionProps = {
-    selectable?: boolean;
-};
-
-export const GroupsSelectBoxGroupSection = styled(
-    SelectBoxGroupSection,
-)<GroupsSelectBoxGroupSectionProps>`
-    outline: 1px solid
-        ${(props) => getColor({ color: "greyLight", theme: props.theme })};
-    background-color: ${(props) =>
-        getColor({
-            color: props.active ? "blue" : "white",
-            theme: props.theme,
-        })};
-    cursor: ${(props) => (props.selectable ? "pointer" : "default")};
-    &:hover {
-        background-color: ${(props) =>
-            getColor({
-                theme: props.theme,
-                color: props.selectable ? "greyLightest" : "white",
-            })};
-    }
-`;
-
-export const GroupComponentsContainer = styled(BoxGroup)`
-    height: 514px;
-    overflow-y: auto;
-    background-color: ${(props) =>
-        getColor({ theme: props.theme, color: "greyLightest" })};
-    border-bottom: 1px solid
-        ${(props) => getColor({ theme: props.theme, color: "greyLight" })};
-`;
-
 type GroupSelectorProps = {
+    groups: Array<GroupMinimal>;
     selectedGroupId?: number | string;
     setSelectedGroupId: (groupId: number | string) => void;
-    groups: Array<GroupMinimal>;
 };
 
 export function GroupSelector({
@@ -49,18 +15,27 @@ export function GroupSelector({
     setSelectedGroupId,
     groups,
 }: GroupSelectorProps) {
+    function isActive(id: number | string) {
+        return selectedGroupId === id;
+    }
+
     const groupComponents = sortBy(groups, (g) => g.name).map((group) => (
-        <GroupsSelectBoxGroupSection
-            selectable
-            active={selectedGroupId === group.id}
+        <SelectBoxGroupSection
+            active={isActive(group.id)}
+            className={cn(
+                "outline-1 outline-gray-300 font-medium",
+                !isActive(group.id) && "hover:bg-gray-100",
+            )}
             key={group.id}
             onClick={() => setSelectedGroupId(group.id)}
         >
             {group.name}
-        </GroupsSelectBoxGroupSection>
+        </SelectBoxGroupSection>
     ));
 
     return (
-        <GroupComponentsContainer>{groupComponents}</GroupComponentsContainer>
+        <ScrollArea className="col-span-1 w-full h-full bg-gray-100 border-b border-gray-300 mr-0">
+            {groupComponents}
+        </ScrollArea>
     );
 }

--- a/src/groups/components/Groups.tsx
+++ b/src/groups/components/Groups.tsx
@@ -1,13 +1,10 @@
 import { useDialogParam } from "@app/hooks";
-import { getColor } from "@app/theme";
-import BoxGroup from "@base/BoxGroup";
 import Button from "@base/Button";
 import InputHeader from "@base/InputHeader";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import RemoveBanner from "@base/RemoveBanner";
 import { sortBy } from "es-toolkit/compat";
 import { useState } from "react";
-import styled from "styled-components";
 import {
     useFetchGroup,
     useListGroups,
@@ -18,36 +15,6 @@ import Create from "./CreateGroup";
 import { GroupMembers } from "./GroupMembers";
 import { GroupPermissions } from "./GroupPermissions";
 import { GroupSelector } from "./GroupSelector";
-
-const ManageGroupsContainer = styled.div`
-    display: grid;
-    grid-template-columns: 1fr 3fr;
-    column-gap: 15px;
-`;
-
-const GroupsHeader = styled.div`
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 15px;
-`;
-
-const NoneSelectedContainer = styled(BoxGroup)`
-    display: flex;
-    flex-direction: column;
-    background-color: ${(props) =>
-        getColor({ theme: props.theme, color: "greyLightest" })};
-    flex: 1 1 auto;
-    height: 300px;
-`;
-
-export const NoneSelected = styled.div`
-    color: ${(props) => props.theme.color.greyDarkest};
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-`;
 
 export default function Groups() {
     const updateGroupMutation = useUpdateGroup();
@@ -74,21 +41,21 @@ export default function Groups() {
 
     return (
         <>
-            <GroupsHeader>
+            <header className="flex items-center justify-between mb-5">
                 <h2>Groups</h2>
                 <Button color="blue" onClick={() => setOpenCreateGroup(true)}>
                     Create
                 </Button>
-            </GroupsHeader>
+            </header>
 
             {groups.length ? (
-                <ManageGroupsContainer>
+                <div className="gap-x-4 grid grid-cols-4">
                     <GroupSelector
                         groups={groups}
                         selectedGroupId={selectedGroupId}
                         setSelectedGroupId={setSelectedGroupId}
                     />
-                    <div>
+                    <div className="col-span-3">
                         <InputHeader
                             id="name"
                             value={selectedGroup.name}
@@ -102,6 +69,7 @@ export default function Groups() {
                         <GroupPermissions selectedGroup={selectedGroup} />
                         <GroupMembers members={selectedGroup.users} />
                         <RemoveBanner
+                            outerClassName="!mb-0"
                             message="Permanently delete this group."
                             buttonText="Delete"
                             onClick={() =>
@@ -109,11 +77,11 @@ export default function Groups() {
                             }
                         />
                     </div>
-                </ManageGroupsContainer>
+                </div>
             ) : (
-                <NoneSelectedContainer>
-                    <NoneSelected>No Groups Found</NoneSelected>
-                </NoneSelectedContainer>
+                <div className="bg-gray-200 flex items-center h-48 justify-center rounded-md text-gray-600">
+                    No Groups Exist
+                </div>
             )}
 
             <Create />

--- a/src/groups/components/__tests__/Groups.test.tsx
+++ b/src/groups/components/__tests__/Groups.test.tsx
@@ -11,7 +11,7 @@ describe("Groups", () => {
     it("should render correctly when loading = true", () => {
         renderWithRouter(<Groups />);
 
-        expect(screen.queryByText("No Groups Found")).not.toBeInTheDocument();
+        expect(screen.queryByText("No Groups Exist")).not.toBeInTheDocument();
         expect(screen.queryByText("cancel_job")).not.toBeInTheDocument();
         expect(screen.queryByText("No Group Members")).not.toBeInTheDocument();
         expect(
@@ -23,7 +23,7 @@ describe("Groups", () => {
         mockApiListGroups([]);
         renderWithRouter(<Groups />);
 
-        expect(await screen.findByText("No Groups Found")).toBeInTheDocument();
+        expect(await screen.findByText("No Groups Exist")).toBeInTheDocument();
         expect(
             screen.queryByRole("button", { name: "Delete" }),
         ).not.toBeInTheDocument();

--- a/src/otus/components/Detail/Isolates/RemoveIsolate.tsx
+++ b/src/otus/components/Detail/Isolates/RemoveIsolate.tsx
@@ -26,7 +26,7 @@ export default function RemoveIsolate({
 }: RemoveIsolateProps) {
     const mutation = useRemoveIsolate();
 
-    const handleConfirm = () =>
+    function handleConfirm() {
         mutation.mutate(
             { otuId, isolateId: id },
             {
@@ -35,6 +35,7 @@ export default function RemoveIsolate({
                 },
             },
         );
+    }
 
     return (
         <RemoveDialog

--- a/src/users/components/UserDetail.tsx
+++ b/src/users/components/UserDetail.tsx
@@ -1,56 +1,19 @@
+import Label from "@/base/Label";
 import { useCheckAdminRole } from "@administration/hooks";
 import { useFetchUser } from "@administration/queries";
 import { AdministratorRoleName } from "@administration/types";
 import { useDialogParam, usePathParams } from "@app/hooks";
-import { getFontSize, getFontWeight } from "@app/theme";
 import Alert from "@base/Alert";
-import { device } from "@base/device";
 import Icon from "@base/Icon";
 import InitialIcon from "@base/InitialIcon";
-import Link from "@base/Link";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
-import styled from "styled-components";
+import { ShieldUserIcon } from "lucide-react";
 import Password from "./Password";
 import PrimaryGroup from "./PrimaryGroup";
 import { UserActivation } from "./UserActivation";
 import { UserActivationBanner } from "./UserActivationBanner";
 import UserGroups from "./UserGroups";
 import UserPermissions from "./UserPermissions";
-
-const AdminIcon = styled(Icon)`
-    padding-left: 10px;
-`;
-
-const UserDetailGroups = styled.div`
-    margin-bottom: 15px;
-
-    @media (min-width: ${device.tablet}) {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        grid-column-gap: ${(props) => props.theme.gap.column};
-    }
-`;
-
-const UserDetailHeader = styled.div`
-    display: flex;
-    margin-bottom: 20px;
-`;
-
-const UserDetailTitle = styled.div`
-    align-items: center;
-    display: flex;
-    flex: 1 0 auto;
-    font-size: ${getFontSize("xl")};
-    font-weight: ${getFontWeight("bold")};
-    margin-left: 15px;
-    .InitialIcon {
-        margin-right: 8px;
-    }
-    a {
-        font-size: ${getFontSize("md")};
-        margin-left: auto;
-    }
-`;
 
 /**
  * The detailed view of a user
@@ -100,20 +63,18 @@ export default function UserDetail() {
 
     return (
         <div>
-            <UserDetailHeader>
-                <UserDetailTitle>
+            <header className="flex items-center justify-between mb-5">
+                <h2 className="flex items-center text-2xl gap-3">
                     <InitialIcon size="xl" handle={handle} />
                     <span>{handle}</span>
-                    {administrator_role ? (
-                        <AdminIcon
-                            aria-label="admin"
-                            name="user-shield"
-                            color="blue"
-                        />
-                    ) : null}
-                    <Link to="/administration/users">Back To List</Link>
-                </UserDetailTitle>
-            </UserDetailHeader>
+                </h2>
+                {administrator_role && (
+                    <Label>
+                        <ShieldUserIcon aria-label="Administrator" size={18} />
+                        Administrator
+                    </Label>
+                )}
+            </header>
 
             <Password
                 key={id}
@@ -122,7 +83,7 @@ export default function UserDetail() {
                 forceReset={force_reset}
             />
 
-            <UserDetailGroups>
+            <div className="mb-4 md:grid md:grid-cols-2 md:gap-x-4">
                 <div>
                     <UserGroups userId={id} memberGroups={groups} />
                     <PrimaryGroup
@@ -132,7 +93,7 @@ export default function UserDetail() {
                     />
                 </div>
                 <UserPermissions permissions={permissions} />
-            </UserDetailGroups>
+            </div>
 
             {data.active ? (
                 <UserActivationBanner

--- a/src/users/components/__tests__/UserDetail.test.tsx
+++ b/src/users/components/__tests__/UserDetail.test.tsx
@@ -64,8 +64,7 @@ describe("<UserDetail />", () => {
             ).toBeInTheDocument();
 
             expect(screen.getByText(userDetail.handle)).toBeInTheDocument();
-            expect(screen.getByLabelText("admin")).toBeInTheDocument();
-            expect(screen.getByText("Back To List")).toBeInTheDocument();
+            expect(screen.getByLabelText("Administrator")).toBeInTheDocument();
 
             expect(
                 screen.getByText("Force user to reset password on next login"),
@@ -119,8 +118,9 @@ describe("<UserDetail />", () => {
             expect(
                 await screen.findByText("Change Password"),
             ).toBeInTheDocument();
-
-            expect(screen.queryByLabelText("admin")).not.toBeInTheDocument();
+            expect(
+                screen.queryByLabelText("Administrator"),
+            ).not.toBeInTheDocument();
             expect(screen.queryByText("User Role")).not.toBeInTheDocument();
             expect(screen.getByText("Group 4")).toBeInTheDocument();
             expect(screen.getByText("create_sample")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- Replace styled-components with Tailwind CSS in UserDetail and Groups components
- Use Radix ScrollArea for the group selector list with dynamic height
- Add `outerClassName` prop to Alert and RemoveBanner for margin overrides
- Net reduction of ~90 lines of code