### PR TITLE
refactor: convert WebSocket connection to typed module singleton

### DIFF
--- a/src/app/Main.tsx
+++ b/src/app/Main.tsx
@@ -4,12 +4,14 @@ import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import MessageBanner from "@message/components/MessageBanner";
 import Nav from "@nav/components/Nav";
 import Sidebar from "@nav/components/Sidebar";
+import type { QueryClient } from "@tanstack/react-query";
 import { useQueryClient } from "@tanstack/react-query";
 import { lazy, Suspense, useEffect } from "react";
 import { Redirect, Route, Switch } from "wouter";
-import WsConnection, {
-	ABANDONED,
-	INITIALIZING,
+import {
+	establishConnection,
+	getConnectionStatus,
+	init,
 } from "./websocket/WsConnection";
 
 const Administration = lazy(
@@ -25,12 +27,11 @@ const ML = lazy(() => import("../ml/components/ML"));
 const DevDialog = lazy(() => import("@dev/components/DeveloperDialog"));
 const UploadOverlay = lazy(() => import("@/uploads/components/UploadOverlay"));
 
-function setupWebSocket(queryClient) {
-	if (!window.ws) {
-		window.ws = new WsConnection(queryClient);
-	}
-	if ([ABANDONED, INITIALIZING].includes(window.ws.connectionStatus)) {
-		window.ws.establishConnection();
+function setupWebSocket(queryClient: QueryClient) {
+	init(queryClient);
+	const status = getConnectionStatus();
+	if (status === "initializing" || status === "abandoned") {
+		establishConnection();
 	}
 }
 

--- a/src/app/websocket/WsConnection.ts
+++ b/src/app/websocket/WsConnection.ts
@@ -1,54 +1,71 @@
+import type { QueryClient } from "@tanstack/react-query";
 import { resetClient } from "../utils";
 import { reactQueryHandler } from "./reactQueryHandler";
+import type { WsMessage } from "./schema";
+import { WsMessageSchema } from "./schema";
 
-export const INITIALIZING = "initializing";
-export const CONNECTING = "connecting";
-export const CONNECTED = "connected";
-export const ABANDONED = "abandoned";
-export const RECONNECTING = "reconnecting";
+type ConnectionStatus =
+	| "initializing"
+	| "connecting"
+	| "connected"
+	| "abandoned"
+	| "reconnecting";
 
-export default function WsConnection(queryClient) {
-	this.reactQueryHandler = reactQueryHandler(queryClient);
+let connection: WebSocket | null = null;
+let connectionStatus: ConnectionStatus = "initializing";
+let interval = 500;
+let handleMessage: ((message: WsMessage) => void) | null = null;
 
-	// When a websocket message is received, this method is called with the message as the sole argument. Every message
-	// has a property "operation" that tells the dispatcher what to do. Illegal operation names will throw an error.
-	this.handle = (message) => {
-		this.reactQueryHandler(message);
+export function init(queryClient: QueryClient): void {
+	if (handleMessage) {
+		return;
+	}
+
+	const handler = reactQueryHandler(queryClient);
+	handleMessage = (message) => handler(message);
+}
+
+export function establishConnection(): void {
+	if (!handleMessage) {
+		throw new Error("WebSocket not initialized. Call init(queryClient) first.");
+	}
+
+	const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+
+	connection = new window.WebSocket(`${protocol}://${window.location.host}/ws`);
+	connectionStatus = "connecting";
+
+	connection.onopen = () => {
+		interval = 500;
+		connectionStatus = "connected";
 	};
 
-	this.interval = 500;
-	this.connectionStatus = INITIALIZING;
+	connection.onmessage = (e) => {
+		const parsed = WsMessageSchema.safeParse(JSON.parse(e.data));
 
-	this.establishConnection = () => {
-		const protocol = window.location.protocol === "https:" ? "wss" : "ws";
-
-		this.connection = new window.WebSocket(
-			`${protocol}://${window.location.host}/ws`,
-		);
-		this.connectionStatus = CONNECTING;
-
-		this.connection.onopen = () => {
-			this.interval = 500;
-			this.connectionStatus = CONNECTED;
-		};
-
-		this.connection.onmessage = (e) => {
-			this.handle(JSON.parse(e.data));
-		};
-
-		this.connection.onclose = (e) => {
-			if (this.interval < 15000) {
-				this.interval += 500;
-			}
-
-			if (e.code === 4000) {
-				resetClient();
-			}
-
-			setTimeout(() => {
-				this.establishConnection();
-				this.connectionStatus = RECONNECTING;
-			}, this.interval);
-		};
+		if (parsed.success) {
+			handleMessage?.(parsed.data);
+		} else {
+			window.console.warn("Invalid WebSocket message", parsed.error);
+		}
 	};
+
+	connection.onclose = (e) => {
+		if (interval < 15000) {
+			interval += 500;
+		}
+
+		if (e.code === 4000) {
+			resetClient();
+		}
+
+		setTimeout(() => {
+			establishConnection();
+			connectionStatus = "reconnecting";
+		}, interval);
+	};
+}
+
+export function getConnectionStatus(): ConnectionStatus {
+	return connectionStatus;
 }

--- a/src/app/websocket/WsConnection.ts
+++ b/src/app/websocket/WsConnection.ts
@@ -30,6 +30,12 @@ export function establishConnection(): void {
 		throw new Error("WebSocket not initialized. Call init(queryClient) first.");
 	}
 
+	if (connectionStatus === "connecting" || connectionStatus === "connected") {
+		return;
+	}
+
+	connection?.close();
+
 	const protocol = window.location.protocol === "https:" ? "wss" : "ws";
 
 	connection = new window.WebSocket(`${protocol}://${window.location.host}/ws`);
@@ -41,12 +47,16 @@ export function establishConnection(): void {
 	};
 
 	connection.onmessage = (e) => {
-		const parsed = WsMessageSchema.safeParse(JSON.parse(e.data));
+		try {
+			const parsed = WsMessageSchema.safeParse(JSON.parse(e.data));
 
-		if (parsed.success) {
-			handleMessage?.(parsed.data);
-		} else {
-			window.console.warn("Invalid WebSocket message", parsed.error);
+			if (parsed.success) {
+				handleMessage?.(parsed.data);
+			} else {
+				window.console.warn("Invalid WebSocket message", parsed.error);
+			}
+		} catch (error) {
+			window.console.error("Failed to parse WebSocket message", error);
 		}
 	};
 

--- a/src/app/websocket/__tests__/schema.test.ts
+++ b/src/app/websocket/__tests__/schema.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { WsMessageSchema } from "../schema";
+
+describe("WsMessageSchema", () => {
+	it("should accept a valid message", () => {
+		const result = WsMessageSchema.safeParse({
+			interface: "samples",
+			operation: "update",
+			data: { id: "abc123", name: "test" },
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("should reject a message without interface", () => {
+		const result = WsMessageSchema.safeParse({
+			operation: "update",
+			data: {},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("should reject a message without operation", () => {
+		const result = WsMessageSchema.safeParse({
+			interface: "samples",
+			data: {},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("should reject a message with non-object data", () => {
+		const result = WsMessageSchema.safeParse({
+			interface: "samples",
+			operation: "update",
+			data: "not an object",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("should reject a message with array data", () => {
+		const result = WsMessageSchema.safeParse({
+			interface: "samples",
+			operation: "update",
+			data: [1, 2, 3],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("should accept a job message with workflow", () => {
+		const result = WsMessageSchema.safeParse({
+			interface: "jobs",
+			operation: "update",
+			data: { workflow: "build_index", id: "job1" },
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("should accept a task message", () => {
+		const result = WsMessageSchema.safeParse({
+			interface: "tasks",
+			operation: "update",
+			data: {
+				type: "clone_reference",
+				id: 1,
+				complete: false,
+				progress: 50,
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+});

--- a/src/app/websocket/reactQueryHandler.ts
+++ b/src/app/websocket/reactQueryHandler.ts
@@ -9,10 +9,11 @@ import { referenceQueryKeys } from "@references/queries";
 import { samplesQueryKeys } from "@samples/queries";
 import type { QueryClient } from "@tanstack/react-query";
 import { get } from "es-toolkit/compat";
+import type { Task } from "@/types/api";
 import { fileQueryKeys } from "@/uploads/queries";
+import type { WsMessage } from "./schema";
 import { taskUpdaters } from "./updaters";
 
-/** Get affected resource query keys by workflow name  */
 const workflowQueries = {
 	build_index: [indexQueryKeys.lists()],
 	create_sample: [samplesQueryKeys.lists()],
@@ -21,21 +22,14 @@ const workflowQueries = {
 	pathoscope_bowtie: [samplesQueryKeys.lists(), analysesQueryKeys.lists()],
 };
 
-/**
- * Invalidate queries that are affected by a job update
- *
- * @param queryClient - The react-query client
- * @param message - The websocket message
- */
-function jobUpdater(queryClient, data) {
-	const queryKeys = workflowQueries[data.workflow];
+function jobUpdater(queryClient: QueryClient, data: WsMessage["data"]) {
+	const queryKeys = workflowQueries[data.workflow as string];
 
 	queryKeys?.forEach((queryKey) => {
 		queryClient.invalidateQueries({ queryKey });
 	});
 }
 
-/**  Get resource keys from interface name */
 const keyFactories = {
 	account: accountKeys,
 	groups: groupQueryKeys,
@@ -49,20 +43,8 @@ const keyFactories = {
 	samples: samplesQueryKeys,
 };
 
-/**
- Create a handler for websocket messages that are related to react-query managed resources
-
- @param queryClient - The react-query client
- @returns A websocket message handler for react-query
- */
-
 export function reactQueryHandler(queryClient: QueryClient) {
-	/**
-    Handle websocket messages related to react-query managed resources
-
-    @param message - The websocket message
-    */
-	return (message) => {
+	return (message: WsMessage) => {
 		const { interface: iface, operation, data } = message;
 		window.console.log(`${iface}.${operation}`);
 
@@ -76,9 +58,9 @@ export function reactQueryHandler(queryClient: QueryClient) {
 		}
 
 		if (iface === "tasks" && operation === "update") {
-			const updater = get(taskUpdaters, data.type);
+			const updater = get(taskUpdaters, data.type as string);
 			if (updater) {
-				updater(queryClient, data);
+				updater(queryClient, data as unknown as Task);
 			}
 		}
 	};

--- a/src/app/websocket/schema.ts
+++ b/src/app/websocket/schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod/v4";
+
+export const WsMessageSchema = z.object({
+	interface: z.string(),
+	operation: z.string(),
+	data: z.record(z.string(), z.unknown()),
+});
+
+export type WsMessage = z.infer<typeof WsMessageSchema>;

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -1,20 +1,11 @@
-import type { QueryClientConfig } from "@tanstack/react-query";
-
 export type VirtoolState = {
 	sentryDsn: string;
 	version: string;
-};
-
-export type WebSocket = {
-	queryClient: QueryClientConfig;
-	connectionStatus: string;
-	establishConnection: () => void;
 };
 
 declare global {
 	interface Window {
 		captureException?: (error: Error) => void;
 		virtool: VirtoolState;
-		ws: WebSocket;
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces the `WsConnection` constructor function and `window.ws` global with a typed module-level singleton (`init`, `establishConnection`, `getConnectionStatus` exports)
- Adds a `WsMessageSchema` (zod) to validate incoming WebSocket messages at the boundary, replacing untyped `JSON.parse` pass-through
- Removes the `window.ws` property from the global `Window` type and replaces exported string constants with a `ConnectionStatus` union type

## Test plan

- [x] `WsMessageSchema` is covered by unit tests in `src/app/websocket/__tests__/schema.test.ts`
- [ ] Verify WebSocket reconnection still works end-to-end in a dev environment
- [ ] Confirm no TypeScript errors with `npm run typecheck`
- [ ] Confirm lint passes with `npm run check`