### PR TITLE
Fix keyboard accessibility for selectable list items

### DIFF
--- a/src/base/BoxGroupSection.tsx
+++ b/src/base/BoxGroupSection.tsx
@@ -1,14 +1,18 @@
 import { cn } from "@app/utils";
-import type { ElementType, ReactNode } from "react";
+import type { ElementType, KeyboardEvent, ReactNode } from "react";
 
 type BoxGroupSectionProps = {
 	active?: boolean;
+	"aria-selected"?: boolean;
 	as?: ElementType;
 	children?: ReactNode;
 	className?: string;
 	disabled?: boolean;
 	onClick?: () => void;
+	onKeyDown?: (e: KeyboardEvent) => void;
+	role?: string;
 	style?: React.CSSProperties;
+	tabIndex?: number;
 };
 
 export default function BoxGroupSection({

--- a/src/base/SelectBoxGroupSection.tsx
+++ b/src/base/SelectBoxGroupSection.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@app/utils";
-import type { ReactNode } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 import BoxGroupSection from "./BoxGroupSection";
 
 type SelectBoxGroupSectionProps = {
@@ -15,10 +15,17 @@ export default function SelectBoxGroupSection({
 	className,
 	onClick,
 }: SelectBoxGroupSectionProps) {
+	function onKeyDown(e: KeyboardEvent) {
+		if (e.key === "Enter" || e.key === " ") {
+			e.preventDefault();
+			onClick?.();
+		}
+	}
+
 	return (
 		<BoxGroupSection
 			active={active}
-			aria-role="option"
+			aria-selected={active}
 			className={cn(
 				"cursor-pointer",
 				"w-full",
@@ -29,6 +36,9 @@ export default function SelectBoxGroupSection({
 				className,
 			)}
 			onClick={onClick}
+			onKeyDown={onKeyDown}
+			role="option"
+			tabIndex={0}
 		>
 			{children}
 		</BoxGroupSection>


### PR DESCRIPTION
## Summary

- Add `tabIndex={0}`, `role="option"`, `aria-selected`, and `onKeyDown` handler to `SelectBoxGroupSection` so items are focusable and activatable via keyboard (Tab, Enter, Space).
- Replace the non-standard `aria-role` attribute with the correct `role` attribute.
- Extend `BoxGroupSection` props type to accept the new attributes.

Fixes VIR-2104.