### PR TITLE
scaffold TanStack route tree foundation with auth layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ React + TypeScript single-page application for Virtool, a bioinformatics platfor
 
 ### When to run checks
 
+- After changing route files in `src/routes/`: run `npx @tanstack/router-cli generate`
+  to regenerate `src/routeTree.gen.ts` before running type checks.
 - Before committing: `npm run check` and `npm run typecheck`.
 - After changing tests: run the specific test file with `npx vitest run <path>`.
 - Full test suite only when asked or when changes are cross-cutting.

--- a/src/app/AppRouter.tsx
+++ b/src/app/AppRouter.tsx
@@ -1,0 +1,24 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { createRouter, RouterProvider } from "@tanstack/react-router";
+import { routeTree } from "@/routeTree.gen";
+
+// @ts-expect-error TanStack Router requires strictNullChecks which is not enabled in this project
+export const router = createRouter({
+	routeTree,
+	defaultPendingMinMs: 0,
+	context: {
+		queryClient: undefined!,
+	},
+});
+
+declare module "@tanstack/react-router" {
+	interface Register {
+		router: typeof router;
+	}
+}
+
+export default function AppRouter() {
+	const queryClient = useQueryClient();
+
+	return <RouterProvider router={router} context={{ queryClient }} />;
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,27 +9,86 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SetupRouteImport } from './routes/setup'
+import { Route as LoginRouteImport } from './routes/login'
+import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 
-export interface FileRoutesByFullPath {}
-export interface FileRoutesByTo {}
+const SetupRoute = SetupRouteImport.update({
+  id: '/setup',
+  path: '/setup',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LoginRoute = LoginRouteImport.update({
+  id: '/login',
+  path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthenticatedRoute = AuthenticatedRouteImport.update({
+  id: '/_authenticated',
+  getParentRoute: () => rootRouteImport,
+} as any)
+
+export interface FileRoutesByFullPath {
+  '/': typeof AuthenticatedRoute
+  '/login': typeof LoginRoute
+  '/setup': typeof SetupRoute
+}
+export interface FileRoutesByTo {
+  '/': typeof AuthenticatedRoute
+  '/login': typeof LoginRoute
+  '/setup': typeof SetupRoute
+}
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
+  '/_authenticated': typeof AuthenticatedRoute
+  '/login': typeof LoginRoute
+  '/setup': typeof SetupRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: never
+  fullPaths: '/' | '/login' | '/setup'
   fileRoutesByTo: FileRoutesByTo
-  to: never
-  id: '__root__'
+  to: '/' | '/login' | '/setup'
+  id: '__root__' | '/_authenticated' | '/login' | '/setup'
   fileRoutesById: FileRoutesById
 }
-export interface RootRouteChildren {}
-
-declare module '@tanstack/react-router' {
-  interface FileRoutesByPath {}
+export interface RootRouteChildren {
+  AuthenticatedRoute: typeof AuthenticatedRoute
+  LoginRoute: typeof LoginRoute
+  SetupRoute: typeof SetupRoute
 }
 
-const rootRouteChildren: RootRouteChildren = {}
+declare module '@tanstack/react-router' {
+  interface FileRoutesByPath {
+    '/setup': {
+      id: '/setup'
+      path: '/setup'
+      fullPath: '/setup'
+      preLoaderRoute: typeof SetupRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_authenticated': {
+      id: '/_authenticated'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof AuthenticatedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+  }
+}
+
+const rootRouteChildren: RootRouteChildren = {
+  AuthenticatedRoute: AuthenticatedRoute,
+  LoginRoute: LoginRoute,
+  SetupRoute: SetupRoute,
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,9 +1,22 @@
-import { createRootRoute, Outlet } from "@tanstack/react-router";
+import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import NotFound from "@base/NotFound";
+import type { QueryClient } from "@tanstack/react-query";
+import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
+
+interface RouterContext {
+	queryClient: QueryClient;
+}
 
 function RootComponent() {
 	return <Outlet />;
 }
 
-export const Route = createRootRoute({
+function NotFoundComponent() {
+	return <NotFound />;
+}
+
+export const Route = createRootRouteWithContext<RouterContext>()({
 	component: RootComponent,
+	pendingComponent: LoadingPlaceholder,
+	notFoundComponent: NotFoundComponent,
 });

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -1,0 +1,35 @@
+import { fetchAccount } from "@account/api";
+import { accountKeys } from "@account/queries";
+import { apiClient } from "@app/api";
+import type { Root } from "@app/types";
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+import { rootKeys } from "@wall/queries";
+
+export const Route = createFileRoute("/_authenticated")({
+	beforeLoad: async ({ context }) => {
+		const { queryClient } = context;
+
+		const rootData = await queryClient.ensureQueryData<Root>({
+			queryKey: rootKeys.all(),
+			queryFn: () => apiClient.get("/").then((res) => res.body),
+		});
+
+		if (rootData.first_user) {
+			throw redirect({ to: "/setup" });
+		}
+
+		try {
+			await queryClient.ensureQueryData({
+				queryKey: accountKeys.all(),
+				queryFn: fetchAccount,
+			});
+		} catch {
+			throw redirect({ to: "/login" });
+		}
+	},
+	component: AuthenticatedLayout,
+});
+
+function AuthenticatedLayout() {
+	return <Outlet />;
+}

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import LoginWall from "@wall/components/LoginWall";
+
+export const Route = createFileRoute("/login")({
+	component: LoginWall,
+});

--- a/src/routes/setup.tsx
+++ b/src/routes/setup.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import FirstUser from "@wall/components/FirstUser";
+
+export const Route = createFileRoute("/setup")({
+	component: FirstUser,
+});


### PR DESCRIPTION
## Summary

- Installs TanStack Router and configures the Vite plugin for file-based routing
- Scaffolds the initial route tree with `__root`, `_authenticated` (layout route), `/login`, and `/setup` file routes
- The `_authenticated` layout route handles auth gating: checks root data for first-user setup, redirects unauthenticated users to `/login`, and passes `queryClient` context through `createRootRouteWithContext`