### PR TITLE
feat(samples): migrate samples routes to TanStack Router

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,21 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as SetupRouteImport } from './routes/setup'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
+import { Route as AuthenticatedSamplesRouteImport } from './routes/_authenticated/samples'
+import { Route as AuthenticatedSamplesIndexRouteImport } from './routes/_authenticated/samples/index'
+import { Route as AuthenticatedSamplesSettingsRouteImport } from './routes/_authenticated/samples/settings'
+import { Route as AuthenticatedSamplesLabelsRouteImport } from './routes/_authenticated/samples/labels'
+import { Route as AuthenticatedSamplesFilesRouteImport } from './routes/_authenticated/samples/files'
+import { Route as AuthenticatedSamplesCreateRouteImport } from './routes/_authenticated/samples/create'
+import { Route as AuthenticatedSamplesSampleIdRouteImport } from './routes/_authenticated/samples/$sampleId'
+import { Route as AuthenticatedSamplesSampleIdIndexRouteImport } from './routes/_authenticated/samples/$sampleId/index'
+import { Route as AuthenticatedSamplesSampleIdRightsRouteImport } from './routes/_authenticated/samples/$sampleId/rights'
+import { Route as AuthenticatedSamplesSampleIdQualityRouteImport } from './routes/_authenticated/samples/$sampleId/quality'
+import { Route as AuthenticatedSamplesSampleIdGeneralRouteImport } from './routes/_authenticated/samples/$sampleId/general'
+import { Route as AuthenticatedSamplesSampleIdFilesRouteImport } from './routes/_authenticated/samples/$sampleId/files'
+import { Route as AuthenticatedSamplesSampleIdAnalysesRouteImport } from './routes/_authenticated/samples/$sampleId/analyses'
+import { Route as AuthenticatedSamplesSampleIdAnalysesIndexRouteImport } from './routes/_authenticated/samples/$sampleId/analyses/index'
+import { Route as AuthenticatedSamplesSampleIdAnalysesAnalysisIdRouteImport } from './routes/_authenticated/samples/$sampleId/analyses/$analysisId'
 
 const SetupRoute = SetupRouteImport.update({
   id: '/setup',
@@ -27,33 +42,216 @@ const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: '/_authenticated',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthenticatedSamplesRoute = AuthenticatedSamplesRouteImport.update({
+  id: '/samples',
+  path: '/samples',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
+const AuthenticatedSamplesIndexRoute =
+  AuthenticatedSamplesIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedSamplesRoute,
+  } as any)
+const AuthenticatedSamplesSettingsRoute =
+  AuthenticatedSamplesSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => AuthenticatedSamplesRoute,
+  } as any)
+const AuthenticatedSamplesLabelsRoute =
+  AuthenticatedSamplesLabelsRouteImport.update({
+    id: '/labels',
+    path: '/labels',
+    getParentRoute: () => AuthenticatedSamplesRoute,
+  } as any)
+const AuthenticatedSamplesFilesRoute =
+  AuthenticatedSamplesFilesRouteImport.update({
+    id: '/files',
+    path: '/files',
+    getParentRoute: () => AuthenticatedSamplesRoute,
+  } as any)
+const AuthenticatedSamplesCreateRoute =
+  AuthenticatedSamplesCreateRouteImport.update({
+    id: '/create',
+    path: '/create',
+    getParentRoute: () => AuthenticatedSamplesRoute,
+  } as any)
+const AuthenticatedSamplesSampleIdRoute =
+  AuthenticatedSamplesSampleIdRouteImport.update({
+    id: '/$sampleId',
+    path: '/$sampleId',
+    getParentRoute: () => AuthenticatedSamplesRoute,
+  } as any)
+const AuthenticatedSamplesSampleIdIndexRoute =
+  AuthenticatedSamplesSampleIdIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedSamplesSampleIdRoute,
+  } as any)
+const AuthenticatedSamplesSampleIdRightsRoute =
+  AuthenticatedSamplesSampleIdRightsRouteImport.update({
+    id: '/rights',
+    path: '/rights',
+    getParentRoute: () => AuthenticatedSamplesSampleIdRoute,
+  } as any)
+const AuthenticatedSamplesSampleIdQualityRoute =
+  AuthenticatedSamplesSampleIdQualityRouteImport.update({
+    id: '/quality',
+    path: '/quality',
+    getParentRoute: () => AuthenticatedSamplesSampleIdRoute,
+  } as any)
+const AuthenticatedSamplesSampleIdGeneralRoute =
+  AuthenticatedSamplesSampleIdGeneralRouteImport.update({
+    id: '/general',
+    path: '/general',
+    getParentRoute: () => AuthenticatedSamplesSampleIdRoute,
+  } as any)
+const AuthenticatedSamplesSampleIdFilesRoute =
+  AuthenticatedSamplesSampleIdFilesRouteImport.update({
+    id: '/files',
+    path: '/files',
+    getParentRoute: () => AuthenticatedSamplesSampleIdRoute,
+  } as any)
+const AuthenticatedSamplesSampleIdAnalysesRoute =
+  AuthenticatedSamplesSampleIdAnalysesRouteImport.update({
+    id: '/analyses',
+    path: '/analyses',
+    getParentRoute: () => AuthenticatedSamplesSampleIdRoute,
+  } as any)
+const AuthenticatedSamplesSampleIdAnalysesIndexRoute =
+  AuthenticatedSamplesSampleIdAnalysesIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedSamplesSampleIdAnalysesRoute,
+  } as any)
+const AuthenticatedSamplesSampleIdAnalysesAnalysisIdRoute =
+  AuthenticatedSamplesSampleIdAnalysesAnalysisIdRouteImport.update({
+    id: '/$analysisId',
+    path: '/$analysisId',
+    getParentRoute: () => AuthenticatedSamplesSampleIdAnalysesRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof AuthenticatedRoute
+  '/': typeof AuthenticatedRouteWithChildren
   '/login': typeof LoginRoute
   '/setup': typeof SetupRoute
+  '/samples': typeof AuthenticatedSamplesRouteWithChildren
+  '/samples/$sampleId': typeof AuthenticatedSamplesSampleIdRouteWithChildren
+  '/samples/create': typeof AuthenticatedSamplesCreateRoute
+  '/samples/files': typeof AuthenticatedSamplesFilesRoute
+  '/samples/labels': typeof AuthenticatedSamplesLabelsRoute
+  '/samples/settings': typeof AuthenticatedSamplesSettingsRoute
+  '/samples/': typeof AuthenticatedSamplesIndexRoute
+  '/samples/$sampleId/analyses': typeof AuthenticatedSamplesSampleIdAnalysesRouteWithChildren
+  '/samples/$sampleId/files': typeof AuthenticatedSamplesSampleIdFilesRoute
+  '/samples/$sampleId/general': typeof AuthenticatedSamplesSampleIdGeneralRoute
+  '/samples/$sampleId/quality': typeof AuthenticatedSamplesSampleIdQualityRoute
+  '/samples/$sampleId/rights': typeof AuthenticatedSamplesSampleIdRightsRoute
+  '/samples/$sampleId/': typeof AuthenticatedSamplesSampleIdIndexRoute
+  '/samples/$sampleId/analyses/$analysisId': typeof AuthenticatedSamplesSampleIdAnalysesAnalysisIdRoute
+  '/samples/$sampleId/analyses/': typeof AuthenticatedSamplesSampleIdAnalysesIndexRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof AuthenticatedRoute
+  '/': typeof AuthenticatedRouteWithChildren
   '/login': typeof LoginRoute
   '/setup': typeof SetupRoute
+  '/samples/create': typeof AuthenticatedSamplesCreateRoute
+  '/samples/files': typeof AuthenticatedSamplesFilesRoute
+  '/samples/labels': typeof AuthenticatedSamplesLabelsRoute
+  '/samples/settings': typeof AuthenticatedSamplesSettingsRoute
+  '/samples': typeof AuthenticatedSamplesIndexRoute
+  '/samples/$sampleId/files': typeof AuthenticatedSamplesSampleIdFilesRoute
+  '/samples/$sampleId/general': typeof AuthenticatedSamplesSampleIdGeneralRoute
+  '/samples/$sampleId/quality': typeof AuthenticatedSamplesSampleIdQualityRoute
+  '/samples/$sampleId/rights': typeof AuthenticatedSamplesSampleIdRightsRoute
+  '/samples/$sampleId': typeof AuthenticatedSamplesSampleIdIndexRoute
+  '/samples/$sampleId/analyses/$analysisId': typeof AuthenticatedSamplesSampleIdAnalysesAnalysisIdRoute
+  '/samples/$sampleId/analyses': typeof AuthenticatedSamplesSampleIdAnalysesIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
-  '/_authenticated': typeof AuthenticatedRoute
+  '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/login': typeof LoginRoute
   '/setup': typeof SetupRoute
+  '/_authenticated/samples': typeof AuthenticatedSamplesRouteWithChildren
+  '/_authenticated/samples/$sampleId': typeof AuthenticatedSamplesSampleIdRouteWithChildren
+  '/_authenticated/samples/create': typeof AuthenticatedSamplesCreateRoute
+  '/_authenticated/samples/files': typeof AuthenticatedSamplesFilesRoute
+  '/_authenticated/samples/labels': typeof AuthenticatedSamplesLabelsRoute
+  '/_authenticated/samples/settings': typeof AuthenticatedSamplesSettingsRoute
+  '/_authenticated/samples/': typeof AuthenticatedSamplesIndexRoute
+  '/_authenticated/samples/$sampleId/analyses': typeof AuthenticatedSamplesSampleIdAnalysesRouteWithChildren
+  '/_authenticated/samples/$sampleId/files': typeof AuthenticatedSamplesSampleIdFilesRoute
+  '/_authenticated/samples/$sampleId/general': typeof AuthenticatedSamplesSampleIdGeneralRoute
+  '/_authenticated/samples/$sampleId/quality': typeof AuthenticatedSamplesSampleIdQualityRoute
+  '/_authenticated/samples/$sampleId/rights': typeof AuthenticatedSamplesSampleIdRightsRoute
+  '/_authenticated/samples/$sampleId/': typeof AuthenticatedSamplesSampleIdIndexRoute
+  '/_authenticated/samples/$sampleId/analyses/$analysisId': typeof AuthenticatedSamplesSampleIdAnalysesAnalysisIdRoute
+  '/_authenticated/samples/$sampleId/analyses/': typeof AuthenticatedSamplesSampleIdAnalysesIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/setup'
+  fullPaths:
+    | '/'
+    | '/login'
+    | '/setup'
+    | '/samples'
+    | '/samples/$sampleId'
+    | '/samples/create'
+    | '/samples/files'
+    | '/samples/labels'
+    | '/samples/settings'
+    | '/samples/'
+    | '/samples/$sampleId/analyses'
+    | '/samples/$sampleId/files'
+    | '/samples/$sampleId/general'
+    | '/samples/$sampleId/quality'
+    | '/samples/$sampleId/rights'
+    | '/samples/$sampleId/'
+    | '/samples/$sampleId/analyses/$analysisId'
+    | '/samples/$sampleId/analyses/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/setup'
-  id: '__root__' | '/_authenticated' | '/login' | '/setup'
+  to:
+    | '/'
+    | '/login'
+    | '/setup'
+    | '/samples/create'
+    | '/samples/files'
+    | '/samples/labels'
+    | '/samples/settings'
+    | '/samples'
+    | '/samples/$sampleId/files'
+    | '/samples/$sampleId/general'
+    | '/samples/$sampleId/quality'
+    | '/samples/$sampleId/rights'
+    | '/samples/$sampleId'
+    | '/samples/$sampleId/analyses/$analysisId'
+    | '/samples/$sampleId/analyses'
+  id:
+    | '__root__'
+    | '/_authenticated'
+    | '/login'
+    | '/setup'
+    | '/_authenticated/samples'
+    | '/_authenticated/samples/$sampleId'
+    | '/_authenticated/samples/create'
+    | '/_authenticated/samples/files'
+    | '/_authenticated/samples/labels'
+    | '/_authenticated/samples/settings'
+    | '/_authenticated/samples/'
+    | '/_authenticated/samples/$sampleId/analyses'
+    | '/_authenticated/samples/$sampleId/files'
+    | '/_authenticated/samples/$sampleId/general'
+    | '/_authenticated/samples/$sampleId/quality'
+    | '/_authenticated/samples/$sampleId/rights'
+    | '/_authenticated/samples/$sampleId/'
+    | '/_authenticated/samples/$sampleId/analyses/$analysisId'
+    | '/_authenticated/samples/$sampleId/analyses/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  AuthenticatedRoute: typeof AuthenticatedRoute
+  AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
   LoginRoute: typeof LoginRoute
   SetupRoute: typeof SetupRoute
 }
@@ -81,11 +279,198 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_authenticated/samples': {
+      id: '/_authenticated/samples'
+      path: '/samples'
+      fullPath: '/samples'
+      preLoaderRoute: typeof AuthenticatedSamplesRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/samples/': {
+      id: '/_authenticated/samples/'
+      path: '/'
+      fullPath: '/samples/'
+      preLoaderRoute: typeof AuthenticatedSamplesIndexRouteImport
+      parentRoute: typeof AuthenticatedSamplesRoute
+    }
+    '/_authenticated/samples/settings': {
+      id: '/_authenticated/samples/settings'
+      path: '/settings'
+      fullPath: '/samples/settings'
+      preLoaderRoute: typeof AuthenticatedSamplesSettingsRouteImport
+      parentRoute: typeof AuthenticatedSamplesRoute
+    }
+    '/_authenticated/samples/labels': {
+      id: '/_authenticated/samples/labels'
+      path: '/labels'
+      fullPath: '/samples/labels'
+      preLoaderRoute: typeof AuthenticatedSamplesLabelsRouteImport
+      parentRoute: typeof AuthenticatedSamplesRoute
+    }
+    '/_authenticated/samples/files': {
+      id: '/_authenticated/samples/files'
+      path: '/files'
+      fullPath: '/samples/files'
+      preLoaderRoute: typeof AuthenticatedSamplesFilesRouteImport
+      parentRoute: typeof AuthenticatedSamplesRoute
+    }
+    '/_authenticated/samples/create': {
+      id: '/_authenticated/samples/create'
+      path: '/create'
+      fullPath: '/samples/create'
+      preLoaderRoute: typeof AuthenticatedSamplesCreateRouteImport
+      parentRoute: typeof AuthenticatedSamplesRoute
+    }
+    '/_authenticated/samples/$sampleId': {
+      id: '/_authenticated/samples/$sampleId'
+      path: '/$sampleId'
+      fullPath: '/samples/$sampleId'
+      preLoaderRoute: typeof AuthenticatedSamplesSampleIdRouteImport
+      parentRoute: typeof AuthenticatedSamplesRoute
+    }
+    '/_authenticated/samples/$sampleId/': {
+      id: '/_authenticated/samples/$sampleId/'
+      path: '/'
+      fullPath: '/samples/$sampleId/'
+      preLoaderRoute: typeof AuthenticatedSamplesSampleIdIndexRouteImport
+      parentRoute: typeof AuthenticatedSamplesSampleIdRoute
+    }
+    '/_authenticated/samples/$sampleId/rights': {
+      id: '/_authenticated/samples/$sampleId/rights'
+      path: '/rights'
+      fullPath: '/samples/$sampleId/rights'
+      preLoaderRoute: typeof AuthenticatedSamplesSampleIdRightsRouteImport
+      parentRoute: typeof AuthenticatedSamplesSampleIdRoute
+    }
+    '/_authenticated/samples/$sampleId/quality': {
+      id: '/_authenticated/samples/$sampleId/quality'
+      path: '/quality'
+      fullPath: '/samples/$sampleId/quality'
+      preLoaderRoute: typeof AuthenticatedSamplesSampleIdQualityRouteImport
+      parentRoute: typeof AuthenticatedSamplesSampleIdRoute
+    }
+    '/_authenticated/samples/$sampleId/general': {
+      id: '/_authenticated/samples/$sampleId/general'
+      path: '/general'
+      fullPath: '/samples/$sampleId/general'
+      preLoaderRoute: typeof AuthenticatedSamplesSampleIdGeneralRouteImport
+      parentRoute: typeof AuthenticatedSamplesSampleIdRoute
+    }
+    '/_authenticated/samples/$sampleId/files': {
+      id: '/_authenticated/samples/$sampleId/files'
+      path: '/files'
+      fullPath: '/samples/$sampleId/files'
+      preLoaderRoute: typeof AuthenticatedSamplesSampleIdFilesRouteImport
+      parentRoute: typeof AuthenticatedSamplesSampleIdRoute
+    }
+    '/_authenticated/samples/$sampleId/analyses': {
+      id: '/_authenticated/samples/$sampleId/analyses'
+      path: '/analyses'
+      fullPath: '/samples/$sampleId/analyses'
+      preLoaderRoute: typeof AuthenticatedSamplesSampleIdAnalysesRouteImport
+      parentRoute: typeof AuthenticatedSamplesSampleIdRoute
+    }
+    '/_authenticated/samples/$sampleId/analyses/': {
+      id: '/_authenticated/samples/$sampleId/analyses/'
+      path: '/'
+      fullPath: '/samples/$sampleId/analyses/'
+      preLoaderRoute: typeof AuthenticatedSamplesSampleIdAnalysesIndexRouteImport
+      parentRoute: typeof AuthenticatedSamplesSampleIdAnalysesRoute
+    }
+    '/_authenticated/samples/$sampleId/analyses/$analysisId': {
+      id: '/_authenticated/samples/$sampleId/analyses/$analysisId'
+      path: '/$analysisId'
+      fullPath: '/samples/$sampleId/analyses/$analysisId'
+      preLoaderRoute: typeof AuthenticatedSamplesSampleIdAnalysesAnalysisIdRouteImport
+      parentRoute: typeof AuthenticatedSamplesSampleIdAnalysesRoute
+    }
   }
 }
 
+interface AuthenticatedSamplesSampleIdAnalysesRouteChildren {
+  AuthenticatedSamplesSampleIdAnalysesAnalysisIdRoute: typeof AuthenticatedSamplesSampleIdAnalysesAnalysisIdRoute
+  AuthenticatedSamplesSampleIdAnalysesIndexRoute: typeof AuthenticatedSamplesSampleIdAnalysesIndexRoute
+}
+
+const AuthenticatedSamplesSampleIdAnalysesRouteChildren: AuthenticatedSamplesSampleIdAnalysesRouteChildren =
+  {
+    AuthenticatedSamplesSampleIdAnalysesAnalysisIdRoute:
+      AuthenticatedSamplesSampleIdAnalysesAnalysisIdRoute,
+    AuthenticatedSamplesSampleIdAnalysesIndexRoute:
+      AuthenticatedSamplesSampleIdAnalysesIndexRoute,
+  }
+
+const AuthenticatedSamplesSampleIdAnalysesRouteWithChildren =
+  AuthenticatedSamplesSampleIdAnalysesRoute._addFileChildren(
+    AuthenticatedSamplesSampleIdAnalysesRouteChildren,
+  )
+
+interface AuthenticatedSamplesSampleIdRouteChildren {
+  AuthenticatedSamplesSampleIdAnalysesRoute: typeof AuthenticatedSamplesSampleIdAnalysesRouteWithChildren
+  AuthenticatedSamplesSampleIdFilesRoute: typeof AuthenticatedSamplesSampleIdFilesRoute
+  AuthenticatedSamplesSampleIdGeneralRoute: typeof AuthenticatedSamplesSampleIdGeneralRoute
+  AuthenticatedSamplesSampleIdQualityRoute: typeof AuthenticatedSamplesSampleIdQualityRoute
+  AuthenticatedSamplesSampleIdRightsRoute: typeof AuthenticatedSamplesSampleIdRightsRoute
+  AuthenticatedSamplesSampleIdIndexRoute: typeof AuthenticatedSamplesSampleIdIndexRoute
+}
+
+const AuthenticatedSamplesSampleIdRouteChildren: AuthenticatedSamplesSampleIdRouteChildren =
+  {
+    AuthenticatedSamplesSampleIdAnalysesRoute:
+      AuthenticatedSamplesSampleIdAnalysesRouteWithChildren,
+    AuthenticatedSamplesSampleIdFilesRoute:
+      AuthenticatedSamplesSampleIdFilesRoute,
+    AuthenticatedSamplesSampleIdGeneralRoute:
+      AuthenticatedSamplesSampleIdGeneralRoute,
+    AuthenticatedSamplesSampleIdQualityRoute:
+      AuthenticatedSamplesSampleIdQualityRoute,
+    AuthenticatedSamplesSampleIdRightsRoute:
+      AuthenticatedSamplesSampleIdRightsRoute,
+    AuthenticatedSamplesSampleIdIndexRoute:
+      AuthenticatedSamplesSampleIdIndexRoute,
+  }
+
+const AuthenticatedSamplesSampleIdRouteWithChildren =
+  AuthenticatedSamplesSampleIdRoute._addFileChildren(
+    AuthenticatedSamplesSampleIdRouteChildren,
+  )
+
+interface AuthenticatedSamplesRouteChildren {
+  AuthenticatedSamplesSampleIdRoute: typeof AuthenticatedSamplesSampleIdRouteWithChildren
+  AuthenticatedSamplesCreateRoute: typeof AuthenticatedSamplesCreateRoute
+  AuthenticatedSamplesFilesRoute: typeof AuthenticatedSamplesFilesRoute
+  AuthenticatedSamplesLabelsRoute: typeof AuthenticatedSamplesLabelsRoute
+  AuthenticatedSamplesSettingsRoute: typeof AuthenticatedSamplesSettingsRoute
+  AuthenticatedSamplesIndexRoute: typeof AuthenticatedSamplesIndexRoute
+}
+
+const AuthenticatedSamplesRouteChildren: AuthenticatedSamplesRouteChildren = {
+  AuthenticatedSamplesSampleIdRoute:
+    AuthenticatedSamplesSampleIdRouteWithChildren,
+  AuthenticatedSamplesCreateRoute: AuthenticatedSamplesCreateRoute,
+  AuthenticatedSamplesFilesRoute: AuthenticatedSamplesFilesRoute,
+  AuthenticatedSamplesLabelsRoute: AuthenticatedSamplesLabelsRoute,
+  AuthenticatedSamplesSettingsRoute: AuthenticatedSamplesSettingsRoute,
+  AuthenticatedSamplesIndexRoute: AuthenticatedSamplesIndexRoute,
+}
+
+const AuthenticatedSamplesRouteWithChildren =
+  AuthenticatedSamplesRoute._addFileChildren(AuthenticatedSamplesRouteChildren)
+
+interface AuthenticatedRouteChildren {
+  AuthenticatedSamplesRoute: typeof AuthenticatedSamplesRouteWithChildren
+}
+
+const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
+  AuthenticatedSamplesRoute: AuthenticatedSamplesRouteWithChildren,
+}
+
+const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
+  AuthenticatedRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
-  AuthenticatedRoute: AuthenticatedRoute,
+  AuthenticatedRoute: AuthenticatedRouteWithChildren,
   LoginRoute: LoginRoute,
   SetupRoute: SetupRoute,
 }

--- a/src/routes/_authenticated/samples.tsx
+++ b/src/routes/_authenticated/samples.tsx
@@ -1,0 +1,14 @@
+import Container from "@base/Container";
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/samples")({
+	component: SamplesLayout,
+});
+
+function SamplesLayout() {
+	return (
+		<Container>
+			<Outlet />
+		</Container>
+	);
+}

--- a/src/routes/_authenticated/samples/$sampleId.tsx
+++ b/src/routes/_authenticated/samples/$sampleId.tsx
@@ -1,0 +1,25 @@
+import { sampleQueryOptions } from "@samples/queries";
+import { createFileRoute, notFound, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/samples/$sampleId")({
+	loader: async ({ context: { queryClient }, params: { sampleId } }) => {
+		try {
+			await queryClient.ensureQueryData(sampleQueryOptions(sampleId));
+		} catch (error) {
+			if (
+				error != null &&
+				typeof error === "object" &&
+				"response" in error &&
+				(error as { response: { status: number } }).response.status === 404
+			) {
+				throw notFound();
+			}
+			throw error;
+		}
+	},
+	component: SampleDetailLayout,
+});
+
+function SampleDetailLayout() {
+	return <Outlet />;
+}

--- a/src/routes/_authenticated/samples/$sampleId/analyses.tsx
+++ b/src/routes/_authenticated/samples/$sampleId/analyses.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute(
+	"/_authenticated/samples/$sampleId/analyses",
+)({
+	component: AnalysesLayout,
+});
+
+function AnalysesLayout() {
+	return <Outlet />;
+}

--- a/src/routes/_authenticated/samples/$sampleId/analyses/$analysisId.tsx
+++ b/src/routes/_authenticated/samples/$sampleId/analyses/$analysisId.tsx
@@ -1,0 +1,8 @@
+import AnalysisDetail from "@analyses/components/AnalysisDetail";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute(
+	"/_authenticated/samples/$sampleId/analyses/$analysisId",
+)({
+	component: AnalysisDetail,
+});

--- a/src/routes/_authenticated/samples/$sampleId/analyses/index.tsx
+++ b/src/routes/_authenticated/samples/$sampleId/analyses/index.tsx
@@ -1,0 +1,8 @@
+import AnalysesList from "@analyses/components/AnalysisList";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute(
+	"/_authenticated/samples/$sampleId/analyses/",
+)({
+	component: AnalysesList,
+});

--- a/src/routes/_authenticated/samples/$sampleId/files.tsx
+++ b/src/routes/_authenticated/samples/$sampleId/files.tsx
@@ -1,0 +1,8 @@
+import SampleDetailFiles from "@samples/components/Files/SampleDetailFiles";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/samples/$sampleId/files")(
+	{
+		component: SampleDetailFiles,
+	},
+);

--- a/src/routes/_authenticated/samples/$sampleId/general.tsx
+++ b/src/routes/_authenticated/samples/$sampleId/general.tsx
@@ -1,0 +1,8 @@
+import SampleDetailGeneral from "@samples/components/Detail/SampleDetailGeneral";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute(
+	"/_authenticated/samples/$sampleId/general",
+)({
+	component: SampleDetailGeneral,
+});

--- a/src/routes/_authenticated/samples/$sampleId/index.tsx
+++ b/src/routes/_authenticated/samples/$sampleId/index.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/samples/$sampleId/")({
+	beforeLoad: ({ params }) => {
+		throw redirect({
+			to: "/samples/$sampleId/general",
+			params: true,
+		});
+	},
+});

--- a/src/routes/_authenticated/samples/$sampleId/quality.tsx
+++ b/src/routes/_authenticated/samples/$sampleId/quality.tsx
@@ -1,0 +1,8 @@
+import Quality from "@samples/components/SampleQuality";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute(
+	"/_authenticated/samples/$sampleId/quality",
+)({
+	component: Quality,
+});

--- a/src/routes/_authenticated/samples/$sampleId/rights.tsx
+++ b/src/routes/_authenticated/samples/$sampleId/rights.tsx
@@ -1,0 +1,8 @@
+import Rights from "@samples/components/Detail/SampleRights";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute(
+	"/_authenticated/samples/$sampleId/rights",
+)({
+	component: Rights,
+});

--- a/src/routes/_authenticated/samples/create.tsx
+++ b/src/routes/_authenticated/samples/create.tsx
@@ -1,0 +1,6 @@
+import CreateSample from "@samples/components/Create/CreateSample";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/samples/create")({
+	component: CreateSample,
+});

--- a/src/routes/_authenticated/samples/files.tsx
+++ b/src/routes/_authenticated/samples/files.tsx
@@ -1,0 +1,6 @@
+import SampleFileManager from "@samples/components/SampleFileManager";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/samples/files")({
+	component: SampleFileManager,
+});

--- a/src/routes/_authenticated/samples/index.tsx
+++ b/src/routes/_authenticated/samples/index.tsx
@@ -1,0 +1,6 @@
+import SamplesList from "@samples/components/SamplesList";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/samples/")({
+	component: SamplesList,
+});

--- a/src/routes/_authenticated/samples/labels.tsx
+++ b/src/routes/_authenticated/samples/labels.tsx
@@ -1,0 +1,6 @@
+import { Labels } from "@labels/components/Labels";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/samples/labels")({
+	component: Labels,
+});

--- a/src/routes/_authenticated/samples/settings.tsx
+++ b/src/routes/_authenticated/samples/settings.tsx
@@ -1,0 +1,6 @@
+import SamplesSettings from "@samples/components/SampleSettings";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_authenticated/samples/settings")({
+	component: SamplesSettings,
+});

--- a/src/samples/components/SampleFileManager.tsx
+++ b/src/samples/components/SampleFileManager.tsx
@@ -1,5 +1,5 @@
 import ContainerNarrow from "@base/ContainerNarrow";
-import { FileManager } from "@/uploads/components/FileManager";
+import { FileManager } from "@uploads/components/FileManager";
 
 export default function SampleFileManager() {
 	return (

--- a/src/samples/components/SampleFileManager.tsx
+++ b/src/samples/components/SampleFileManager.tsx
@@ -1,0 +1,27 @@
+import ContainerNarrow from "@base/ContainerNarrow";
+import { FileManager } from "@/uploads/components/FileManager";
+
+export default function SampleFileManager() {
+	return (
+		<ContainerNarrow>
+			<FileManager
+				accept={{
+					"application/gzip": [".fasta.gz", ".fa.gz", ".fastq.gz", ".fq.gz"],
+					"text/plain": [".fasta", ".fa", ".fastq", ".fq"],
+				}}
+				fileType="reads"
+				message={
+					<div className="flex flex-col gap-1 items-center">
+						<span className="font-medium text-lg">
+							Drag files here to upload
+						</span>
+						<span className="text-gray-600">
+							Supports plain or gzipped FASTA and FASTQ
+						</span>
+					</div>
+				}
+				regex={/\.f(ast)?q(\.gz)?$/}
+			/>
+		</ContainerNarrow>
+	);
+}

--- a/src/samples/components/Samples.tsx
+++ b/src/samples/components/Samples.tsx
@@ -1,44 +1,12 @@
 import Container from "@base/Container";
-import ContainerNarrow from "@base/ContainerNarrow";
 import { Labels } from "@labels/components/Labels";
 import { Route, Switch } from "wouter";
-import { FileManager } from "@/uploads/components/FileManager";
 import CreateSample from "./Create/CreateSample";
 import SampleDetail from "./Detail/SampleDetail";
+import SampleFileManager from "./SampleFileManager";
 import SamplesSettings from "./SampleSettings";
 import SamplesList from "./SamplesList";
 
-/**
- * Displays the file manager for samples allowing users to upload/delete uploads
- */
-function SampleFileManager() {
-	return (
-		<ContainerNarrow>
-			<FileManager
-				accept={{
-					"application/gzip": [".fasta.gz", ".fa.gz", ".fastq.gz", ".fq.gz"],
-					"text/plain": [".fasta", ".fa", ".fastq", ".fq"],
-				}}
-				fileType="reads"
-				message={
-					<div className="flex flex-col gap-1 items-center">
-						<span className="font-medium text-lg">
-							Drag files here to upload
-						</span>
-						<span className="text-gray-600">
-							Supports plain or gzipped FASTA and FASTQ
-						</span>
-					</div>
-				}
-				regex={/\.f(ast)?q(\.gz)?$/}
-			/>
-		</ContainerNarrow>
-	);
-}
-
-/**
- * The samples view with routes to sample-related components
- */
 export default function Samples() {
 	return (
 		<Container>

--- a/src/samples/queries.ts
+++ b/src/samples/queries.ts
@@ -62,7 +62,7 @@ export function useListSamples(
 }
 
 export function sampleQueryOptions(sampleId: string) {
-	return queryOptions({
+	return queryOptions<Sample, ErrorResponse>({
 		queryKey: samplesQueryKeys.detail(sampleId),
 		queryFn: () => getSample(sampleId),
 	});

--- a/src/samples/queries.ts
+++ b/src/samples/queries.ts
@@ -1,6 +1,7 @@
 import type { Label } from "@labels/types";
 import {
 	keepPreviousData,
+	queryOptions,
 	useMutation,
 	useQuery,
 	useQueryClient,
@@ -60,17 +61,15 @@ export function useListSamples(
 	});
 }
 
-/**
- * Fetches a single sample
- *
- * @param sampleId - The id of the sample to fetch
- * @returns A single sample
- */
-export function useFetchSample(sampleId: string) {
-	return useQuery<Sample, ErrorResponse>({
+export function sampleQueryOptions(sampleId: string) {
+	return queryOptions({
 		queryKey: samplesQueryKeys.detail(sampleId),
 		queryFn: () => getSample(sampleId),
 	});
+}
+
+export function useFetchSample(sampleId: string) {
+	return useQuery(sampleQueryOptions(sampleId));
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds TanStack file-based route definitions for all samples routes under `src/routes/_authenticated/samples/`, including the sample list, create, labels, settings, files, and all sample-detail sub-routes (general, quality, rights, files, analyses, and analysis detail)
- Extracts `sampleQueryOptions` from `useFetchSample` so the `$sampleId` route loader can prefetch the sample and throw a typed `notFound()` on 404
- Extracts `SampleFileManager` into its own file so it can be imported by both the new TanStack route and the existing wouter-based `Samples.tsx` without duplication