### PR TITLE
refactor: replace TypeScript enums with string literal unions

### DIFF
--- a/src/account/components/ApiKeyAdministratorInfo.tsx
+++ b/src/account/components/ApiKeyAdministratorInfo.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { hasSufficientAdminRole } from "@administration/utils";
 import Alert from "@base/Alert";
 import { useFetchAccount } from "../queries";
@@ -9,10 +8,7 @@ import { useFetchAccount } from "../queries";
 export default function ApiKeyAdministratorInfo() {
 	const { data, isPending } = useFetchAccount();
 
-	if (
-		!isPending &&
-		hasSufficientAdminRole(AdministratorRoleName.BASE, data.administrator_role)
-	) {
+	if (!isPending && hasSufficientAdminRole("base", data.administrator_role)) {
 		return (
 			<Alert color="purple">
 				<div>

--- a/src/account/components/__tests__/AccountProfile.test.tsx
+++ b/src/account/components/__tests__/AccountProfile.test.tsx
@@ -1,5 +1,4 @@
 import AccountProfile from "@account/components/AccountProfile";
-import { AdministratorRoleName } from "@administration/types";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
@@ -13,7 +12,7 @@ import { describe, expect, it } from "vitest";
 describe("<AccountProfile />", () => {
 	it("should render when administrator", async () => {
 		const account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 
 		mockApiGetAccount(account);
@@ -34,7 +33,7 @@ describe("<AccountProfile />", () => {
 
 	it("should render with initial email", async () => {
 		const account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 			email: "virtool.devs@gmail.com",
 		});
 
@@ -50,7 +49,7 @@ describe("<AccountProfile />", () => {
 
 	it("should handle email changes", async () => {
 		const account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 			email: "",
 		});
 
@@ -78,7 +77,7 @@ describe("<AccountProfile />", () => {
 
 	it("should handle password changes", async () => {
 		const account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 		mockApiGetAccount(account);
 		renderWithProviders(<AccountProfile />);
@@ -113,7 +112,7 @@ describe("<AccountProfile />", () => {
 
 	it("should show success message after password change", async () => {
 		const account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 
 		mockApiGetAccount(account);

--- a/src/account/components/__tests__/ApiKeys.test.tsx
+++ b/src/account/components/__tests__/ApiKeys.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
@@ -33,7 +32,7 @@ describe("<ApiKeys />", () => {
 
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 		mockApiGetApiKeys([]);
@@ -98,7 +97,7 @@ describe("<ApiKeys />", () => {
 	it("should show administrator notice when appropriate", async () => {
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 		mockApiGetApiKeys([]);

--- a/src/account/types.ts
+++ b/src/account/types.ts
@@ -1,10 +1,7 @@
 import type { GroupMinimal, Permissions } from "@groups/types";
 import type { User } from "@users/types";
 
-export enum QuickAnalyzeWorkflow {
-	nuvs = "nuvs",
-	pathoscope_bowtie = "pathoscope_bowtie",
-}
+export type QuickAnalyzeWorkflow = "nuvs" | "pathoscope_bowtie";
 
 export type APIKeyMinimal = {
 	created_at?: string;

--- a/src/administration/components/AdministrationTabs.tsx
+++ b/src/administration/components/AdministrationTabs.tsx
@@ -1,6 +1,6 @@
 import Tabs from "@base/Tabs";
 import TabsLink from "@base/TabsLink";
-import { AdministratorRoleName } from "../types";
+import type { AdministratorRoleName } from "../types";
 import { hasSufficientAdminRole } from "../utils";
 
 type AdministratorTabsProps = {
@@ -12,25 +12,23 @@ export default function AdministrationTabs({
 }: AdministratorTabsProps) {
 	const tabs = [];
 
-	if (
-		hasSufficientAdminRole(AdministratorRoleName.SETTINGS, administratorRole)
-	) {
+	if (hasSufficientAdminRole("settings", administratorRole)) {
 		tabs.push(<TabsLink to="/administration/settings">Settings</TabsLink>);
 	}
 
-	if (hasSufficientAdminRole(AdministratorRoleName.USERS, administratorRole)) {
+	if (hasSufficientAdminRole("users", administratorRole)) {
 		tabs.push(
 			<TabsLink to="/administration/users?status=active">Users</TabsLink>,
 		);
 	}
 
-	if (hasSufficientAdminRole(AdministratorRoleName.FULL, administratorRole)) {
+	if (hasSufficientAdminRole("full", administratorRole)) {
 		tabs.push(
 			<TabsLink to="/administration/administrators">Administrators</TabsLink>,
 		);
 	}
 
-	if (hasSufficientAdminRole(AdministratorRoleName.USERS, administratorRole)) {
+	if (hasSufficientAdminRole("users", administratorRole)) {
 		tabs.push(<TabsLink to="/administration/groups">Groups</TabsLink>);
 	}
 

--- a/src/administration/components/Settings.tsx
+++ b/src/administration/components/Settings.tsx
@@ -8,7 +8,6 @@ import Groups from "@groups/components/Groups";
 import { ManageUsers } from "@users/components/ManageUsers";
 import UserDetail from "@users/components/UserDetail";
 import { Redirect, Route, Switch } from "wouter";
-import { AdministratorRoleName } from "../types";
 import { hasSufficientAdminRole } from "../utils";
 import AdministrationTabs from "./AdministrationTabs";
 import ManageAdministrators from "./AdministratorList";
@@ -18,7 +17,7 @@ export default function Settings() {
 	const { data: account, isPending } = useFetchAccount();
 
 	const redirect = hasSufficientAdminRole(
-		AdministratorRoleName.SETTINGS,
+		"settings",
 		account?.administrator_role,
 	)
 		? "settings"

--- a/src/administration/components/__tests__/AdministratorCreate.test.tsx
+++ b/src/administration/components/__tests__/AdministratorCreate.test.tsx
@@ -1,5 +1,4 @@
 import AdministratorCreate from "@administration/components/AdministratorCreate";
-import { AdministratorRoleName } from "@administration/types";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeAccount, mockApiGetAccount } from "@tests/fake/account";
@@ -15,7 +14,7 @@ import { describe, expect, it } from "vitest";
 describe("<AdministratorCreate>", () => {
 	it("should render form", async () => {
 		const account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 		mockApiGetAccount(account);
 
@@ -47,7 +46,7 @@ describe("<AdministratorCreate>", () => {
 
 	it("should promote admin when correct", async () => {
 		const account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 		mockApiGetAccount(account);
 
@@ -58,7 +57,7 @@ describe("<AdministratorCreate>", () => {
 
 		const set_role_scope = mockSetAdministratorRoleAPI({
 			user: users[0],
-			new_role: AdministratorRoleName.FULL,
+			new_role: "full",
 		});
 
 		renderWithProviders(<AdministratorCreate />);
@@ -79,14 +78,12 @@ describe("<AdministratorCreate>", () => {
 		await userEvent.click(screen.getByRole("combobox", { name: "Role" }));
 		await userEvent.click(
 			screen.getByRole("option", {
-				name: `${AdministratorRoleName.FULL} Administrator`,
+				name: `${"full"} Administrator`,
 			}),
 		);
 		const roleTrigger = screen.getByRole("combobox", { name: "Role" });
 		expect(
-			within(roleTrigger).getByText(
-				`${AdministratorRoleName.FULL} Administrator`,
-			),
+			within(roleTrigger).getByText(`${"full"} Administrator`),
 		).toBeInTheDocument();
 
 		await userEvent.click(screen.getByRole("button", { name: "Save" }));
@@ -97,7 +94,7 @@ describe("<AdministratorCreate>", () => {
 
 	it("should filter users", async () => {
 		const account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 		mockApiGetAccount(account);
 

--- a/src/administration/components/__tests__/AdministratorList.test.tsx
+++ b/src/administration/components/__tests__/AdministratorList.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeAccount, mockApiGetAccount } from "@tests/fake/account";
@@ -19,13 +18,13 @@ import ManageAdministrators from "../AdministratorList";
 describe("<Administrators>", () => {
 	it("should render", async () => {
 		const account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 		mockApiGetAccount(account);
 
 		const users = createFakeUsers(2);
-		users[0].administrator_role = AdministratorRoleName.FULL;
-		users[1].administrator_role = AdministratorRoleName.BASE;
+		users[0].administrator_role = "full";
+		users[1].administrator_role = "base";
 		mockApiFindUsers(users);
 
 		mockGetAdministratorRoles();
@@ -44,7 +43,7 @@ describe("<Administrators>", () => {
 			}),
 		).toBeInTheDocument();
 		expect(
-			within(user_1).getByText(`${AdministratorRoleName.FULL} Administrator`),
+			within(user_1).getByText(`${"full"} Administrator`),
 		).toBeInTheDocument();
 
 		const user_2 = screen.getByText(users[1].handle).closest("div");
@@ -54,7 +53,7 @@ describe("<Administrators>", () => {
 			}),
 		).toBeInTheDocument();
 		expect(
-			within(user_2).getByText(`${AdministratorRoleName.BASE} Administrator`),
+			within(user_2).getByText(`${"base"} Administrator`),
 		).toBeInTheDocument();
 
 		nock.cleanAll();
@@ -62,12 +61,12 @@ describe("<Administrators>", () => {
 
 	it("should change user role when dropdown is changed", async () => {
 		const account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 		mockApiGetAccount(account);
 
 		const user = createFakeUser({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 		mockApiFindUsers([user]);
 
@@ -75,7 +74,7 @@ describe("<Administrators>", () => {
 
 		const set_role_scope = mockSetAdministratorRoleAPI({
 			user,
-			new_role: AdministratorRoleName.BASE,
+			new_role: "base",
 		});
 
 		renderWithRouter(<ManageAdministrators />);
@@ -83,7 +82,7 @@ describe("<Administrators>", () => {
 		await userEvent.click(await screen.findByRole("combobox"));
 		await userEvent.click(
 			await screen.findByRole("option", {
-				name: `${AdministratorRoleName.BASE} Administrator`,
+				name: `${"base"} Administrator`,
 			}),
 		);
 
@@ -93,12 +92,12 @@ describe("<Administrators>", () => {
 
 	it("should remove admin role when trash icon clicked", async () => {
 		const account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 		mockApiGetAccount(account);
 
 		const user = createFakeUser({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 		mockApiFindUsers([user]);
 

--- a/src/administration/components/__tests__/Settings.test.tsx
+++ b/src/administration/components/__tests__/Settings.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { screen, waitFor } from "@testing-library/react";
 import { createFakeAccount } from "@tests/fake/account";
 import {
@@ -24,7 +23,7 @@ describe("<Settings />", () => {
 	});
 
 	it("should render", async () => {
-		account.administrator_role = AdministratorRoleName.FULL;
+		account.administrator_role = "full";
 		scope = nock("http://localhost").get("/api/account").reply(200, account);
 		renderWithRouter(<Settings />, path);
 
@@ -43,7 +42,7 @@ describe("<Settings />", () => {
 	});
 
 	it("should render all options for full administrators", async () => {
-		account.administrator_role = AdministratorRoleName.FULL;
+		account.administrator_role = "full";
 		scope = nock("http://localhost").get("/api/account").reply(200, account);
 		renderWithRouter(<Settings />, path);
 
@@ -56,7 +55,7 @@ describe("<Settings />", () => {
 	});
 
 	it("should render only groups and users for users administrators", async () => {
-		account.administrator_role = AdministratorRoleName.USERS;
+		account.administrator_role = "users";
 		scope = nock("http://localhost").get("/api/account").reply(200, account);
 		renderWithRouter(<Settings />, path);
 

--- a/src/administration/types.ts
+++ b/src/administration/types.ts
@@ -14,13 +14,12 @@ export type AdministratorRole = {
 /**
  * All administrator roles
  */
-export enum AdministratorRoleName {
-	FULL = "full",
-	SETTINGS = "settings",
-	SPACES = "spaces",
-	USERS = "users",
-	BASE = "base",
-}
+export type AdministratorRoleName =
+	| "full"
+	| "settings"
+	| "spaces"
+	| "users"
+	| "base";
 
 export type Settings = {
 	default_source_types: string[];

--- a/src/administration/utils.ts
+++ b/src/administration/utils.ts
@@ -33,7 +33,10 @@ export function hasSufficientAdminRole(
 /**
  * Permissions granted to each administrator role
  */
-export const AdministratorPermissions: Record<string, AdministratorRoleName> = {
+export const AdministratorPermissions: Record<
+	Permission,
+	AdministratorRoleName
+> = {
 	cancel_job: "base",
 	create_ref: "base",
 	modify_hmm: "base",
@@ -57,7 +60,7 @@ export function checkAdminRoleOrPermissionsFromAccount(
 ): boolean {
 	return (
 		hasSufficientAdminRole(
-			AdministratorPermissions[permission as string],
+			AdministratorPermissions[permission],
 			account.administrator_role,
 		) || account.permissions[permission]
 	);

--- a/src/administration/utils.ts
+++ b/src/administration/utils.ts
@@ -1,16 +1,16 @@
 import type { Account } from "@account/types";
 import type { Permission } from "@groups/types";
-import { AdministratorRoleName } from "./types";
+import type { AdministratorRoleName } from "./types";
 
 /**
  * The permissions level of each administrator role
  */
 const AdministratorPermissionsLevel: Record<AdministratorRoleName, number> = {
-	[AdministratorRoleName.FULL]: 0,
-	[AdministratorRoleName.SETTINGS]: 1,
-	[AdministratorRoleName.SPACES]: 2,
-	[AdministratorRoleName.USERS]: 3,
-	[AdministratorRoleName.BASE]: 4,
+	full: 0,
+	settings: 1,
+	spaces: 2,
+	users: 3,
+	base: 4,
 };
 
 /**
@@ -34,14 +34,14 @@ export function hasSufficientAdminRole(
  * Permissions granted to each administrator role
  */
 export const AdministratorPermissions: Record<string, AdministratorRoleName> = {
-	cancel_job: AdministratorRoleName.BASE,
-	create_ref: AdministratorRoleName.BASE,
-	modify_hmm: AdministratorRoleName.BASE,
-	remove_job: AdministratorRoleName.BASE,
-	upload_file: AdministratorRoleName.FULL,
-	create_sample: AdministratorRoleName.FULL,
-	modify_subtraction: AdministratorRoleName.FULL,
-	remove_file: AdministratorRoleName.FULL,
+	cancel_job: "base",
+	create_ref: "base",
+	modify_hmm: "base",
+	remove_job: "base",
+	upload_file: "full",
+	create_sample: "full",
+	modify_subtraction: "full",
+	remove_file: "full",
 };
 
 /**

--- a/src/administration/utils.ts
+++ b/src/administration/utils.ts
@@ -5,13 +5,13 @@ import { AdministratorRoleName } from "./types";
 /**
  * The permissions level of each administrator role
  */
-enum AdministratorPermissionsLevel {
-	full,
-	settings,
-	spaces,
-	users,
-	base,
-}
+const AdministratorPermissionsLevel: Record<AdministratorRoleName, number> = {
+	[AdministratorRoleName.FULL]: 0,
+	[AdministratorRoleName.SETTINGS]: 1,
+	[AdministratorRoleName.SPACES]: 2,
+	[AdministratorRoleName.USERS]: 3,
+	[AdministratorRoleName.BASE]: 4,
+};
 
 /**
  * Check if a user has a sufficient admin role
@@ -33,16 +33,16 @@ export function hasSufficientAdminRole(
 /**
  * Permissions granted to each administrator role
  */
-export enum AdministratorPermissions {
-	cancel_job = AdministratorRoleName.BASE,
-	create_ref = AdministratorRoleName.BASE,
-	modify_hmm = AdministratorRoleName.BASE,
-	remove_job = AdministratorRoleName.BASE,
-	upload_file = AdministratorRoleName.FULL,
-	create_sample = AdministratorRoleName.FULL,
-	modify_subtraction = AdministratorRoleName.FULL,
-	remove_file = AdministratorRoleName.FULL,
-}
+export const AdministratorPermissions: Record<string, AdministratorRoleName> = {
+	cancel_job: AdministratorRoleName.BASE,
+	create_ref: AdministratorRoleName.BASE,
+	modify_hmm: AdministratorRoleName.BASE,
+	remove_job: AdministratorRoleName.BASE,
+	upload_file: AdministratorRoleName.FULL,
+	create_sample: AdministratorRoleName.FULL,
+	modify_subtraction: AdministratorRoleName.FULL,
+	remove_file: AdministratorRoleName.FULL,
+};
 
 /**
  * Check if a user has a sufficient admin role or legacy permissions to perform an action

--- a/src/analyses/components/AnalysisItem.tsx
+++ b/src/analyses/components/AnalysisItem.tsx
@@ -1,5 +1,4 @@
 import { useCheckAdminRole } from "@administration/hooks";
-import { AdministratorRoleName } from "@administration/types";
 import { getWorkflowDisplayName } from "@app/utils";
 import Attribution from "@base/Attribution";
 import Box from "@base/Box";
@@ -32,9 +31,7 @@ export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 		subtractions,
 		created_at,
 	} = analysis;
-	const { hasPermission: canModify } = useCheckAdminRole(
-		AdministratorRoleName.USERS,
-	);
+	const { hasPermission: canModify } = useCheckAdminRole("users");
 	const onRemove = useRemoveAnalysis(id);
 
 	const title = checkSupportedWorkflow(workflow) ? (

--- a/src/analyses/components/AnalysisItem.tsx
+++ b/src/analyses/components/AnalysisItem.tsx
@@ -5,7 +5,7 @@ import Attribution from "@base/Attribution";
 import Box from "@base/Box";
 import Icon from "@base/Icon";
 import Link from "@base/Link";
-import ProgressCircle, { sizes } from "@base/ProgressCircle";
+import ProgressCircle from "@base/ProgressCircle";
 import SlashList from "@base/SlashList";
 import { Equal, EqualNot } from "lucide-react";
 import { JobNested } from "@/jobs/types";
@@ -68,7 +68,7 @@ export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 						<ProgressCircle
 							progress={job.progress || 0}
 							state={job.state || "pending"}
-							size={sizes.md}
+							size="md"
 						/>
 					)}
 				</div>

--- a/src/analyses/components/__tests__/AnalysisList.test.tsx
+++ b/src/analyses/components/__tests__/AnalysisList.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { formatPath } from "@app/hooks";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -55,7 +54,7 @@ describe("<AnalysesList />", () => {
 	describe("<AnalysesToolbar />", () => {
 		it("should show analysis creation when user is full admin", async () => {
 			const account = createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			});
 			mockApiGetAccount(account);
 			mockApiGetSampleDetail(sample);
@@ -109,7 +108,7 @@ describe("<AnalysesList />", () => {
 		it("should change state once create analysis is clicked", async () => {
 			mockApiGetAccount(
 				createFakeAccount({
-					administrator_role: AdministratorRoleName.FULL,
+					administrator_role: "full",
 				}),
 			);
 			mockApiGetSampleDetail(sample);

--- a/src/base/ProgressCircle.tsx
+++ b/src/base/ProgressCircle.tsx
@@ -2,14 +2,7 @@ import { cn } from "@app/utils";
 import type { JobState } from "@jobs/types";
 import { Progress } from "radix-ui";
 
-export enum sizes {
-	xs = "xs",
-	sm = "sm",
-	md = "md",
-	lg = "lg",
-	xl = "xl",
-	xxl = "xxl",
-}
+export type sizes = "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
 
 const colorToHex: Record<string, string> = {
 	blue: "#0B7FE5",
@@ -75,7 +68,7 @@ type ProgressCircleProps = {
 
 export default function ProgressCircle({
 	progress,
-	size = sizes.md,
+	size = "md",
 	state = "pending",
 }: ProgressCircleProps) {
 	const circleSize = progressCircleSizes[size];

--- a/src/groups/types.ts
+++ b/src/groups/types.ts
@@ -23,16 +23,15 @@ export type Permissions = {
 	upload_file: boolean;
 };
 
-export enum Permission {
-	cancel_job = "cancel_job",
-	create_ref = "create_ref",
-	create_sample = "create_sample",
-	modify_hmm = "modify_hmm",
-	modify_subtraction = "modify_subtraction",
-	remove_file = "remove_file",
-	remove_job = "remove_job",
-	upload_file = "upload_file",
-}
+export type Permission =
+	| "cancel_job"
+	| "create_ref"
+	| "create_sample"
+	| "modify_hmm"
+	| "modify_subtraction"
+	| "remove_file"
+	| "remove_job"
+	| "upload_file";
 
 export type PermissionsUpdate = {
 	cancel_job?: boolean;

--- a/src/hmm/components/HmmInstall.tsx
+++ b/src/hmm/components/HmmInstall.tsx
@@ -5,7 +5,6 @@ import Button from "@base/Button";
 import Icon from "@base/Icon";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import ProgressBarAffixed from "@base/ProgressBarAffixed";
-import { Permission } from "@groups/types";
 import { useQueryClient } from "@tanstack/react-query";
 import { Info } from "lucide-react";
 import { useEffect } from "react";
@@ -17,9 +16,8 @@ import { hmmQueryKeys, useInstallHmm, useListHmms } from "../queries";
 export function HmmInstall() {
 	const { data, isPending } = useListHmms(1, 25);
 	const queryClient = useQueryClient();
-	const { hasPermission: canInstall } = useCheckAdminRoleOrPermission(
-		Permission.modify_hmm,
-	);
+	const { hasPermission: canInstall } =
+		useCheckAdminRoleOrPermission("modify_hmm");
 	const installMutation = useInstallHmm();
 
 	const taskComplete = data?.status?.task?.complete;

--- a/src/hmm/components/__tests__/HmmList.test.tsx
+++ b/src/hmm/components/__tests__/HmmList.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { screen } from "@testing-library/react";
 import { createFakeAccount, mockApiGetAccount } from "@tests/fake/account";
 import { createFakeHmmSearchResults, mockApiGetHmms } from "@tests/fake/hmm";
@@ -54,7 +53,7 @@ describe("<HmmList />", () => {
 			});
 			const scope = mockApiGetHmms(fakeHMMData);
 			const account = createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			});
 			mockApiGetAccount(account);
 			renderWithRouter(<HMM />, path);
@@ -113,7 +112,7 @@ describe("<HmmList />", () => {
 			});
 			const scope = mockApiGetHmms(fakeHMMData);
 			const account = createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			});
 			mockApiGetAccount(account);
 			renderWithRouter(<HMM />, path);

--- a/src/indexes/components/Item/IndexItemIcon.tsx
+++ b/src/indexes/components/Item/IndexItemIcon.tsx
@@ -1,4 +1,4 @@
-import ProgressCircle, { sizes } from "@base/ProgressCircle";
+import ProgressCircle from "@base/ProgressCircle";
 import type { JobNested } from "@jobs/types";
 import { CircleCheck } from "lucide-react";
 
@@ -36,7 +36,7 @@ export function IndexItemIcon({
 				<ProgressCircle
 					progress={job?.progress || 0}
 					state={job?.state || "pending"}
-					size={sizes.md}
+					size="md"
 				/>
 			)}
 			<span className="font-medium">{ready ? "Active" : "Building"}</span>

--- a/src/indexes/components/RebuildAlert.tsx
+++ b/src/indexes/components/RebuildAlert.tsx
@@ -1,7 +1,7 @@
 import { usePageParam } from "@app/hooks";
 import Alert from "@base/Alert";
 import Link from "@base/Link";
-import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
+import { useCheckReferenceRight } from "@references/hooks";
 import { AlertCircle, Info } from "lucide-react";
 import { useFindIndexes } from "../queries";
 
@@ -15,10 +15,7 @@ type RebuildAlertProps = {
 export default function RebuildAlert({ refId }: RebuildAlertProps) {
 	const { page } = usePageParam();
 	const { data, isPending } = useFindIndexes(page, 25, refId);
-	const { hasPermission: hasRights } = useCheckReferenceRight(
-		refId,
-		ReferenceRight.build,
-	);
+	const { hasPermission: hasRights } = useCheckReferenceRight(refId, "build");
 
 	if (isPending) {
 		return null;

--- a/src/indexes/components/__tests__/Indexes.test.tsx
+++ b/src/indexes/components/__tests__/Indexes.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import References from "@references/components/References";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -29,7 +28,7 @@ describe("<Indexes />", () => {
 		mockApiGetReferenceDetail(reference);
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 		mockApiGetSettings(createFakeSettings());

--- a/src/jobs/components/JobItem.tsx
+++ b/src/jobs/components/JobItem.tsx
@@ -2,7 +2,7 @@ import { getWorkflowDisplayName } from "@app/utils";
 import Attribution from "@base/Attribution";
 import BoxGroupSection from "@base/BoxGroupSection";
 import Link from "@base/Link";
-import ProgressCircle, { sizes } from "@base/ProgressCircle";
+import ProgressCircle from "@base/ProgressCircle";
 import JobStateIcon from "@jobs/components/JobStateIcon";
 import type { JobState, Workflow } from "@jobs/types";
 import type { UserNested } from "@users/types";
@@ -49,7 +49,7 @@ export default function JobItem({
 				{state === "succeeded" ? (
 					<JobStateIcon state={state} />
 				) : (
-					<ProgressCircle size={sizes.md} state={state} progress={progress} />
+					<ProgressCircle size="md" state={state} progress={progress} />
 				)}
 			</div>
 		</BoxGroupSection>

--- a/src/nav/components/Nav.tsx
+++ b/src/nav/components/Nav.tsx
@@ -1,5 +1,5 @@
 import { useLogout } from "@account/queries";
-import { AdministratorRoleName } from "@administration/types";
+import type { AdministratorRoleName } from "@administration/types";
 import { hasSufficientAdminRole } from "@administration/utils";
 import { useDialogParam } from "@app/hooks";
 import Dropdown from "@base/Dropdown";
@@ -67,10 +67,7 @@ export default function Nav({ administrator_role, handle }: NavBarProps) {
 						<div />
 
 						<DropdownMenuLink to="/account">Account</DropdownMenuLink>
-						{hasSufficientAdminRole(
-							AdministratorRoleName.USERS,
-							administrator_role,
-						) && (
+						{hasSufficientAdminRole("users", administrator_role) && (
 							<DropdownMenuLink to="/administration">
 								Administration{" "}
 							</DropdownMenuLink>

--- a/src/nav/components/Sidebar.tsx
+++ b/src/nav/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { AdministratorRoleName } from "@administration/types";
+import type { AdministratorRoleName } from "@administration/types";
 import { hasSufficientAdminRole } from "@administration/utils";
 import { cn } from "@app/utils";
 import { FolderOpen, List, Settings, Tag } from "lucide-react";
@@ -13,10 +13,7 @@ type SidebarProps = {
  * Displays the sidebar with routes to manage the component
  */
 export default function Sidebar({ administratorRole }: SidebarProps) {
-	const fullAdministrator = hasSufficientAdminRole(
-		AdministratorRoleName.FULL,
-		administratorRole,
-	);
+	const fullAdministrator = hasSufficientAdminRole("full", administratorRole);
 
 	return (
 		<div

--- a/src/nav/components/__tests__/Nav.test.tsx
+++ b/src/nav/components/__tests__/Nav.test.tsx
@@ -1,4 +1,4 @@
-import { AdministratorRoleName } from "@administration/types";
+import type { AdministratorRoleName } from "@administration/types";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithRouter } from "@tests/setup";
@@ -6,8 +6,12 @@ import { describe, expect, it } from "vitest";
 import Nav from "../Nav";
 
 describe("<Nav />", () => {
-	const props = {
-		administrator_role: AdministratorRoleName.FULL,
+	const props: {
+		administrator_role: AdministratorRoleName;
+		dev: boolean;
+		handle: string;
+	} = {
+		administrator_role: "full",
 		dev: false,
 		handle: "Bob",
 	};

--- a/src/otus/components/Detail/Isolates/IsolateEditor.tsx
+++ b/src/otus/components/Detail/Isolates/IsolateEditor.tsx
@@ -5,7 +5,7 @@ import SubviewHeader from "@base/SubviewHeader";
 import SubviewHeaderTitle from "@base/SubviewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
 import { useCurrentOtuContext } from "@otus/queries";
-import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
+import { useCheckReferenceRight } from "@references/hooks";
 import IsolateDetail from "./IsolateDetail";
 import IsolateItem from "./IsolateItem";
 
@@ -24,7 +24,7 @@ export default function IsolateEditor() {
 
 	const { hasPermission: canModify } = useCheckReferenceRight(
 		reference.id,
-		ReferenceRight.modify,
+		"modify",
 	);
 
 	const activeIsolate = isolates.length

--- a/src/otus/components/Detail/OtuHeaderIcons.tsx
+++ b/src/otus/components/Detail/OtuHeaderIcons.tsx
@@ -1,6 +1,6 @@
 import { useDialogParam } from "@app/hooks";
 import IconButton from "@base/IconButton";
-import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
+import { useCheckReferenceRight } from "@references/hooks";
 import { Pencil, Trash } from "lucide-react";
 import OtuEdit from "../OtuEdit";
 import OtuRemove from "../OtuRemove";
@@ -25,7 +25,7 @@ export function OtuHeaderIcons({
 	const { setOpen: setOpenRemoveOTU } = useDialogParam("openRemoveOTU");
 	const { hasPermission: canModify } = useCheckReferenceRight(
 		refId,
-		ReferenceRight.modify_otu,
+		"modify_otu",
 	);
 
 	return canModify ? (

--- a/src/otus/components/Detail/Schema/Schema.tsx
+++ b/src/otus/components/Detail/Schema/Schema.tsx
@@ -4,7 +4,7 @@ import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundBox from "@base/NoneFoundBox";
 import { useFetchOTU, useUpdateOTU } from "@otus/queries";
 import type { OtuSegment } from "@otus/types";
-import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
+import { useCheckReferenceRight } from "@references/hooks";
 import Button from "@/base/Button";
 import AddSegment from "./AddSegment";
 import EditSegment from "./EditSegment";
@@ -17,7 +17,7 @@ import Segment from "./Segment";
 export default function Schema() {
 	const { refId, otuId } = usePathParams<{ otuId: string; refId: string }>();
 	const { hasPermission: canModify, isPending: isPendingPermission } =
-		useCheckReferenceRight(refId, ReferenceRight.modify_otu);
+		useCheckReferenceRight(refId, "modify_otu");
 
 	const { setOpen: setOpenAddSegment } = useDialogParam("openAddSegment");
 

--- a/src/otus/components/Detail/Schema/__tests__/RemoveSegment.test.tsx
+++ b/src/otus/components/Detail/Schema/__tests__/RemoveSegment.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { formatPath } from "@app/hooks";
 import References from "@references/components/References";
 import { screen, waitFor } from "@testing-library/react";
@@ -32,7 +31,7 @@ describe("<RemoveSegment />", () => {
 		mockApiGetSettings(createFakeSettings());
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 

--- a/src/otus/components/OtuToolbar.tsx
+++ b/src/otus/components/OtuToolbar.tsx
@@ -2,7 +2,7 @@ import { formatSearchParams } from "@app/hooks";
 import InputSearch from "@base/InputSearch";
 import LinkButton from "@base/LinkButton";
 import Toolbar from "@base/Toolbar";
-import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
+import { useCheckReferenceRight } from "@references/hooks";
 import type { ReferenceRemotesFrom } from "@references/types";
 import type { ChangeEvent } from "react";
 
@@ -31,7 +31,7 @@ export default function OtuToolbar({
 }: OtuToolbarProps) {
 	const { hasPermission: canCreate } = useCheckReferenceRight(
 		refId,
-		ReferenceRight.modify_otu,
+		"modify_otu",
 	);
 
 	return (

--- a/src/otus/components/__tests__/OTUList.test.tsx
+++ b/src/otus/components/__tests__/OTUList.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import References from "@references/components/References";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -73,7 +72,7 @@ describe("<OTUsList />", () => {
 		it("should not render creation button when [canCreate=true]", async () => {
 			const scope = mockApiFindOtus(OTUs, reference.id);
 			const account = createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			});
 			mockApiGetAccount(account);
 			renderWithRouter(<References />, path);

--- a/src/otus/components/__tests__/OtuRemove.test.tsx
+++ b/src/otus/components/__tests__/OtuRemove.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { formatPath } from "@app/hooks";
 import References from "@references/components/References";
 import { screen, waitFor } from "@testing-library/react";
@@ -35,7 +34,7 @@ describe("<RemoveOTU />", () => {
 		mockApiGetSettings(createFakeSettings());
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 

--- a/src/otus/types.ts
+++ b/src/otus/types.ts
@@ -3,14 +3,16 @@ import type { ReferenceNested } from "@references/types";
 import type { UserNested } from "@users/types";
 import type { SearchResult } from "@/types/api";
 
-export enum Molecule {
-	ds_dna = "dsDNA",
-	ds_rna = "dsRNA",
-	ss_dna = "ssDNA",
-	ss_rna = "ssRNA",
-	ss_rna_neg = "ssRNA-",
-	ss_rna_pos = "ssRNA+",
-}
+export const Molecule = {
+	ds_dna: "dsDNA",
+	ds_rna: "dsRNA",
+	ss_dna: "ssDNA",
+	ss_rna: "ssRNA",
+	ss_rna_neg: "ssRNA-",
+	ss_rna_pos: "ssRNA+",
+} as const;
+
+export type Molecule = (typeof Molecule)[keyof typeof Molecule];
 
 export type HistoryMethod =
 	| "add_isolate"

--- a/src/otus/types.ts
+++ b/src/otus/types.ts
@@ -12,22 +12,21 @@ export enum Molecule {
 	ss_rna_pos = "ssRNA+",
 }
 
-export enum HistoryMethod {
-	add_isolate = "add_isolate",
-	create = "create",
-	create_sequence = "create_sequence",
-	clone = "clone",
-	edit = "edit",
-	edit_sequence = "edit_sequence",
-	edit_isolate = "edit_isolate",
-	remove = "remove",
-	remote = "remote",
-	remove_isolate = "remove_isolate",
-	remove_sequence = "remove_sequence",
-	import_otu = "import",
-	set_as_default = "set_as_default",
-	update = "update",
-}
+export type HistoryMethod =
+	| "add_isolate"
+	| "create"
+	| "create_sequence"
+	| "clone"
+	| "edit"
+	| "edit_sequence"
+	| "edit_isolate"
+	| "remove"
+	| "remote"
+	| "remove_isolate"
+	| "remove_sequence"
+	| "import"
+	| "set_as_default"
+	| "update";
 
 /** Contains information on history change */
 export type HistoryNested = {

--- a/src/references/components/Detail/EditReference.tsx
+++ b/src/references/components/Detail/EditReference.tsx
@@ -4,7 +4,7 @@ import SaveButton from "@base/SaveButton";
 import { useUpdateReference } from "@references/queries";
 import type { Reference } from "@references/types";
 import { useForm } from "react-hook-form";
-import { ReferenceForm, ReferenceFormMode } from "../ReferenceForm";
+import { ReferenceForm } from "../ReferenceForm";
 
 export type FormValues = {
 	name: string;
@@ -49,11 +49,7 @@ export default function EditReference({ detail }: EditReferenceProps) {
 			<DialogContent>
 				<DialogTitle>Edit Reference</DialogTitle>
 				<form onSubmit={handleSubmit((values) => handleEdit({ ...values }))}>
-					<ReferenceForm
-						errors={errors}
-						mode={ReferenceFormMode.edit}
-						register={register}
-					/>
+					<ReferenceForm errors={errors} mode="edit" register={register} />
 					<DialogFooter>
 						<SaveButton />
 					</DialogFooter>

--- a/src/references/components/Detail/ReferenceDetailHeader.tsx
+++ b/src/references/components/Detail/ReferenceDetailHeader.tsx
@@ -5,7 +5,7 @@ import ViewHeader from "@base/ViewHeader";
 import ViewHeaderAttribution from "@base/ViewHeaderAttribution";
 import ViewHeaderIcons from "@base/ViewHeaderIcons";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
-import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
+import { useCheckReferenceRight } from "@references/hooks";
 import { Lock, Pencil } from "lucide-react";
 import { useLocation } from "wouter";
 
@@ -30,10 +30,7 @@ export default function ReferenceDetailHeader({
 }: ReferenceDetailHeaderProps) {
 	const [location] = useLocation();
 	const { setOpen: setOpenEditReference } = useDialogParam("openEditReference");
-	const { hasPermission: canModify } = useCheckReferenceRight(
-		refId,
-		ReferenceRight.modify,
-	);
+	const { hasPermission: canModify } = useCheckReferenceRight(refId, "modify");
 
 	const showIcons = location.endsWith("/manage");
 

--- a/src/references/components/Detail/ReferenceMembers.tsx
+++ b/src/references/components/Detail/ReferenceMembers.tsx
@@ -4,7 +4,7 @@ import BoxGroup from "@base/BoxGroup";
 import BoxGroupHeader from "@base/BoxGroupHeader";
 import BoxGroupSection from "@base/BoxGroupSection";
 import Icon from "@base/Icon";
-import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
+import { useCheckReferenceRight } from "@references/hooks";
 import { useRemoveReferenceUser } from "@references/queries";
 import type { ReferenceGroup, ReferenceUser } from "@references/types";
 import { AlertCircle } from "lucide-react";
@@ -41,10 +41,7 @@ export default function ReferenceMembers({
 	} = useUrlSearchParam<string>(`edit${noun}Id`);
 
 	const mutation = useRemoveReferenceUser(refId, noun);
-	const { hasPermission: canModify } = useCheckReferenceRight(
-		refId,
-		ReferenceRight.modify,
-	);
+	const { hasPermission: canModify } = useCheckReferenceRight(refId, "modify");
 
 	function handleHide() {
 		setOpenAdd(false);

--- a/src/references/components/Detail/__tests__/ReferenceDetailHeader.test.tsx
+++ b/src/references/components/Detail/__tests__/ReferenceDetailHeader.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { screen } from "@testing-library/react";
 import { createFakeAccount, mockApiGetAccount } from "@tests/fake/account";
 import {
@@ -19,7 +18,7 @@ describe("<ReferenceDetailHeaderIcon />", () => {
 		mockApiGetReferenceDetail(reference);
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 		props = {
@@ -64,7 +63,7 @@ describe("<ReferenceDetailHeaderIcon />", () => {
 		props.isRemote = true;
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 		renderWithRouter(<ReferenceDetailHeader {...props} />, path);
@@ -75,7 +74,7 @@ describe("<ReferenceDetailHeaderIcon />", () => {
 	it("should render when [isRemote=false]", () => {
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 		renderWithRouter(<ReferenceDetailHeader {...props} />, path);

--- a/src/references/components/EmptyReference.tsx
+++ b/src/references/components/EmptyReference.tsx
@@ -3,7 +3,7 @@ import Button from "@base/Button";
 import { DialogFooter } from "@base/Dialog";
 import { useForm } from "react-hook-form";
 import { useCreateReference } from "../queries";
-import { ReferenceForm, ReferenceFormMode } from "./ReferenceForm";
+import { ReferenceForm } from "./ReferenceForm";
 
 type FormValues = {
 	name: string;
@@ -41,11 +41,7 @@ export default function EmptyReference() {
 				}),
 			)}
 		>
-			<ReferenceForm
-				errors={errors}
-				mode={ReferenceFormMode.empty}
-				register={register}
-			/>
+			<ReferenceForm errors={errors} mode="empty" register={register} />
 			<DialogFooter>
 				<Button type="submit" color="blue">
 					Save

--- a/src/references/components/ReferenceForm.tsx
+++ b/src/references/components/ReferenceForm.tsx
@@ -5,10 +5,7 @@ import InputSimple from "@base/InputSimple";
 import TextArea from "@base/TextArea";
 import type { FieldErrors, UseFormRegister } from "react-hook-form";
 
-export enum ReferenceFormMode {
-	edit = "edit",
-	empty = "empty",
-}
+export type ReferenceFormMode = "edit" | "empty";
 
 type FormValues = {
 	name: string;
@@ -31,7 +28,7 @@ type ReferenceFormProps = {
 export function ReferenceForm({ errors, mode, register }: ReferenceFormProps) {
 	let organismComponent;
 
-	if (mode === ReferenceFormMode.empty || mode === ReferenceFormMode.edit) {
+	if (mode === "empty" || mode === "edit") {
 		organismComponent = (
 			<InputGroup>
 				<InputLabel htmlFor="organism">Organism</InputLabel>

--- a/src/references/components/ReferenceItem.tsx
+++ b/src/references/components/ReferenceItem.tsx
@@ -5,7 +5,6 @@ import BoxGroupSection from "@base/BoxGroupSection";
 import IconButton from "@base/IconButton";
 import Link from "@base/Link";
 import ProgressCircle from "@base/ProgressCircle";
-import { Permission } from "@groups/types";
 import type { ReferenceMinimal } from "@references/types";
 import { Copy } from "lucide-react";
 import type { ReactNode } from "react";
@@ -23,9 +22,8 @@ export function ReferenceItem({ reference }: ReferenceItemProps) {
 
 	const { created_at, id, name, task, user } = reference;
 
-	const { hasPermission: canCreate } = useCheckAdminRoleOrPermission(
-		Permission.create_ref,
-	);
+	const { hasPermission: canCreate } =
+		useCheckAdminRoleOrPermission("create_ref");
 
 	let end: ReactNode = null;
 

--- a/src/references/components/ReferenceOfficial.tsx
+++ b/src/references/components/ReferenceOfficial.tsx
@@ -3,7 +3,6 @@ import Box from "@base/Box";
 import Button from "@base/Button";
 import ExternalLink from "@base/ExternalLink";
 import Icon from "@base/Icon";
-import { Permission } from "@groups/types";
 import { CloudDownload } from "lucide-react";
 import { useRemoteReference } from "../queries";
 
@@ -17,9 +16,7 @@ type ReferenceOfficialProps = {
 export default function ReferenceOfficial({
 	officialInstalled,
 }: ReferenceOfficialProps) {
-	const { hasPermission } = useCheckAdminRoleOrPermission(
-		Permission.create_ref,
-	);
+	const { hasPermission } = useCheckAdminRoleOrPermission("create_ref");
 	const mutation = useRemoteReference();
 	const show = !officialInstalled && hasPermission;
 

--- a/src/references/components/ReferenceToolbar.tsx
+++ b/src/references/components/ReferenceToolbar.tsx
@@ -3,16 +3,14 @@ import { formatSearchParams, useUrlSearchParam } from "@app/hooks";
 import InputSearch from "@base/InputSearch";
 import LinkButton from "@base/LinkButton";
 import Toolbar from "@base/Toolbar";
-import { Permission } from "@groups/types";
 
 /**
  * A toolbar which allows the references to be filtered by name
  */
 export default function ReferenceToolbar() {
 	const { value: term, setValue: setTerm } = useUrlSearchParam<string>("find");
-	const { hasPermission: canCreate } = useCheckAdminRoleOrPermission(
-		Permission.create_ref,
-	);
+	const { hasPermission: canCreate } =
+		useCheckAdminRoleOrPermission("create_ref");
 
 	return (
 		<Toolbar>

--- a/src/references/hooks.ts
+++ b/src/references/hooks.ts
@@ -1,5 +1,4 @@
 import { useFetchAccount } from "@account/queries";
-import { AdministratorRoleName } from "@administration/types";
 import { apiClient } from "@app/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -137,7 +136,7 @@ export function useCheckReferenceRight(
 		return { hasPermission: false, isPending: true };
 	}
 
-	if (account.administrator_role === AdministratorRoleName.FULL) {
+	if (account.administrator_role === "full") {
 		return { hasPermission: true, isPending: false };
 	}
 

--- a/src/references/hooks.ts
+++ b/src/references/hooks.ts
@@ -116,11 +116,7 @@ export function useUpdateSourceTypes(
 /**
  * All reference rights
  */
-export enum ReferenceRight {
-	build = "build",
-	modify = "modify",
-	modify_otu = "modify_otu",
-}
+export type ReferenceRight = "build" | "modify" | "modify_otu";
 
 /**
  * Check if the logged in account has the passed `right` on the reference detail is loaded for.

--- a/src/samples/components/Create/CreateSample.tsx
+++ b/src/samples/components/Create/CreateSample.tsx
@@ -20,7 +20,7 @@ import { Clock, WandSparkles } from "lucide-react";
 import { useEffect } from "react";
 import { Controller } from "react-hook-form";
 import { useInfiniteFindFiles } from "@/uploads/queries";
-import { type Upload, UploadType } from "@/uploads/types";
+import type { Upload } from "@/uploads/types";
 import LibraryTypeSelector from "./LibraryTypeSelector";
 import ReadSelector from "./ReadSelector";
 import SampleUserGroup from "./SampleUserGroup";
@@ -65,7 +65,7 @@ export default function CreateSample() {
 		isPending: isPendingReads,
 		isFetchingNextPage,
 		fetchNextPage,
-	} = useInfiniteFindFiles(UploadType.reads, 25);
+	} = useInfiniteFindFiles("reads", 25);
 	const {
 		control,
 		formState: { errors },

--- a/src/samples/components/Create/ReadSelector.tsx
+++ b/src/samples/components/Create/ReadSelector.tsx
@@ -18,7 +18,7 @@ import type {
 import { Repeat, Undo } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { useValidateFiles } from "@/uploads/hooks";
-import { type FileResponse, UploadType } from "@/uploads/types";
+import type { FileResponse } from "@/uploads/types";
 import ReadSelectorItem from "./ReadSelectorItem";
 
 type ReadSelectorProps = {
@@ -52,7 +52,7 @@ export default function ReadSelector({
 	error,
 	selected,
 }: ReadSelectorProps) {
-	useValidateFiles(UploadType.reads, selected, onSelect);
+	useValidateFiles("reads", selected, onSelect);
 
 	const [term, setTerm] = useState("");
 	const [selectedFiles, setSelectedFiles] = useState(selected);

--- a/src/samples/components/Create/__tests__/CreateSample.test.tsx
+++ b/src/samples/components/Create/__tests__/CreateSample.test.tsx
@@ -1,4 +1,3 @@
-import { LibraryType } from "@samples/types";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mockApiListGroups } from "@tests/api/groups";
@@ -83,7 +82,7 @@ describe("<CreateSample>", () => {
 			"",
 			"",
 			"",
-			LibraryType.normal,
+			"normal",
 			[file.id],
 			[],
 			[],
@@ -115,7 +114,7 @@ describe("<CreateSample>", () => {
 			"Clone AB",
 			"Apple",
 			"Earth",
-			LibraryType.normal,
+			"normal",
 			[files[0].id, files[1].id],
 			[labels[0].id],
 			[subtractionShortlist.id],

--- a/src/samples/components/Detail/SampleRights.tsx
+++ b/src/samples/components/Detail/SampleRights.tsx
@@ -1,6 +1,5 @@
 import { useFetchAccount } from "@account/queries";
 import { useCheckAdminRole } from "@administration/hooks";
-import { AdministratorRoleName } from "@administration/types";
 import { usePathParams } from "@app/hooks";
 import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
@@ -25,7 +24,7 @@ import { useQueryClient } from "@tanstack/react-query";
 export default function SampleRights() {
 	const { sampleId } = usePathParams<{ sampleId: string }>();
 
-	const { hasPermission } = useCheckAdminRole(AdministratorRoleName.FULL);
+	const { hasPermission } = useCheckAdminRole("full");
 	const { data: sample, isPending: isPendingSample } = useFetchSample(sampleId);
 	const { data: account, isPending: isPendingAccount } = useFetchAccount();
 	const { data: groups, isPending: isPendingGroups } = useListGroups();

--- a/src/samples/components/Detail/__tests__/SampleRights.test.tsx
+++ b/src/samples/components/Detail/__tests__/SampleRights.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import Samples from "@samples/components/Samples";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -34,7 +33,7 @@ describe("<SampleRights />", () => {
 	it("should render", async () => {
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 		renderWithRouter(<Samples />, path);
@@ -54,7 +53,7 @@ describe("<SampleRights />", () => {
 	it("should handle group change when input is changed", async () => {
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 		renderWithRouter(<Samples />, path);
@@ -65,7 +64,7 @@ describe("<SampleRights />", () => {
 	it("should handle group rights change when input is changed", async () => {
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 		renderWithRouter(<Samples />, `/samples/${sample.id}/rights`);
@@ -76,7 +75,7 @@ describe("<SampleRights />", () => {
 	it("should handle all users' rights change when input is changed", async () => {
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 		renderWithRouter(<Samples />, path);

--- a/src/samples/components/Samples.tsx
+++ b/src/samples/components/Samples.tsx
@@ -3,7 +3,6 @@ import ContainerNarrow from "@base/ContainerNarrow";
 import { Labels } from "@labels/components/Labels";
 import { Route, Switch } from "wouter";
 import { FileManager } from "@/uploads/components/FileManager";
-import { UploadType } from "@/uploads/types";
 import CreateSample from "./Create/CreateSample";
 import SampleDetail from "./Detail/SampleDetail";
 import SamplesSettings from "./SampleSettings";
@@ -20,7 +19,7 @@ function SampleFileManager() {
 					"application/gzip": [".fasta.gz", ".fa.gz", ".fastq.gz", ".fq.gz"],
 					"text/plain": [".fasta", ".fa", ".fastq", ".fq"],
 				}}
-				fileType={UploadType.reads}
+				fileType="reads"
 				message={
 					<div className="flex flex-col gap-1 items-center">
 						<span className="font-medium text-lg">

--- a/src/samples/components/SamplesToolbar.tsx
+++ b/src/samples/components/SamplesToolbar.tsx
@@ -2,13 +2,11 @@ import { useCheckAdminRoleOrPermission } from "@administration/hooks";
 import InputSearch from "@base/InputSearch";
 import LinkButton from "@base/LinkButton";
 import Toolbar from "@base/Toolbar";
-import { Permission } from "@groups/types";
 import SampleSelectionToolbar from "./SampleSelectionToolbar";
 
 function SampleSearchToolbar({ onChange, term }) {
-	const { hasPermission: canCreate } = useCheckAdminRoleOrPermission(
-		Permission.create_sample,
-	);
+	const { hasPermission: canCreate } =
+		useCheckAdminRoleOrPermission("create_sample");
 
 	return (
 		<Toolbar>

--- a/src/samples/components/Tag/WorkflowTag.tsx
+++ b/src/samples/components/Tag/WorkflowTag.tsx
@@ -1,6 +1,6 @@
 import Icon from "@base/Icon";
 import Loader from "@base/Loader";
-import { WorkflowState } from "@samples/types";
+import type { WorkflowState } from "@samples/types";
 import { CheckCircle } from "lucide-react";
 import { BaseWorkflowTag } from "./BaseWorkflowTag";
 import { WorkflowLabelIcon } from "./WorkflowLabelIcon";
@@ -24,7 +24,7 @@ export default function WorkflowTag({
 	return (
 		<BaseWorkflowTag>
 			<WorkflowLabelIcon>
-				{workflowState === WorkflowState.PENDING ? (
+				{workflowState === "pending" ? (
 					<Loader size="10px" color="white" />
 				) : (
 					<Icon icon={CheckCircle} size={14} />

--- a/src/samples/components/Tag/WorkflowTags.tsx
+++ b/src/samples/components/Tag/WorkflowTags.tsx
@@ -1,5 +1,5 @@
 import { getWorkflowDisplayName } from "@app/utils";
-import { type SampleWorkflows, WorkflowState } from "@samples/types";
+import type { SampleWorkflows } from "@samples/types";
 import { Link } from "wouter";
 import { BaseWorkflowTag } from "./BaseWorkflowTag";
 import WorkflowTag from "./WorkflowTag";
@@ -22,7 +22,7 @@ type WorkflowTagsProps = {
 export default function WorkflowTags({ id, workflows }: WorkflowTagsProps) {
 	const workflowTags = Object.entries(workflows).reduce(
 		(tags, [key, value]) => {
-			if (value === WorkflowState.COMPLETE || value === WorkflowState.PENDING) {
+			if (value === "complete" || value === "pending") {
 				tags.push(
 					<WorkflowTag
 						key={key}

--- a/src/samples/components/__tests__/SamplesList.test.tsx
+++ b/src/samples/components/__tests__/SamplesList.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeAccount, mockApiGetAccount } from "@tests/fake/account";
@@ -57,7 +56,7 @@ describe("<SamplesList />", () => {
 	it("should render create button when [canModify=true]", async () => {
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 		renderWithRouter(<SamplesList />, path);

--- a/src/samples/hooks.ts
+++ b/src/samples/hooks.ts
@@ -1,5 +1,4 @@
 import { useFetchAccount } from "@account/queries";
-import { AdministratorRoleName } from "@administration/types";
 import { hasSufficientAdminRole } from "@administration/utils";
 import { useFetchSample } from "./queries";
 
@@ -18,10 +17,7 @@ export function useCheckCanEditSample(sampleId: string) {
 	}
 
 	const hasPermission =
-		hasSufficientAdminRole(
-			AdministratorRoleName.FULL,
-			account.administrator_role,
-		) ||
+		hasSufficientAdminRole("full", account.administrator_role) ||
 		sample.all_write ||
 		sample.user.id === account.id ||
 		(sample.group_write &&

--- a/src/samples/types.ts
+++ b/src/samples/types.ts
@@ -14,12 +14,7 @@ import type { SubtractionNested } from "../subtraction/types";
 import type { SearchResult } from "../types/api";
 
 /* All workflow states */
-export enum WorkflowState {
-	COMPLETE = "complete",
-	PENDING = "pending",
-	NONE = "none",
-	INCOMPATIBLE = "incompatible",
-}
+export type WorkflowState = "complete" | "pending" | "none" | "incompatible";
 
 /* All Library types */
 export enum LibraryType {

--- a/src/samples/types.ts
+++ b/src/samples/types.ts
@@ -17,12 +17,7 @@ import type { SearchResult } from "../types/api";
 export type WorkflowState = "complete" | "pending" | "none" | "incompatible";
 
 /* All Library types */
-export enum LibraryType {
-	amplicon = "amplicon",
-	srna = "srna",
-	other = "other",
-	normal = "normal",
-}
+export type LibraryType = "amplicon" | "srna" | "other" | "normal";
 
 /* All workflow states for a sample */
 export type SampleWorkflows = {

--- a/src/sequences/components/CreateSequenceLink.tsx
+++ b/src/sequences/components/CreateSequenceLink.tsx
@@ -1,6 +1,6 @@
 import { useUrlSearchParam } from "@app/hooks";
 import { cn } from "@app/utils";
-import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
+import { useCheckReferenceRight } from "@references/hooks";
 
 type CreateSequenceLinkProps = {
 	refId: string;
@@ -12,7 +12,7 @@ type CreateSequenceLinkProps = {
 export default function CreateSequenceLink({ refId }: CreateSequenceLinkProps) {
 	const { hasPermission: canModify } = useCheckReferenceRight(
 		refId,
-		ReferenceRight.modify_otu,
+		"modify_otu",
 	);
 	const { setValue: setOpenCreateSequence } =
 		useUrlSearchParam("openCreateSequence");

--- a/src/sequences/components/SequenceButtons.tsx
+++ b/src/sequences/components/SequenceButtons.tsx
@@ -4,7 +4,7 @@ import IconButton from "@base/IconButton";
 import { useGetActiveIsolateId } from "@otus/hooks";
 import { useCurrentOtuContext } from "@otus/queries";
 import { DownloadLink } from "@references/components/Detail/DownloadLink";
-import { ReferenceRight, useCheckReferenceRight } from "@references/hooks";
+import { useCheckReferenceRight } from "@references/hooks";
 import { Pencil, Trash } from "lucide-react";
 
 type SequenceButtonsProps = {
@@ -29,7 +29,7 @@ export default function SequenceButtons({
 
 	const { hasPermission: canModify } = useCheckReferenceRight(
 		reference.id,
-		ReferenceRight.modify_otu,
+		"modify_otu",
 	);
 	const isolateId = useGetActiveIsolateId(otu);
 

--- a/src/sequences/components/__tests__/CreateSequence.test.tsx
+++ b/src/sequences/components/__tests__/CreateSequence.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { formatPath } from "@app/hooks";
 import References from "@references/components/References";
 import { screen } from "@testing-library/react";
@@ -33,7 +32,7 @@ describe("<CreateSequence>", () => {
 		mockApiGetSettings(createFakeSettings());
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 

--- a/src/sequences/components/__tests__/EditSequence.test.tsx
+++ b/src/sequences/components/__tests__/EditSequence.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { formatPath } from "@app/hooks";
 import References from "@references/components/References";
 import { screen } from "@testing-library/react";
@@ -37,7 +36,7 @@ describe("<SequenceEdit>", () => {
 		mockApiGetSettings(createFakeSettings());
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 		path = formatPath(`/refs/${reference.id}/otus/${otu.id}/otu`, {

--- a/src/sequences/components/__tests__/RemoveSequence.test.tsx
+++ b/src/sequences/components/__tests__/RemoveSequence.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { formatPath } from "@app/hooks";
 import { faker } from "@faker-js/faker";
 import References from "@references/components/References";
@@ -39,7 +38,7 @@ describe("<RemoveSequence />", () => {
 		mockApiGetSettings(createFakeSettings());
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 

--- a/src/subtraction/components/Detail/SubtractionDetail.tsx
+++ b/src/subtraction/components/Detail/SubtractionDetail.tsx
@@ -7,7 +7,6 @@ import Table from "@base/Table";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderIcons from "@base/ViewHeaderIcons";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
-import { Permission } from "@groups/types";
 import { useFetchSubtraction } from "@subtraction/queries";
 import type { NucleotideComposition } from "@subtraction/types";
 import { Pencil, Trash } from "lucide-react";
@@ -30,9 +29,8 @@ export default function SubtractionDetail() {
 	const { subtractionId } = usePathParams<{ subtractionId: string }>();
 
 	const { data, isPending, isError } = useFetchSubtraction(subtractionId);
-	const { hasPermission: canModify } = useCheckAdminRoleOrPermission(
-		Permission.modify_subtraction,
-	);
+	const { hasPermission: canModify } =
+		useCheckAdminRoleOrPermission("modify_subtraction");
 
 	const { open: openRemoveSubtraction, setOpen: setOpenRemoveSubtraction } =
 		useDialogParam("openRemoveSubtraction");

--- a/src/subtraction/components/SubtractionCreate.tsx
+++ b/src/subtraction/components/SubtractionCreate.tsx
@@ -17,7 +17,6 @@ import { RestoredAlert } from "@forms/components/RestoredAlert";
 import { usePersistentForm } from "@forms/hooks";
 import { Controller } from "react-hook-form";
 import { useInfiniteFindFiles } from "@/uploads/queries";
-import { UploadType } from "@/uploads/types";
 import { useCreateSubtraction } from "../queries";
 import { SubtractionFileSelector } from "./SubtractionFileSelector";
 
@@ -50,7 +49,7 @@ export default function SubtractionCreate() {
 		isPending,
 		isFetchingNextPage,
 		fetchNextPage,
-	} = useInfiniteFindFiles(UploadType.subtraction, 25);
+	} = useInfiniteFindFiles("subtraction", 25);
 
 	const mutation = useCreateSubtraction();
 

--- a/src/subtraction/components/SubtractionFileManager.tsx
+++ b/src/subtraction/components/SubtractionFileManager.tsx
@@ -1,5 +1,4 @@
 import { FileManager } from "@/uploads/components/FileManager";
-import { UploadType } from "@/uploads/types";
 
 /**
  * Displays a list of subtraction uploads with functionality to upload/delete uploads
@@ -11,7 +10,7 @@ export function SubtractionFileManager() {
 				"application/gzip": [".fasta.gz", ".fa.gz"],
 				"application/text": [".fasta", ".fa"],
 			}}
-			fileType={UploadType.subtraction}
+			fileType="subtraction"
 			message={
 				<div className="flex flex-col gap-1 items-center">
 					<span className="font-medium text-base">

--- a/src/subtraction/components/SubtractionFileSelector.tsx
+++ b/src/subtraction/components/SubtractionFileSelector.tsx
@@ -8,7 +8,7 @@ import type {
 	InfiniteQueryObserverResult,
 } from "@tanstack/react-query/";
 import { useValidateFiles } from "@/uploads/hooks";
-import { type FileResponse, type Upload, UploadType } from "@/uploads/types";
+import type { FileResponse, Upload } from "@/uploads/types";
 import { SubtractionFileItem } from "./SubtractionFileItem";
 
 type SubtractionFileSelectorProps = {
@@ -52,7 +52,7 @@ export function SubtractionFileSelector({
 	isPending,
 	isFetchingNextPage,
 }: SubtractionFileSelectorProps) {
-	useValidateFiles(UploadType.subtraction, selected, onClick);
+	useValidateFiles("subtraction", selected, onClick);
 
 	const items = files.pages.flatMap((page) => page.items);
 

--- a/src/subtraction/components/SubtractionItem.tsx
+++ b/src/subtraction/components/SubtractionItem.tsx
@@ -1,6 +1,6 @@
 import BoxGroupSection from "@base/BoxGroupSection";
 import Link from "@base/Link";
-import ProgressCircle, { sizes } from "@base/ProgressCircle";
+import ProgressCircle from "@base/ProgressCircle";
 import { JobNested } from "@jobs/types";
 import type { SubtractionMinimal } from "../types";
 import { SubtractionAttribution } from "./Attribution";
@@ -31,7 +31,7 @@ export function SubtractionItem({
 			{!ready && job && (
 				<span className="flex items-center justify-end text-base font-medium [&>svg]:mr-1">
 					<ProgressCircle
-						size={sizes.md}
+						size="md"
 						progress={parsedJob.progress}
 						state={parsedJob.state ?? "pending"}
 					/>

--- a/src/subtraction/components/SubtractionToolbar.tsx
+++ b/src/subtraction/components/SubtractionToolbar.tsx
@@ -3,7 +3,6 @@ import { updateSearchParam } from "@app/hooks";
 import InputSearch from "@base/InputSearch";
 import LinkButton from "@base/LinkButton";
 import Toolbar from "@base/Toolbar";
-import { Permission } from "@groups/types";
 import { useSearch } from "wouter";
 import SubtractionCreate from "./SubtractionCreate";
 
@@ -22,9 +21,7 @@ export default function SubtractionToolbar({
 	term,
 	handleChange,
 }: SubtractionToolbarProps) {
-	const { hasPermission } = useCheckAdminRoleOrPermission(
-		Permission.modify_subtraction,
-	);
+	const { hasPermission } = useCheckAdminRoleOrPermission("modify_subtraction");
 	const search = useSearch();
 
 	return (

--- a/src/subtraction/components/__tests__/CreateSubtraction.test.tsx
+++ b/src/subtraction/components/__tests__/CreateSubtraction.test.tsx
@@ -6,7 +6,6 @@ import { createFakeFile, mockApiListFiles } from "@tests/fake/files";
 import { mockApiCreateSubtraction } from "@tests/fake/subtractions";
 import { renderWithRouter } from "@tests/setup";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { UploadType } from "@/uploads/types";
 import SubtractionCreate from "../SubtractionCreate";
 
 describe("<SubtractionCreate />", () => {
@@ -29,7 +28,7 @@ describe("<SubtractionCreate />", () => {
 	it("should render error when submitted with no name or file entered", async () => {
 		const file = createFakeFile({
 			name: "subtraction.fq.gz",
-			type: UploadType.subtraction,
+			type: "subtraction",
 		});
 		mockApiListFiles([file]);
 		renderWithRouter(<SubtractionCreate />, path);
@@ -44,7 +43,7 @@ describe("<SubtractionCreate />", () => {
 	it("should submit correct values when all fields selected", async () => {
 		const file = createFakeFile({
 			name: "testsubtraction1",
-			type: UploadType.subtraction,
+			type: "subtraction",
 		});
 		const name = "testSubtractionname";
 		const nickname = "testSubtractionNickname";
@@ -69,7 +68,7 @@ describe("<SubtractionCreate />", () => {
 	it("should restore form values from session storage", async () => {
 		const file = createFakeFile({
 			name: "testSubtraction1",
-			type: UploadType.subtraction,
+			type: "subtraction",
 		});
 		const name = "testSubtractionName";
 		const nickname = "testSubtractionNickname";
@@ -100,7 +99,7 @@ describe("<SubtractionCreate />", () => {
 	it("should persist values into session storage", async () => {
 		const file = createFakeFile({
 			name: "ath.fa.gz",
-			type: UploadType.subtraction,
+			type: "subtraction",
 		});
 		const name = "Arabidopsis thaliana";
 		const nickname = "Thale cress";

--- a/src/subtraction/components/__tests__/SubtractionFileManager.test.tsx
+++ b/src/subtraction/components/__tests__/SubtractionFileManager.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { formatPath } from "@app/hooks";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -20,7 +19,7 @@ describe("<SubtractionFileManager />", () => {
 	it("should reject uploads that don't pass validation", async () => {
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 		mockApiListFiles([createFakeFile({ name: "subtraction.fq.gz" })]);

--- a/src/subtraction/components/__tests__/SubtractionList.test.tsx
+++ b/src/subtraction/components/__tests__/SubtractionList.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeAccount, mockApiGetAccount } from "@tests/fake/account";
@@ -52,7 +51,7 @@ describe("<SubtractionList />", () => {
 	it("should render create button when [canModify=true]", async () => {
 		const scope = mockApiGetSubtractions([subtractions]);
 		const account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 		mockApiGetAccount(account);
 		renderWithRouter(<SubtractionList />);

--- a/src/tests/fake/account.ts
+++ b/src/tests/fake/account.ts
@@ -1,8 +1,4 @@
-import {
-	type Account,
-	type APIKeyMinimal,
-	QuickAnalyzeWorkflow,
-} from "@account/types";
+import type { Account, APIKeyMinimal } from "@account/types";
 import { faker } from "@faker-js/faker";
 import type { Permissions } from "@groups/types";
 import nock from "nock";
@@ -11,7 +7,7 @@ import { createFakePermissions } from "./permissions";
 import { createFakeUser } from "./user";
 
 const defaultSettings = {
-	quick_analyze_workflow: QuickAnalyzeWorkflow.pathoscope_bowtie,
+	quick_analyze_workflow: "pathoscope_bowtie",
 	show_ids: true,
 	show_versions: true,
 	skip_quick_analyze_dialog: true,

--- a/src/tests/fake/files.ts
+++ b/src/tests/fake/files.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import nock from "nock";
-import { type Upload, UploadType } from "@/uploads/types";
+import type { Upload } from "@/uploads/types";
 import { createFakeUserNested } from "./user";
 
 /**
@@ -21,7 +21,7 @@ export function createFakeFile(overrides?: Partial<Upload>): Upload {
 		removed_at: undefined,
 		reserved: false,
 		size: faker.number.int(),
-		type: UploadType.reads,
+		type: "reads",
 		uploaded_at: faker.date.past().toISOString(),
 		user: createFakeUserNested(),
 		...overrides,

--- a/src/tests/fake/otus.ts
+++ b/src/tests/fake/otus.ts
@@ -1,13 +1,12 @@
 import { faker } from "@faker-js/faker";
 import type { UpdateOTUProps } from "@otus/queries";
-import {
-	HistoryMethod,
-	type HistoryNested,
-	type Otu,
-	type OtuIsolate,
-	type OtuMinimal,
-	type OtuSegment,
-	type OtuSequence,
+import type {
+	HistoryNested,
+	Otu,
+	OtuIsolate,
+	OtuMinimal,
+	OtuSegment,
+	OtuSequence,
 } from "@otus/types";
 import nock from "nock";
 import { createFakeReferenceNested } from "./references";
@@ -21,7 +20,7 @@ export function createFakeHistoryNested(): HistoryNested {
 		created_at: faker.date.past().toISOString(),
 		description: faker.lorem.lines(1),
 		id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
-		method_name: HistoryMethod.create,
+		method_name: "create",
 		user: createFakeUserNested(),
 	};
 }

--- a/src/tests/fake/samples.ts
+++ b/src/tests/fake/samples.ts
@@ -1,11 +1,11 @@
 import { faker } from "@faker-js/faker";
 import type { SampleRightsUpdate } from "@samples/api";
-import {
+import type {
 	LibraryType,
-	type Quality,
-	type Read,
-	type Sample,
-	type SampleMinimal,
+	Quality,
+	Read,
+	Sample,
+	SampleMinimal,
 } from "@samples/types";
 import nock from "nock";
 import { createFakeServerJobNested } from "./jobs";
@@ -29,7 +29,7 @@ export function createFakeSampleMinimal(
 		isolate: faker.word.noun({ strategy: "any-length" }),
 		job: createFakeServerJobNested({ workflow: "create_sample" }),
 		labels: [createFakeLabelNested()],
-		library_type: LibraryType.normal,
+		library_type: "normal",
 		notes: faker.lorem.lines(5),
 		nuvs: faker.datatype.boolean(),
 		pathoscope: faker.datatype.boolean(),

--- a/src/tests/fake/samples.ts
+++ b/src/tests/fake/samples.ts
@@ -6,7 +6,6 @@ import {
 	type Read,
 	type Sample,
 	type SampleMinimal,
-	WorkflowState,
 } from "@samples/types";
 import nock from "nock";
 import { createFakeServerJobNested } from "./jobs";
@@ -22,7 +21,7 @@ import { createFakeUserNested } from "./user";
 export function createFakeSampleMinimal(
 	overrides?: Partial<SampleMinimal>,
 ): SampleMinimal {
-	const defaultSampleMinimal = {
+	const defaultSampleMinimal: SampleMinimal = {
 		id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
 		name: `${faker.word.noun({ strategy: "any-length" })} ${faker.number.int()}`,
 		created_at: faker.date.past().toISOString(),
@@ -37,8 +36,8 @@ export function createFakeSampleMinimal(
 		ready: true,
 		user: createFakeUserNested(),
 		workflows: {
-			nuvs: WorkflowState.NONE,
-			pathoscope: WorkflowState.NONE,
+			nuvs: "none",
+			pathoscope: "none",
 		},
 	};
 

--- a/src/uploads/components/FileManager.tsx
+++ b/src/uploads/components/FileManager.tsx
@@ -9,7 +9,6 @@ import Pagination from "@base/Pagination";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
-import { Permission } from "@groups/types";
 import { capitalize } from "es-toolkit";
 import { AlertCircle } from "lucide-react";
 import type { ReactNode } from "react";
@@ -55,11 +54,11 @@ export function FileManager({
 
 	const canUpload = checkAdminRoleOrPermissionsFromAccount(
 		account,
-		Permission.upload_file,
+		"upload_file",
 	);
 	const canDelete = checkAdminRoleOrPermissionsFromAccount(
 		account,
-		Permission.remove_file,
+		"remove_file",
 	);
 
 	const title = `${fileType === "reads" ? "Read" : capitalize(fileType)} Files`;

--- a/src/uploads/components/__tests__/FileManager.test.tsx
+++ b/src/uploads/components/__tests__/FileManager.test.tsx
@@ -5,7 +5,6 @@ import userEvent from "@testing-library/user-event";
 import { createFakeAccount, mockApiGetAccount } from "@tests/fake/account";
 import { createFakeFile, mockApiListFiles } from "@tests/fake/files";
 import { renderWithRouter } from "@tests/setup";
-import { UploadType } from "@uploads/types";
 import { upload } from "@uploads/uploader";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FileManager, type FileManagerProps } from "../FileManager";
@@ -23,7 +22,7 @@ describe("<FileManager>", () => {
 			accept: {
 				"application/gzip": [".fasta.gz", ".fa.gz", ".fastq.gz", ".fq.gz"],
 			},
-			fileType: UploadType.reads,
+			fileType: "reads",
 			message: "",
 		};
 		path = formatPath("/samples/uploads", { page: 1 });

--- a/src/uploads/components/__tests__/FileManager.test.tsx
+++ b/src/uploads/components/__tests__/FileManager.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { formatPath } from "@app/hooks";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -96,7 +95,7 @@ describe("<FileManager>", () => {
 	it("should take custom message", async () => {
 		mockApiGetAccount(
 			createFakeAccount({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 			}),
 		);
 		mockApiListFiles([createFakeFile({ name: "subtraction.fq.gz" })], true);

--- a/src/uploads/types.ts
+++ b/src/uploads/types.ts
@@ -1,12 +1,7 @@
 import type { UserNested } from "@users/types";
 import type { SearchResult } from "@/types/api";
 
-export enum UploadType {
-	hmm = "hmm",
-	reference = "reference",
-	reads = "reads",
-	subtraction = "subtraction",
-}
+export type UploadType = "hmm" | "reference" | "reads" | "subtraction";
 
 export type FileResponse = SearchResult & {
 	items: Upload[];

--- a/src/users/components/ManageUsers.tsx
+++ b/src/users/components/ManageUsers.tsx
@@ -1,5 +1,4 @@
 import { useCheckAdminRole } from "@administration/hooks";
-import { AdministratorRoleName } from "@administration/types";
 import { useUrlSearchParam } from "@app/hooks";
 import Alert from "@base/Alert";
 import InputSearch from "@base/InputSearch";
@@ -21,9 +20,7 @@ export function ManageUsers() {
 		"status",
 		"active",
 	);
-	const { hasPermission, isPending } = useCheckAdminRole(
-		AdministratorRoleName.USERS,
-	);
+	const { hasPermission, isPending } = useCheckAdminRole("users");
 
 	if (isPending) {
 		return <LoadingPlaceholder />;

--- a/src/users/components/UserDetail.tsx
+++ b/src/users/components/UserDetail.tsx
@@ -1,6 +1,5 @@
 import { useCheckAdminRole } from "@administration/hooks";
 import { useFetchUser, useUpdateUser } from "@administration/queries";
-import { AdministratorRoleName } from "@administration/types";
 import { usePathParams } from "@app/hooks";
 import Alert from "@base/Alert";
 import InitialIcon from "@base/InitialIcon";
@@ -20,9 +19,7 @@ export default function UserDetail() {
 	const { userId } = usePathParams<{ userId: string }>();
 	const { data, isPending } = useFetchUser(Number(userId));
 	const { hasPermission: canEdit } = useCheckAdminRole(
-		data?.administrator_role === null
-			? AdministratorRoleName.USERS
-			: AdministratorRoleName.FULL,
+		data?.administrator_role === null ? "users" : "full",
 	);
 
 	const mutation = useUpdateUser();

--- a/src/users/components/UserItem.tsx
+++ b/src/users/components/UserItem.tsx
@@ -1,5 +1,5 @@
 import { useCheckAdminRole } from "@administration/hooks";
-import { AdministratorRoleName } from "@administration/types";
+import type { AdministratorRoleName } from "@administration/types";
 import BoxGroupSection from "@base/BoxGroupSection";
 import InitialIcon from "@base/InitialIcon";
 import Label from "@base/Label";
@@ -25,9 +25,7 @@ export function UserItem({
 	primary_group,
 }: UserItemProps): ReactElement {
 	const { hasPermission: canEdit } = useCheckAdminRole(
-		administrator_role === null
-			? AdministratorRoleName.USERS
-			: AdministratorRoleName.FULL,
+		administrator_role === null ? "users" : "full",
 	);
 
 	return (

--- a/src/users/components/__tests__/ManageUsers.test.tsx
+++ b/src/users/components/__tests__/ManageUsers.test.tsx
@@ -1,4 +1,3 @@
-import { AdministratorRoleName } from "@administration/types";
 import { screen } from "@testing-library/react";
 import { createFakeAccount, mockApiGetAccount } from "@tests/fake/account";
 import { createFakeUsers, mockApiFindUsers } from "@tests/fake/user";
@@ -9,10 +8,10 @@ import { ManageUsers } from "../ManageUsers";
 describe("<ManageUsers />", () => {
 	it("should render correctly with 3 users", async () => {
 		const users = createFakeUsers(3);
-		users[0].administrator_role = AdministratorRoleName.FULL;
+		users[0].administrator_role = "full";
 		await mockApiFindUsers(users);
 		const account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 		mockApiGetAccount(account);
 
@@ -28,7 +27,7 @@ describe("<ManageUsers />", () => {
 
 	it("should render correctly when documents = null", async () => {
 		const account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 		mockApiGetAccount(account);
 

--- a/src/users/components/__tests__/UserDetail.test.tsx
+++ b/src/users/components/__tests__/UserDetail.test.tsx
@@ -1,5 +1,4 @@
 import Settings from "@administration/components/Settings";
-import { AdministratorRoleName } from "@administration/types";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mockApiListGroups } from "@tests/api/groups";
@@ -39,7 +38,7 @@ describe("<UserDetail />", () => {
 			active: true,
 		});
 		account = createFakeAccount({
-			administrator_role: AdministratorRoleName.FULL,
+			administrator_role: "full",
 		});
 	});
 
@@ -51,7 +50,7 @@ describe("<UserDetail />", () => {
 			mockApiGetAccount(account);
 
 			const userDetail = createFakeUser({
-				administrator_role: AdministratorRoleName.FULL,
+				administrator_role: "full",
 				groups,
 			});
 


### PR DESCRIPTION
## Summary

Replaces all 12 remaining TypeScript `enum` declarations with string literal unions (and `const` objects where runtime values are needed). Resolves VIR-2270.

Enums removed:

- `QuickAnalyzeWorkflow` (`@account/types`)
- `HistoryMethod` (`@otus/types`)
- `AdministratorPermissions` + internal `AdministratorPermissionsLevel` (`@administration/utils`) — replaced with plain `Record` consts
- `ReferenceFormMode` (`@references/components/ReferenceForm`)
- `Molecule` (`@otus/types`) — kept the indirection via `const` object + derived type, since keys differ from values (`ds_dna` → `"dsDNA"`)
- `sizes` (`@base/ProgressCircle`)
- `WorkflowState`, `LibraryType` (`@samples/types`)
- `ReferenceRight` (`@references/hooks`)
- `UploadType` (`@uploads/types`)
- `AdministratorRoleName` (`@administration/types`)
- `Permission` (`@groups/types`)

Each enum migrated in a separate commit so the diff stays reviewable and `git bisect` remains useful.

The `sizes` enum in `src/app/theme.ts` listed in the issue was already gone — no action needed.

## Notes

- `npm run typecheck` passes cleanly.
- `npm run check` passes; warning count unchanged from the baseline (158).
- Full vitest run: 340/340 tests pass.
- No behaviour changes — pure type-level migration. Runtime values for `Molecule`, `AdministratorPermissions`, and `AdministratorPermissionsLevel` are preserved by their `const` replacements.