### PR TITLE
feat: add TanStack Router search-param compatibility shim

### DIFF
--- a/docs/projects/tanstack-router-migration.md
+++ b/docs/projects/tanstack-router-migration.md
@@ -97,6 +97,21 @@ about adding SSR and server functions — not re-learning routing.
 - **React Query provider in tests.** Every test wraps in a fresh `QueryClient` via
   `renderWithProviders`. That wrapping must remain.
 
+## User-Visible URL Changes
+
+These changes take effect when the search-param compatibility shim (I4) is swapped in
+at cutover (I13).
+
+- **D14 — Array params use JSON encoding.** List/array search params change from
+  repeated keys (`?labels=1&labels=2`) to a single JSON-encoded array
+  (`?labels=%5B1%2C2%5D`). This is a consequence of TanStack Router's default
+  `parseSearch`/`stringifySearch` (no custom serializer, per D3). Bookmarked URLs with
+  the old repeated-key format will not be read correctly after cutover.
+- **D15 — Dialog params are stripped when false.** Dialog presence/absence is preserved:
+  `setOpen(true)` writes the key, `setOpen(false)` removes it. The URL will never
+  contain `?openX=false` — the shim collapses falsy values to `undefined`, which the
+  JSON serializer strips.
+
 ## Wouter to TanStack Router API Mapping
 
 | wouter | TanStack Router | Notes |

--- a/src/app/__tests__/hooks.tanstack.test.tsx
+++ b/src/app/__tests__/hooks.tanstack.test.tsx
@@ -162,6 +162,15 @@ describe("useDialogParam", () => {
 		expect(screen.getByTestId("open")).toHaveTextContent("true");
 	});
 
+	it("reads open as false when param is the string 'false'", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="openCreate" />,
+			'/samples?openCreate="false"',
+		);
+
+		expect(screen.getByTestId("open")).toHaveTextContent("false");
+	});
+
 	it("reads open state as false when param is absent", async () => {
 		await renderWithTanStackRouter(
 			<TestHarness paramKey="openCreate" />,

--- a/src/app/__tests__/hooks.tanstack.test.tsx
+++ b/src/app/__tests__/hooks.tanstack.test.tsx
@@ -1,0 +1,304 @@
+import {
+	createMemoryHistory,
+	createRootRoute,
+	createRoute,
+	createRouter,
+	Outlet,
+	RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import {
+	useDialogParam,
+	useListSearchParam,
+	useNaiveUrlSearchParam,
+	usePageParam,
+	useUrlSearchParam,
+} from "../hooks.tanstack";
+
+async function renderWithTanStackRouter(
+	ui: React.ReactElement,
+	initialPath: string,
+) {
+	const rootRoute = createRootRoute({ component: () => <Outlet /> });
+	const catchAllRoute = createRoute({
+		getParentRoute: () => rootRoute,
+		path: "$",
+		component: () => ui,
+	});
+	rootRoute.addChildren([catchAllRoute]);
+
+	// @ts-expect-error createRouter requires strictNullChecks which is not enabled project-wide
+	const router = createRouter({
+		routeTree: rootRoute,
+		history: createMemoryHistory({ initialEntries: [initialPath] }),
+		defaultPendingMinMs: 0,
+	});
+
+	await router.load();
+	return render(<RouterProvider router={router} />);
+}
+
+describe("useNaiveUrlSearchParam", () => {
+	function TestHarness({
+		paramKey,
+		defaultValue,
+	}: {
+		paramKey: string;
+		defaultValue?: string;
+	}) {
+		const { value, setValue, unsetValue } = useNaiveUrlSearchParam(
+			paramKey,
+			defaultValue,
+		);
+		return (
+			<div>
+				<span data-testid="value">{value ?? "null"}</span>
+				<button onClick={() => setValue("updated")} type="button">
+					set
+				</button>
+				<button onClick={() => unsetValue()} type="button">
+					unset
+				</button>
+			</div>
+		);
+	}
+
+	it("reads an existing search param", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="find" />,
+			"/samples?find=hello",
+		);
+
+		expect(screen.getByTestId("value")).toHaveTextContent("hello");
+	});
+
+	it("returns null when param is absent and no default", async () => {
+		await renderWithTanStackRouter(<TestHarness paramKey="find" />, "/samples");
+
+		expect(screen.getByTestId("value")).toHaveTextContent("null");
+	});
+
+	it("applies default value when param is absent", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="find" defaultValue="default" />,
+			"/samples",
+		);
+
+		expect(screen.getByTestId("value")).toHaveTextContent("default");
+	});
+
+	it("writes a search param", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="find" />,
+			"/samples?find=hello",
+		);
+
+		await userEvent.click(screen.getByText("set"));
+
+		expect(screen.getByTestId("value")).toHaveTextContent("updated");
+	});
+
+	it("unsets a search param", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="find" />,
+			"/samples?find=hello",
+		);
+
+		await userEvent.click(screen.getByText("unset"));
+
+		expect(screen.getByTestId("value")).toHaveTextContent("null");
+	});
+});
+
+describe("useUrlSearchParam", () => {
+	function TestHarness({ paramKey }: { paramKey: string }) {
+		const { value } = useUrlSearchParam(paramKey);
+		return <span data-testid="value">{String(value)}</span>;
+	}
+
+	it("coerces numeric string to number", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="page" />,
+			"/samples?page=3",
+		);
+
+		expect(screen.getByTestId("value")).toHaveTextContent("3");
+	});
+
+	it("coerces boolean string to boolean", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="active" />,
+			"/samples?active=true",
+		);
+
+		expect(screen.getByTestId("value")).toHaveTextContent("true");
+	});
+});
+
+describe("useDialogParam", () => {
+	function TestHarness({ paramKey }: { paramKey: string }) {
+		const { open, setOpen } = useDialogParam(paramKey);
+		return (
+			<div>
+				<span data-testid="open">{String(open)}</span>
+				<button onClick={() => setOpen(true)} type="button">
+					open
+				</button>
+				<button onClick={() => setOpen(false)} type="button">
+					close
+				</button>
+			</div>
+		);
+	}
+
+	it("reads open state as true when param is present", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="openCreate" />,
+			"/samples?openCreate=true",
+		);
+
+		expect(screen.getByTestId("open")).toHaveTextContent("true");
+	});
+
+	it("reads open state as false when param is absent", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="openCreate" />,
+			"/samples",
+		);
+
+		expect(screen.getByTestId("open")).toHaveTextContent("false");
+	});
+
+	it("setOpen(true) sets the param", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="openCreate" />,
+			"/samples",
+		);
+
+		await userEvent.click(screen.getByText("open"));
+
+		expect(screen.getByTestId("open")).toHaveTextContent("true");
+	});
+
+	it("setOpen(false) strips the param from the URL (D15)", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="openCreate" />,
+			"/samples?openCreate=true",
+		);
+
+		await userEvent.click(screen.getByText("close"));
+
+		expect(screen.getByTestId("open")).toHaveTextContent("false");
+	});
+});
+
+describe("usePageParam", () => {
+	function TestHarness() {
+		const { page, setPage } = usePageParam();
+		return (
+			<div>
+				<span data-testid="page">{page}</span>
+				<button onClick={() => setPage(5)} type="button">
+					go to 5
+				</button>
+			</div>
+		);
+	}
+
+	it("defaults to 1 when absent", async () => {
+		await renderWithTanStackRouter(<TestHarness />, "/samples");
+
+		expect(screen.getByTestId("page")).toHaveTextContent("1");
+	});
+
+	it("reads the page param", async () => {
+		await renderWithTanStackRouter(<TestHarness />, "/samples?page=3");
+
+		expect(screen.getByTestId("page")).toHaveTextContent("3");
+	});
+
+	it("sets the page param", async () => {
+		await renderWithTanStackRouter(<TestHarness />, "/samples");
+
+		await userEvent.click(screen.getByText("go to 5"));
+
+		expect(screen.getByTestId("page")).toHaveTextContent("5");
+	});
+});
+
+describe("useListSearchParam", () => {
+	function TestHarness({
+		paramKey,
+		defaultValues,
+	}: {
+		paramKey: string;
+		defaultValues?: number[];
+	}) {
+		const { values, setValues } = useListSearchParam<number>(
+			paramKey,
+			defaultValues,
+		);
+		return (
+			<div>
+				<span data-testid="values">{JSON.stringify(values)}</span>
+				<button onClick={() => setValues([10, 20])} type="button">
+					set
+				</button>
+				<button onClick={() => setValues([])} type="button">
+					clear
+				</button>
+			</div>
+		);
+	}
+
+	it("reads JSON-encoded array values", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="labels" />,
+			"/samples?labels=%5B1%2C2%5D",
+		);
+
+		expect(screen.getByTestId("values")).toHaveTextContent("[1,2]");
+	});
+
+	it("returns empty array when absent with no defaults", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="labels" />,
+			"/samples",
+		);
+
+		expect(screen.getByTestId("values")).toHaveTextContent("[]");
+	});
+
+	it("applies default values when absent", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="labels" defaultValues={[1, 2]} />,
+			"/samples",
+		);
+
+		expect(screen.getByTestId("values")).toHaveTextContent("[1,2]");
+	});
+
+	it("writes values", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="labels" />,
+			"/samples",
+		);
+
+		await userEvent.click(screen.getByText("set"));
+
+		expect(screen.getByTestId("values")).toHaveTextContent("[10,20]");
+	});
+
+	it("setValues([]) strips the key", async () => {
+		await renderWithTanStackRouter(
+			<TestHarness paramKey="labels" />,
+			"/samples?labels=%5B1%2C2%5D",
+		);
+
+		await userEvent.click(screen.getByText("clear"));
+
+		expect(screen.getByTestId("values")).toHaveTextContent("[]");
+	});
+});

--- a/src/app/hooks.tanstack.ts
+++ b/src/app/hooks.tanstack.ts
@@ -1,0 +1,143 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { castSearchParamValue, type SearchParam } from "./hooks";
+
+// TanStack Router's navigate expects a strictly typed search reducer.
+// The shim operates outside route-level type safety (strict: false),
+// so we use this type to bypass the reducer constraint.
+// biome-ignore lint/suspicious/noExplicitAny: shim operates outside strict route typing
+type AnySearchReducer = any;
+
+function castIfString(value: unknown): unknown {
+	return typeof value === "string" ? castSearchParamValue(value) : value;
+}
+
+export function useNaiveUrlSearchParam(
+	key: string,
+	defaultValue?: SearchParam,
+): {
+	value: string;
+	setValue: (value: SearchParam) => void;
+	unsetValue: () => void;
+} {
+	const search = useSearch({ strict: false }) as Record<string, unknown>;
+	const navigate = useNavigate();
+
+	useEffect(() => {
+		if (defaultValue !== undefined && search[key] === undefined) {
+			navigate({
+				search: ((prev: Record<string, unknown>) => ({
+					...prev,
+					[key]: defaultValue,
+				})) as AnySearchReducer,
+				replace: true,
+			});
+		}
+	}, [defaultValue, key, search[key], navigate]);
+
+	const raw = search[key];
+	const value =
+		raw !== undefined
+			? String(raw)
+			: defaultValue !== undefined
+				? String(defaultValue)
+				: null;
+
+	return {
+		value,
+		setValue: (value: SearchParam) =>
+			navigate({
+				search: ((prev: Record<string, unknown>) => ({
+					...prev,
+					[key]: value,
+				})) as AnySearchReducer,
+				replace: true,
+			}),
+		unsetValue: () =>
+			navigate({
+				search: ((prev: Record<string, unknown>) => ({
+					...prev,
+					[key]: undefined,
+				})) as AnySearchReducer,
+				replace: true,
+			}),
+	};
+}
+
+export function useUrlSearchParam<T extends SearchParam>(
+	key: string,
+	defaultValue?: T,
+) {
+	const { value, ...rest } = useNaiveUrlSearchParam(key, defaultValue);
+
+	return { value: castIfString(value) as T, ...rest };
+}
+
+export function useListSearchParam<T extends SearchParam>(
+	key: string,
+	defaultValues?: T[],
+): { values: T[]; setValues: (newValue: T[]) => void } {
+	const search = useSearch({ strict: false }) as Record<string, unknown>;
+	const navigate = useNavigate();
+
+	const raw = search[key];
+	const values = Array.isArray(raw) ? raw : [];
+
+	useEffect(() => {
+		if (defaultValues?.length && values.length === 0) {
+			navigate({
+				search: ((prev: Record<string, unknown>) => ({
+					...prev,
+					[key]: defaultValues,
+				})) as AnySearchReducer,
+				replace: true,
+			});
+		}
+	}, [defaultValues, key, values.length, navigate]);
+
+	function setValues(newValues: T[]) {
+		navigate({
+			search: ((prev: Record<string, unknown>) => ({
+				...prev,
+				[key]: newValues.length ? newValues : undefined,
+			})) as AnySearchReducer,
+		});
+	}
+
+	const effectiveValues = values.length
+		? values
+		: ((defaultValues as string[]) ?? []);
+
+	return {
+		values: effectiveValues.map(castIfString) as T[],
+		setValues,
+	};
+}
+
+export function useDialogParam(key: string) {
+	const search = useSearch({ strict: false }) as Record<string, unknown>;
+	const navigate = useNavigate();
+
+	const open = Boolean(search[key]);
+
+	function setOpen(value: boolean) {
+		navigate({
+			search: ((prev: Record<string, unknown>) => ({
+				...prev,
+				[key]: value || undefined,
+			})) as AnySearchReducer,
+			replace: true,
+		});
+	}
+
+	return { open, setOpen };
+}
+
+export function usePageParam() {
+	const {
+		value: page,
+		setValue: setPage,
+		unsetValue: unsetPage,
+	} = useUrlSearchParam<number>("page");
+	return { page: page || 1, setPage, unsetPage };
+}

--- a/src/app/hooks.tanstack.ts
+++ b/src/app/hooks.tanstack.ts
@@ -9,6 +9,9 @@ import { castSearchParamValue, type SearchParam } from "./hooks";
 type AnySearchReducer = any;
 
 function castIfString(value: unknown): unknown {
+	if (value == null) {
+		return undefined;
+	}
 	return typeof value === "string" ? castSearchParamValue(value) : value;
 }
 
@@ -104,9 +107,7 @@ export function useListSearchParam<T extends SearchParam>(
 		});
 	}
 
-	const effectiveValues = values.length
-		? values
-		: ((defaultValues as string[]) ?? []);
+	const effectiveValues = values.length ? values : (defaultValues ?? []);
 
 	return {
 		values: effectiveValues.map(castIfString) as T[],
@@ -118,7 +119,7 @@ export function useDialogParam(key: string) {
 	const search = useSearch({ strict: false }) as Record<string, unknown>;
 	const navigate = useNavigate();
 
-	const open = Boolean(search[key]);
+	const open = Boolean(castIfString(search[key]));
 
 	function setOpen(value: boolean) {
 		navigate({

--- a/src/app/hooks.tsx
+++ b/src/app/hooks.tsx
@@ -188,7 +188,7 @@ function unsetUrlSearchParam(key, navigate, search, location) {
 	return search;
 }
 
-type SearchParam = string | boolean | number | null;
+export type SearchParam = string | boolean | number | null;
 
 type navigate = <S>(
 	to: string | URL,
@@ -200,7 +200,7 @@ type navigate = <S>(
  *
  * @param value - search param value to be converted
  */
-function castSearchParamValue(value: string) {
+export function castSearchParamValue(value: string) {
 	if (value === null) {
 		return undefined;
 	}


### PR DESCRIPTION
## Summary

- Adds `src/app/hooks.tanstack.ts` — a set of TanStack Router hooks (`useNaiveUrlSearchParam`, `useUrlSearchParam`, `useListSearchParam`, `useDialogParam`, `usePageParam`) that mirror the existing wouter-based search-param API so components can be migrated incrementally without changing call sites.
- Exports `SearchParam` and `castSearchParamValue` from `hooks.tsx` so the shim can reuse them without duplication.
- Documents two user-visible URL format changes that take effect at TanStack Router cutover: JSON-encoded array params (D14) and falsy dialog params being stripped from the URL (D15).