### PR TITLE
chore: add MCP tool permissions to Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,7 +38,13 @@
       "Bash(npm run build*)",
       "Bash(npm run storybook*)",
       "Bash(npx vitest*)",
-      "Bash(npx tsc *)"
+      "Bash(npx tsc *)",
+      "mcp__context7__resolve-library-id",
+      "mcp__context7__query-docs",
+      "mcp__linear-virtool__get_*",
+      "mcp__linear-virtool__list_*",
+      "mcp__linear-virtool__search_*",
+      "mcp__linear-virtool__extract_*"
     ],
     "deny": [
       "Bash(rm -rf *)",


### PR DESCRIPTION
## Summary

- Allow Context7 and Linear MCP tools in Claude Code settings so they can be used without manual approval each time.