### PR TITLE
docs: discourage git -C flag in agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,8 @@ Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`.
 - Title: lowercase, no period, under 72 characters.
 - Scope is optional but preferred.
 - Don't push or create PRs unless asked.
+- Don't use `git -C <path>` unless necessary. It triggers permission prompts that
+  aren't worth the trouble. Run git commands from the working directory instead.
 
 ## Testing
 


### PR DESCRIPTION
Adds guidance to AGENTS.md to avoid using `git -C <path>` in commands. It triggers unnecessary permission prompts in Claude Code's allowed tools settings and is rarely worth the friction.