### PR TITLE
refactor: isolate superagent type and clean up docs

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,54 +1,54 @@
 # Testing
 
-For most UI components in virtool they are tested via integration testing.
-In short, this means that components are tested in the larger context of the view they are a part of.
-Doing it this way allows for detection of interoperability problems and simulation of more real use cases
+Most UI components in Virtool are tested via integration testing. Components are
+tested in the larger context of the view they are a part of. This allows
+detection of interoperability problems and simulation of more realistic use
+cases.
 
 ## Integration
 
-The biggest goal for testing in the UI is to ensure that the user experience works as expected.
-To that end the biggest thing we have to ensure is that the UI behaves as expected when all the pieces are
-assembled.
-For that reason we primarily rely on integration tests for testing components as that ensures related groups of components work
-together.
-Since this involves rendering a whole view, there is increased need to fake large sections of data.
-To reduce the burden simulating large portions of the application we have created helpers to assist writing tests.
+The primary goal for testing is to ensure that the user experience works as
+expected. We rely on integration tests because they ensure related groups of
+components work together. Since this involves rendering a whole view, there is
+increased need to fake large sections of data. To reduce the burden of simulating
+large portions of the application, we have created helpers to assist with writing
+tests.
 
 ## Dependencies
 
-As part spinning up a view for testing it is often required to ensure that
-certain dependencies are present as parents of the component.
+Spinning up a view for testing often requires certain dependencies as parents of
+the component.
 
 Most commonly a component will need one or more of:
 
 - QueryClient (react-query)
-- ThemeProvider (styled-components)
 - MemoryRouter (wouter)
 
-To make providing these less cumbersome our test setup exports helper functions
-which will wrap the components in the providers prior to rendering.
-For most cases `renderWithProviders` will ensure most needed providers are supplied.
+To make providing these less cumbersome, our test setup exports helper functions
+that wrap the components in providers prior to rendering. For most cases
+`renderWithProviders` will ensure the needed providers are supplied.
 
-## Data faking
+## Data Faking
 
-To fully test the functionality of most components requires the creation of fake data.
-To simply this process faking functions are created for the test environment.
-These functions are designed to return data matching the data models used in the api.
-While they provide fake values for all required fields by default, override values can also
-be provided if specific values are needed.
-Make use of these functions whenever possible to generate data returned from the API.
-By centralizing the data faking in this way it reduces redundancy in the tests and ensures that
-changes to the models are tested in all view tests that use the fakers.
+Fully testing a component's functionality requires the creation of fake data.
+Faking functions in `src/tests/fake/` return data matching the API's data models.
+They provide fake values for all required fields by default, but override values
+can be provided when specific values are needed.
 
-## API mocking
+Use these functions whenever possible for data returned from the API.
+Centralizing data faking reduces redundancy and ensures that model changes are
+tested across all views that use the fakers.
 
-During the course of normal operation many components will need to make requests to the API.
-To accommodate this in a testing environment we use `nock` to intercept request made to the backend.
-Instead of mocking out the query functions, we intercept the http request chekcing that
-the components and queries are working together as expected as part of the test.
+## API Mocking
 
-In order to simplify writing tests that need API mocks, we use a set of standard mocking functions for
-intercepting API requests. These functions intercept specific API requests while allow the user specify the request
-body, URL path parameters, search parameters, and response body for API calls that support them.
+Many components make requests to the API during normal operation. To accommodate
+this in tests, we use `nock` to intercept requests made to the backend. Instead
+of mocking query functions, we intercept the HTTP request to verify that
+components and queries work together as expected.
 
-For details about on how to write API mocks see the [nock](https://github.com/nock/nock?tab=readme-ov-file#usage) documentation.
+Standard mocking functions simplify writing tests that need API mocks. These
+functions intercept specific API requests and allow specifying the request body,
+URL path parameters, search parameters, and response body.
+
+For details on writing API mocks, see the
+[nock documentation](https://github.com/nock/nock?tab=readme-ov-file#usage).

--- a/src/account/api.ts
+++ b/src/account/api.ts
@@ -1,7 +1,7 @@
 import { apiClient, type ApiResponse } from "@app/api";
 import type { Permissions } from "@groups/types";
 import type { User } from "@users/types";
-import type { Account, APIKeyMinimal } from "./types";
+import type { Account, AccountSettings, APIKeyMinimal } from "./types";
 
 /**
  * Gets complete account data for the current user.
@@ -48,7 +48,7 @@ export function getSettings(): Promise<ApiResponse> {
  * @returns A promise resolving to a response containing the
  * user's updated personal settings.
  */
-export function updateSettings({ update }): Promise<ApiResponse> {
+export function updateSettings({ update }: { update: Partial<AccountSettings> }): Promise<ApiResponse> {
 	return apiClient.patch("/account/settings").send(update);
 }
 

--- a/src/account/api.ts
+++ b/src/account/api.ts
@@ -1,7 +1,6 @@
-import { apiClient } from "@app/api";
+import { apiClient, type ApiResponse } from "@app/api";
 import type { Permissions } from "@groups/types";
 import type { User } from "@users/types";
-import type { Response } from "superagent";
 import type { Account, APIKeyMinimal } from "./types";
 
 /**
@@ -10,7 +9,7 @@ import type { Account, APIKeyMinimal } from "./types";
  * @returns A promise resolving to a response containing the
  * current user's account data.
  */
-export function get(): Promise<Response> {
+export function get(): Promise<ApiResponse> {
 	return apiClient.get("/account");
 }
 
@@ -38,7 +37,7 @@ export function updateAccount(update: AccountUpdate): Promise<User> {
  * @returns A promise resolving to a response containing the
  * current user's personal settings.
  */
-export function getSettings(): Promise<Response> {
+export function getSettings(): Promise<ApiResponse> {
 	return apiClient.get("/account/settings");
 }
 
@@ -49,7 +48,7 @@ export function getSettings(): Promise<Response> {
  * @returns A promise resolving to a response containing the
  * user's updated personal settings.
  */
-export function updateSettings({ update }): Promise<Response> {
+export function updateSettings({ update }): Promise<ApiResponse> {
 	return apiClient.patch("/account/settings").send(update);
 }
 
@@ -151,7 +150,7 @@ export function login({
 	handle: string;
 	password: string;
 	remember: boolean;
-}): Promise<Response> {
+}): Promise<ApiResponse> {
 	return apiClient.post("/account/login").send({
 		handle,
 		password,
@@ -183,7 +182,7 @@ export function resetPassword({
 }: {
 	password: string;
 	resetCode: string;
-}): Promise<Response> {
+}): Promise<ApiResponse> {
 	return apiClient.post("/account/reset").send({
 		password,
 		reset_code: resetCode,

--- a/src/account/api.ts
+++ b/src/account/api.ts
@@ -1,4 +1,4 @@
-import { apiClient, type ApiResponse } from "@app/api";
+import { type ApiResponse, apiClient } from "@app/api";
 import type { Permissions } from "@groups/types";
 import type { User } from "@users/types";
 import type { Account, AccountSettings, APIKeyMinimal } from "./types";
@@ -48,7 +48,11 @@ export function getSettings(): Promise<ApiResponse> {
  * @returns A promise resolving to a response containing the
  * user's updated personal settings.
  */
-export function updateSettings({ update }: { update: Partial<AccountSettings> }): Promise<ApiResponse> {
+export function updateSettings({
+	update,
+}: {
+	update: Partial<AccountSettings>;
+}): Promise<ApiResponse> {
 	return apiClient.patch("/account/settings").send(update);
 }
 

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1,5 +1,7 @@
 import Superagent, { type Request } from "superagent";
 
+export type { Response as ApiResponse } from "superagent";
+
 const agent = Superagent.agent();
 
 function prefixRequestUrl(request: Request) {

--- a/src/references/hooks.ts
+++ b/src/references/hooks.ts
@@ -1,11 +1,10 @@
 import { useFetchAccount } from "@account/queries";
-import { apiClient } from "@app/api";
+import { apiClient, type ApiResponse } from "@app/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { difference, union } from "es-toolkit/array";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
-import type { Response } from "superagent";
 import z from "zod";
 import { useFetchReference } from "./queries";
 
@@ -50,10 +49,10 @@ export function useUpdateSourceTypes(
 	const [lastRemoved, setLastRemoved] = useState("");
 
 	const mutation = useMutation({
-		mutationFn: async (sourceTypes: string[]): Promise<Response> => {
+		mutationFn: async (sourceTypes: string[]): Promise<ApiResponse> => {
 			return apiClient.patch(path).send({ [key]: sourceTypes });
 		},
-		onSuccess: (data: Response) => {
+		onSuccess: (data: ApiResponse) => {
 			const updatedSourceTypes = data.body[key];
 
 			if (sourceTypes.length > updatedSourceTypes) {

--- a/src/references/hooks.ts
+++ b/src/references/hooks.ts
@@ -1,5 +1,5 @@
 import { useFetchAccount } from "@account/queries";
-import { apiClient, type ApiResponse } from "@app/api";
+import { type ApiResponse, apiClient } from "@app/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { difference, union } from "es-toolkit/array";

--- a/src/wall/queries.ts
+++ b/src/wall/queries.ts
@@ -1,10 +1,9 @@
 import { fetchAccount, login, resetPassword } from "@account/api";
 import { accountKeys } from "@account/queries";
 import type { Account } from "@account/types";
-import { apiClient } from "@app/api";
+import { apiClient, type ApiResponse } from "@app/api";
 import type { Root } from "@app/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type { Response } from "superagent";
 
 import type { ErrorResponse } from "@/types/api";
 
@@ -63,7 +62,7 @@ export function useLoginMutation() {
 	const queryClient = useQueryClient();
 
 	return useMutation<
-		Response,
+		ApiResponse,
 		ErrorResponse,
 		{ handle: string; password: string; remember: boolean }
 	>({
@@ -86,7 +85,7 @@ export function useResetPasswordMutation() {
 	const queryClient = useQueryClient();
 
 	return useMutation<
-		Response,
+		ApiResponse,
 		ErrorResponse,
 		{ password: string; resetCode: string }
 	>({

--- a/src/wall/queries.ts
+++ b/src/wall/queries.ts
@@ -1,7 +1,7 @@
 import { fetchAccount, login, resetPassword } from "@account/api";
 import { accountKeys } from "@account/queries";
 import type { Account } from "@account/types";
-import { apiClient, type ApiResponse } from "@app/api";
+import { type ApiResponse, apiClient } from "@app/api";
 import type { Root } from "@app/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 


### PR DESCRIPTION
## Summary
- Exports `ApiResponse` from `@app/api.ts` as a re-export of superagent's `Response` type, removing direct `superagent` imports scattered across feature modules (`account`, `references`, `wall`)
- Cleans up `docs/Testing.md` by removing a stale `ThemeProvider` reference and rewriting the content for clarity and conciseness

## Test plan
- [ ] Verify typecheck passes (`npm run typecheck`)
- [ ] Verify lint/format passes (`npm run check`)
- [ ] Confirm account login, password reset, and reference source-type editing still work end-to-end