### PR TITLE
chore: migrate keyframe animations to @theme and remove tailwindcss-animate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "virtool-ui.igboyes-vir-2229-remove-storybook-from-virtool-ui",
+  "name": "virtool-ui.igboyes-vir-2232-migrate-keyframe-animations-to-theme-and-remove-tailwindcss",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -31,7 +31,6 @@
         "styled-components": "^6.3.11",
         "superagent": "^8.0.9",
         "tailwind-merge": "^3.5.0",
-        "tailwindcss-animate": "^1.0.7",
         "tsx": "^4.21.0",
         "winston": "^3.19.0",
         "wouter": "^3.9.0",
@@ -8741,16 +8740,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tailwindcss-animate": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
-      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders"
-      }
     },
     "node_modules/tapable": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "styled-components": "^6.3.11",
     "superagent": "^8.0.9",
     "tailwind-merge": "^3.5.0",
-    "tailwindcss-animate": "^1.0.7",
     "tsx": "^4.21.0",
     "winston": "^3.19.0",
     "wouter": "^3.9.0",

--- a/src/administration/components/AdministratorUserSelect.tsx
+++ b/src/administration/components/AdministratorUserSelect.tsx
@@ -28,7 +28,7 @@ function renderRow(user) {
 	);
 }
 
-function toString(user: User) {
+function userToString(user: User) {
 	return user?.handle;
 }
 
@@ -55,7 +55,7 @@ export default function AdministratorUserSelect({
 			term={term}
 			selectedItem={value || null}
 			renderRow={renderRow}
-			itemToString={toString}
+			itemToString={userToString}
 			onFilter={onTermChange}
 			onChange={onChange}
 			id={id}

--- a/src/app/style.css
+++ b/src/app/style.css
@@ -21,6 +21,138 @@
 @theme {
 	--font-sans: "Inter", sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
 	--color-virtool: #3c8786;
+
+	--animate-overlayShow: overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+	--animate-contentShow: contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+	--animate-slideDown: slideDown 100ms ease-in;
+	--animate-rotate: rotate 0.75s linear infinite;
+	--animate-fade: fade 1.25s ease-in-out infinite alternate;
+	--animate-contentOpen: contentOpen 150ms cubic-bezier(0.16, 1, 0.3, 1);
+	--animate-comboBoxContentOpen: comboBoxContentOpen 150ms
+		cubic-bezier(0.16, 1, 0.3, 1);
+	--animate-slideUpAndFade: slideUpAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1);
+	--animate-slideDownAndFade: slideDownAndFade 400ms
+		cubic-bezier(0.16, 1, 0.3, 1);
+	--animate-slideRightAndFade: slideRightAndFade 400ms
+		cubic-bezier(0.16, 1, 0.3, 1);
+	--animate-slideLeftAndFade: slideLeftAndFade 400ms
+		cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes overlayShow {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes contentShow {
+	from {
+		opacity: 0;
+		transform: translate(-50%, -48%) scale(0.96);
+	}
+	to {
+		opacity: 1;
+		transform: translate(-50%, -50%) scale(1);
+	}
+}
+
+@keyframes slideDown {
+	from {
+		opacity: 0;
+		transform: translateY(-10px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@keyframes rotate {
+	0% {
+		transform: rotate(0deg);
+	}
+	50% {
+		transform: rotate(180deg);
+	}
+	100% {
+		transform: rotate(360deg);
+	}
+}
+
+@keyframes fade {
+	from {
+		opacity: 0.6;
+		transform: scale(1);
+	}
+	to {
+		opacity: 1;
+		transform: scale(1.1);
+	}
+}
+
+@keyframes contentOpen {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes comboBoxContentOpen {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes slideUpAndFade {
+	from {
+		opacity: 0;
+		transform: translateY(2px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@keyframes slideDownAndFade {
+	from {
+		opacity: 0;
+		transform: translateY(-2px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@keyframes slideRightAndFade {
+	from {
+		opacity: 0;
+		transform: translateX(-2px);
+	}
+	to {
+		opacity: 1;
+		transform: translateX(0);
+	}
+}
+
+@keyframes slideLeftAndFade {
+	from {
+		opacity: 0;
+		transform: translateX(2px);
+	}
+	to {
+		opacity: 1;
+		transform: translateX(0);
+	}
 }
 
 html {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,36 +1,3 @@
-import tailwindcssAnimate from "tailwindcss-animate";
-
 export default {
-    content: ["./src/**/*.{css,html,js,jsx,ts,tsx}"],
-    prefix: "",
-    theme: {
-        extend: {
-            keyframes: {
-                overlayShow: {
-                    from: { opacity: "0" },
-                    to: { opacity: "1" },
-                },
-                contentShow: {
-                    from: {
-                        opacity: "0",
-                        transform: "translate(-50%, -48%) scale(0.96)",
-                    },
-                    to: {
-                        opacity: "1",
-                        transform: "translate(-50%, -50%) scale(1)",
-                    },
-                },
-                slideDown: {
-                    "0%": { opacity: "0", transform: "translateY(-10px)" },
-                    "100%": { opacity: "1", transform: "translateY(0)" },
-                },
-            },
-            animation: {
-                overlayShow: "overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1)",
-                contentShow: "contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1)",
-                slideDown: "slideDown 100ms ease-in",
-            },
-        },
-    },
-    plugins: [tailwindcssAnimate],
+	content: ["./src/**/*.{css,html,js,jsx,ts,tsx}"],
 };


### PR DESCRIPTION
## Summary

- Move all 11 keyframe animation definitions into `src/app/style.css` using Tailwind v4 native `@theme` custom properties and `@keyframes` blocks
- Remove the `tailwindcss-animate` plugin and clean up `tailwind.config.js`
- Fix pre-existing `noShadowRestrictedNames` lint error in `AdministratorUserSelect.tsx`

Closes VIR-2232