### PR TITLE
chore: migrate analyses routes to TanStack Router with detail loader

### DIFF
--- a/src/analyses/components/AnalysisDetail.tsx
+++ b/src/analyses/components/AnalysisDetail.tsx
@@ -3,7 +3,6 @@ import { usePathParams } from "@app/hooks";
 import { getWorkflowDisplayName } from "@app/utils";
 import Box from "@base/Box";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
-import NotFound from "@base/NotFound";
 import RelativeTime from "@base/RelativeTime";
 import SubviewHeader from "@base/SubviewHeader";
 import SubviewHeaderAttribution from "@base/SubviewHeaderAttribution";
@@ -25,12 +24,8 @@ export default function AnalysisDetail() {
 		analysisId: string;
 		sampleId: string;
 	}>();
-	const { data: analysis, isPending, error } = useGetAnalysis(analysisId);
+	const { data: analysis, isPending } = useGetAnalysis(analysisId);
 	const { data: sample, isPending: isPendingSample } = useFetchSample(sampleId);
-
-	if (error?.response.status === 404) {
-		return <NotFound />;
-	}
 
 	if (isPending || isPendingSample) {
 		return <LoadingPlaceholder />;

--- a/src/analyses/components/Iimi/IimiToolbar.tsx
+++ b/src/analyses/components/Iimi/IimiToolbar.tsx
@@ -1,5 +1,5 @@
 import { AnalysisViewerSort } from "@analyses/components/Viewer/Sort";
-import { useUrlSearchParam } from "@app/hooks";
+import { useUrlSearchParam } from "@app/hooks.tanstack";
 import InputSearch from "@base/InputSearch";
 import InputSimple from "@base/InputSimple";
 import Toolbar from "@base/Toolbar";

--- a/src/analyses/components/Iimi/IimiViewer.tsx
+++ b/src/analyses/components/Iimi/IimiViewer.tsx
@@ -1,6 +1,6 @@
 import type { FormattedIimiAnalysis, FormattedIimiHit } from "@analyses/types";
 import { useFuse } from "@app/fuse";
-import { useUrlSearchParam } from "@app/hooks";
+import { useUrlSearchParam } from "@app/hooks.tanstack";
 import Accordion from "@base/Accordion";
 import Box from "@base/Box";
 import { orderBy } from "es-toolkit";

--- a/src/analyses/components/Iimi/__tests__/IimiViewer.test.tsx
+++ b/src/analyses/components/Iimi/__tests__/IimiViewer.test.tsx
@@ -1,10 +1,54 @@
-import { screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+	createMemoryHistory,
+	createRootRoute,
+	createRoute,
+	createRouter,
+	RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeIimiAnalysis } from "@tests/fake/analyses";
-import { renderWithRouter } from "@tests/setup";
 import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod/v4";
 import { formatData } from "../../../utils";
 import { IimiViewer } from "../IimiViewer";
+
+const iimiSearchSchema = z.object({
+	find: z.string().optional().catch(undefined),
+	sort: z.string().optional().catch(undefined),
+	minProbability: z.string().optional().catch(undefined),
+});
+
+async function renderWithAnalysisRoute(ui: React.ReactElement, search = "") {
+	const rootRoute = createRootRoute();
+	const testRoute = createRoute({
+		getParentRoute: () => rootRoute,
+		path: "/",
+		validateSearch: iimiSearchSchema,
+		component: () => ui,
+	});
+	rootRoute.addChildren([testRoute]);
+
+	const queryClient = new QueryClient();
+
+	// @ts-expect-error createRouter requires strictNullChecks which is not enabled project-wide
+	const router = createRouter({
+		routeTree: rootRoute,
+		history: createMemoryHistory({
+			initialEntries: [`/${search}`],
+		}),
+		defaultPendingMinMs: 0,
+	});
+
+	await router.load();
+
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<RouterProvider router={router} />
+		</QueryClientProvider>,
+	);
+}
 
 describe("<IimiViewer />", () => {
 	let formattedIimiAnalysis;
@@ -17,7 +61,6 @@ describe("<IimiViewer />", () => {
 			workflow: "iimi",
 		});
 
-		// Define three hits with known values for testing
 		predefinedHits = [
 			{
 				...formattedIimiAnalysis.results.hits[0],
@@ -47,7 +90,9 @@ describe("<IimiViewer />", () => {
 	});
 
 	it("should render", async () => {
-		renderWithRouter(<IimiViewer detail={formattedIimiAnalysis} />);
+		await renderWithAnalysisRoute(
+			<IimiViewer detail={formattedIimiAnalysis} />,
+		);
 
 		expect(
 			screen.getByText("Iimi is an experimental workflow."),
@@ -59,11 +104,9 @@ describe("<IimiViewer />", () => {
 			screen.getByText(/This analysis could become inaccessible at any time/),
 		).toBeInTheDocument();
 
-		// Check probability  filter and search inputs.
 		expect(screen.getByDisplayValue("0.500")).toBeInTheDocument();
 		expect(screen.getByText("Sort: PScore")).toBeInTheDocument();
 
-		// Make sure first hit is open.
 		expect(
 			screen.getByText(formattedIimiAnalysis.results.hits[0].name),
 		).toBeInTheDocument();
@@ -81,7 +124,7 @@ describe("<IimiViewer />", () => {
 			["Medium Probability Virus", "High Probability Virus"],
 		],
 		["name", "Name", ["High Probability Virus", "Medium Probability Virus"]],
-	])("should sort hits correctly by %s", (sortKey, expectedText, expectedOrder) => {
+	])("should sort hits correctly by %s", async (sortKey, expectedText, expectedOrder) => {
 		const testAnalysis = {
 			...formattedIimiAnalysis,
 			results: {
@@ -89,7 +132,10 @@ describe("<IimiViewer />", () => {
 			},
 		};
 
-		renderWithRouter(<IimiViewer detail={testAnalysis} />, `/?sort=${sortKey}`);
+		await renderWithAnalysisRoute(
+			<IimiViewer detail={testAnalysis} />,
+			`?sort=${sortKey}`,
+		);
 
 		expect(screen.getByText(`Sort: ${expectedText}`)).toBeInTheDocument();
 
@@ -102,7 +148,7 @@ describe("<IimiViewer />", () => {
 		});
 	});
 
-	it("should filter hits by minimum probability", () => {
+	it("should filter hits by minimum probability", async () => {
 		const testAnalysis = {
 			...formattedIimiAnalysis,
 			results: {
@@ -110,18 +156,18 @@ describe("<IimiViewer />", () => {
 			},
 		};
 
-		renderWithRouter(<IimiViewer detail={testAnalysis} />);
+		await renderWithAnalysisRoute(<IimiViewer detail={testAnalysis} />);
 
-		// Should show high (0.9) and medium (0.7) probability hits (both >= 0.5 default threshold)
 		expect(screen.getByText("High Probability Virus")).toBeInTheDocument();
 		expect(screen.getByText("Medium Probability Virus")).toBeInTheDocument();
 
-		// Should not show low probability hit (0.3 < 0.5 threshold)
 		expect(screen.queryByText("Low Probability Virus")).not.toBeInTheDocument();
 	});
 
 	it("should allow expanding OTU details", async () => {
-		renderWithRouter(<IimiViewer detail={formattedIimiAnalysis} />);
+		await renderWithAnalysisRoute(
+			<IimiViewer detail={formattedIimiAnalysis} />,
+		);
 
 		expect(
 			screen.getByText(formattedIimiAnalysis.results.hits[0].name),
@@ -132,7 +178,6 @@ describe("<IimiViewer />", () => {
 		});
 		await userEvent.click(otu);
 
-		// Check that isolate details are visible after expansion
 		const isolate = formattedIimiAnalysis.results.hits[0].isolates[0];
 		const expectedIsolateName = `${isolate.source_type} ${isolate.source_name}`;
 		expect(
@@ -148,30 +193,25 @@ describe("<IimiViewer />", () => {
 			},
 		};
 
-		renderWithRouter(<IimiViewer detail={testAnalysis} />);
+		await renderWithAnalysisRoute(<IimiViewer detail={testAnalysis} />);
 
-		// Initially should show high (0.9) and medium (0.7) probability hits (both >= 0.5 default threshold)
 		expect(screen.getByText("High Probability Virus")).toBeInTheDocument();
 		expect(screen.getByText("Medium Probability Virus")).toBeInTheDocument();
 		expect(screen.queryByText("Low Probability Virus")).not.toBeInTheDocument();
 
-		// Change threshold to 0.8 to filter out medium probability hit
 		const probabilityInput = screen.getByDisplayValue("0.500");
 		await userEvent.clear(probabilityInput);
 		await userEvent.type(probabilityInput, "0.8");
 
-		// Now should only show high probability hit
 		expect(screen.getByText("High Probability Virus")).toBeInTheDocument();
 		expect(
 			screen.queryByText("Medium Probability Virus"),
 		).not.toBeInTheDocument();
 		expect(screen.queryByText("Low Probability Virus")).not.toBeInTheDocument();
 
-		// Change threshold to 0.2 to show all hits
 		await userEvent.clear(probabilityInput);
 		await userEvent.type(probabilityInput, "0.2");
 
-		// Now should show all three hits
 		expect(screen.getByText("High Probability Virus")).toBeInTheDocument();
 		expect(screen.getByText("Medium Probability Virus")).toBeInTheDocument();
 		expect(screen.getByText("Low Probability Virus")).toBeInTheDocument();

--- a/src/analyses/components/Nuvs/NuvsDetail.tsx
+++ b/src/analyses/components/Nuvs/NuvsDetail.tsx
@@ -1,7 +1,7 @@
 import { useGetActiveHit } from "@analyses/hooks";
 import type { FormattedNuvsHit, NuvsOrf as NuvsOrfType } from "@analyses/types";
 import { calculateAnnotatedOrfCount } from "@analyses/utils";
-import { useUrlSearchParam } from "@app/hooks";
+import { useUrlSearchParam } from "@app/hooks.tanstack";
 import Badge from "@base/Badge";
 import { sortBy } from "es-toolkit";
 import NuvsBlast from "./NuvsBlast";

--- a/src/analyses/components/Nuvs/NuvsItem.tsx
+++ b/src/analyses/components/Nuvs/NuvsItem.tsx
@@ -1,6 +1,6 @@
 import NuvsValues from "@analyses/components/Nuvs/NuvsValues";
 import type { FormattedNuvsHit } from "@analyses/types";
-import { useUrlSearchParam } from "@app/hooks";
+import { useUrlSearchParam } from "@app/hooks.tanstack";
 import { cn } from "@app/utils";
 import Badge from "@base/Badge";
 import Box from "@base/Box";

--- a/src/analyses/components/Nuvs/NuvsList.tsx
+++ b/src/analyses/components/Nuvs/NuvsList.tsx
@@ -3,7 +3,7 @@ import NuvsItem from "@analyses/components/Nuvs/NuvsItem";
 import { useKeyNavigation } from "@analyses/components/Viewer/hooks";
 import { useSortAndFilterNuVsHits } from "@analyses/hooks";
 import type { FormattedNuvsAnalysis } from "@analyses/types";
-import { useUrlSearchParam } from "@app/hooks";
+import { useUrlSearchParam } from "@app/hooks.tanstack";
 import Key from "@base/Key";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useRef } from "react";

--- a/src/analyses/components/Nuvs/NuvsToolbar.tsx
+++ b/src/analyses/components/Nuvs/NuvsToolbar.tsx
@@ -1,4 +1,4 @@
-import { useUrlSearchParam } from "@app/hooks";
+import { useUrlSearchParam } from "@app/hooks.tanstack";
 import ButtonToggle from "@base/ButtonToggle";
 import InputSearch from "@base/InputSearch";
 import Toolbar from "@base/Toolbar";

--- a/src/analyses/components/Nuvs/__tests__/NuVsViewer.test.tsx
+++ b/src/analyses/components/Nuvs/__tests__/NuVsViewer.test.tsx
@@ -1,14 +1,69 @@
 import NuvsViewer from "@analyses/components/Nuvs/NuvsViewer";
-import { screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+	createMemoryHistory,
+	createRootRoute,
+	createRoute,
+	createRouter,
+	RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
 	createFakeFormattedNuVsAnalysis,
 	mockApiBlastNuVs,
 } from "@tests/fake/analyses";
 import { createFakeSample } from "@tests/fake/samples";
-import { renderWithRouter } from "@tests/setup";
 import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+
+const analysisSearchSchema = z.object({
+	find: z.string().optional().catch(undefined),
+	sort: z.string().optional().catch(undefined),
+	sortDesc: z.boolean().optional().catch(undefined),
+	filterOtus: z.boolean().optional().catch(undefined),
+	filterIsolates: z.boolean().optional().catch(undefined),
+	reads: z.boolean().optional().catch(undefined),
+	filterSequences: z.boolean().optional().catch(undefined),
+	filterOrfs: z.boolean().optional().catch(undefined),
+	activeHit: z.string().optional().catch(undefined),
+});
+
+async function renderWithAnalysisRoute(ui: React.ReactElement) {
+	const rootRoute = createRootRoute();
+	const authenticatedRoute = createRoute({
+		getParentRoute: () => rootRoute,
+		id: "_authenticated",
+	});
+	const analysisRoute = createRoute({
+		getParentRoute: () => authenticatedRoute,
+		path: "samples/$sampleId/analyses/$analysisId",
+		validateSearch: analysisSearchSchema,
+		component: () => ui,
+	});
+	authenticatedRoute.addChildren([analysisRoute]);
+	rootRoute.addChildren([authenticatedRoute]);
+
+	const queryClient = new QueryClient();
+
+	// @ts-expect-error createRouter requires strictNullChecks which is not enabled project-wide
+	const router = createRouter({
+		routeTree: rootRoute,
+		history: createMemoryHistory({
+			initialEntries: ["/samples/test-sample/analyses/test-analysis"],
+		}),
+		defaultPendingMinMs: 0,
+	});
+
+	await router.load();
+
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<RouterProvider router={router} />
+		</QueryClientProvider>,
+	);
+}
 
 describe("<NuvsViewer />", () => {
 	let props;
@@ -27,11 +82,11 @@ describe("<NuvsViewer />", () => {
 	afterEach(() => nock.cleanAll());
 
 	describe("<NuVsDetail />", () => {
-		it("should render correctly", () => {
-			renderWithRouter(<NuvsViewer {...props} />);
+		it("should render correctly", async () => {
+			await renderWithAnalysisRoute(<NuvsViewer {...props} />);
 
 			expect(
-				screen.getByText(
+				await screen.findByText(
 					"This sequence has no BLAST information attached to it.",
 				),
 			).toBeInTheDocument();
@@ -43,10 +98,10 @@ describe("<NuvsViewer />", () => {
 
 		it("should render blast when clicked", async () => {
 			const scope = mockApiBlastNuVs(nuvs.id, nuvs.results.hits[0].index);
-			renderWithRouter(<NuvsViewer {...props} />);
+			await renderWithAnalysisRoute(<NuvsViewer {...props} />);
 
 			await userEvent.click(
-				screen.getByRole("button", { name: "BLAST at NCBI" }),
+				await screen.findByRole("button", { name: "BLAST at NCBI" }),
 			);
 			scope.done();
 		});
@@ -54,7 +109,7 @@ describe("<NuvsViewer />", () => {
 
 	describe("<NuVsExport />", () => {
 		it("should render export dialog when exporting", async () => {
-			renderWithRouter(<NuvsViewer {...props} />);
+			await renderWithAnalysisRoute(<NuvsViewer {...props} />);
 
 			await userEvent.click(screen.getByRole("button", { name: "Export" }));
 			expect(screen.getByText("Export Analysis")).toBeInTheDocument();

--- a/src/analyses/components/Pathoscope/PathoscopeDetail.tsx
+++ b/src/analyses/components/Pathoscope/PathoscopeDetail.tsx
@@ -1,5 +1,5 @@
 import type { FormattedPathoscopeHit } from "@analyses/types";
-import { useUrlSearchParam } from "@app/hooks";
+import { useUrlSearchParam } from "@app/hooks.tanstack";
 import ScrollSyncContainer from "@base/ScrollSyncContainer";
 import { maxBy } from "es-toolkit";
 import PathoscopeIsolate from "./PathoscopeIsolate";

--- a/src/analyses/components/Pathoscope/PathoscopeIsolate.tsx
+++ b/src/analyses/components/Pathoscope/PathoscopeIsolate.tsx
@@ -1,4 +1,4 @@
-import { useUrlSearchParam } from "@app/hooks";
+import { useUrlSearchParam } from "@app/hooks.tanstack";
 import { toScientificNotation } from "@app/utils";
 import ScrollSync from "@base/ScrollSync";
 import PathoscopeSequence from "./PathoscopeSequence";

--- a/src/analyses/components/Pathoscope/PathoscopeItem.tsx
+++ b/src/analyses/components/Pathoscope/PathoscopeItem.tsx
@@ -1,6 +1,6 @@
 import AnalysisValue from "@analyses/components/AnalysisValue";
 import type { FormattedPathoscopeHit } from "@analyses/types";
-import { useUrlSearchParam } from "@app/hooks";
+import { useUrlSearchParam } from "@app/hooks.tanstack";
 import { toScientificNotation } from "@app/utils";
 import AccordionContent from "@base/AccordionContent";
 import AccordionScrollingItem from "@base/AccordionScrollingItem";

--- a/src/analyses/components/Pathoscope/PathoscopeToolbar.tsx
+++ b/src/analyses/components/Pathoscope/PathoscopeToolbar.tsx
@@ -1,4 +1,4 @@
-import { useUrlSearchParam } from "@app/hooks";
+import { useUrlSearchParam } from "@app/hooks.tanstack";
 import ButtonToggle from "@base/ButtonToggle";
 import Dropdown from "@base/Dropdown";
 import DropdownButton from "@base/DropdownButton";

--- a/src/analyses/components/Pathoscope/PathoscopeViewer.tsx
+++ b/src/analyses/components/Pathoscope/PathoscopeViewer.tsx
@@ -1,5 +1,5 @@
 import type { FormattedPathoscopeAnalysis } from "@analyses/types";
-import { useUrlSearchParam } from "@app/hooks";
+import { useUrlSearchParam } from "@app/hooks.tanstack";
 import Alert from "@base/Alert";
 import type { Sample } from "@samples/types";
 import { PathoscopeList } from "./PathoscopeList";

--- a/src/analyses/hooks.ts
+++ b/src/analyses/hooks.ts
@@ -1,15 +1,19 @@
 import { createFuse } from "@app/fuse";
-import { useUrlSearchParam } from "@app/hooks";
 import { useListIndexes } from "@indexes/queries";
 import type { IndexMinimal } from "@indexes/types";
 import { useFetchSample } from "@samples/queries";
 import { useFetchSubtractionsShortlist } from "@subtraction/queries";
 import type { SubtractionOption } from "@subtraction/types";
+import { useSearch } from "@tanstack/react-router";
 import { groupBy, maxBy, sortBy } from "es-toolkit";
 import type {
 	FormattedNuvsAnalysis,
 	FormattedPathoscopeAnalysis,
 } from "./types";
+
+const searchOptions = {
+	from: "/_authenticated/samples/$sampleId/analyses/$analysisId",
+} as const;
 
 /** Sort and filter a list of pathoscope hits  */
 export function useSortAndFilterPathoscopeHits(
@@ -18,10 +22,7 @@ export function useSortAndFilterPathoscopeHits(
 ) {
 	let hits = detail.results.hits;
 
-	const { value: find } = useUrlSearchParam<string>("find");
-	const { value: filterOtus } = useUrlSearchParam<boolean>("filterOtus");
-	const { value: sortKey } = useUrlSearchParam<string>("sort");
-	const { value: sortDesc } = useUrlSearchParam<boolean>("sortDesc");
+	const { find, filterOtus, sort, sortDesc } = useSearch(searchOptions);
 
 	const fuse = createFuse(hits, ["name", "abbreviation"]);
 
@@ -36,7 +37,7 @@ export function useSortAndFilterPathoscopeHits(
 		);
 	}
 
-	const sortedHits = sortBy(hits, [(hit) => hit[sortKey as string]]);
+	const sortedHits = sortBy(hits, [(hit) => hit[sort as string]]);
 
 	if (sortDesc) {
 		sortedHits.reverse();
@@ -49,10 +50,7 @@ export function useSortAndFilterPathoscopeHits(
 export function useSortAndFilterNuVsHits(detail: FormattedNuvsAnalysis) {
 	let hits = detail.results.hits;
 
-	const { value: find } = useUrlSearchParam<string>("find");
-	const { value: filterSequences } =
-		useUrlSearchParam<boolean>("filterSequences");
-	const { value: sortKey } = useUrlSearchParam<string>("sort");
+	const { find, filterSequences, sort } = useSearch(searchOptions);
 
 	const fuse = createFuse(hits, ["name", "families"]);
 
@@ -65,17 +63,17 @@ export function useSortAndFilterNuVsHits(detail: FormattedNuvsAnalysis) {
 	}
 
 	const sortedHits =
-		sortKey === "orfs"
+		sort === "orfs"
 			? sortBy(hits, [(hit) => hit.annotatedOrfCount]).reverse()
-			: sortBy(hits, [(hit) => hit[sortKey as string]]);
+			: sortBy(hits, [(hit) => hit[sort as string]]);
 
 	return sortedHits;
 }
 
 export function useGetActiveHit(matches) {
-	const { value: activeHit } = useUrlSearchParam<string>("activeHit");
+	const { activeHit } = useSearch(searchOptions);
 
-	if (activeHit !== null) {
+	if (activeHit) {
 		return matches.find((match) => match.id === Number(activeHit)) || null;
 	}
 

--- a/src/analyses/hooks.ts
+++ b/src/analyses/hooks.ts
@@ -6,7 +6,6 @@ import { useFetchSample } from "@samples/queries";
 import { useFetchSubtractionsShortlist } from "@subtraction/queries";
 import type { SubtractionOption } from "@subtraction/types";
 import { groupBy, maxBy, sortBy } from "es-toolkit";
-import { useSearch } from "wouter";
 import type {
 	FormattedNuvsAnalysis,
 	FormattedPathoscopeAnalysis,
@@ -18,26 +17,28 @@ export function useSortAndFilterPathoscopeHits(
 	maxReadLength: number,
 ) {
 	let hits = detail.results.hits;
-	const search = useSearch();
-	const searchParams = new URLSearchParams(search);
+
+	const { value: find } = useUrlSearchParam<string>("find");
+	const { value: filterOtus } = useUrlSearchParam<boolean>("filterOtus");
+	const { value: sortKey } = useUrlSearchParam<string>("sort");
+	const { value: sortDesc } = useUrlSearchParam<boolean>("sortDesc");
 
 	const fuse = createFuse(hits, ["name", "abbreviation"]);
 
-	if (searchParams.get("find")) {
-		hits = fuse.search(searchParams.get("find")).map((result) => result.item);
+	if (find) {
+		hits = fuse.search(String(find)).map((result) => result.item);
 	}
 
-	if (searchParams.get("filterOtus") === "true") {
+	if (filterOtus) {
 		hits = hits.filter(
 			(hit) =>
 				hit.pi * detail.results.readCount >= (hit.length * 0.8) / maxReadLength,
 		);
 	}
 
-	const sortKey = searchParams.get("sort");
-	const sortedHits = sortBy(hits, [(hit) => hit[sortKey]]);
+	const sortedHits = sortBy(hits, [(hit) => hit[sortKey as string]]);
 
-	if (searchParams.get("sortDesc") === "true") {
+	if (sortDesc) {
 		sortedHits.reverse();
 	}
 
@@ -46,25 +47,27 @@ export function useSortAndFilterPathoscopeHits(
 
 /** Sort and filter a list of Nuvs hits  */
 export function useSortAndFilterNuVsHits(detail: FormattedNuvsAnalysis) {
-	const search = useSearch();
-	const searchParams = new URLSearchParams(search);
-
 	let hits = detail.results.hits;
+
+	const { value: find } = useUrlSearchParam<string>("find");
+	const { value: filterSequences } =
+		useUrlSearchParam<boolean>("filterSequences");
+	const { value: sortKey } = useUrlSearchParam<string>("sort");
 
 	const fuse = createFuse(hits, ["name", "families"]);
 
-	if (searchParams.get("find")) {
-		hits = fuse.search(searchParams.get("find")).map((result) => result.item);
+	if (find) {
+		hits = fuse.search(String(find)).map((result) => result.item);
 	}
 
-	if (searchParams.get("filterSequences") === "true") {
+	if (filterSequences) {
 		hits = hits.filter((hit) => hit.e !== undefined);
 	}
 
 	const sortedHits =
-		searchParams.get("sort") === "orfs"
+		sortKey === "orfs"
 			? sortBy(hits, [(hit) => hit.annotatedOrfCount]).reverse()
-			: sortBy(hits, [(hit) => hit[searchParams.get("sort")]]);
+			: sortBy(hits, [(hit) => hit[sortKey as string]]);
 
 	return sortedHits;
 }

--- a/src/analyses/queries.ts
+++ b/src/analyses/queries.ts
@@ -1,6 +1,7 @@
 import { samplesQueryKeys } from "@samples/queries";
 import {
 	keepPreviousData,
+	queryOptions,
 	useMutation,
 	useQuery,
 	useQueryClient,
@@ -72,17 +73,15 @@ export function useRemoveAnalysis(analysisId: string) {
 	return () => mutation.mutate({ analysisId });
 }
 
-/**
- * Fetch complete information for a single analysis
- *
- * @param analysisId - The id of the analysis to fetch
- * @returns A complete analysis
- */
-export function useGetAnalysis(analysisId: string) {
-	const queryResult = useQuery<Analysis, ErrorResponse>({
+export function analysisQueryOptions(analysisId: string) {
+	return queryOptions<Analysis, ErrorResponse>({
 		queryKey: analysesQueryKeys.detail(analysisId),
 		queryFn: () => getAnalysis({ analysisId }),
 	});
+}
+
+export function useGetAnalysis(analysisId: string) {
+	const queryResult = useQuery(analysisQueryOptions(analysisId));
 
 	return {
 		...queryResult,

--- a/src/routes/_authenticated/samples/$sampleId/analyses/$analysisId.tsx
+++ b/src/routes/_authenticated/samples/$sampleId/analyses/$analysisId.tsx
@@ -11,6 +11,7 @@ const analysisDetailSearchSchema = z.object({
 	filterIsolates: z.boolean().optional().catch(undefined),
 	reads: z.boolean().optional().catch(undefined),
 	filterSequences: z.boolean().optional().catch(undefined),
+	filterOrfs: z.boolean().optional().catch(undefined),
 	activeHit: z.string().optional().catch(undefined),
 });
 

--- a/src/routes/_authenticated/samples/$sampleId/analyses/$analysisId.tsx
+++ b/src/routes/_authenticated/samples/$sampleId/analyses/$analysisId.tsx
@@ -1,8 +1,37 @@
 import AnalysisDetail from "@analyses/components/AnalysisDetail";
-import { createFileRoute } from "@tanstack/react-router";
+import { analysisQueryOptions } from "@analyses/queries";
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { z } from "zod/v4";
+
+const analysisDetailSearchSchema = z.object({
+	find: z.string().optional().catch(undefined),
+	sort: z.string().optional().catch(undefined),
+	sortDesc: z.boolean().optional().catch(undefined),
+	filterOtus: z.boolean().optional().catch(undefined),
+	filterIsolates: z.boolean().optional().catch(undefined),
+	reads: z.boolean().optional().catch(undefined),
+	filterSequences: z.boolean().optional().catch(undefined),
+	activeHit: z.string().optional().catch(undefined),
+});
 
 export const Route = createFileRoute(
 	"/_authenticated/samples/$sampleId/analyses/$analysisId",
 )({
+	validateSearch: analysisDetailSearchSchema,
+	loader: async ({ context: { queryClient }, params: { analysisId } }) => {
+		try {
+			await queryClient.ensureQueryData(analysisQueryOptions(analysisId));
+		} catch (error) {
+			if (
+				error != null &&
+				typeof error === "object" &&
+				"response" in error &&
+				(error as { response: { status: number } }).response.status === 404
+			) {
+				throw notFound();
+			}
+			throw error;
+		}
+	},
 	component: AnalysisDetail,
 });

--- a/src/routes/_authenticated/samples/$sampleId/analyses/index.tsx
+++ b/src/routes/_authenticated/samples/$sampleId/analyses/index.tsx
@@ -1,8 +1,15 @@
 import AnalysesList from "@analyses/components/AnalysisList";
 import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod/v4";
+
+const analysesListSearchSchema = z.object({
+	page: z.number().default(1).catch(1),
+	openCreateAnalysis: z.boolean().optional().catch(undefined),
+});
 
 export const Route = createFileRoute(
 	"/_authenticated/samples/$sampleId/analyses/",
 )({
+	validateSearch: analysesListSearchSchema,
 	component: AnalysesList,
 });


### PR DESCRIPTION
## Summary
- Migrates analyses routes to TanStack Router, adding a route-level loader that prefetches analysis data via `queryClient.ensureQueryData` and throws `notFound()` on 404s instead of handling it in the component
- Extracts `analysisQueryOptions` from `useGetAnalysis` to enable reuse in both the hook and the route loader
- Replaces `wouter`'s `useSearch` with `useUrlSearchParam` for reading search params in `useSortAndFilterPathoscopeHits` and `useSortAndFilterNuVsHits`, and adds `validateSearch` schemas for both the analyses list and detail routes

## Test plan
- [ ] Navigate to a sample's analyses list and verify it loads correctly with pagination (`page` param)
- [ ] Open an analysis detail view and verify it loads the analysis data
- [ ] Navigate to a non-existent analysis ID and verify a 404/not-found page is shown
- [ ] Verify Pathoscope analysis filtering and sorting (find, filterOtus, sort, sortDesc) still work via URL search params
- [ ] Verify NuVs analysis filtering and sorting (find, filterSequences, sort) still work via URL search params
- [ ] Run `npx vitest run` on analyses tests to confirm no regressions