### PR TITLE
refactor: migrate samples/ styled-components to Tailwind

### DIFF
--- a/src/samples/components/Create/ReadSelector.tsx
+++ b/src/samples/components/Create/ReadSelector.tsx
@@ -1,4 +1,4 @@
-import { getBorder, getFontWeight, theme } from "@app/theme";
+import { cn } from "@app/utils";
 import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
 import Button from "@base/Button";
@@ -17,43 +17,9 @@ import type {
 } from "@tanstack/react-query/";
 import { Repeat, Undo } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
-import styled from "styled-components";
 import { useValidateFiles } from "@/uploads/hooks";
 import { type FileResponse, UploadType } from "@/uploads/types";
 import ReadSelectorItem from "./ReadSelectorItem";
-
-type ReadSelectorBoxProps = {
-	error: string;
-};
-
-const ReadSelectorBox = styled(Box)<ReadSelectorBoxProps>`
-    ${(props) => (props.error ? `border-color: ${theme.color.red};` : "")};
-`;
-
-const ReadSelectorError = styled(InputError)`
-    margin-bottom: 10px;
-`;
-
-const ReadSelectorHeader = styled.label`
-    align-items: center;
-    display: flex;
-    font-weight: ${getFontWeight("thick")};
-
-    label {
-        margin: 0;
-    }
-
-    span {
-        color: grey;
-        margin-left: auto;
-    }
-`;
-
-const StyledScrollListElement = styled(CompactScrollList)`
-    border: ${(props) => getBorder(props)};
-    border-radius: ${(props) => props.theme.borderRadius.sm};
-    height: 400px;
-`;
 
 type ReadSelectorProps = {
 	/** Samples uploads on current page */
@@ -163,15 +129,15 @@ export default function ReadSelector({
 
 	return (
 		<div>
-			<ReadSelectorHeader>
+			<label className="flex items-center font-medium [&_label]:m-0 [&_span]:text-gray-500 [&_span]:ml-auto">
 				<PseudoLabel>Read files</PseudoLabel>
 				<span>
 					{pairedness}
 					{selected.length} of {total_count} selected
 				</span>
-			</ReadSelectorHeader>
+			</label>
 
-			<ReadSelectorBox error={error}>
+			<Box className={cn(error && "border-red-600")}>
 				<Toolbar>
 					<div className="flex-grow">
 						<InputSearch
@@ -189,7 +155,8 @@ export default function ReadSelector({
 				</Toolbar>
 				{noneFound || (
 					<>
-						<StyledScrollListElement
+						<CompactScrollList
+							className="border border-gray-300 rounded h-96"
 							fetchNextPage={fetchNextPage}
 							isFetchingNextPage={isFetchingNextPage}
 							isPending={isPending}
@@ -197,10 +164,10 @@ export default function ReadSelector({
 							renderRow={renderRow}
 						/>
 
-						<ReadSelectorError>{error}</ReadSelectorError>
+						<InputError className="mb-2.5">{error}</InputError>
 					</>
 				)}
-			</ReadSelectorBox>
+			</Box>
 		</div>
 	);
 }

--- a/src/samples/components/Create/SampleUserGroup.tsx
+++ b/src/samples/components/Create/SampleUserGroup.tsx
@@ -2,11 +2,6 @@ import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import InputSelect from "@base/InputSelect";
 import type { GroupMinimal } from "@groups/types";
-import styled from "styled-components";
-
-const SampleUserGroupItem = styled.option`
-    text-transform: capitalize;
-`;
 
 type SampleUserGroupProps = {
 	selected: string;
@@ -24,9 +19,9 @@ export default function SampleUserGroup({
 	onChange,
 }: SampleUserGroupProps) {
 	const groupComponents = groups.map((group) => (
-		<SampleUserGroupItem key={group.id} value={group.id}>
+		<option className="capitalize" key={group.id} value={group.id}>
 			{group.name}
-		</SampleUserGroupItem>
+		</option>
 	));
 
 	return (

--- a/src/samples/components/Detail/Sidebar.tsx
+++ b/src/samples/components/Detail/Sidebar.tsx
@@ -1,17 +1,8 @@
 import type { LabelNested } from "@labels/types";
 import { useUpdateSample } from "@samples/queries";
 import type { SubtractionNested } from "@subtraction/types";
-import styled from "styled-components";
 import DefaultSubtractions from "../Sidebar/DefaultSubtractions";
 import SampleLabels from "../Sidebar/SampleLabels";
-
-const StyledSidebar = styled.div`
-    align-items: stretch;
-    flex-direction: column;
-    display: flex;
-    width: 320px;
-    z-index: 0;
-`;
 
 type SidebarProps = {
 	sampleId: string;
@@ -30,7 +21,7 @@ export default function Sidebar({
 	const mutation = useUpdateSample(sampleId);
 
 	return (
-		<StyledSidebar>
+		<div className="flex flex-col items-stretch w-80 z-0">
 			<SampleLabels
 				onUpdate={(labels) => {
 					mutation.mutate({ update: { labels } });
@@ -45,6 +36,6 @@ export default function Sidebar({
 					(subtraction) => subtraction.id,
 				)}
 			/>
-		</StyledSidebar>
+		</div>
 	);
 }

--- a/src/samples/components/Files/ReadItem.tsx
+++ b/src/samples/components/Files/ReadItem.tsx
@@ -1,19 +1,5 @@
-import { fontWeight } from "@app/theme";
 import { byteSize } from "@app/utils";
 import BoxGroupSection from "@base/BoxGroupSection";
-import styled from "styled-components";
-
-const ReadItemMain = styled.div`
-    align-items: center;
-    display: flex;
-`;
-
-const StyledReadItem = styled(BoxGroupSection)`
-    align-items: flex-start;
-    display: flex;
-    font-weight: ${fontWeight.thick};
-    justify-content: space-between;
-`;
 
 /**
  * Sanitize a string for use as a filename by replacing invalid characters
@@ -43,15 +29,15 @@ export default function ReadItem({
 	const downloadName = `${sanitizeFileName(sampleName)}_${side}.fq.gz`;
 
 	return (
-		<StyledReadItem>
-			<ReadItemMain>
+		<BoxGroupSection className="flex items-start font-medium justify-between">
+			<div className="flex items-center">
 				<div>
 					<a href={`/api/${download_url}`} download={downloadName}>
 						{downloadName}
 					</a>
 				</div>
-			</ReadItemMain>
+			</div>
 			{byteSize(size, true)}
-		</StyledReadItem>
+		</BoxGroupSection>
 	);
 }

--- a/src/samples/components/Files/SampleReads.tsx
+++ b/src/samples/components/Files/SampleReads.tsx
@@ -1,17 +1,7 @@
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupHeader from "@base/BoxGroupHeader";
 import type { Read } from "@samples/types";
-import styled from "styled-components";
 import ReadItem from "./ReadItem";
-
-const SampleReadsTitle = styled.h2`
-    display: flex;
-    justify-content: space-between;
-
-    & > a {
-        cursor: pointer;
-    }
-`;
 
 type SampleReadsProps = {
 	/** A list of reads used to create the sample */
@@ -45,7 +35,7 @@ export default function SampleReads({ reads, sampleName }: SampleReadsProps) {
 	return (
 		<BoxGroup>
 			<BoxGroupHeader>
-				<SampleReadsTitle>Reads</SampleReadsTitle>
+				<h2 className="flex justify-between">Reads</h2>
 				<p>The input sequencing data used to create this sample.</p>
 			</BoxGroupHeader>
 			{fileComponents}

--- a/src/samples/components/Filter/SampleFilters.tsx
+++ b/src/samples/components/Filter/SampleFilters.tsx
@@ -1,12 +1,6 @@
 import type { Label } from "@labels/types";
-import styled from "styled-components";
 import LabelFilter from "./LabelFilter";
 import WorkflowFilter from "./WorkflowFilter";
-
-const StyledSampleFilters = styled.div`
-    grid-column: 2;
-    grid-row: 2;
-`;
 
 type SampleFilterProps = {
 	/** A list of labels */
@@ -36,13 +30,13 @@ export default function SampleFilters({
 	selectedWorkflows,
 }: SampleFilterProps) {
 	return (
-		<StyledSampleFilters>
+		<div className="col-start-2 row-start-2">
 			<LabelFilter
 				labels={labels}
 				onClick={onClickLabels}
 				selected={selectedLabels}
 			/>
 			<WorkflowFilter selected={selectedWorkflows} onClick={onClickWorkflows} />
-		</StyledSampleFilters>
+		</div>
 	);
 }

--- a/src/samples/components/Filter/WorkflowFilter.tsx
+++ b/src/samples/components/Filter/WorkflowFilter.tsx
@@ -1,5 +1,4 @@
-import { getBorder, getFontSize } from "@app/theme";
-import { getWorkflowDisplayName } from "@app/utils";
+import { cn, getWorkflowDisplayName } from "@app/utils";
 import Box from "@base/Box";
 import Icon from "@base/Icon";
 import SideBarSection from "@base/SideBarSection";
@@ -7,45 +6,6 @@ import SidebarHeader from "@base/SidebarHeader";
 import { WorkflowStates } from "@samples/utils";
 import { xor } from "es-toolkit/array";
 import { Check, type LucideIcon, Play, X } from "lucide-react";
-import styled from "styled-components";
-
-const WorkflowFilterLabel = styled.div`
-    padding: 4px 8px;
-`;
-
-const StyledWorkflowFilterControlButton = styled.button`
-    align-items: center;
-    background-color: ${(props) =>
-			props.theme.color[
-				props["aria-pressed"] === true ? "purple" : "purpleLightest"
-			]};
-    color: ${(props) =>
-			props.theme.color[
-				props["aria-pressed"] === true ? "white" : "purpleDark"
-			]};
-
-    border: 2px solid ${(props) => props.theme.color.purple};
-    border-radius: 20px;
-    cursor: pointer;
-    justify-content: center;
-    display: flex;
-    height: 30px;
-    transform: scale(
-        ${(props) => (props["aria-pressed"] === "true" ? 1 : 0.95)}
-    );
-    width: 30px;
-
-    i {
-        font-size: ${getFontSize("md")};
-    }
-
-    &[aria-pressed="false"]:hover,
-    &[aria-pressed="false"]:focus {
-        background-color: ${(props) => props.theme.color.purpleLight};
-        color: ${(props) => props.theme.color.purpleDarkest};
-        outline: none;
-    }
-`;
 
 type WorkflowFilterControlButtonProps = {
 	/* Indicates if the button is active */
@@ -65,32 +25,21 @@ function WorkflowFilterControlButton({
 	onClick,
 }: WorkflowFilterControlButtonProps) {
 	return (
-		<StyledWorkflowFilterControlButton
+		<button
+			className={cn(
+				"flex items-center justify-center border-2 border-purple-400 rounded-full cursor-pointer h-8 w-8 [&_i]:text-sm",
+				active
+					? "bg-purple-400 text-white"
+					: "bg-purple-50 text-purple-600 scale-95 hover:bg-purple-300 hover:text-purple-800 hover:outline-none focus:bg-purple-300 focus:text-purple-800 focus:outline-none",
+			)}
 			aria-pressed={active}
 			onClick={() => onClick(value)}
+			type="button"
 		>
 			<Icon icon={icon} />
-		</StyledWorkflowFilterControlButton>
+		</button>
 	);
 }
-
-const WorkflowFilterControlPath = styled.div`
-    border: ${getBorder};
-    flex: 1 0 auto;
-    height: 2px;
-`;
-
-const WorkflowFilterControlButtons = styled.div`
-    align-items: center;
-    display: flex;
-    justify-content: stretch;
-    padding: 4px 8px 8px;
-`;
-
-const StyledWorkflowFilterControl = styled(Box)`
-    background: ${(props) => props.theme.color.white};
-    padding: 0;
-`;
 
 type WorkflowFilterControlProps = {
 	/* The workflow to filter */
@@ -111,33 +60,31 @@ function WorkflowFilterControl({
 	}
 
 	return (
-		<StyledWorkflowFilterControl>
-			<WorkflowFilterLabel>
-				{getWorkflowDisplayName(workflow)}
-			</WorkflowFilterLabel>
-			<WorkflowFilterControlButtons>
+		<Box className="bg-white p-0">
+			<div className="px-2 py-1">{getWorkflowDisplayName(workflow)}</div>
+			<div className="flex items-center justify-stretch px-2 pt-1 pb-2">
 				<WorkflowFilterControlButton
 					active={states.includes(WorkflowStates.NONE)}
 					icon={X}
 					value={WorkflowStates.NONE}
 					onClick={handleClick}
 				/>
-				<WorkflowFilterControlPath />
+				<div className="border border-gray-300 flex-auto h-0.5" />
 				<WorkflowFilterControlButton
 					active={states.includes(WorkflowStates.PENDING)}
 					icon={Play}
 					value={WorkflowStates.PENDING}
 					onClick={handleClick}
 				/>
-				<WorkflowFilterControlPath />
+				<div className="border border-gray-300 flex-auto h-0.5" />
 				<WorkflowFilterControlButton
 					active={states.includes(WorkflowStates.READY)}
 					icon={Check}
 					value={WorkflowStates.READY}
 					onClick={handleClick}
 				/>
-			</WorkflowFilterControlButtons>
-		</StyledWorkflowFilterControl>
+			</div>
+		</Box>
 	);
 }
 

--- a/src/samples/components/Item/SampleItem.tsx
+++ b/src/samples/components/Item/SampleItem.tsx
@@ -1,79 +1,14 @@
 import { useDialogParam } from "@app/hooks";
-import { getFontSize, getFontWeight } from "@app/theme";
 import Attribution from "@base/Attribution";
 import Box from "@base/Box";
 import Checkbox from "@base/Checkbox";
 import Link from "@base/Link";
 import type { SampleMinimal } from "@samples/types";
-import styled from "styled-components";
 import { JobNested } from "@/jobs/types";
 import SampleLabel from "../Label/SampleLabel";
 import SampleLibraryTypeLabel from "../Label/SampleLibraryTypeLabel";
 import WorkflowTags from "../Tag/WorkflowTags";
 import EndIcon from "./EndIcon";
-
-const SampleItemCheckboxContainer = styled.div`
-    grid-column-start: 1;
-    cursor: pointer;
-    display: flex;
-    padding-right: 15px;
-    max-width: 30px;
-`;
-
-const SampleItemLabels = styled.div`
-    margin-top: 10px;
-    & > *:not(:last-child) {
-        margin-right: 5px;
-    }
-    display: flex;
-`;
-
-const SampleItemData = styled.div`
-    grid-column-start: 2;
-    display: flex;
-    flex: 3;
-    flex-direction: column;
-    min-width: 250px;
-`;
-
-const SampleItemMain = styled.div`
-    align-items: center;
-    display: flex;
-    position: relative;
-`;
-
-const SampleItemWorkflows = styled.div`
-    grid-column-start: 3;
-    display: flex;
-    flex: 2;
-    white-space: nowrap;
-`;
-
-const SampleItemIcon = styled.div`
-    display: flex;
-    min-width: 80px;
-`;
-
-const SampleItemTitle = styled.div`
-    display: flex;
-    flex-direction: column;
-    flex: 3;
-    overflow: hidden;
-
-    a {
-        font-size: ${getFontSize("lg")};
-        font-weight: ${getFontWeight("thick")};
-        margin: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
-`;
-
-const StyledSampleItem = styled(Box)`
-    align-items: stretch;
-    display: flex;
-    flex-basis: 0;
-`;
 
 type SampleItemProps = {
 	/** Minimal sample data */
@@ -108,33 +43,36 @@ export default function SampleItem({
 	const job = sample.job && JobNested.parse(sample.job);
 
 	return (
-		<StyledSampleItem>
-			<SampleItemCheckboxContainer onClick={handleSelect}>
+		<Box className="flex items-stretch basis-0">
+			<div
+				className="col-start-1 cursor-pointer flex pr-4 max-w-8"
+				onClick={handleSelect}
+			>
 				<Checkbox checked={checked} id={`SampleCheckbox${sample.id}`} />
-			</SampleItemCheckboxContainer>
+			</div>
 
-			<SampleItemData>
-				<SampleItemMain>
-					<SampleItemTitle>
+			<div className="col-start-2 flex flex-3 flex-col min-w-64">
+				<div className="flex items-center relative">
+					<div className="flex flex-col flex-3 overflow-hidden [&_a]:text-base [&_a]:font-medium [&_a]:m-0 [&_a]:overflow-hidden [&_a]:text-ellipsis">
 						<Link to={`/samples/${sample.id}`}>{sample.name}</Link>
 						<Attribution time={sample.created_at} user={sample.user.handle} />
-					</SampleItemTitle>
-				</SampleItemMain>
-				<SampleItemLabels>
+					</div>
+				</div>
+				<div className="flex mt-2.5 [&>*:not(:last-child)]:mr-1">
 					<SampleLibraryTypeLabel libraryType={sample.library_type} />
 					{sample.labels.map((label) => (
 						<SampleLabel {...label} key={label.id} size="sm" />
 					))}
-				</SampleItemLabels>
-			</SampleItemData>
-			<SampleItemWorkflows>
+				</div>
+			</div>
+			<div className="col-start-3 flex flex-2 whitespace-nowrap">
 				{sample.ready && (
 					<WorkflowTags id={sample.id} workflows={sample.workflows} />
 				)}
-			</SampleItemWorkflows>
-			<SampleItemIcon>
+			</div>
+			<div className="flex min-w-20">
 				<EndIcon job={job} onClick={onQuickAnalyze} ready={sample.ready} />
-			</SampleItemIcon>
-		</StyledSampleItem>
+			</div>
+		</Box>
 	);
 }

--- a/src/samples/components/SampleFilesMessage.tsx
+++ b/src/samples/components/SampleFilesMessage.tsx
@@ -1,6 +1,7 @@
 import Alert from "@base/Alert";
 
 type SampleFilesMessageProps = {
+	className?: string;
 	/** Indicates whether to show the alert for legacy sample uploads */
 	showLegacy: boolean;
 };
@@ -9,10 +10,11 @@ type SampleFilesMessageProps = {
  * Displays an alert message regarding legacy sample uploads
  */
 export default function SampleFilesMessage({
+	className,
 	showLegacy,
 }: SampleFilesMessageProps) {
 	return showLegacy ? (
-		<Alert color="orange" block>
+		<Alert className={className} color="orange" block>
 			<p>
 				<strong>
 					Virtool now retains raw data for newly created samples instead of

--- a/src/samples/components/SampleQuality.tsx
+++ b/src/samples/components/SampleQuality.tsx
@@ -1,18 +1,8 @@
 import { usePathParams } from "@app/hooks";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import { Quality } from "@quality/components/Quality";
-import styled from "styled-components";
 import { useFetchSample } from "../queries";
 import LegacyAlert from "./SampleFilesMessage";
-
-const SampleQualityLegacyAlert = styled(LegacyAlert)`
-    margin-bottom: 20px;
-`;
-
-const StyledSampleQuality = styled.div`
-    display: flex;
-    flex-direction: column;
-`;
 
 /**
  * Samples quality view showing charts for bases, composition, and sequences
@@ -26,13 +16,13 @@ export default function SampleQuality() {
 	}
 
 	return (
-		<StyledSampleQuality>
-			<SampleQualityLegacyAlert showLegacy={data.is_legacy} />
+		<div className="flex flex-col">
+			<LegacyAlert className="mb-5" showLegacy={data.is_legacy} />
 			<Quality
 				bases={data.quality.bases}
 				composition={data.quality.composition}
 				sequences={data.quality.sequences}
 			/>
-		</StyledSampleQuality>
+		</div>
 	);
 }

--- a/src/samples/components/SampleSelectionToolbar.tsx
+++ b/src/samples/components/SampleSelectionToolbar.tsx
@@ -3,26 +3,7 @@ import Button from "@base/Button";
 import Icon from "@base/Icon";
 import LinkButton from "@base/LinkButton";
 import { AreaChart } from "lucide-react";
-import styled from "styled-components";
 import { useSearch } from "wouter";
-
-const SampleSelectionToolbarTop = styled.div`
-    align-items: center;
-    display: flex;
-    margin-bottom: 15px;
-
-    button {
-        height: 38px;
-    }
-
-    button:first-child {
-        align-items: center;
-        display: flex;
-        flex: 1;
-        justify-content: flex-start;
-        margin-right: 3px;
-    }
-`;
 
 type SampleSelectionToolbarProps = {
 	/** A callback function to clear selected samples */
@@ -40,7 +21,7 @@ export default function SampleSelectionToolbar({
 }: SampleSelectionToolbarProps) {
 	const search = useSearch();
 	return (
-		<SampleSelectionToolbarTop>
+		<div className="flex items-center mb-4 [&_button]:h-10 [&_button:first-child]:flex [&_button:first-child]:flex-1 [&_button:first-child]:items-center [&_button:first-child]:justify-start [&_button:first-child]:mr-0.5">
 			<Button onClick={onClear}>
 				Clear selection of {selected.length} samples
 			</Button>
@@ -50,6 +31,6 @@ export default function SampleSelectionToolbar({
 			>
 				<Icon icon={AreaChart} /> Quick Analyze
 			</LinkButton>
-		</SampleSelectionToolbarTop>
+		</div>
 	);
 }

--- a/src/samples/components/SamplesList.tsx
+++ b/src/samples/components/SamplesList.tsx
@@ -16,26 +16,10 @@ import { useListSamples } from "@samples/queries";
 import type { SampleMinimal } from "@samples/types";
 import { intersectionWith, union, xor } from "es-toolkit/array";
 import { useState } from "react";
-import styled from "styled-components";
 import SampleFilters from "./Filter/SampleFilters";
 import SampleItem from "./Item/SampleItem";
 import SampleToolbar from "./SamplesToolbar";
 import SampleLabels from "./Sidebar/ManageLabels";
-
-const SamplesListHeader = styled.div`
-    grid-column: 1;
-`;
-
-const SamplesListContent = styled.div`
-    grid-row: 2;
-    min-width: 550px;
-`;
-
-const StyledSamplesList = styled.div`
-    display: grid;
-    grid-column-gap: ${(props) => props.theme.gap.column};
-    grid-template-columns: minmax(auto, 1150px) max(320px, 10%);
-`;
 
 /**
  * A list of samples with filtering
@@ -101,8 +85,13 @@ export default function SamplesList() {
 					(document, id) => document.id === id,
 				)}
 			/>
-			<StyledSamplesList>
-				<SamplesListHeader>
+			<div
+				className="grid gap-4"
+				style={{
+					gridTemplateColumns: "minmax(auto, 1150px) max(320px, 10%)",
+				}}
+			>
+				<div className="col-start-1">
 					<ViewHeader title="Samples">
 						<ViewHeaderTitle>
 							Samples <ViewHeaderTitleBadge>{total_count}</ViewHeaderTitleBadge>
@@ -114,8 +103,8 @@ export default function SamplesList() {
 						term={term}
 						onChange={(e) => setTerm(e.target.value)}
 					/>
-				</SamplesListHeader>
-				<SamplesListContent>
+				</div>
+				<div className="row-start-2 min-w-xl">
 					{!documents.length ? (
 						<NoneFoundBox key="noSample" noun="samples" />
 					) : (
@@ -127,7 +116,7 @@ export default function SamplesList() {
 							pageCount={page_count}
 						/>
 					)}
-				</SamplesListContent>
+				</div>
 				{selected.length ? (
 					<SampleLabels
 						labels={labels}
@@ -146,7 +135,7 @@ export default function SamplesList() {
 						onClickWorkflows={setFilterWorkflows}
 					/>
 				)}
-			</StyledSamplesList>
+			</div>
 		</>
 	);
 }

--- a/src/samples/components/Sidebar/DefaultSubtractions.tsx
+++ b/src/samples/components/Sidebar/DefaultSubtractions.tsx
@@ -1,27 +1,15 @@
-import { fontWeight, getColor, getFontSize } from "@app/theme";
 import Link from "@base/Link";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import SideBarSection from "@base/SideBarSection";
 import SidebarHeader from "@base/SidebarHeader";
 import { useFetchSubtractionsShortlist } from "@subtraction/queries";
 import { xor } from "es-toolkit/array";
-import styled from "styled-components";
 import SampleSidebarList from "./SampleSidebarList";
 import SampleSidebarSelector from "./SampleSidebarSelector";
 
 function SubtractionInner({ name }) {
 	return name;
 }
-
-const SampleSubtractionFooter = styled.div`
-    display: flex;
-    color: ${(props) => getColor({ theme: props.theme, color: "greyDarkest" })};
-    a {
-        margin-left: 5px;
-        font-size: ${getFontSize("md")};
-        font-weight: ${fontWeight.thick};
-    }
-`;
 
 type DefaultSubtractionsProps = {
 	/** List of subtraction ids associated with the sample. */
@@ -66,9 +54,9 @@ export default function DefaultSubtractions({
 				)}
 			/>
 			{Boolean(subtractionOptions.length) || (
-				<SampleSubtractionFooter>
+				<div className="flex text-gray-600 [&_a]:ml-1 [&_a]:text-sm [&_a]:font-medium">
 					No subtractions found. <Link to="/subtractions">Create one</Link>.
-				</SampleSubtractionFooter>
+				</div>
 			)}
 		</SideBarSection>
 	);

--- a/src/samples/components/Sidebar/SampleLabels.tsx
+++ b/src/samples/components/Sidebar/SampleLabels.tsx
@@ -1,24 +1,12 @@
-import { fontWeight, getColor, getFontSize } from "@app/theme";
 import Link from "@base/Link";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import SideBarSection from "@base/SideBarSection";
 import SidebarHeader from "@base/SidebarHeader";
 import { useFetchLabels } from "@labels/queries";
 import { xor } from "es-toolkit/array";
-import styled from "styled-components";
 import SampleLabel from "../Label/SampleLabel";
 import SampleSidebarList from "./SampleSidebarList";
 import SampleSidebarSelector from "./SampleSidebarSelector";
-
-const SampleLabelsFooter = styled.div`
-    display: flex;
-    color: ${(props) => getColor({ theme: props.theme, color: "greyDarkest" })};
-    a {
-        margin-left: 5px;
-        font-size: ${getFontSize("md")};
-        font-weight: ${fontWeight.thick};
-    }
-`;
 
 type SampleLabelsProps = {
 	/** List of label ids associated with the sample */
@@ -61,9 +49,9 @@ export default function SampleLabels({
 				items={data.filter((item) => sampleLabels.includes(item.id))}
 			/>
 			{Boolean(data.length) || (
-				<SampleLabelsFooter>
+				<div className="flex text-gray-600 [&_a]:ml-1 [&_a]:text-sm [&_a]:font-medium">
 					No labels found. <Link to="/samples/labels">Create one</Link>.
-				</SampleLabelsFooter>
+				</div>
 			)}
 		</SideBarSection>
 	);

--- a/src/samples/components/Sidebar/SampleSidebarList.tsx
+++ b/src/samples/components/Sidebar/SampleSidebarList.tsx
@@ -1,13 +1,6 @@
 import type { Label } from "@labels/types";
 import type { SubtractionOption } from "@subtraction/types";
-import styled from "styled-components";
 import SampleLabel from "../Label/SampleLabel";
-
-const SampleSidebarListItem = styled(SampleLabel)`
-    background-color: ${(props) => props.theme.color.white};
-    display: inline;
-    margin: 0 5px 5px 0;
-`;
 
 type SampleSidebarListProps = {
 	/** List of labels or subtractions associated with the sample */
@@ -19,7 +12,12 @@ type SampleSidebarListProps = {
  */
 export default function SampleSidebarList({ items }: SampleSidebarListProps) {
 	const sampleItemComponents = items.map((item) => (
-		<SampleSidebarListItem key={item.id} color={item.color} name={item.name} />
+		<SampleLabel
+			className="bg-white inline m-0 mr-1 mb-1"
+			key={item.id}
+			color={item.color}
+			name={item.name}
+		/>
 	));
 
 	return <div className="flex flex-wrap">{sampleItemComponents}</div>;

--- a/src/samples/components/Sidebar/SampleSidebarMultiselectList.tsx
+++ b/src/samples/components/Sidebar/SampleSidebarMultiselectList.tsx
@@ -1,21 +1,5 @@
 import type { SampleLabel } from "@samples/queries";
-import styled from "styled-components";
 import SampleMultiSelectLabel from "../Label/SampleMultiSelectLabel";
-
-const StyledSampleSidebarList = styled.div`
-    display: flex;
-    flex-flow: wrap;
-`;
-
-const SampleSidebarMultiSelectListItem = styled(SampleMultiSelectLabel)`
-    background-color: ${(props) => props.theme.color.white};
-    display: inline;
-    margin: 4px 0;
-
-    &:not(:last-child) {
-        margin-right: 8px;
-    }
-`;
 
 type SampleSidebarMultiselectList = {
 	/** List of labels that can be used to filter samples */
@@ -29,7 +13,8 @@ export default function SampleSidebarMultiselectList({
 	items,
 }: SampleSidebarMultiselectList) {
 	const sampleItemComponents = items.map(({ id, color, name, allLabeled }) => (
-		<SampleSidebarMultiSelectListItem
+		<SampleMultiSelectLabel
+			className="bg-white inline my-1 last:mr-0 mr-2"
 			key={id}
 			color={color}
 			name={name}
@@ -37,7 +22,5 @@ export default function SampleSidebarMultiselectList({
 		/>
 	));
 
-	return (
-		<StyledSampleSidebarList>{sampleItemComponents}</StyledSampleSidebarList>
-	);
+	return <div className="flex flex-wrap">{sampleItemComponents}</div>;
 }

--- a/src/samples/components/Sidebar/SampleSidebarSelector.tsx
+++ b/src/samples/components/Sidebar/SampleSidebarSelector.tsx
@@ -1,5 +1,4 @@
 import { useFuse } from "@app/fuse";
-import { fontWeight, getFontSize } from "@app/theme";
 import BoxGroupSearch from "@base/BoxGroupSearch";
 import Icon from "@base/Icon";
 import Link from "@base/Link";
@@ -9,28 +8,7 @@ import type { Label } from "@labels/types";
 import type { SubtractionOption } from "@subtraction/types";
 import { Pen } from "lucide-react";
 import type { ReactNode } from "react";
-import styled from "styled-components";
 import SampleSidebarSelectorItem from "./SampleSidebarSelectorItem";
-
-const SampleSidebarSelectorButton = styled.div`
-    display: flex;
-    border-top: 1px solid;
-    border-color: ${(props) => props.theme.color.greyLight};
-    width: 100%;
-    align-items: flex-end;
-
-    a {
-        margin-left: auto;
-        font-size: ${getFontSize("md")};
-        font-weight: ${fontWeight.thick};
-        padding: 10px 10px 10px 0;
-    }
-`;
-
-const SampleItemComponentsContainer = styled.div`
-    max-height: 300px;
-    overflow-y: scroll;
-`;
 
 type SampleSidebarSelectorProps = {
 	/** The link to manage labels or subtractions */
@@ -106,12 +84,10 @@ export default function SampleSidebarSelector({
 				value={term}
 				onChange={setTerm}
 			/>
-			<SampleItemComponentsContainer>
-				{itemComponents}
-			</SampleItemComponentsContainer>
-			<SampleSidebarSelectorButton>
+			<div className="max-h-80 overflow-y-scroll">{itemComponents}</div>
+			<div className="flex border-t border-gray-300 w-full items-end [&_a]:ml-auto [&_a]:text-sm [&_a]:font-medium [&_a]:py-2.5 [&_a]:pr-2.5 [&_a]:pl-0">
 				<Link to={manageLink}> Manage</Link>
-			</SampleSidebarSelectorButton>
+			</div>
 		</Popover>
 	);
 }

--- a/src/samples/components/Sidebar/SampleSidebarSelectorItem.tsx
+++ b/src/samples/components/Sidebar/SampleSidebarSelectorItem.tsx
@@ -1,34 +1,6 @@
-import { getFontSize } from "@app/theme";
-import BoxGroupSection from "@base/BoxGroupSection";
 import Icon from "@base/Icon";
 import { Check, Minus } from "lucide-react";
 import type { ReactNode } from "react";
-import styled from "styled-components";
-
-const StyledSampleSidebarSelectorItem = styled(BoxGroupSection)`
-    align-items: stretch;
-    display: flex;
-    padding: 10px 10px 10px 5px;
-
-    p {
-        font-size: ${getFontSize("md")};
-        margin: 5px 0 0;
-    }
-`;
-
-const SampleSidebarSelectorItemCheck = styled.div`
-    align-items: center;
-    color: ${(props) => props.theme.color.greyDark};
-    display: flex;
-    justify-content: center;
-    margin-right: 5px;
-    width: 32px;
-`;
-
-const SampleSidebarSelectorItemContents = styled.div`
-    display: flex;
-    align-items: center;
-`;
 
 type SampleSidebarSelectorItemProps = {
 	children: ReactNode;
@@ -52,18 +24,16 @@ export default function SampleSidebarSelectorItem({
 	selected,
 }: SampleSidebarSelectorItemProps) {
 	return (
-		<StyledSampleSidebarSelectorItem
-			as="button"
-			type={"button"}
+		<button
+			className="bg-transparent block border-gray-300 not-last:border-b-1 py-2.5 pr-2.5 pl-1 relative text-inherit w-full flex items-stretch [&_p]:text-sm [&_p]:mt-1 [&_p]:mb-0"
+			type="button"
 			onClick={() => onClick(id)}
 			aria-label={name}
 		>
-			<SampleSidebarSelectorItemCheck>
+			<div className="flex items-center justify-center text-gray-500 mr-1 w-8">
 				{selected && <Icon icon={partiallySelected ? Minus : Check} />}
-			</SampleSidebarSelectorItemCheck>
-			<SampleSidebarSelectorItemContents>
-				{children}
-			</SampleSidebarSelectorItemContents>
-		</StyledSampleSidebarSelectorItem>
+			</div>
+			<div className="flex items-center">{children}</div>
+		</button>
 	);
 }

--- a/src/samples/components/Tag/WorkflowLabelIcon.tsx
+++ b/src/samples/components/Tag/WorkflowLabelIcon.tsx
@@ -1,9 +1,6 @@
-import styled from "styled-components";
-
 /**
  * The icon in a workflow tag.
  */
-export const WorkflowLabelIcon = styled.span`
-    margin-right: 3px;
-    width: 12px;
-`;
+export function WorkflowLabelIcon({ children }: { children: React.ReactNode }) {
+	return <span className="mr-0.5 w-3">{children}</span>;
+}


### PR DESCRIPTION
## Summary

- Convert all ~20 local `styled.*` declarations in `src/samples/` to Tailwind utility classes, removing all `styled-components` and `@app/theme` imports from the module
- Use `cn()` for conditional styling (e.g., workflow filter button pressed states, error borders), inline `style` prop for complex CSS grid values in `SamplesList`, and Tailwind variants for interactive states
- Net reduction of 330 lines across 19 files

Closes VIR-2240