### PR TITLE
migrate administration routes to TanStack Router with role-based beforeLoad

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,13 +64,18 @@ Every feature directory has a `@name` alias (e.g., `@app/utils`, `@base/Button`,
 - **wouter** for routing
 - **React Query** (`@tanstack/react-query`) for server state
 - **zustand** for client state
-- **react-hook-form** + **zod** for forms and validation
+- **react-hook-form** + **zod v4** for forms and validation
 - **superagent** for API calls (via `@app/api.ts` client)
 - **styled-components** for CSS-in-JS (legacy, still in use)
 - **Tailwind CSS v4** for utility styles (preferred for new code)
 - **Radix UI** primitives for accessible components
 - **CVA** (`class-variance-authority`) for component variants
 - **Lucide React** for icons
+
+### TanStack Router search params
+
+Zod v4 schemas can be passed directly to `validateSearch` — `@tanstack/zod-adapter`
+is not needed. Use `.default()` and `.catch()` for defaults and fallbacks.
 
 ### API calls
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,13 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as SetupRouteImport } from './routes/setup'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
+import { Route as AuthenticatedAdministrationRouteRouteImport } from './routes/_authenticated/administration/route'
+import { Route as AuthenticatedAdministrationIndexRouteImport } from './routes/_authenticated/administration/index'
+import { Route as AuthenticatedAdministrationSettingsRouteImport } from './routes/_authenticated/administration/settings'
+import { Route as AuthenticatedAdministrationGroupsRouteImport } from './routes/_authenticated/administration/groups'
+import { Route as AuthenticatedAdministrationAdministratorsRouteImport } from './routes/_authenticated/administration/administrators'
+import { Route as AuthenticatedAdministrationUsersIndexRouteImport } from './routes/_authenticated/administration/users/index'
+import { Route as AuthenticatedAdministrationUsersUserIdRouteImport } from './routes/_authenticated/administration/users/$userId'
 
 const SetupRoute = SetupRouteImport.update({
   id: '/setup',
@@ -27,33 +34,125 @@ const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: '/_authenticated',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthenticatedAdministrationRouteRoute =
+  AuthenticatedAdministrationRouteRouteImport.update({
+    id: '/administration',
+    path: '/administration',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
+const AuthenticatedAdministrationIndexRoute =
+  AuthenticatedAdministrationIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedAdministrationRouteRoute,
+  } as any)
+const AuthenticatedAdministrationSettingsRoute =
+  AuthenticatedAdministrationSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => AuthenticatedAdministrationRouteRoute,
+  } as any)
+const AuthenticatedAdministrationGroupsRoute =
+  AuthenticatedAdministrationGroupsRouteImport.update({
+    id: '/groups',
+    path: '/groups',
+    getParentRoute: () => AuthenticatedAdministrationRouteRoute,
+  } as any)
+const AuthenticatedAdministrationAdministratorsRoute =
+  AuthenticatedAdministrationAdministratorsRouteImport.update({
+    id: '/administrators',
+    path: '/administrators',
+    getParentRoute: () => AuthenticatedAdministrationRouteRoute,
+  } as any)
+const AuthenticatedAdministrationUsersIndexRoute =
+  AuthenticatedAdministrationUsersIndexRouteImport.update({
+    id: '/users/',
+    path: '/users/',
+    getParentRoute: () => AuthenticatedAdministrationRouteRoute,
+  } as any)
+const AuthenticatedAdministrationUsersUserIdRoute =
+  AuthenticatedAdministrationUsersUserIdRouteImport.update({
+    id: '/users/$userId',
+    path: '/users/$userId',
+    getParentRoute: () => AuthenticatedAdministrationRouteRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof AuthenticatedRoute
+  '/': typeof AuthenticatedRouteWithChildren
   '/login': typeof LoginRoute
   '/setup': typeof SetupRoute
+  '/administration': typeof AuthenticatedAdministrationRouteRouteWithChildren
+  '/administration/administrators': typeof AuthenticatedAdministrationAdministratorsRoute
+  '/administration/groups': typeof AuthenticatedAdministrationGroupsRoute
+  '/administration/settings': typeof AuthenticatedAdministrationSettingsRoute
+  '/administration/': typeof AuthenticatedAdministrationIndexRoute
+  '/administration/users/$userId': typeof AuthenticatedAdministrationUsersUserIdRoute
+  '/administration/users/': typeof AuthenticatedAdministrationUsersIndexRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof AuthenticatedRoute
+  '/': typeof AuthenticatedRouteWithChildren
   '/login': typeof LoginRoute
   '/setup': typeof SetupRoute
+  '/administration/administrators': typeof AuthenticatedAdministrationAdministratorsRoute
+  '/administration/groups': typeof AuthenticatedAdministrationGroupsRoute
+  '/administration/settings': typeof AuthenticatedAdministrationSettingsRoute
+  '/administration': typeof AuthenticatedAdministrationIndexRoute
+  '/administration/users/$userId': typeof AuthenticatedAdministrationUsersUserIdRoute
+  '/administration/users': typeof AuthenticatedAdministrationUsersIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
-  '/_authenticated': typeof AuthenticatedRoute
+  '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/login': typeof LoginRoute
   '/setup': typeof SetupRoute
+  '/_authenticated/administration': typeof AuthenticatedAdministrationRouteRouteWithChildren
+  '/_authenticated/administration/administrators': typeof AuthenticatedAdministrationAdministratorsRoute
+  '/_authenticated/administration/groups': typeof AuthenticatedAdministrationGroupsRoute
+  '/_authenticated/administration/settings': typeof AuthenticatedAdministrationSettingsRoute
+  '/_authenticated/administration/': typeof AuthenticatedAdministrationIndexRoute
+  '/_authenticated/administration/users/$userId': typeof AuthenticatedAdministrationUsersUserIdRoute
+  '/_authenticated/administration/users/': typeof AuthenticatedAdministrationUsersIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/setup'
+  fullPaths:
+    | '/'
+    | '/login'
+    | '/setup'
+    | '/administration'
+    | '/administration/administrators'
+    | '/administration/groups'
+    | '/administration/settings'
+    | '/administration/'
+    | '/administration/users/$userId'
+    | '/administration/users/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/setup'
-  id: '__root__' | '/_authenticated' | '/login' | '/setup'
+  to:
+    | '/'
+    | '/login'
+    | '/setup'
+    | '/administration/administrators'
+    | '/administration/groups'
+    | '/administration/settings'
+    | '/administration'
+    | '/administration/users/$userId'
+    | '/administration/users'
+  id:
+    | '__root__'
+    | '/_authenticated'
+    | '/login'
+    | '/setup'
+    | '/_authenticated/administration'
+    | '/_authenticated/administration/administrators'
+    | '/_authenticated/administration/groups'
+    | '/_authenticated/administration/settings'
+    | '/_authenticated/administration/'
+    | '/_authenticated/administration/users/$userId'
+    | '/_authenticated/administration/users/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  AuthenticatedRoute: typeof AuthenticatedRoute
+  AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
   LoginRoute: typeof LoginRoute
   SetupRoute: typeof SetupRoute
 }
@@ -81,11 +180,103 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_authenticated/administration': {
+      id: '/_authenticated/administration'
+      path: '/administration'
+      fullPath: '/administration'
+      preLoaderRoute: typeof AuthenticatedAdministrationRouteRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/administration/': {
+      id: '/_authenticated/administration/'
+      path: '/'
+      fullPath: '/administration/'
+      preLoaderRoute: typeof AuthenticatedAdministrationIndexRouteImport
+      parentRoute: typeof AuthenticatedAdministrationRouteRoute
+    }
+    '/_authenticated/administration/settings': {
+      id: '/_authenticated/administration/settings'
+      path: '/settings'
+      fullPath: '/administration/settings'
+      preLoaderRoute: typeof AuthenticatedAdministrationSettingsRouteImport
+      parentRoute: typeof AuthenticatedAdministrationRouteRoute
+    }
+    '/_authenticated/administration/groups': {
+      id: '/_authenticated/administration/groups'
+      path: '/groups'
+      fullPath: '/administration/groups'
+      preLoaderRoute: typeof AuthenticatedAdministrationGroupsRouteImport
+      parentRoute: typeof AuthenticatedAdministrationRouteRoute
+    }
+    '/_authenticated/administration/administrators': {
+      id: '/_authenticated/administration/administrators'
+      path: '/administrators'
+      fullPath: '/administration/administrators'
+      preLoaderRoute: typeof AuthenticatedAdministrationAdministratorsRouteImport
+      parentRoute: typeof AuthenticatedAdministrationRouteRoute
+    }
+    '/_authenticated/administration/users/': {
+      id: '/_authenticated/administration/users/'
+      path: '/users'
+      fullPath: '/administration/users/'
+      preLoaderRoute: typeof AuthenticatedAdministrationUsersIndexRouteImport
+      parentRoute: typeof AuthenticatedAdministrationRouteRoute
+    }
+    '/_authenticated/administration/users/$userId': {
+      id: '/_authenticated/administration/users/$userId'
+      path: '/users/$userId'
+      fullPath: '/administration/users/$userId'
+      preLoaderRoute: typeof AuthenticatedAdministrationUsersUserIdRouteImport
+      parentRoute: typeof AuthenticatedAdministrationRouteRoute
+    }
   }
 }
 
+interface AuthenticatedAdministrationRouteRouteChildren {
+  AuthenticatedAdministrationAdministratorsRoute: typeof AuthenticatedAdministrationAdministratorsRoute
+  AuthenticatedAdministrationGroupsRoute: typeof AuthenticatedAdministrationGroupsRoute
+  AuthenticatedAdministrationSettingsRoute: typeof AuthenticatedAdministrationSettingsRoute
+  AuthenticatedAdministrationIndexRoute: typeof AuthenticatedAdministrationIndexRoute
+  AuthenticatedAdministrationUsersUserIdRoute: typeof AuthenticatedAdministrationUsersUserIdRoute
+  AuthenticatedAdministrationUsersIndexRoute: typeof AuthenticatedAdministrationUsersIndexRoute
+}
+
+const AuthenticatedAdministrationRouteRouteChildren: AuthenticatedAdministrationRouteRouteChildren =
+  {
+    AuthenticatedAdministrationAdministratorsRoute:
+      AuthenticatedAdministrationAdministratorsRoute,
+    AuthenticatedAdministrationGroupsRoute:
+      AuthenticatedAdministrationGroupsRoute,
+    AuthenticatedAdministrationSettingsRoute:
+      AuthenticatedAdministrationSettingsRoute,
+    AuthenticatedAdministrationIndexRoute:
+      AuthenticatedAdministrationIndexRoute,
+    AuthenticatedAdministrationUsersUserIdRoute:
+      AuthenticatedAdministrationUsersUserIdRoute,
+    AuthenticatedAdministrationUsersIndexRoute:
+      AuthenticatedAdministrationUsersIndexRoute,
+  }
+
+const AuthenticatedAdministrationRouteRouteWithChildren =
+  AuthenticatedAdministrationRouteRoute._addFileChildren(
+    AuthenticatedAdministrationRouteRouteChildren,
+  )
+
+interface AuthenticatedRouteChildren {
+  AuthenticatedAdministrationRouteRoute: typeof AuthenticatedAdministrationRouteRouteWithChildren
+}
+
+const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
+  AuthenticatedAdministrationRouteRoute:
+    AuthenticatedAdministrationRouteRouteWithChildren,
+}
+
+const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
+  AuthenticatedRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
-  AuthenticatedRoute: AuthenticatedRoute,
+  AuthenticatedRoute: AuthenticatedRouteWithChildren,
   LoginRoute: LoginRoute,
   SetupRoute: SetupRoute,
 }

--- a/src/routes/_authenticated/administration/administrators.tsx
+++ b/src/routes/_authenticated/administration/administrators.tsx
@@ -1,0 +1,14 @@
+import ManageAdministrators from "@administration/components/AdministratorList";
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+const searchSchema = z.object({
+	page: z.number().default(1).catch(1),
+});
+
+export const Route = createFileRoute(
+	"/_authenticated/administration/administrators",
+)({
+	validateSearch: searchSchema,
+	component: ManageAdministrators,
+});

--- a/src/routes/_authenticated/administration/groups.tsx
+++ b/src/routes/_authenticated/administration/groups.tsx
@@ -1,0 +1,12 @@
+import Groups from "@groups/components/Groups";
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+const searchSchema = z.object({
+	openCreateGroup: z.boolean().optional().catch(undefined),
+});
+
+export const Route = createFileRoute("/_authenticated/administration/groups")({
+	validateSearch: searchSchema,
+	component: Groups,
+});

--- a/src/routes/_authenticated/administration/index.tsx
+++ b/src/routes/_authenticated/administration/index.tsx
@@ -1,0 +1,21 @@
+import { fetchAccount } from "@account/api";
+import { accountKeys } from "@account/queries";
+import { hasSufficientAdminRole } from "@administration/utils";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/administration/")({
+	beforeLoad: async ({ context }) => {
+		const { queryClient } = context;
+
+		const account = await queryClient.ensureQueryData({
+			queryKey: accountKeys.all(),
+			queryFn: fetchAccount,
+		});
+
+		if (hasSufficientAdminRole("settings", account.administrator_role)) {
+			throw redirect({ to: "/administration/settings" });
+		}
+
+		throw redirect({ to: "/administration/users" });
+	},
+});

--- a/src/routes/_authenticated/administration/route.tsx
+++ b/src/routes/_authenticated/administration/route.tsx
@@ -1,0 +1,41 @@
+import { fetchAccount } from "@account/api";
+import { accountKeys, useFetchAccount } from "@account/queries";
+import AdministrationTabs from "@administration/components/AdministrationTabs";
+import { hasSufficientAdminRole } from "@administration/utils";
+import ContainerNarrow from "@base/ContainerNarrow";
+import ContainerWide from "@base/ContainerWide";
+import ViewHeader from "@base/ViewHeader";
+import ViewHeaderTitle from "@base/ViewHeaderTitle";
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/administration")({
+	beforeLoad: async ({ context }) => {
+		const { queryClient } = context;
+
+		const account = await queryClient.ensureQueryData({
+			queryKey: accountKeys.all(),
+			queryFn: fetchAccount,
+		});
+
+		if (!hasSufficientAdminRole("users", account.administrator_role)) {
+			throw redirect({ to: "/" });
+		}
+	},
+	component: AdministrationLayout,
+});
+
+function AdministrationLayout() {
+	const { data: account } = useFetchAccount();
+
+	return (
+		<ContainerWide>
+			<ViewHeader title="Administration">
+				<ViewHeaderTitle>Administration</ViewHeaderTitle>
+			</ViewHeader>
+			<AdministrationTabs administratorRole={account.administrator_role} />
+			<ContainerNarrow>
+				<Outlet />
+			</ContainerNarrow>
+		</ContainerWide>
+	);
+}

--- a/src/routes/_authenticated/administration/route.tsx
+++ b/src/routes/_authenticated/administration/route.tsx
@@ -1,5 +1,5 @@
 import { fetchAccount } from "@account/api";
-import { accountKeys, useFetchAccount } from "@account/queries";
+import { accountKeys } from "@account/queries";
 import AdministrationTabs from "@administration/components/AdministrationTabs";
 import { hasSufficientAdminRole } from "@administration/utils";
 import ContainerNarrow from "@base/ContainerNarrow";
@@ -20,12 +20,14 @@ export const Route = createFileRoute("/_authenticated/administration")({
 		if (!hasSufficientAdminRole("users", account.administrator_role)) {
 			throw redirect({ to: "/" });
 		}
+
+		return { account };
 	},
 	component: AdministrationLayout,
 });
 
 function AdministrationLayout() {
-	const { data: account } = useFetchAccount();
+	const { account } = Route.useRouteContext();
 
 	return (
 		<ContainerWide>

--- a/src/routes/_authenticated/administration/settings.tsx
+++ b/src/routes/_authenticated/administration/settings.tsx
@@ -1,0 +1,8 @@
+import ServerSettings from "@administration/components/ServerSettings";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/administration/settings")(
+	{
+		component: ServerSettings,
+	},
+);

--- a/src/routes/_authenticated/administration/users/$userId.tsx
+++ b/src/routes/_authenticated/administration/users/$userId.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from "@tanstack/react-router";
+import UserDetail from "@users/components/UserDetail";
+
+export const Route = createFileRoute(
+	"/_authenticated/administration/users/$userId",
+)({
+	component: UserDetail,
+});

--- a/src/routes/_authenticated/administration/users/index.tsx
+++ b/src/routes/_authenticated/administration/users/index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ManageUsers } from "@users/components/ManageUsers";
+import { z } from "zod";
+
+const searchSchema = z.object({
+	status: z.string().default("").catch(""),
+	page: z.number().default(1).catch(1),
+	openCreateUser: z.boolean().optional().catch(undefined),
+});
+
+export const Route = createFileRoute("/_authenticated/administration/users/")({
+	validateSearch: searchSchema,
+	component: ManageUsers,
+});

--- a/src/routes/_authenticated/administration/users/index.tsx
+++ b/src/routes/_authenticated/administration/users/index.tsx
@@ -3,7 +3,7 @@ import { ManageUsers } from "@users/components/ManageUsers";
 import { z } from "zod";
 
 const searchSchema = z.object({
-	status: z.string().default("").catch(""),
+	status: z.string().default("active").catch("active"),
 	page: z.number().default(1).catch(1),
 	openCreateUser: z.boolean().optional().catch(undefined),
 });


### PR DESCRIPTION
## Summary

- Adds TanStack Router file-based routes for all administration sub-routes (`/administration`, `/administration/settings`, `/administration/groups`, `/administration/administrators`, `/administration/users/`, `/administration/users/$userId`)
- Uses `beforeLoad` on the administration layout route to enforce role-based access — users without sufficient admin role are redirected to `/`; the index route redirects to the appropriate tab based on role
- Validates search params with Zod v4 schemas directly on `validateSearch` (no adapter needed) and updates `AGENTS.md` to document this pattern

## Test plan

- [ ] Visit `/administration` as an admin with full role — confirm redirect to `/administration/settings`
- [ ] Visit `/administration` as an admin with only `users` role — confirm redirect to `/administration/users`
- [ ] Visit `/administration` as a non-admin — confirm redirect to `/`
- [ ] Navigate between all administration tabs (Administrators, Groups, Settings, Users) and confirm each loads correctly
- [ ] Visit `/administration/users/$userId` with a valid user ID — confirm user detail loads
- [ ] Confirm search params (`page`, `status`, `openCreateUser`, `openCreateGroup`) are preserved and validated correctly