### PR TITLE
refactor: extract shared button CVA and input/icon class constants

### DIFF
--- a/src/base/Button.tsx
+++ b/src/base/Button.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@app/utils";
 import type { ComponentType, ReactNode } from "react";
+import { buttonVariants } from "./buttonVariants";
 
 export type ButtonProps = {
 	active?: boolean;
@@ -30,36 +31,10 @@ function Button({
 	return (
 		<As
 			className={cn(
-				className,
-				{
-					"bg-blue-600": color === "blue",
-					"bg-red-600": color === "red",
-					"bg-green-600": color === "green",
-					"bg-gray-200": color === "gray",
-					"bg-purple-600": color === "purple",
-				},
-				"cursor-pointer",
+				buttonVariants({ color, size }),
 				"gap-1.5",
-				"items-center",
-				"inline-flex",
-				"font-medium",
-				{ "min-h-10": size === "large", "min-h-8": size === "small" },
-				{
-					"opacity-50": disabled,
-					"opacity-100": !disabled,
-				},
-				"px-4",
-				"rounded-md",
-				"select-none",
-				{
-					"text-black": ["gray"].includes(color),
-					"text-white": ["blue", "green", "purple", "red"].includes(color),
-				},
-				{
-					"text-lg": size === "large",
-					"text-sm": size === "small",
-				},
-				"hover:shadow-lg",
+				disabled ? "opacity-50" : "opacity-100",
+				className,
 			)}
 			disabled={disabled}
 			onBlur={onBlur}

--- a/src/base/ButtonToggle.tsx
+++ b/src/base/ButtonToggle.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@app/utils";
 import { Toggle } from "radix-ui";
 import type { ReactNode, Ref } from "react";
+import { buttonVariants } from "./buttonVariants";
 
 type ButtonToggleProps = {
 	children: ReactNode;
@@ -17,21 +18,7 @@ export default function ButtonToggle({
 }: ButtonToggleProps) {
 	return (
 		<Toggle.Root
-			className={cn(
-				"bg-gray-200",
-				"cursor-pointer",
-				"items-center",
-				"inline-flex",
-				"font-medium",
-				"min-h-10",
-				"px-4",
-				"rounded-md",
-				"select-none",
-				"text-black",
-				"text-lg",
-				"hover:shadow-lg",
-				"active:inset-2",
-			)}
+			className={cn(buttonVariants(), "active:inset-2")}
 			onPressedChange={onPressedChange}
 			pressed={pressed}
 			ref={ref}

--- a/src/base/Icon.tsx
+++ b/src/base/Icon.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@app/utils";
 import type { LucideIcon } from "lucide-react";
+import { iconTextColor } from "./styles";
 import type { IconColor } from "./types";
 
 export type IconProps = {
@@ -24,16 +25,7 @@ export default function Icon({
 				"text-inherit",
 				"inline-block",
 				"align-middle",
-				{
-					"text-blue-500": color === "blue",
-					"text-black": color === "black",
-					"text-green-500": color === "green",
-					"text-gray-400": color === "gray",
-					"text-gray-500": color === "grayDark",
-					"text-red-500": color === "red",
-					"text-orange-500": color === "orange",
-					"text-purple-500": color === "purple",
-				},
+				color && iconTextColor[color],
 				className,
 			)}
 			size={size}

--- a/src/base/Input.tsx
+++ b/src/base/Input.tsx
@@ -2,6 +2,11 @@ import { cn } from "@app/utils";
 import { type ElementType, type ReactNode, type Ref, useContext } from "react";
 import type { UseFormRegisterReturn } from "react-hook-form";
 import InputContext from "./InputContext";
+import {
+	inputBaseClasses,
+	inputErrorClasses,
+	inputFocusClasses,
+} from "./styles";
 
 export interface InputProps {
 	"aria-label"?: string;
@@ -58,10 +63,8 @@ export default function Input({
 			ref={ref}
 			autoFocus={autoFocus}
 			className={cn(
-				"bg-white border rounded-[3px] shadow-[inset_0_1px_1px_rgba(0,0,0,0.075)] block text-sm h-auto outline-none py-2 px-2.5 relative transition-all duration-150 ease-in-out w-full",
-				error
-					? "border-red-500 focus:border-red-500 focus:ring-2 focus:ring-red-500/50"
-					: "border-gray-300 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/50",
+				inputBaseClasses,
+				error ? inputErrorClasses : inputFocusClasses,
 				{
 					"read-only:bg-gray-100": Component !== "select",
 				},

--- a/src/base/InputSimple.tsx
+++ b/src/base/InputSimple.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@app/utils";
 import React from "react";
+import { inputBaseClasses, inputFocusClasses } from "./styles";
 
 export interface InputSimpleProps
 	extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -13,8 +14,8 @@ const InputSimple = React.forwardRef<HTMLInputElement, InputSimpleProps>(
 			<input
 				ref={ref}
 				className={cn(
-					"bg-white border border-gray-300 rounded-[3px] shadow-[inset_0_1px_1px_rgba(0,0,0,0.075)] block text-sm h-auto outline-none py-2 px-2.5 relative transition-all duration-150 ease-in-out w-full",
-					"focus:border-blue-500 focus:ring-2 focus:ring-blue-500/50",
+					inputBaseClasses,
+					inputFocusClasses,
 					"read-only:bg-gray-100",
 					className,
 				)}

--- a/src/base/LinkButton.tsx
+++ b/src/base/LinkButton.tsx
@@ -20,14 +20,7 @@ export default function LinkButton({
 }: LinkButtonProps) {
 	return (
 		<Link
-			className={cn(
-				buttonVariants({ color }),
-				{
-					"hover:text-black": color === "gray",
-					"hover:text-white": ["blue", "green", "red"].includes(color),
-				},
-				className,
-			)}
+			className={cn(buttonVariants({ color }), className)}
 			replace={replace}
 			to={to}
 		>

--- a/src/base/LinkButton.tsx
+++ b/src/base/LinkButton.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@app/utils";
 import type { ReactNode } from "react";
+import { buttonVariants } from "./buttonVariants";
 import Link from "./Link";
 
 interface LinkButtonProps {
@@ -20,29 +21,12 @@ export default function LinkButton({
 	return (
 		<Link
 			className={cn(
-				className,
-				"items-center",
+				buttonVariants({ color }),
 				{
-					"bg-blue-600": color === "blue",
-					"bg-gray-200": color === "gray",
-					"bg-green-600": color === "green",
-					"bg-red-600": color === "red",
-				},
-				"inline-flex",
-				"font-medium",
-				"min-h-10",
-				"px-4",
-				"rounded-md",
-				{
-					"text-black": ["gray"].includes(color),
-					"text-white": ["blue", "green", "red"].includes(color),
-				},
-				"text-lg",
-				"hover:shadow-lg",
-				{
-					"hover:text-black": ["gray"].includes(color),
+					"hover:text-black": color === "gray",
 					"hover:text-white": ["blue", "green", "red"].includes(color),
 				},
+				className,
 			)}
 			replace={replace}
 			to={to}

--- a/src/base/ToggleGroupItem.tsx
+++ b/src/base/ToggleGroupItem.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@app/utils";
 import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui";
 import type { ReactNode } from "react";
+import { buttonVariants } from "./buttonVariants";
 
 type ToggleGroupItemProps = {
 	children: ReactNode;
@@ -14,19 +15,10 @@ export default function ToggleGroupItem({
 	return (
 		<ToggleGroupPrimitive.Item
 			className={cn(
-				"bg-gray-200",
-				"cursor-pointer",
-				"items-center",
-				"inline-flex",
-				"font-medium",
-				"min-h-10",
-				"px-4",
-				"select-none",
-				"text-black",
-				"text-lg",
+				buttonVariants(),
+				"rounded-none",
 				"aria-checked:bg-gray-300",
 				"first:rounded-l-md",
-				"hover:shadow-lg",
 				"last:rounded-r-md",
 			)}
 			value={value}

--- a/src/base/buttonVariants.ts
+++ b/src/base/buttonVariants.ts
@@ -1,19 +1,19 @@
 import { cva } from "class-variance-authority";
 
 export const buttonVariants = cva(
-	"cursor-pointer items-center inline-flex font-medium px-4 select-none hover:shadow-lg",
+	"cursor-pointer items-center inline-flex font-medium px-4 rounded-md select-none hover:shadow-lg",
 	{
 		variants: {
 			color: {
-				gray: "bg-gray-200 text-black",
-				blue: "bg-blue-600 text-white",
-				green: "bg-green-600 text-white",
-				red: "bg-red-600 text-white",
-				purple: "bg-purple-600 text-white",
+				gray: "bg-gray-200 text-black hover:text-black",
+				blue: "bg-blue-600 text-white hover:text-white",
+				green: "bg-green-600 text-white hover:text-white",
+				red: "bg-red-600 text-white hover:text-white",
+				purple: "bg-purple-600 text-white hover:text-white",
 			},
 			size: {
-				large: "min-h-10 text-lg rounded-md",
-				small: "min-h-8 text-sm rounded-md",
+				large: "min-h-10 text-lg",
+				small: "min-h-8 text-sm",
 			},
 		},
 		defaultVariants: { color: "gray", size: "large" },

--- a/src/base/buttonVariants.ts
+++ b/src/base/buttonVariants.ts
@@ -1,0 +1,21 @@
+import { cva } from "class-variance-authority";
+
+export const buttonVariants = cva(
+	"cursor-pointer items-center inline-flex font-medium px-4 select-none hover:shadow-lg",
+	{
+		variants: {
+			color: {
+				gray: "bg-gray-200 text-black",
+				blue: "bg-blue-600 text-white",
+				green: "bg-green-600 text-white",
+				red: "bg-red-600 text-white",
+				purple: "bg-purple-600 text-white",
+			},
+			size: {
+				large: "min-h-10 text-lg rounded-md",
+				small: "min-h-8 text-sm rounded-md",
+			},
+		},
+		defaultVariants: { color: "gray", size: "large" },
+	},
+);

--- a/src/base/styles.ts
+++ b/src/base/styles.ts
@@ -1,0 +1,23 @@
+/** Base classes shared by Input and InputSimple */
+export const inputBaseClasses =
+	"bg-white border rounded-[3px] shadow-[inset_0_1px_1px_rgba(0,0,0,0.075)] block text-sm h-auto outline-none py-2 px-2.5 relative transition-all duration-150 ease-in-out w-full";
+
+/** Focus ring for inputs in normal (non-error) state */
+export const inputFocusClasses =
+	"border-gray-300 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/50";
+
+/** Focus ring + border for inputs in error state */
+export const inputErrorClasses =
+	"border-red-500 focus:border-red-500 focus:ring-2 focus:ring-red-500/50";
+
+/** Icon text color mapping shared by Icon and IconButton */
+export const iconTextColor: Record<string, string> = {
+	blue: "text-blue-500",
+	black: "text-black",
+	green: "text-green-500",
+	gray: "text-gray-400",
+	grayDark: "text-gray-500",
+	red: "text-red-500",
+	orange: "text-orange-500",
+	purple: "text-purple-500",
+};

--- a/src/base/styles.ts
+++ b/src/base/styles.ts
@@ -10,14 +10,17 @@ export const inputFocusClasses =
 export const inputErrorClasses =
 	"border-red-500 focus:border-red-500 focus:ring-2 focus:ring-red-500/50";
 
+import type { IconColor } from "./types";
+
 /** Icon text color mapping shared by Icon and IconButton */
-export const iconTextColor: Record<string, string> = {
-	blue: "text-blue-500",
+export const iconTextColor: Record<IconColor, string> = {
 	black: "text-black",
-	green: "text-green-500",
+	blue: "text-blue-500",
 	gray: "text-gray-400",
 	grayDark: "text-gray-500",
-	red: "text-red-500",
+	green: "text-green-500",
+	grey: "text-gray-400",
 	orange: "text-orange-500",
 	purple: "text-purple-500",
+	red: "text-red-500",
 };


### PR DESCRIPTION
## Summary

- Extract a shared `buttonVariants` CVA in `src/base/buttonVariants.ts` for the button family (Button, LinkButton, ButtonToggle, ToggleGroupItem) which shared ~80% of their base Tailwind classes
- Extract shared input base/focus/error class constants in `src/base/styles.ts`, deduplicating identical long class strings between Input and InputSimple
- Extract shared `iconTextColor` mapping in `src/base/styles.ts`, replacing repeated inline color conditionals in Icon

Resolves VIR-2271