### PR TITLE
docs: discourage manual testing plans in PR bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`.
 - Title: lowercase, no period, under 72 characters.
 - Scope is optional but preferred.
 - Don't push or create PRs unless asked.
-- Don't write a manual testing plan in PR bodies.
+- Don't include a Test plan section in PR descriptions.
 - Don't use `git -C <path>` unless necessary. It triggers permission prompts that
   aren't worth the trouble. Run git commands from the working directory instead.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`.
 - Title: lowercase, no period, under 72 characters.
 - Scope is optional but preferred.
 - Don't push or create PRs unless asked.
+- Don't write a manual testing plan in PR bodies.
 - Don't use `git -C <path>` unless necessary. It triggers permission prompts that
   aren't worth the trouble. Run git commands from the working directory instead.
 


### PR DESCRIPTION
## Summary
- Adds a note to AGENTS.md instructing agents not to write manual testing plans in pull request bodies

## Test plan
- [ ] Verify the added line appears in AGENTS.md under the Git section