### PR TITLE
refactor: simplify bucket-1 nested tailwind selectors (VIR-2272)

### DIFF
--- a/src/analyses/components/Nuvs/NuvsDetail.tsx
+++ b/src/analyses/components/Nuvs/NuvsDetail.tsx
@@ -11,7 +11,7 @@ import NuvsValues from "./NuvsValues";
 
 function NuvsFamilies({ families }) {
 	return (
-		<div className="flex border border-gray-300 rounded my-2.5 mb-1 overflow-hidden">
+		<div className="flex border border-gray-300 rounded mt-2.5 mb-1 overflow-hidden">
 			<div className="py-1 px-2.5 bg-gray-100 border-r border-gray-300">
 				Families
 			</div>

--- a/src/analyses/components/Nuvs/NuvsDetail.tsx
+++ b/src/analyses/components/Nuvs/NuvsDetail.tsx
@@ -11,9 +11,13 @@ import NuvsValues from "./NuvsValues";
 
 function NuvsFamilies({ families }) {
 	return (
-		<div className="flex border border-gray-300 rounded my-2.5 mb-1 overflow-hidden [&_div]:py-1 [&_div]:px-2.5 [&_div:first-child]:bg-gray-100 [&_div:first-child]:border-r [&_div:first-child]:border-gray-300">
-			<div>Families</div>
-			<div>{families.length ? families.join(", ") : "None"}</div>
+		<div className="flex border border-gray-300 rounded my-2.5 mb-1 overflow-hidden">
+			<div className="py-1 px-2.5 bg-gray-100 border-r border-gray-300">
+				Families
+			</div>
+			<div className="py-1 px-2.5">
+				{families.length ? families.join(", ") : "None"}
+			</div>
 		</div>
 	);
 }
@@ -68,8 +72,8 @@ export default function NuvsDetail({
 
 	return (
 		<NuvsDetailContainer>
-			<div className="mb-2.5 [&_h3]:flex [&_h3]:items-center [&_h3]:justify-between [&_h3]:text-base [&_h3]:font-bold [&_h3]:m-0 [&_span]:text-sm [&_span]:font-bold">
-				<h3>
+			<div className="mb-2.5 [&_span]:text-sm [&_span]:font-bold">
+				<h3 className="flex items-center justify-between text-base font-bold m-0">
 					Sequence {index}
 					<Badge className="text-base py-2 px-3">{sequence.length} bp</Badge>
 				</h3>

--- a/src/dev/components/DeveloperDialog.tsx
+++ b/src/dev/components/DeveloperDialog.tsx
@@ -79,24 +79,6 @@ export default function DeveloperDialog() {
 				</div>
 				<div className="flex items-center p-4">
 					<div>
-						<h3 className="mb-1 mt-0">Create Subtraction</h3>
-						<p className="m-0">Creates a subtraction that is ready for use.</p>
-					</div>
-					<div className="ml-auto">
-						<Button
-							color="red"
-							onClick={() =>
-								mutation.mutate({
-									command: "create_subtraction",
-								})
-							}
-						>
-							Create Subtraction
-						</Button>
-					</div>
-				</div>
-				<div className="flex items-center p-4">
-					<div>
 						<h3 className="mb-1 mt-0">Force Delete Jobs</h3>
 						<p className="m-0">
 							Forces cancellation, then deletion of all jobs regardless of

--- a/src/dev/components/DeveloperDialog.tsx
+++ b/src/dev/components/DeveloperDialog.tsx
@@ -15,9 +15,9 @@ export default function DeveloperDialog() {
 			<DialogContent size="lg">
 				<DialogTitle>Developer</DialogTitle>
 				<div className="flex items-center p-4">
-					<div className="[&>h3]:mb-1 [&>h3]:mt-0 [&>p]:m-0">
-						<h3>Clear Users</h3>
-						<p>
+					<div>
+						<h3 className="mb-1 mt-0">Clear Users</h3>
+						<p className="m-0">
 							Remove existing users. You will be required to create a first
 							user.
 						</p>
@@ -42,9 +42,9 @@ export default function DeveloperDialog() {
 					</div>
 				</div>
 				<div className="flex items-center p-4">
-					<div className="[&>h3]:mb-1 [&>h3]:mt-0 [&>p]:m-0">
-						<h3>Create Sample</h3>
-						<p>Creates a sample that is ready for use.</p>
+					<div>
+						<h3 className="mb-1 mt-0">Create Sample</h3>
+						<p className="m-0">Creates a sample that is ready for use.</p>
 					</div>
 					<div className="ml-auto">
 						<Button
@@ -60,9 +60,9 @@ export default function DeveloperDialog() {
 					</div>
 				</div>
 				<div className="flex items-center p-4">
-					<div className="[&>h3]:mb-1 [&>h3]:mt-0 [&>p]:m-0">
-						<h3>Create Subtraction</h3>
-						<p>Creates a subtraction that is ready for use.</p>
+					<div>
+						<h3 className="mb-1 mt-0">Create Subtraction</h3>
+						<p className="m-0">Creates a subtraction that is ready for use.</p>
 					</div>
 					<div className="ml-auto">
 						<Button
@@ -78,9 +78,9 @@ export default function DeveloperDialog() {
 					</div>
 				</div>
 				<div className="flex items-center p-4">
-					<div className="[&>h3]:mb-1 [&>h3]:mt-0 [&>p]:m-0">
-						<h3>Create Subtraction</h3>
-						<p>Creates a subtraction that is ready for use.</p>
+					<div>
+						<h3 className="mb-1 mt-0">Create Subtraction</h3>
+						<p className="m-0">Creates a subtraction that is ready for use.</p>
 					</div>
 					<div className="ml-auto">
 						<Button
@@ -96,9 +96,9 @@ export default function DeveloperDialog() {
 					</div>
 				</div>
 				<div className="flex items-center p-4">
-					<div className="[&>h3]:mb-1 [&>h3]:mt-0 [&>p]:m-0">
-						<h3>Force Delete Jobs</h3>
-						<p>
+					<div>
+						<h3 className="mb-1 mt-0">Force Delete Jobs</h3>
+						<p className="m-0">
 							Forces cancellation, then deletion of all jobs regardless of
 							status.
 						</p>

--- a/src/samples/components/Create/ReadSelector.tsx
+++ b/src/samples/components/Create/ReadSelector.tsx
@@ -129,9 +129,9 @@ export default function ReadSelector({
 
 	return (
 		<div>
-			<label className="flex items-center font-medium [&_label]:m-0 [&_span]:text-gray-500 [&_span]:ml-auto">
+			<label className="flex items-center font-medium [&_label]:m-0">
 				<PseudoLabel>Read files</PseudoLabel>
-				<span>
+				<span className="text-gray-500 ml-auto">
 					{pairedness}
 					{selected.length} of {total_count} selected
 				</span>

--- a/src/samples/components/Create/ReadSelectorItem.tsx
+++ b/src/samples/components/Create/ReadSelectorItem.tsx
@@ -35,12 +35,12 @@ export default function ReadSelectorItem({
 			active={selected}
 			className="flex items-center justify-between select-none"
 		>
-			<div className="flex items-center [&_strong]:font-medium">
+			<div className="flex items-center">
 				<span className="text-2xl mr-4">
 					<Icon icon={File} />
 				</span>
 				<div>
-					<strong>{name}</strong>
+					<strong className="font-medium">{name}</strong>
 					<div>{byteSize(size)}</div>
 				</div>
 			</div>

--- a/src/samples/components/Item/EndIcon.tsx
+++ b/src/samples/components/Item/EndIcon.tsx
@@ -28,7 +28,7 @@ export default function SampleItemEndIcon({
 	className,
 }: SampleItemEndIconProps) {
 	const containerClasses = cn(
-		"flex items-center justify-center ml-auto [&_strong]:ml-1",
+		"flex items-center justify-center ml-auto",
 		className,
 	);
 
@@ -52,7 +52,7 @@ export default function SampleItemEndIcon({
 				progress={job?.progress || 0}
 				state={job?.state || "pending"}
 			/>
-			<strong>Creating</strong>
+			<strong className="ml-1">Creating</strong>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

Where a `[&_elem]:...` nested selector targets an element rendered directly in the same component's JSX, the classes are moved onto that element so the styling is visible at the point of use.

Scope is limited to this "bucket 1" case. Nested selectors are preserved where they're actually doing work:
- Wrapper components that style children passed via `{children}` (e.g. `SectionHeader`, `BoxGroupHeader`, `Table`).
- Pseudo-elements (`SlashList`).
- Parent-state → child combinators (`InputHeader`).
- Nested selectors targeting DOM rendered by a child component (e.g. `NuvsDetail`'s `[&_span]` → `NuvsValues`).

## Files touched

- `src/dev/components/DeveloperDialog.tsx` — 5× `[&>h3]:mb-1 [&>h3]:mt-0 [&>p]:m-0`.
- `src/samples/components/Item/EndIcon.tsx` — `[&_strong]:ml-1`.
- `src/samples/components/Create/ReadSelectorItem.tsx` — `[&_strong]:font-medium`.
- `src/samples/components/Create/ReadSelector.tsx` — `[&_span]:text-gray-500 [&_span]:ml-auto` (kept `[&_label]:m-0` since it resets `PseudoLabel`'s internal label margin).
- `src/analyses/components/Nuvs/NuvsDetail.tsx` — `NuvsFamilies` div-selectors and sequence-header `[&_h3]:*`.

Refs VIR-2272.