### PR TITLE
refactor: migrate Radix UI wrapper components to Tailwind

### DIFF
--- a/src/base/AccordionContent.tsx
+++ b/src/base/AccordionContent.tsx
@@ -1,14 +1,22 @@
+import { cn } from "@app/utils";
 import { Accordion as AccordionPrimitive } from "radix-ui";
-import styled from "styled-components";
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 /** display the content of the accordion dropdown based on state */
-const AccordionContent = styled(AccordionPrimitive.Content)`
-    overflow: hidden;
-    padding: 0 15px;
-
-    &[data-state="closed"] {
-        display: none;
-    }
-`;
+const AccordionContent = forwardRef<
+	HTMLDivElement,
+	ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(function AccordionContent({ className, ...props }, ref) {
+	return (
+		<AccordionPrimitive.Content
+			ref={ref}
+			className={cn(
+				"overflow-hidden px-4 data-[state=closed]:hidden",
+				className,
+			)}
+			{...props}
+		/>
+	);
+});
 
 export default AccordionContent;

--- a/src/base/AccordionScrollingItem.tsx
+++ b/src/base/AccordionScrollingItem.tsx
@@ -1,13 +1,5 @@
-import { getBorder } from "@app/theme";
 import { Accordion as AccordionPrimitive } from "radix-ui";
 import { createRef, type ReactNode, useEffect } from "react";
-import styled from "styled-components";
-
-const StyledAccordionItem = styled(AccordionPrimitive.Item)`
-    border: ${getBorder};
-    margin-bottom: 10px;
-    scroll-margin-top: 50px;
-`;
 
 /** Composed radix accordion item for handling scroll logic  */
 function ComposedScrollingAccordionItem(props) {
@@ -23,7 +15,13 @@ function ComposedScrollingAccordionItem(props) {
 		}
 	}, [props["data-state"], ref?.current]);
 
-	return <div {...props} ref={ref} />;
+	return (
+		<div
+			{...props}
+			ref={ref}
+			className="border border-gray-300 mb-2.5 scroll-mt-12"
+		/>
+	);
 }
 
 type AccordionScrollingItemProps = {
@@ -39,10 +37,10 @@ export default function AccordionScrollingItem({
 	children,
 }: AccordionScrollingItemProps) {
 	return (
-		<StyledAccordionItem value={value} asChild>
+		<AccordionPrimitive.Item value={value} asChild>
 			<ComposedScrollingAccordionItem>
 				{children}
 			</ComposedScrollingAccordionItem>
-		</StyledAccordionItem>
+		</AccordionPrimitive.Item>
 	);
 }

--- a/src/base/AccordionTrigger.tsx
+++ b/src/base/AccordionTrigger.tsx
@@ -1,21 +1,22 @@
-import { getColor } from "@app/theme";
+import { cn } from "@app/utils";
 import { Accordion as AccordionPrimitive } from "radix-ui";
-import styled from "styled-components";
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 /** button for toggling the display of accordion contents  */
-const AccordionTrigger = styled(AccordionPrimitive.Trigger)`
-    align-items: center;
-    background-color: ${(props) => props.theme.color.white};
-    border: none;
-    display: flex;
-    justify-content: space-between;
-    padding: 10px 15px;
-    width: 100%;
-
-    &:hover {
-        background-color: ${(props) =>
-					getColor({ color: "greyHover", theme: props.theme })};
-    }
-`;
+const AccordionTrigger = forwardRef<
+	HTMLButtonElement,
+	ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(function AccordionTrigger({ className, ...props }, ref) {
+	return (
+		<AccordionPrimitive.Trigger
+			ref={ref}
+			className={cn(
+				"flex items-center justify-between w-full bg-white border-none px-4 py-2.5 hover:bg-gray-50",
+				className,
+			)}
+			{...props}
+		/>
+	);
+});
 
 export default AccordionTrigger;

--- a/src/base/ComboBox.tsx
+++ b/src/base/ComboBox.tsx
@@ -1,32 +1,9 @@
-import {
-	borderRadius,
-	boxShadow,
-	getBorder,
-	getColor,
-	getFontWeight,
-} from "@app/theme";
+import { cn } from "@app/utils";
 import { useCombobox } from "downshift";
 import { ChevronDown } from "lucide-react";
-import styled, { keyframes } from "styled-components";
 import WrapRow from "./ComboBoxItem";
 import Icon from "./Icon";
 import InputSearch from "./InputSearch";
-
-const StyledTriggerButton = styled.button`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 5px 10px;
-    background-color: ${({ theme }) => getColor({ color: "white", theme })};
-    border: ${getBorder};
-    border-radius: ${borderRadius.sm};
-    font-weight: ${getFontWeight("thick")};
-    text-transform: capitalize;
-    width: 100%;
-    svg {
-        margin-left: 5px;
-    }
-`;
 
 function ComboboxTriggerButton({
 	TriggerButtonProps,
@@ -35,63 +12,23 @@ function ComboboxTriggerButton({
 	id,
 }) {
 	return (
-		<StyledTriggerButton {...TriggerButtonProps} id={id} type="button">
+		<button
+			className="flex justify-between items-center px-2.5 py-1.5 bg-white border border-gray-300 rounded font-medium capitalize w-full [&_svg]:ml-1"
+			{...TriggerButtonProps}
+			id={id}
+			type="button"
+		>
 			{selectedItem ? renderRow(selectedItem) : "Select user"}
 			<Icon icon={ChevronDown} />
-		</StyledTriggerButton>
+		</button>
 	);
 }
 
-const ComboBoxContentOpen = keyframes`  
-  from {
-    opacity: 0;
-  }
-  to {  
-    opacity: 1;
-  }
-`;
-
-interface Content {
-	$isOpen: boolean;
-}
-
-const Content = styled.ul<Content>`
-    transform-origin: top center;
-    animation: ${ComboBoxContentOpen} 150ms cubic-bezier(0.16, 1, 0.3, 1);
-    top: 100%;
-    padding: 0;
-    margin-top: 0;
-    position: absolute;
-    background-color: white;
-    width: 100%;
-    max-height: 20rem;
-    overflow-y: auto;
-    overflow-x: hidden;
-    outline: 0;
-    transition: opacity 0.1s ease;
-    box-shadow: ${boxShadow.md};
-    border: ${getBorder};
-    border-radius: ${borderRadius.md};
-    z-index: 110;
-    display: ${(props) => (props.$isOpen ? "block" : "none")};
-`;
-
-const ComboBoxContainer = styled.div`
-    display: flex;
-    position: relative;
-    flex-direction: column;
-    width: 100%;
-`;
-
-const InputSearchContainer = styled.div`
-    margin: 10px 5px;
-`;
-
 function ComboBoxSearch({ getInputProps }) {
 	return (
-		<InputSearchContainer>
+		<div className="mx-1 my-2.5">
 			<InputSearch {...getInputProps()} />
-		</InputSearchContainer>
+		</div>
 	);
 }
 
@@ -144,17 +81,23 @@ export default function ComboBox({
 	const rows = items.map(WrapRow(renderRow, getItemProps));
 
 	return (
-		<ComboBoxContainer>
+		<div className="flex relative flex-col w-full">
 			<ComboboxTriggerButton
 				TriggerButtonProps={getToggleButtonProps()}
 				selectedItem={selectedItem}
 				renderRow={renderRow}
 				id={id}
 			/>
-			<Content {...getMenuProps()} $isOpen={isOpen}>
+			<ul
+				className={cn(
+					"origin-top animate-comboBoxContentOpen top-full p-0 mt-0 absolute bg-white w-full max-h-80 overflow-y-auto overflow-x-hidden outline-0 transition-opacity duration-100 ease-in shadow-md border border-gray-300 rounded-md z-50",
+					isOpen ? "block" : "hidden",
+				)}
+				{...getMenuProps()}
+			>
 				<ComboBoxSearch getInputProps={getInputProps} />
 				{isOpen && rows}
-			</Content>
-		</ComboBoxContainer>
+			</ul>
+		</div>
 	);
 }

--- a/src/base/ComboBoxItem.tsx
+++ b/src/base/ComboBoxItem.tsx
@@ -1,30 +1,16 @@
-import { getColor } from "@app/theme";
-import styled from "styled-components";
-
-const ComboBoxItem = styled.li`
-    padding: 10px 10px;
-
-    &:hover {
-        background-color: ${({ theme }) =>
-					getColor({ color: "greyHover", theme })};
-        border: 0;
-    }
-`;
-
-ComboBoxItem.displayName = "ComboBoxItem";
-
 export default function WrapRow(renderRow, getItemProps) {
 	function WrappedRow(item, index) {
 		return (
-			<ComboBoxItem
+			<li
 				key={item.id}
+				className="px-2.5 py-2.5 hover:bg-gray-50 hover:border-0"
 				{...getItemProps({
 					item: item.id,
 					index,
 				})}
 			>
 				{renderRow(item)}
-			</ComboBoxItem>
+			</li>
 		);
 	}
 	return WrappedRow;

--- a/src/base/DropdownMenuItem.tsx
+++ b/src/base/DropdownMenuItem.tsx
@@ -1,16 +1,21 @@
+import { cn } from "@app/utils";
 import { DropdownMenu } from "radix-ui";
-import styled from "styled-components";
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
-const DropdownMenuItem = styled(DropdownMenu.Item)`
-    color: ${(props) => props.theme.color.black};
-    cursor: pointer;
-    min-width: 160px;
-    padding: 10px 15px;
-
-    &:hover {
-        background-color: ${(props) => props.theme.color.greyHover};
-        color: ${(props) => props.theme.color.black};
-    }
-`;
+const DropdownMenuItem = forwardRef<
+	HTMLDivElement,
+	ComponentPropsWithoutRef<typeof DropdownMenu.Item>
+>(function DropdownMenuItem({ className, ...props }, ref) {
+	return (
+		<DropdownMenu.Item
+			ref={ref}
+			className={cn(
+				"text-black cursor-pointer min-w-40 px-4 py-2.5 hover:bg-gray-50 hover:text-black",
+				className,
+			)}
+			{...props}
+		/>
+	);
+});
 
 export default DropdownMenuItem;

--- a/src/base/DropdownMenuTrigger.tsx
+++ b/src/base/DropdownMenuTrigger.tsx
@@ -1,10 +1,21 @@
+import { cn } from "@app/utils";
 import { DropdownMenu } from "radix-ui";
-import styled from "styled-components";
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
-const DropdownMenuTrigger = styled(DropdownMenu.Trigger)`
-    all: unset;
-    display: flex;
-    cursor: pointer;
-`;
+const DropdownMenuTrigger = forwardRef<
+	HTMLButtonElement,
+	ComponentPropsWithoutRef<typeof DropdownMenu.Trigger>
+>(function DropdownMenuTrigger({ className, ...props }, ref) {
+	return (
+		<DropdownMenu.Trigger
+			ref={ref}
+			className={cn(
+				"flex cursor-pointer appearance-none border-none bg-transparent p-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+});
 
 export default DropdownMenuTrigger;

--- a/src/base/SelectButton.tsx
+++ b/src/base/SelectButton.tsx
@@ -1,24 +1,7 @@
-import { borderRadius, getBorder, getColor, getFontWeight } from "@app/theme";
+import { cn } from "@app/utils";
 import Icon from "@base/Icon";
 import type { LucideIcon } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
-import styled from "styled-components";
-
-const SelectTrigger = styled(SelectPrimitive.Trigger)`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 5px 10px;
-    background-color: ${({ theme }) => getColor({ color: "white", theme })};
-    border: ${getBorder};
-    border-radius: ${borderRadius.sm};
-    font-weight: ${getFontWeight("thick")};
-    text-transform: capitalize;
-
-    svg {
-        margin-left: 5px;
-    }
-`;
 
 type SelectButtonProps = {
 	placeholder?: string;
@@ -34,9 +17,15 @@ export default function SelectButton({
 	id,
 }: SelectButtonProps) {
 	return (
-		<SelectTrigger className={className} id={id}>
+		<SelectPrimitive.Trigger
+			className={cn(
+				"flex justify-between items-center px-2.5 py-1.5 bg-white border border-gray-300 rounded font-medium capitalize [&_svg]:ml-1",
+				className,
+			)}
+			id={id}
+		>
 			<SelectPrimitive.Value placeholder={placeholder} />
 			<Icon icon={LucideIcon} />
-		</SelectTrigger>
+		</SelectPrimitive.Trigger>
 	);
 }

--- a/src/base/SelectContent.tsx
+++ b/src/base/SelectContent.tsx
@@ -1,61 +1,25 @@
-import { borderRadius, boxShadow, getColor } from "@app/theme";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
-import styled, { keyframes } from "styled-components";
 import Icon from "./Icon";
-
-const ContentOpen = keyframes`
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-`;
-
-const StyledContent = styled(SelectPrimitive.Content)`
-    transform-origin: top center;
-    animation: ${ContentOpen} 150ms cubic-bezier(0.16, 1, 0.3, 1);
-    background-color: white;
-    border-radius: ${borderRadius.md};
-    box-shadow: ${boxShadow.md};
-    overflow: hidden;
-    z-index: 110;
-    max-height: var(--radix-select-content-available-height);
-    min-width: var(--radix-select-trigger-width);
-
-    &:first-child {
-        margin-top: 10px;
-    }
-`;
-
-const ScrollSection = styled(SelectPrimitive.ScrollUpButton)`
-    margin: 5px 0;
-    display: flex;
-    justify-content: center;
-    &:hover {
-        background-color: ${(props) =>
-					getColor({ color: "greyHover", theme: props.theme })};
-    }
-`;
 
 export default function SelectContent({ children, position, align }) {
 	return (
 		<SelectPrimitive.Portal>
-			<StyledContent
+			<SelectPrimitive.Content
+				className="origin-top animate-contentOpen bg-white rounded-md shadow-md overflow-hidden z-50 max-h-[var(--radix-select-content-available-height)] min-w-[var(--radix-select-trigger-width)] first:mt-2.5"
 				position={position}
 				align={align}
 				side="bottom"
 				avoidCollisions={false}
 			>
-				<ScrollSection>
+				<SelectPrimitive.ScrollUpButton className="my-1 flex justify-center hover:bg-gray-50">
 					<Icon icon={ChevronUp} />
-				</ScrollSection>
+				</SelectPrimitive.ScrollUpButton>
 				<SelectPrimitive.Viewport>{children}</SelectPrimitive.Viewport>
-				<ScrollSection as={SelectPrimitive.ScrollDownButton}>
+				<SelectPrimitive.ScrollDownButton className="my-1 flex justify-center hover:bg-gray-50">
 					<Icon icon={ChevronDown} />
-				</ScrollSection>
-			</StyledContent>
+				</SelectPrimitive.ScrollDownButton>
+			</SelectPrimitive.Content>
 		</SelectPrimitive.Portal>
 	);
 }

--- a/src/base/SelectItem.tsx
+++ b/src/base/SelectItem.tsx
@@ -1,39 +1,18 @@
-import { getColor, getFontSize, getFontWeight } from "@app/theme";
 import { Select as SelectPrimitive } from "radix-ui";
-import styled from "styled-components";
-
-const StyledSelectItem = styled(SelectPrimitive.Item)`
-    font-size: ${getFontSize("md")};
-    font-weight: ${getFontWeight("thick")};
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    padding: 5px 35px 5px 25px;
-    position: relative;
-    user-select: none;
-    margin-bottom: 5px;
-    text-transform: capitalize;
-
-    &:hover {
-        background-color: ${({ theme }) =>
-					getColor({ color: "greyHover", theme })};
-        border: 0;
-    }
-`;
-
-const Description = styled.div`
-    font-size: ${getFontSize("sm")};
-    font-weight: ${getFontWeight("normal")};
-    color: ${({ theme }) => getColor({ color: "greyDarkest", theme })};
-    margin-top: 5px;
-    white-space: pre-wrap;
-`;
 
 export default function SelectItem({ value, children, description }) {
 	return (
-		<StyledSelectItem value={value} key={value}>
+		<SelectPrimitive.Item
+			className="text-sm font-medium flex flex-col items-start py-1.5 pr-9 pl-6 relative select-none mb-1 capitalize hover:bg-gray-50 hover:border-0"
+			value={value}
+			key={value}
+		>
 			<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-			{description && <Description>{description}</Description>}
-		</StyledSelectItem>
+			{description && (
+				<div className="text-xs font-normal text-gray-600 mt-1 whitespace-pre-wrap">
+					{description}
+				</div>
+			)}
+		</SelectPrimitive.Item>
 	);
 }

--- a/src/base/Tooltip.tsx
+++ b/src/base/Tooltip.tsx
@@ -1,82 +1,5 @@
-import { boxShadow } from "@app/theme";
 import { Tooltip as TooltipPrimitive } from "radix-ui";
 import type { ReactNode } from "react";
-import styled, { keyframes } from "styled-components";
-
-const slideUpAndFade = keyframes`
-  from {
-    opacity: 0;
-    transform: translateY(2px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-`;
-
-const slideDownAndFade = keyframes`
-  from {
-    opacity: 0;
-    transform: translateY(-2px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-`;
-
-const slideRightAndFade = keyframes`
-    from {
-    opacity: 0;
-    transform: translateX(-2px);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-`;
-
-const slideLeftAndFade = keyframes`
-  from {
-    opacity: 0;
-    transform: translateX(2px);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-`;
-
-const TooltipContent = styled(TooltipPrimitive.Content)`
-    border-radius: 4px;
-    padding: 0.6rem 1.2rem;
-    font-size: 15px;
-    line-height: 1;
-    background-color: rgba(0, 0, 0, 0.8);
-    color: white;
-    box-shadow: ${boxShadow.lg};
-    animation-duration: 400ms;
-    animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-    will-change: transform, opacity;
-    text-transform: capitalize;
-    z-index: 20;
-
-    &[data-state="delayed-open"][data-side="top"] {
-        animation-name: ${slideDownAndFade};
-    }
-
-    &[data-state="delayed-open"][data-side="right"] {
-        animation-name: ${slideLeftAndFade};
-    }
-
-    &[data-state="delayed-open"][data-side="bottom"] {
-        animation-name: ${slideUpAndFade};
-    }
-
-    &[data-state="delayed-open"][data-side="left"] {
-        animation-name: ${slideRightAndFade};
-    }
-`;
 
 type TooltipProps = {
 	children: ReactNode;
@@ -94,10 +17,14 @@ export default function Tooltip({
 			<TooltipPrimitive.Root>
 				<TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
 				<TooltipPrimitive.Portal>
-					<TooltipContent side={position} sideOffset={5}>
+					<TooltipPrimitive.Content
+						className="rounded px-4 py-2 text-sm leading-none bg-black/80 text-white shadow-lg will-change-[transform,opacity] capitalize z-20 data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade"
+						side={position}
+						sideOffset={5}
+					>
 						{tip}
 						<TooltipPrimitive.Arrow />
-					</TooltipContent>
+					</TooltipPrimitive.Content>
 				</TooltipPrimitive.Portal>
 			</TooltipPrimitive.Root>
 		</TooltipPrimitive.Provider>


### PR DESCRIPTION
## Summary

- Migrate 11 Radix UI wrapper components in `src/base/` from `styled-components` to Tailwind `className`
- Replace inline keyframe definitions with `@theme` animation variables already defined in `style.css`
- Components that are extended by consumers via `styled()` (AccordionTrigger, SelectButton) now merge `className` via `cn()` for backward compatibility

**Components migrated:** AccordionContent, AccordionScrollingItem, AccordionTrigger, ComboBox, ComboBoxItem, DropdownMenuItem, DropdownMenuTrigger, SelectButton, SelectContent, SelectItem, Tooltip

Resolves VIR-2237