### PR TITLE
refactor: migrate references/, otus/, and sequences/ styled-components to Tailwind

### DIFF
--- a/src/base/BoxGroupSection.tsx
+++ b/src/base/BoxGroupSection.tsx
@@ -8,6 +8,7 @@ type BoxGroupSectionProps = {
 	className?: string;
 	disabled?: boolean;
 	onClick?: () => void;
+	style?: React.CSSProperties;
 };
 
 export default function BoxGroupSection({

--- a/src/base/TextArea.tsx
+++ b/src/base/TextArea.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@app/utils";
 import type { ElementType, ReactNode, Ref } from "react";
 import Input from "./Input";
 
@@ -16,11 +17,11 @@ type TextAreaProps = {
 	onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
-export default function TextArea({ ref, ...props }: TextAreaProps) {
+export default function TextArea({ className, ref, ...props }: TextAreaProps) {
 	return (
 		<Input
 			as="textarea"
-			className="h-56 resize-y overflow-y-scroll"
+			className={cn("h-56 resize-y overflow-y-scroll", className)}
 			{...props}
 			ref={ref}
 		/>

--- a/src/otus/components/Detail/History/Change.tsx
+++ b/src/otus/components/Detail/History/Change.tsx
@@ -20,7 +20,6 @@ import {
 	Star,
 	Trash,
 } from "lucide-react";
-import styled from "styled-components";
 
 const methodIconProps = {
 	add_isolate: {
@@ -90,25 +89,6 @@ function getMethodIcon(methodName: string) {
 	return <Icon {...props} />;
 }
 
-const StyledChange = styled(BoxGroupSection)`
-    align-items: center;
-    display: grid;
-    grid-template-columns: 42px 2fr 1fr 15px;
-
-    div:first-child {
-        min-width: 42px;
-    }
-`;
-
-const Description = styled.div`
-    align-items: center;
-    display: flex;
-
-    i {
-        margin-right: 5px;
-    }
-`;
-
 type ChangeProps = {
 	id: string;
 	createdAt: string;
@@ -134,15 +114,18 @@ export default function Change({
 	const mutation = useRevertOTU(otu.id);
 
 	return (
-		<StyledChange>
+		<BoxGroupSection
+			className="grid items-center"
+			style={{ gridTemplateColumns: "42px 2fr 1fr 15px" }}
+		>
 			<div>
 				<Label>{otu.version}</Label>
 			</div>
 
-			<Description>
+			<div className="flex items-center">
 				{getMethodIcon(methodName)}
 				<span>{description || "No Description"}</span>
-			</Description>
+			</div>
 
 			<Attribution time={createdAt} user={user.handle} verb="" />
 
@@ -153,6 +136,6 @@ export default function Change({
 					onClick={() => (unbuilt ? mutation.mutate({ changeId: id }) : null)}
 				/>
 			)}
-		</StyledChange>
+		</BoxGroupSection>
 	);
 }

--- a/src/otus/components/Detail/Isolates/IsolateDetail.tsx
+++ b/src/otus/components/Detail/Isolates/IsolateDetail.tsx
@@ -9,35 +9,8 @@ import type { OtuIsolate } from "@otus/types";
 import { DownloadLink } from "@references/components/Detail/DownloadLink";
 import Sequences from "@sequences/components/Sequences";
 import { Pencil, Star, Trash } from "lucide-react";
-import styled from "styled-components";
 import EditIsolate from "./EditIsolate";
 import RemoveIsolate from "./RemoveIsolate";
-
-const IsolateDetailHeader = styled(Box)`
-    align-items: center;
-    display: flex;
-    font-size: ${(props) => props.theme.fontSize.lg};
-    flex-direction: row;
-    justify-content: space-between;
-
-    div:first-child {
-        font-weight: bold;
-    }
-
-    svg {
-        padding-left: 5px;
-    }
-
-    a:last-child {
-        margin-left: 5px;
-    }
-`;
-
-const StyledIsolateDetail = styled.div`
-    flex: 1;
-    min-height: 0;
-    min-width: 0;
-`;
 
 type IsolateDetailProps = {
 	/** The Isolate that is currently selected */
@@ -69,7 +42,7 @@ export default function IsolateDetail({
 	const mutation = useSetIsolateAsDefault();
 
 	return (
-		<StyledIsolateDetail>
+		<div className="flex-1 min-h-0 min-w-0">
 			<EditIsolate
 				key={activeIsolate.id}
 				otuId={otuId}
@@ -90,17 +63,18 @@ export default function IsolateDetail({
 				show={openRemoveIsolate}
 			/>
 
-			<IsolateDetailHeader>
-				<div>{formatIsolateName(activeIsolate)}</div>
+			<Box className="flex items-center text-base justify-between">
+				<div className="font-bold">{formatIsolateName(activeIsolate)}</div>
 				<div>
 					{activeIsolate.default && (
 						<Label color="green">
-							<Icon icon={Star} /> Default Isolate
+							<Icon className="pl-1" icon={Star} /> Default Isolate
 						</Label>
 					)}
 					{canModify && (
 						<>
 							<IconButton
+								className="pl-1"
 								IconComponent={Pencil}
 								color="grayDark"
 								tip="edit isolate"
@@ -108,6 +82,7 @@ export default function IsolateDetail({
 							/>
 							{!activeIsolate.default && (
 								<IconButton
+									className="pl-1"
 									IconComponent={Star}
 									color="green"
 									tip="set as default"
@@ -120,6 +95,7 @@ export default function IsolateDetail({
 								/>
 							)}
 							<IconButton
+								className="pl-1"
 								IconComponent={Trash}
 								color="red"
 								tip="remove isolate"
@@ -128,14 +104,15 @@ export default function IsolateDetail({
 						</>
 					)}
 					<DownloadLink
+						className="ml-1"
 						href={`/api/otus/${otuId}/isolates/${activeIsolate.id}.fa`}
 					>
 						FASTA
 					</DownloadLink>
 				</div>
-			</IsolateDetailHeader>
+			</Box>
 
 			<Sequences otuId={otuId} activeIsolate={activeIsolate} />
-		</StyledIsolateDetail>
+		</div>
 	);
 }

--- a/src/otus/components/Detail/Isolates/IsolateForm.tsx
+++ b/src/otus/components/Detail/Isolates/IsolateForm.tsx
@@ -6,14 +6,7 @@ import InputLabel from "@base/InputLabel";
 import InputSimple from "@base/InputSimple";
 import SaveButton from "@base/SaveButton";
 import { useForm } from "react-hook-form";
-import styled from "styled-components";
 import { SourceType } from "./SourceType";
-
-const IsolateFormFields = styled.div`
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-column-gap: ${(props) => props.theme.gap.column};
-`;
 
 type IsolateFormValues = {
 	sourceName: string;
@@ -49,7 +42,7 @@ export default function IsolateForm({
 
 	return (
 		<form onSubmit={handleSubmit((values) => onSubmit({ ...values }))}>
-			<IsolateFormFields>
+			<div className="grid grid-cols-2 gap-4">
 				<SourceType
 					restrictSourceTypes={restrictSourceTypes}
 					allowedSourceTypes={allowedSourceTypes}
@@ -65,7 +58,7 @@ export default function IsolateForm({
 						disabled={watch("sourceType").toLowerCase() === "unknown"}
 					/>
 				</InputGroup>
-			</IsolateFormFields>
+			</div>
 
 			<InputGroup>
 				<InputLabel htmlFor="isolateName">Isolate Name</InputLabel>

--- a/src/otus/components/Detail/Schema/Segment.tsx
+++ b/src/otus/components/Detail/Schema/Segment.tsx
@@ -5,16 +5,6 @@ import IconButton from "@base/IconButton";
 import Label from "@base/Label";
 import type { OtuSegment } from "@otus/types";
 import { ChevronDown, ChevronUp, Pencil, Trash } from "lucide-react";
-import styled from "styled-components";
-
-const StyledSegment = styled(BoxGroupSection)`
-    display: grid;
-    align-items: center;
-    grid-template-columns: 45fr 1fr 10fr 10fr;
-    padding: 0 16px;
-    line-height: 1;
-    height: 51px;
-`;
 
 type SegmentProps = {
 	/** Whether the user has permission to modify the otu */
@@ -47,7 +37,10 @@ export default function Segment({
 		useUrlSearchParam<string>("editSegmentName");
 
 	return (
-		<StyledSegment>
+		<BoxGroupSection
+			className="grid items-center px-4 leading-none h-12"
+			style={{ gridTemplateColumns: "45fr 1fr 10fr 10fr" }}
+		>
 			<strong>{segment.name}</strong>
 
 			{segment.required ? (
@@ -100,6 +93,6 @@ export default function Segment({
 					onClick={onMoveDown}
 				/>
 			</div>
-		</StyledSegment>
+		</BoxGroupSection>
 	);
 }

--- a/src/otus/components/Detail/Schema/SegmentForm.tsx
+++ b/src/otus/components/Detail/Schema/SegmentForm.tsx
@@ -8,7 +8,6 @@ import InputSimple from "@base/InputSimple";
 import SaveButton from "@base/SaveButton";
 import { Molecule, type OtuSegment } from "@otus/types";
 import { Controller, useForm } from "react-hook-form";
-import styled from "styled-components";
 
 const moleculeTypes = [
 	"",
@@ -19,12 +18,6 @@ const moleculeTypes = [
 	Molecule.ss_rna,
 	Molecule.ds_rna,
 ];
-
-const SegmentFormBody = styled.div`
-    display: grid;
-    grid-template-columns: 3fr 1fr;
-    grid-column-gap: ${(props) => props.theme.gap.column};
-`;
 
 type FormValues = {
 	segmentName: string;
@@ -73,7 +66,7 @@ export default function SegmentForm({
 
 	return (
 		<form onSubmit={handleSubmit((values) => onSubmit({ ...values }))}>
-			<SegmentFormBody>
+			<div className="grid gap-4" style={{ gridTemplateColumns: "3fr 1fr" }}>
 				<InputGroup>
 					<InputLabel htmlFor="name">Name</InputLabel>
 					<InputSimple
@@ -111,7 +104,7 @@ export default function SegmentForm({
 				<DialogFooter>
 					<SaveButton />
 				</DialogFooter>
-			</SegmentFormBody>
+			</div>
 		</form>
 	);
 }

--- a/src/otus/components/OtuForm.tsx
+++ b/src/otus/components/OtuForm.tsx
@@ -5,13 +5,6 @@ import InputLabel from "@base/InputLabel";
 import InputSimple from "@base/InputSimple";
 import SaveButton from "@base/SaveButton";
 import { useForm } from "react-hook-form";
-import styled from "styled-components";
-
-const OtuFormBody = styled.div`
-    display: grid;
-    grid-template-columns: 9fr 4fr;
-    grid-column-gap: ${(props) => props.theme.gap.column};
-`;
 
 type FormValues = {
 	name: string;
@@ -46,7 +39,7 @@ export default function OtuForm({
 
 	return (
 		<form onSubmit={handleSubmit((values) => onSubmit({ ...values }))}>
-			<OtuFormBody>
+			<div className="grid gap-4" style={{ gridTemplateColumns: "9fr 4fr" }}>
 				<InputGroup>
 					<InputLabel htmlFor="name">Name</InputLabel>
 					<InputSimple
@@ -60,7 +53,7 @@ export default function OtuForm({
 					<InputLabel htmlFor="abbreviation">Abbreviation</InputLabel>
 					<InputSimple id="abbreviation" {...register("abbreviation")} />
 				</InputGroup>
-			</OtuFormBody>
+			</div>
 			<DialogFooter>
 				<SaveButton />
 			</DialogFooter>

--- a/src/otus/components/OtuIssues.tsx
+++ b/src/otus/components/OtuIssues.tsx
@@ -1,18 +1,6 @@
 import { formatIsolateName } from "@app/utils";
 import Alert from "@base/Alert";
-import styled from "styled-components";
 import type { OtuIsolate } from "../types";
-
-const StyledOTUIssues = styled(Alert)`
-    h5 {
-        font-weight: bold;
-        margin: 0 0 15px;
-    }
-
-    ul {
-        margin: 0 0 10px;
-    }
-`;
 
 type OtuIssuesProps = {
 	/** The isolates associated with the OTU */
@@ -86,12 +74,12 @@ export default function OtuIssues({ isolates, issues }: OtuIssuesProps) {
 	}
 
 	return (
-		<StyledOTUIssues color="orange" block>
-			<h5>
+		<Alert color="orange" block>
+			<h5 className="font-bold mt-0 mb-4">
 				There are some issues that must be resolved before this OTU can be
 				included in the next index build
 			</h5>
-			<ul>{errors}</ul>
-		</StyledOTUIssues>
+			<ul className="mt-0 mb-2.5">{errors}</ul>
+		</Alert>
 	);
 }

--- a/src/otus/components/OtuItem.tsx
+++ b/src/otus/components/OtuItem.tsx
@@ -1,28 +1,5 @@
-import { getFontSize, getFontWeight } from "@app/theme";
 import BoxGroupSection from "@base/BoxGroupSection";
 import Link from "@base/Link";
-import styled from "styled-components";
-
-const OTUItemName = styled(Link)`
-    font-size: ${getFontSize("lg")};
-    font-weight: ${getFontWeight("thick")};
-`;
-
-const OTUItemUnverified = styled.span`
-    display: flex;
-    justify-content: flex-end;
-`;
-
-const OTUItemAbbreviation = styled.span`
-    display: flex;
-    justify-content: flex-start;
-`;
-
-const StyledOTUItem = styled(BoxGroupSection)`
-    align-items: center;
-    display: grid;
-    grid-template-columns: 5fr 2fr 1fr;
-`;
 
 type OtuItemProps = {
 	abbreviation: string;
@@ -43,10 +20,15 @@ export default function OtuItem({
 	verified,
 }: OtuItemProps) {
 	return (
-		<StyledOTUItem key={id}>
-			<OTUItemName to={`/refs/${refId}/otus/${id}`}>{name}</OTUItemName>
-			<OTUItemAbbreviation>{abbreviation}</OTUItemAbbreviation>
-			{verified || <OTUItemUnverified>Unverified</OTUItemUnverified>}
-		</StyledOTUItem>
+		<BoxGroupSection
+			className="grid items-center"
+			style={{ gridTemplateColumns: "5fr 2fr 1fr" }}
+		>
+			<Link className="text-base font-medium" to={`/refs/${refId}/otus/${id}`}>
+				{name}
+			</Link>
+			<span className="flex justify-start">{abbreviation}</span>
+			{verified || <span className="flex justify-end">Unverified</span>}
+		</BoxGroupSection>
 	);
 }

--- a/src/references/components/CloneReference.tsx
+++ b/src/references/components/CloneReference.tsx
@@ -13,16 +13,6 @@ import { useCloneReference } from "@references/queries";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import type { ReferenceMinimal } from "references/types";
-import styled from "styled-components";
-
-const ReferenceBox = styled(Box)`
-    display: flex;
-    align-items: center;
-
-    span:last-child {
-        margin-left: auto;
-    }
-`;
 
 type FormValues = {
 	name: string;
@@ -84,14 +74,15 @@ export default function CloneReference({ references }: CloneReferenceProps) {
 				<form onSubmit={handleSubmit(onSubmit)}>
 					<PseudoLabel>Selected reference</PseudoLabel>
 					{reference && (
-						<ReferenceBox>
+						<Box className="flex items-center">
 							<strong>{reference.name}</strong>
 							<Badge className="ml-1.5">{reference.otu_count} OTUs</Badge>
 							<Attribution
+								className="ml-auto"
 								time={reference.created_at}
 								user={reference.user.handle}
 							/>
-						</ReferenceBox>
+						</Box>
 					)}
 					<InputGroup>
 						<InputLabel htmlFor="name">Name</InputLabel>

--- a/src/references/components/Detail/LatestBuild.tsx
+++ b/src/references/components/Detail/LatestBuild.tsx
@@ -3,16 +3,6 @@ import Link from "@base/Link";
 import NoneFoundSection from "@base/NoneFoundSection";
 import RelativeTime from "@base/RelativeTime";
 import type { ReferenceBuild } from "@references/types";
-import styled from "styled-components";
-
-const StyledLatestBuild = styled(BoxGroupSection)`
-    align-items: center;
-    display: flex;
-
-    a {
-        margin-left: auto;
-    }
-`;
 
 type LatestBuildProps = {
 	id: string;
@@ -26,7 +16,7 @@ type LatestBuildProps = {
 export function LatestBuild({ id, latestBuild }: LatestBuildProps) {
 	if (latestBuild) {
 		return (
-			<StyledLatestBuild>
+			<BoxGroupSection className="flex items-center">
 				<div>
 					<strong>
 						<Link to={`/refs/${id}/indexes/${latestBuild.id}`}>
@@ -38,7 +28,7 @@ export function LatestBuild({ id, latestBuild }: LatestBuildProps) {
 						{latestBuild.user.handle}
 					</span>
 				</div>
-			</StyledLatestBuild>
+			</BoxGroupSection>
 		);
 	}
 

--- a/src/references/components/Detail/MemberItem.tsx
+++ b/src/references/components/Detail/MemberItem.tsx
@@ -1,33 +1,14 @@
 import BoxGroupSection from "@base/BoxGroupSection";
 import Button from "@base/Button";
 import InitialIcon from "@base/InitialIcon";
-import styled from "styled-components";
-
-const StyledMemberItemIcon = styled.div`
-    align-items: center;
-    display: flex;
-    padding-right: 8px;
-`;
 
 function MemberItemIcon({ handle }) {
 	return (
-		<StyledMemberItemIcon>
+		<div className="flex items-center pr-2">
 			<InitialIcon handle={handle} size="lg" />
-		</StyledMemberItemIcon>
+		</div>
 	);
 }
-
-const MemberItemButtons = styled.span`
-    align-items: center;
-    display: flex;
-    gap: 4px;
-    margin-left: auto;
-`;
-
-const StyledMemberItem = styled(BoxGroupSection)`
-    align-items: center;
-    display: flex;
-`;
 
 export type MemberItemProps = {
 	/** Whether the current user can modify members in the list */
@@ -57,19 +38,19 @@ export default function MemberItem({
 	onRemove,
 }: MemberItemProps) {
 	return (
-		<StyledMemberItem>
+		<BoxGroupSection className="flex items-center">
 			<MemberItemIcon handle={handleOrName} />
 			{handleOrName}
 			{canModify && (
-				<MemberItemButtons>
+				<span className="flex items-center gap-1 ml-auto">
 					<Button onClick={() => onEdit(id)} size="small">
 						Edit
 					</Button>
 					<Button onClick={() => onRemove(id)} size="small" color="red">
 						Remove
 					</Button>
-				</MemberItemButtons>
+				</span>
 			)}
-		</StyledMemberItem>
+		</BoxGroupSection>
 	);
 }

--- a/src/references/components/Detail/ReferenceRight.tsx
+++ b/src/references/components/Detail/ReferenceRight.tsx
@@ -1,34 +1,10 @@
 import Checkbox from "@base/Checkbox";
-import styled from "styled-components";
 
 const descriptions = {
 	build: "Can build new indexes for the reference.",
 	modify: "Can modify reference properties and settings.",
 	modify_otu: "Can modify OTU records in the reference.",
 };
-
-export const MemberRightCheckbox = styled(Checkbox)`
-    margin-top: 1px;
-`;
-
-const MemberRightDescription = styled.div`
-    display: flex;
-    flex-direction: column;
-    padding-left: 10px;
-
-    small {
-        padding-top: 3px;
-    }
-`;
-
-const StyledMemberRight = styled.div`
-    align-items: flex-start;
-    display: flex;
-
-    &:not(:last-child) {
-        margin-bottom: 15px;
-    }
-`;
 
 type MemberRightProps = {
 	/** The name of the right */
@@ -44,17 +20,19 @@ type MemberRightProps = {
  */
 export function ReferenceRight({ right, enabled, onToggle }: MemberRightProps) {
 	return (
-		<StyledMemberRight>
-			<MemberRightCheckbox
-				checked={enabled}
-				id={`ReferenceRightCheckbox-${right}`}
-				key={right}
-				onClick={() => onToggle(right, !enabled)}
-			/>
-			<MemberRightDescription>
+		<div className="flex items-start not-last:mb-4">
+			<div className="mt-px">
+				<Checkbox
+					checked={enabled}
+					id={`ReferenceRightCheckbox-${right}`}
+					key={right}
+					onClick={() => onToggle(right, !enabled)}
+				/>
+			</div>
+			<div className="flex flex-col pl-2.5">
 				<strong>{right}</strong>
-				<small>{descriptions[right]}</small>
-			</MemberRightDescription>
-		</StyledMemberRight>
+				<small className="pt-0.5">{descriptions[right]}</small>
+			</div>
+		</div>
 	);
 }

--- a/src/references/components/ImportReference.tsx
+++ b/src/references/components/ImportReference.tsx
@@ -8,13 +8,8 @@ import InputSimple from "@base/InputSimple";
 import ProgressBarAffixed from "@base/ProgressBarAffixed";
 import SaveButton from "@base/SaveButton";
 import { Controller, useForm } from "react-hook-form";
-import styled from "styled-components";
 import { UploadBar } from "@/uploads/components/UploadBar";
 import { useImportReference, useUploadReference } from "../queries";
-
-const ImportReferenceUpload = styled.div`
-    margin-bottom: 15px;
-`;
 
 export default function ImportReference() {
 	const navigate = useNavigate();
@@ -57,7 +52,7 @@ export default function ImportReference() {
 				name="upload"
 				rules={{ required: true }}
 				render={({ field: { onChange } }) => (
-					<ImportReferenceUpload>
+					<div className="mb-4">
 						<ProgressBarAffixed color="green" now={progress} />
 						<UploadBar
 							message={uploadBarMessage}
@@ -72,7 +67,7 @@ export default function ImportReference() {
 							{errors.upload?.type === "required" &&
 								"A reference file must be uploaded"}
 						</InputError>
-					</ImportReferenceUpload>
+					</div>
 				)}
 			/>
 

--- a/src/references/components/ReferenceForm.tsx
+++ b/src/references/components/ReferenceForm.tsx
@@ -4,11 +4,6 @@ import InputLabel from "@base/InputLabel";
 import InputSimple from "@base/InputSimple";
 import TextArea from "@base/TextArea";
 import type { FieldErrors, UseFormRegister } from "react-hook-form";
-import styled from "styled-components";
-
-const StyledInputGroup = styled(InputGroup)`
-    padding-bottom: 0;
-`;
 
 export enum ReferenceFormMode {
 	edit = "edit",
@@ -47,14 +42,14 @@ export function ReferenceForm({ errors, mode, register }: ReferenceFormProps) {
 
 	return (
 		<>
-			<StyledInputGroup>
+			<InputGroup className="pb-0">
 				<InputLabel htmlFor="name">Name</InputLabel>
 				<InputSimple
 					id="name"
 					{...register("name", { required: "Required Field" })}
 				/>
 				<InputError>{errors.name?.message}</InputError>
-			</StyledInputGroup>
+			</InputGroup>
 
 			{organismComponent}
 

--- a/src/references/components/ReferenceOfficial.tsx
+++ b/src/references/components/ReferenceOfficial.tsx
@@ -5,23 +5,7 @@ import ExternalLink from "@base/ExternalLink";
 import Icon from "@base/Icon";
 import { Permission } from "@groups/types";
 import { CloudDownload } from "lucide-react";
-import styled from "styled-components";
 import { useRemoteReference } from "../queries";
-
-const StyledReferenceOfficial = styled(Box)`
-    align-items: center;
-    display: flex;
-
-    h5 {
-        font-size: ${(props) => props.theme.fontSize.lg};
-        font-weight: ${(props) => props.theme.fontWeight.thick};
-    }
-
-    button {
-        margin-left: auto;
-        min-width: 83px;
-    }
-`;
 
 type ReferenceOfficialProps = {
 	officialInstalled: boolean;
@@ -40,9 +24,9 @@ export default function ReferenceOfficial({
 	const show = !officialInstalled && hasPermission;
 
 	return show ? (
-		<StyledReferenceOfficial>
+		<Box className="flex items-center">
 			<div>
-				<h5>Official Reference</h5>
+				<h5 className="text-base font-medium">Official Reference</h5>
 				<p>
 					<span>We have published an official </span>
 					<ExternalLink href="https://github.com/virtool/ref-plant-viruses">
@@ -56,6 +40,7 @@ export default function ReferenceOfficial({
 				</p>
 			</div>
 			<Button
+				className="ml-auto"
 				color="blue"
 				onClick={() =>
 					mutation.mutate({
@@ -65,6 +50,6 @@ export default function ReferenceOfficial({
 			>
 				<Icon icon={CloudDownload} /> Install
 			</Button>
-		</StyledReferenceOfficial>
+		</Box>
 	) : null;
 }

--- a/src/references/components/SourceTypes/LocalSourceTypes.tsx
+++ b/src/references/components/SourceTypes/LocalSourceTypes.tsx
@@ -1,6 +1,5 @@
 import SettingsCheckbox from "@administration/components/SettingsCheckbox";
 import { usePathParams } from "@app/hooks";
-import { getColor } from "@app/theme";
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupDisabled from "@base/BoxGroupDisabled";
 import BoxGroupHeader from "@base/BoxGroupHeader";
@@ -19,44 +18,7 @@ import {
 	useUpdateReference,
 } from "@references/queries";
 import { Undo2 } from "lucide-react";
-import styled from "styled-components";
 import SourceTypeList from "./SourceTypeList";
-
-const SourceTypeBoxGroupSection = styled(BoxGroupSection)`
-    button {
-        width: 60px;
-        height: 34px;
-        margin-left: auto;
-        text-align: center;
-        justify-content: center;
-        margin-right: 5px;
-    }
-
-    label {
-        display: block;
-        margin-bottom: 3px;
-    }
-`;
-
-const SourceTypeInput = styled.span`
-    display: flex;
-    flex: 1 0 auto;
-    margin-right: 10px;
-    flex-direction: column;
-`;
-
-const SourceTypesUndo = styled(BoxGroupSection)`
-    display: flex;
-    background: ${(props) =>
-			getColor({ color: "greyHover", theme: props.theme })};
-    align-items: center;
-    svg {
-        margin-left: auto;
-    }
-    span > strong {
-        text-transform: capitalize;
-    }
-`;
 
 export function LocalSourceTypes() {
 	const { refId } = usePathParams<{ refId: string }>();
@@ -118,31 +80,40 @@ export function LocalSourceTypes() {
 				<BoxGroupDisabled disabled={!restrictSourceTypes}>
 					<SourceTypeList sourceTypes={sourceTypes} onRemove={handleRemove} />
 					{lastRemoved && (
-						<SourceTypesUndo>
+						<BoxGroupSection className="flex items-center bg-gray-50">
 							<span>
-								The source type <strong>{lastRemoved}</strong> was just removed.
+								The source type{" "}
+								<strong className="capitalize">{lastRemoved}</strong> was just
+								removed.
 							</span>
 							<IconButton
+								className="ml-auto"
 								IconComponent={Undo2}
 								tip="undo"
 								onClick={handleUndo}
 							/>
-						</SourceTypesUndo>
+						</BoxGroupSection>
 					)}
-					<SourceTypeBoxGroupSection>
+					<BoxGroupSection>
 						<form onSubmit={handleSubmit}>
-							<label htmlFor="sourceType">Add Source Type </label>
+							<label className="block mb-1" htmlFor="sourceType">
+								Add Source Type{" "}
+							</label>
 							<InputContainer className="flex mb-[5px]">
-								<SourceTypeInput>
+								<span className="flex flex-auto mr-2.5 flex-col">
 									<InputSimple id="sourceType" {...register("sourceType")} />
 									<InputError>{error}</InputError>
-								</SourceTypeInput>
-								<Button color="green" type="submit">
+								</span>
+								<Button
+									className="w-15 h-8.5 ml-auto text-center justify-center mr-1"
+									color="green"
+									type="submit"
+								>
 									Add
 								</Button>
 							</InputContainer>
 						</form>
-					</SourceTypeBoxGroupSection>
+					</BoxGroupSection>
 				</BoxGroupDisabled>
 			</BoxGroup>
 		</section>

--- a/src/references/components/SourceTypes/LocalSourceTypes.tsx
+++ b/src/references/components/SourceTypes/LocalSourceTypes.tsx
@@ -104,13 +104,18 @@ export function LocalSourceTypes() {
 									<InputSimple id="sourceType" {...register("sourceType")} />
 									<InputError>{error}</InputError>
 								</span>
-								<Button
-									className="w-15 h-8.5 ml-auto text-center justify-center mr-1"
-									color="green"
-									type="submit"
+								<div
+									className="ml-auto mr-1"
+									style={{ width: "60px", height: "34px" }}
 								>
-									Add
-								</Button>
+									<Button
+										className="w-full h-full text-center justify-center"
+										color="green"
+										type="submit"
+									>
+										Add
+									</Button>
+								</div>
 							</InputContainer>
 						</form>
 					</BoxGroupSection>

--- a/src/sequences/components/SequenceField.tsx
+++ b/src/sequences/components/SequenceField.tsx
@@ -4,12 +4,6 @@ import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import TextArea from "@base/TextArea";
 import { useFormContext } from "react-hook-form";
-import styled from "styled-components";
-
-const SequenceFieldTextArea = styled(TextArea)`
-    font-family: ${(props) => props.theme.fontFamily.monospace};
-    text-transform: uppercase;
-`;
 
 /**
  * Displays the sequence field of a form.
@@ -26,7 +20,8 @@ export default function SequenceField() {
 			<InputLabel htmlFor="sequence">
 				Sequence <Badge>{watch("sequence")?.length}</Badge>
 			</InputLabel>
-			<SequenceFieldTextArea
+			<TextArea
+				className="font-mono uppercase"
 				id="sequence"
 				{...register("sequence", {
 					required: "Required Field",

--- a/src/sequences/components/SequenceSegmentField.tsx
+++ b/src/sequences/components/SequenceSegmentField.tsx
@@ -34,7 +34,7 @@ type SequenceSegmentProps = {
 function SequenceSegment({ name, required }: SequenceSegmentProps) {
 	return (
 		<SelectPrimitive.Item
-			className="text-sm font-medium py-1 px-6 pl-6 relative select-none mb-1 capitalize hover:bg-gray-50 hover:border-0"
+			className="text-sm font-medium py-1 pl-6 pr-9 relative select-none mb-1 capitalize hover:bg-gray-50 hover:border-0"
 			value={name}
 			key={name}
 		>

--- a/src/sequences/components/SequenceSegmentField.tsx
+++ b/src/sequences/components/SequenceSegmentField.tsx
@@ -1,4 +1,3 @@
-import { fontWeight, getColor, getFontSize, getFontWeight } from "@app/theme";
 import Box from "@base/Box";
 import Icon from "@base/Icon";
 import InputGroup from "@base/InputGroup";
@@ -12,36 +11,6 @@ import type { OtuSegment } from "@otus/types";
 import { ChevronDown, CircleAlert } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
 import { Controller, useFormContext } from "react-hook-form";
-import styled from "styled-components";
-
-const SegmentSelectContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-
-    button {
-        flex-grow: 1;
-        padding: 10px 10px;
-    }
-`;
-
-const NoSchema = styled(Box)`
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
-
-    a,
-    h5 {
-        font-weight: ${fontWeight.thick};
-    }
-
-    h5 {
-        margin: 0 0 5px;
-    }
-
-    p {
-        margin: 0;
-    }
-`;
 
 type SequenceSegmentFieldProps = {
 	/** Whether a schema exists for the selected OTU */
@@ -51,39 +20,6 @@ type SequenceSegmentFieldProps = {
 	/** A list of unreferenced segments */
 	segments: OtuSegment[];
 };
-
-const SequenceSegmentRequired = styled.span`
-    align-items: center;
-    display: flex;
-    margin-left: auto;
-
-    span {
-        margin-left: 4px;
-    }
-`;
-
-const StyledSelectItem = styled(SelectPrimitive.Item)`
-    font-size: ${getFontSize("md")};
-    font-weight: ${getFontWeight("thick")};
-    padding: 5px 35px 5px 25px;
-    position: relative;
-    user-select: none;
-    margin-bottom: 5px;
-    text-transform: capitalize;
-
-    &:hover {
-        background-color: ${({ theme }) =>
-					getColor({ color: "greyHover", theme })};
-        border: 0;
-    }
-`;
-
-const StyledSequenceSegment = styled.div`
-    align-items: center;
-    display: flex;
-    font-weight: ${fontWeight.thick};
-    width: 100%;
-`;
 
 type SequenceSegmentProps = {
 	/** The name of the segment */
@@ -97,20 +33,24 @@ type SequenceSegmentProps = {
  */
 function SequenceSegment({ name, required }: SequenceSegmentProps) {
 	return (
-		<StyledSelectItem value={name} key={name}>
+		<SelectPrimitive.Item
+			className="text-sm font-medium py-1 px-6 pl-6 relative select-none mb-1 capitalize hover:bg-gray-50 hover:border-0"
+			value={name}
+			key={name}
+		>
 			<SelectPrimitive.ItemText>
-				<StyledSequenceSegment>
+				<div className="flex items-center font-medium w-full">
 					<span>{name}</span>
 
 					{required && (
-						<SequenceSegmentRequired>
+						<span className="flex items-center ml-auto">
 							<Icon icon={CircleAlert} />
-							<span>Required</span>
-						</SequenceSegmentRequired>
+							<span className="ml-1">Required</span>
+						</span>
 					)}
-				</StyledSequenceSegment>
+				</div>
 			</SelectPrimitive.ItemText>
-		</StyledSelectItem>
+		</SelectPrimitive.Item>
 	);
 }
 
@@ -137,7 +77,7 @@ export default function SequenceSegmentField({
 		return (
 			<InputGroup>
 				<InputLabel htmlFor="segment">Segment</InputLabel>
-				<SegmentSelectContainer>
+				<div className="flex flex-col [&_button]:grow [&_button]:p-2.5">
 					<Controller
 						control={control}
 						render={({ field: { onChange, value } }) => {
@@ -168,7 +108,7 @@ export default function SequenceSegmentField({
 						}}
 						name="segment"
 					/>
-				</SegmentSelectContainer>
+				</div>
 			</InputGroup>
 		);
 	}
@@ -176,18 +116,25 @@ export default function SequenceSegmentField({
 	return (
 		<InputGroup>
 			<InputLabel>Segment</InputLabel>
-			<NoSchema>
+			<Box className="flex items-center justify-between">
 				<div>
-					<h5>No schema is defined for this OTU.</h5>
-					<p>
+					<h5 className="font-medium mt-0 mb-1">
+						No schema is defined for this OTU.
+					</h5>
+					<p className="m-0">
 						A schema defines the sequence segments that should be present in
 						isolates of the OTU.{" "}
 					</p>
 				</div>
 				<div>
-					<Link to={`/refs/${refId}/otus/${otuId}/schema`}>Add a Schema</Link>
+					<Link
+						className="font-medium"
+						to={`/refs/${refId}/otus/${otuId}/schema`}
+					>
+						Add a Schema
+					</Link>
 				</div>
-			</NoSchema>
+			</Box>
 		</InputGroup>
 	);
 }

--- a/src/sequences/components/SequenceValues.tsx
+++ b/src/sequences/components/SequenceValues.tsx
@@ -1,49 +1,25 @@
-import styled from "styled-components";
-
-export const SequenceValue = styled.div`
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-
-    p,
-    small {
-        margin: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }
-
-    small {
-        color: ${(props) => props.theme.color.greyDark};
-        font-size: ${(props) => props.theme.fontSize.sm};
-        font-weight: bold;
-        text-transform: uppercase;
-    }
-`;
-
-export const StyledSequenceTitleValue = styled(SequenceValue)`
-    flex: 1;
-`;
-
 export function SequenceTitleValue({ label, value }) {
 	return (
-		<StyledSequenceTitleValue>
-			<p>{value}</p>
-			<small>{label}</small>
-		</StyledSequenceTitleValue>
+		<div className="flex flex-col min-w-0 flex-1">
+			<p className="m-0 overflow-hidden text-ellipsis whitespace-nowrap">
+				{value}
+			</p>
+			<small className="m-0 overflow-hidden text-ellipsis whitespace-nowrap text-gray-500 text-xs font-bold uppercase">
+				{label}
+			</small>
+		</div>
 	);
 }
 
-const StyledSequenceAccessionValue = styled(SequenceValue)`
-    width: 100px;
-    margin-right: 20px;
-`;
-
 export function SequenceAccessionValue({ accession }) {
 	return (
-		<StyledSequenceAccessionValue>
-			<p>{accession}</p>
-			<small>ACCESSION</small>
-		</StyledSequenceAccessionValue>
+		<div className="flex flex-col min-w-0 w-24 mr-5">
+			<p className="m-0 overflow-hidden text-ellipsis whitespace-nowrap">
+				{accession}
+			</p>
+			<small className="m-0 overflow-hidden text-ellipsis whitespace-nowrap text-gray-500 text-xs font-bold uppercase">
+				ACCESSION
+			</small>
+		</div>
 	);
 }

--- a/src/sequences/components/Sequences.tsx
+++ b/src/sequences/components/Sequences.tsx
@@ -1,27 +1,14 @@
-import { getFontSize } from "@app/theme";
 import Badge from "@base/Badge";
 import BoxGroup from "@base/BoxGroup";
 import NoneFoundSection from "@base/NoneFoundSection";
 import { useCurrentOtuContext } from "@otus/queries";
 import type { OtuIsolate } from "@otus/types";
 import sortSequencesBySegment from "@otus/utils";
-import styled from "styled-components";
 import CreateSequence from "./CreateSequence";
 import CreateSequenceLink from "./CreateSequenceLink";
 import RemoveSequence from "./RemoveSequence";
 import Sequence from "./Sequence";
 import SequenceEdit from "./SequenceEdit";
-
-const IsolateSequencesHeader = styled.label`
-    align-items: center;
-    display: flex;
-    font-weight: ${getFontSize("thick")};
-
-    strong {
-        font-size: ${getFontSize("lg")};
-        padding-right: 5px;
-    }
-`;
 
 type IsolateSequencesProps = {
 	/** The Isolate that is currently selected */
@@ -55,11 +42,11 @@ export default function Sequences({
 
 	return (
 		<>
-			<IsolateSequencesHeader>
-				<strong>Sequences</strong>
+			<label className="flex items-center font-medium">
+				<strong className="text-base pr-1">Sequences</strong>
 				<Badge>{sequences.length}</Badge>
 				<CreateSequenceLink refId={reference.id} />
-			</IsolateSequencesHeader>
+			</label>
 
 			<BoxGroup>{sequenceComponents}</BoxGroup>
 


### PR DESCRIPTION
## Summary

- Replace all `styled-components` in `src/references/` (8 files), `src/otus/` (8 files), and `src/sequences/` (4 files) with Tailwind utility classes
- Use inline `style` for non-standard CSS grid fractions (e.g., `5fr 2fr 1fr`) since arbitrary Tailwind values are not allowed
- Add `style` prop to `BoxGroupSection` and fix `className` merging in `TextArea` to support the migration
- Remove all `styled-components` and `theme.ts` imports from the migrated directories

Resolves VIR-2241