### PR TITLE
feat: add useMatchPartialPath for TanStack Router and ban useMatchRoute

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,6 +16,17 @@
     "enabled": true,
     "rules": {
       "style": {
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "paths": {
+              "@tanstack/react-router": {
+                "importNames": ["useMatchRoute"],
+                "message": "useMatchRoute breaks React Compiler reactivity (TanStack Router #4499). Use useMatchPartialPath from @app/useMatchPartialPath.tanstack instead."
+              }
+            }
+          }
+        },
         "useLiteralEnumMembers": "warn"
       },
       "suspicious": {

--- a/docs/projects/tanstack-router-migration.md
+++ b/docs/projects/tanstack-router-migration.md
@@ -63,9 +63,15 @@ about adding SSR and server functions — not re-learning routing.
 
 - Keep `babel-plugin-react-compiler` unchanged.
 - Avoid `useMatchRoute` due to open reactivity bug under React Compiler (TanStack
-  Router #4499). Use `useLocation`/`useMatches` instead.
+  Router #4499). Use `useLocation`/`useMatches` instead. A Biome
+  `noRestrictedImports` rule enforces this ban at lint time.
 - If the bug is encountered elsewhere, selectively exclude affected files from the
   compiler.
+- **`"use no memo"` escape hatch:** Adding the string directive `"use no memo"` at
+  the top of a component or hook opts it out of React Compiler memoization. Use this
+  only as a last resort when a TanStack Router API triggers a Compiler reactivity bug
+  and no alternative API exists. Prefer swapping to a Compiler-safe API first (e.g.
+  `useLocation` over `useMatchRoute`).
 
 ### Bundle size
 

--- a/src/app/__tests__/useMatchPartialPath.tanstack.test.tsx
+++ b/src/app/__tests__/useMatchPartialPath.tanstack.test.tsx
@@ -1,0 +1,106 @@
+import {
+	createMemoryHistory,
+	createRootRoute,
+	createRoute,
+	createRouter,
+	Outlet,
+	RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useMatchPartialPath } from "../useMatchPartialPath.tanstack";
+
+function TestHarness({ path, exclude }: { path: string; exclude?: string[] }) {
+	const result = useMatchPartialPath(path, exclude);
+	return <span data-testid="result">{String(result)}</span>;
+}
+
+async function renderWithTanStackRouter(
+	ui: React.ReactElement,
+	initialPath: string,
+) {
+	const rootRoute = createRootRoute({ component: () => <Outlet /> });
+	const catchAllRoute = createRoute({
+		getParentRoute: () => rootRoute,
+		path: "$",
+		component: () => ui,
+	});
+	rootRoute.addChildren([catchAllRoute]);
+
+	// @ts-expect-error createRouter requires strictNullChecks which is not enabled project-wide
+	const router = createRouter({
+		routeTree: rootRoute,
+		history: createMemoryHistory({ initialEntries: [initialPath] }),
+		defaultPendingMinMs: 0,
+	});
+
+	await router.load();
+	return render(<RouterProvider router={router} />);
+}
+
+async function getResult() {
+	const el = await screen.findByTestId("result");
+	return el.textContent === "true";
+}
+
+describe("useMatchPartialPath (tanstack)", () => {
+	it("returns true when location starts with path", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness path="/samples" />,
+			"/samples/abc123",
+		);
+
+		expect(await getResult()).toBe(true);
+	});
+
+	it("returns true for exact match", async () => {
+		await renderWithTanStackRouter(<TestHarness path="/samples" />, "/samples");
+
+		expect(await getResult()).toBe(true);
+	});
+
+	it("returns false when location does not start with path", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness path="/samples" />,
+			"/refs/abc123",
+		);
+
+		expect(await getResult()).toBe(false);
+	});
+
+	it("strips trailing slashes from path before matching", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness path="/samples/" />,
+			"/samples/abc123",
+		);
+
+		expect(await getResult()).toBe(true);
+	});
+
+	it("strips query parameters from path before matching", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness path="/samples?page=1" />,
+			"/samples/abc123",
+		);
+
+		expect(await getResult()).toBe(true);
+	});
+
+	it("returns false when location is in exclude list", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness path="/refs" exclude={["/refs/settings"]} />,
+			"/refs/settings",
+		);
+
+		expect(await getResult()).toBe(false);
+	});
+
+	it("returns true when location matches and is not excluded", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness path="/refs" exclude={["/refs/settings"]} />,
+			"/refs/abc123",
+		);
+
+		expect(await getResult()).toBe(true);
+	});
+});

--- a/src/app/__tests__/useMatchPartialPath.tanstack.test.tsx
+++ b/src/app/__tests__/useMatchPartialPath.tanstack.test.tsx
@@ -103,4 +103,22 @@ describe("useMatchPartialPath (tanstack)", () => {
 
 		expect(await getResult()).toBe(true);
 	});
+
+	it("does not match partial segments", async () => {
+		await renderWithTanStackRouter(<TestHarness path="/sample" />, "/samples");
+
+		expect(await getResult()).toBe(false);
+	});
+
+	it("does not match all paths when given root path", async () => {
+		await renderWithTanStackRouter(<TestHarness path="/" />, "/samples");
+
+		expect(await getResult()).toBe(false);
+	});
+
+	it("matches root path exactly", async () => {
+		await renderWithTanStackRouter(<TestHarness path="/" />, "/");
+
+		expect(await getResult()).toBe(true);
+	});
 });

--- a/src/app/useMatchPartialPath.tanstack.ts
+++ b/src/app/useMatchPartialPath.tanstack.ts
@@ -7,5 +7,8 @@ export function useMatchPartialPath(path: string, exclude?: string[]): boolean {
 		return false;
 	}
 
-	return pathname.startsWith(path.split("?")[0].replace(/\/+$/, ""));
+	const normalizedPath = path.split("?")[0].replace(/\/+$/, "") || "/";
+	return (
+		pathname === normalizedPath || pathname.startsWith(`${normalizedPath}/`)
+	);
 }

--- a/src/app/useMatchPartialPath.tanstack.ts
+++ b/src/app/useMatchPartialPath.tanstack.ts
@@ -1,0 +1,11 @@
+import { useLocation } from "@tanstack/react-router";
+
+export function useMatchPartialPath(path: string, exclude?: string[]): boolean {
+	const pathname = useLocation({ select: (l) => l.pathname });
+
+	if (exclude?.includes(pathname)) {
+		return false;
+	}
+
+	return pathname.startsWith(path.split("?")[0].replace(/\/+$/, ""));
+}


### PR DESCRIPTION
## Summary

- Adds `useMatchPartialPath` hook in `src/app/useMatchPartialPath.tanstack.ts` that uses `useLocation` (Compiler-safe) instead of `useMatchRoute` to check whether the current pathname starts with a given path prefix
- Adds a Biome `noRestrictedImports` rule that errors when `useMatchRoute` is imported from `@tanstack/react-router`, since it breaks React Compiler reactivity (TanStack Router #4499)
- Updates the TanStack Router migration project doc to reference the lint rule and document the `"use no memo"` escape hatch as a last resort

## Test plan

- [ ] `npx vitest run src/app/__tests__/useMatchPartialPath.tanstack.test.tsx` — all 7 cases pass
- [ ] `npm run check` — Biome reports no errors; verify the `noRestrictedImports` rule is active by temporarily adding `import { useMatchRoute } from "@tanstack/react-router"` to any file and confirming a lint error