### PR TITLE
refactor(jobs): drop v1 state shim and switch job ids to int

### DIFF
--- a/src/analyses/components/AnalysisItem.tsx
+++ b/src/analyses/components/AnalysisItem.tsx
@@ -7,7 +7,7 @@ import Link from "@base/Link";
 import ProgressCircle from "@base/ProgressCircle";
 import SlashList from "@base/SlashList";
 import { Equal, EqualNot } from "lucide-react";
-import { JobNested } from "@/jobs/types";
+import { JobNestedSchema } from "@/jobs/types";
 import { useRemoveAnalysis } from "../queries";
 import type { AnalysisMinimal } from "../types";
 import { checkSupportedWorkflow } from "../utils";
@@ -47,7 +47,7 @@ export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 		</div>
 	);
 
-	const job = analysis.job && JobNested.parse(analysis.job);
+	const job = analysis.job && JobNestedSchema.parse(analysis.job);
 
 	return (
 		<Box className="text-gray-600 mb-2.5">

--- a/src/analyses/components/AnalysisItem.tsx
+++ b/src/analyses/components/AnalysisItem.tsx
@@ -63,8 +63,8 @@ export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 						<AnalysisItemRightIcon canModify={canModify} onRemove={onRemove} />
 					) : (
 						<ProgressCircle
-							progress={job.progress || 0}
-							state={job.state || "pending"}
+							progress={job?.progress ?? 0}
+							state={job?.state ?? "pending"}
 							size="md"
 						/>
 					)}

--- a/src/jobs/api.ts
+++ b/src/jobs/api.ts
@@ -27,7 +27,7 @@ export async function findJobs(
  * @param jobId - The id of the job to fetch
  * @returns A promise resolving to a single job
  */
-export async function fetchJob(jobId: string): Promise<ServerJob> {
+export async function fetchJob(jobId: number): Promise<ServerJob> {
 	const response = await apiClient.get(`/jobs/v2/${jobId}`);
 	return response.body;
 }

--- a/src/jobs/components/JobDetail.tsx
+++ b/src/jobs/components/JobDetail.tsx
@@ -48,7 +48,7 @@ function PendingJobAlert({ createdAt }: { createdAt: Date }) {
  */
 export default function JobDetail() {
 	const { jobId } = routeApi.useParams();
-	const { data, isPending, error } = useFetchJob(jobId);
+	const { data, isPending, error } = useFetchJob(Number(jobId));
 
 	if (error) {
 		if ("status" in error && error.status === 404) {

--- a/src/jobs/components/JobDetail.tsx
+++ b/src/jobs/components/JobDetail.tsx
@@ -48,7 +48,12 @@ function PendingJobAlert({ createdAt }: { createdAt: Date }) {
  */
 export default function JobDetail() {
 	const { jobId } = routeApi.useParams();
-	const { data, isPending, error } = useFetchJob(Number(jobId));
+	const numericJobId = Number(jobId);
+	const { data, isPending, error } = useFetchJob(numericJobId);
+
+	if (!Number.isInteger(numericJobId)) {
+		return <NotFound />;
+	}
 
 	if (error) {
 		if ("status" in error && error.status === 404) {

--- a/src/jobs/components/JobItem.tsx
+++ b/src/jobs/components/JobItem.tsx
@@ -9,7 +9,7 @@ import type { UserNested } from "@users/types";
 
 export type JobItemProps = {
 	/** The job id */
-	id: string;
+	id: number;
 
 	/** When the job was created */
 	createdAt: Date;

--- a/src/jobs/components/__tests__/JobItem.test.tsx
+++ b/src/jobs/components/__tests__/JobItem.test.tsx
@@ -10,7 +10,7 @@ describe("<JobItem />", () => {
 
 	beforeEach(() => {
 		props = {
-			id: "foo",
+			id: 42,
 			workflow: "build_index",
 			createdAt: new Date("2022-12-22T21:37:49.429000Z"),
 			progress: 0,

--- a/src/jobs/queries.ts
+++ b/src/jobs/queries.ts
@@ -46,5 +46,6 @@ export function useFetchJob(jobId: number) {
 		queryKey: jobQueryKeys.detail(jobId),
 		queryFn: () => fetchJob(jobId),
 		select: JobSchema.parse,
+		enabled: Number.isInteger(jobId),
 	});
 }

--- a/src/jobs/queries.ts
+++ b/src/jobs/queries.ts
@@ -1,6 +1,6 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { fetchJob, findJobs } from "./api";
-import { Job, JobSearchResult, type JobState } from "./types";
+import { JobSchema, JobSearchResultSchema, type JobState } from "./types";
 
 /**
  * Factory object for generating job query keys
@@ -31,7 +31,7 @@ export function useFindJobs(
 		queryKey: jobQueryKeys.list([page, per_page, ...states]),
 		queryFn: () => findJobs(page, per_page, states),
 		placeholderData: keepPreviousData,
-		select: JobSearchResult.parse,
+		select: JobSearchResultSchema.parse,
 	});
 }
 
@@ -45,6 +45,6 @@ export function useFetchJob(jobId: string) {
 	return useQuery({
 		queryKey: jobQueryKeys.detail(jobId),
 		queryFn: () => fetchJob(jobId),
-		select: Job.parse,
+		select: JobSchema.parse,
 	});
 }

--- a/src/jobs/queries.ts
+++ b/src/jobs/queries.ts
@@ -11,7 +11,7 @@ export const jobQueryKeys = {
 	list: (filters: Array<string | number | boolean>) =>
 		["job", "list", ...filters] as const,
 	details: () => ["job", "details"] as const,
-	detail: (jobId: string) => ["job", "details", jobId] as const,
+	detail: (jobId: number) => ["job", "details", jobId] as const,
 };
 
 /**
@@ -41,7 +41,7 @@ export function useFindJobs(
  * @param jobId - The id of the job to get
  * @returns Query results containing the job
  */
-export function useFetchJob(jobId: string) {
+export function useFetchJob(jobId: number) {
 	return useQuery({
 		queryKey: jobQueryKeys.detail(jobId),
 		queryFn: () => fetchJob(jobId),

--- a/src/jobs/types.ts
+++ b/src/jobs/types.ts
@@ -9,29 +9,6 @@ const JobStateSchema = z.enum([
 ]);
 export type JobState = z.infer<typeof JobStateSchema>;
 
-const JobStateV1Schema = z.enum([
-	"cancelled",
-	"complete",
-	"error",
-	"preparing",
-	"running",
-	"terminated",
-	"timeout",
-	"waiting",
-]);
-type JobStateV1 = z.infer<typeof JobStateV1Schema>;
-
-const V1_TO_V2_STATE: Record<JobStateV1, JobState> = {
-	cancelled: "cancelled",
-	complete: "succeeded",
-	error: "failed",
-	preparing: "running",
-	running: "running",
-	terminated: "failed",
-	timeout: "failed",
-	waiting: "pending",
-};
-
 export const Workflow = z.preprocess(
 	(val) => (val === "pathoscope_bowtie" ? "pathoscope" : val),
 	z.enum([
@@ -46,12 +23,12 @@ export const Workflow = z.preprocess(
 export type Workflow = z.infer<typeof Workflow>;
 export type ServerWorkflow = z.input<typeof Workflow>;
 
-export const JobNested = z
+export const JobNestedSchema = z
 	.object({
 		created_at: z.coerce.date(),
-		id: z.string(),
+		id: z.int(),
 		progress: z.int(),
-		state: JobStateV1Schema,
+		state: JobStateSchema,
 		user: z.object({
 			handle: z.string(),
 			id: z.int(),
@@ -62,16 +39,16 @@ export const JobNested = z
 		createdAt: created_at,
 		id,
 		progress,
-		state: V1_TO_V2_STATE[state],
+		state,
 		user,
 		workflow,
 	}));
-export type ServerJobNested = z.input<typeof JobNested>;
-export type JobNested = z.infer<typeof JobNested>;
+export type ServerJobNested = z.input<typeof JobNestedSchema>;
+export type JobNested = z.infer<typeof JobNestedSchema>;
 
-export const JobMinimal = z
+export const JobMinimalSchema = z
 	.object({
-		id: z.string(),
+		id: z.int(),
 		created_at: z.coerce.date(),
 		progress: z.int(),
 		state: JobStateSchema,
@@ -90,10 +67,10 @@ export const JobMinimal = z
 		workflow,
 	}));
 
-export type ServerJobMinimal = z.input<typeof JobMinimal>;
-export type JobMinimal = z.infer<typeof JobMinimal>;
+export type ServerJobMinimal = z.input<typeof JobMinimalSchema>;
+export type JobMinimal = z.infer<typeof JobMinimalSchema>;
 
-const JobStep = z
+const JobStepSchema = z
 	.object({
 		description: z.string(),
 		id: z.string(),
@@ -109,10 +86,10 @@ const JobStep = z
 		description,
 		startedAt: started_at,
 	}));
-export type ServerJobStep = z.input<typeof JobStep>;
-export type JobStep = z.infer<typeof JobStep>;
+export type ServerJobStep = z.input<typeof JobStepSchema>;
+export type JobStep = z.infer<typeof JobStepSchema>;
 
-const JobClaim = z
+const JobClaimSchema = z
 	.object({
 		cpu: z.number(),
 		image: z.string(),
@@ -131,14 +108,14 @@ const JobClaim = z
 			workflowVersion: workflow_version,
 		}),
 	);
-export type ServerJobClaim = z.input<typeof JobClaim>;
-export type JobClaim = z.infer<typeof JobClaim>;
+export type ServerJobClaim = z.input<typeof JobClaimSchema>;
+export type JobClaim = z.infer<typeof JobClaimSchema>;
 
-export const Job = z
+export const JobSchema = z
 	.object({
 		args: z.record(z.string(), z.unknown()),
-		id: z.string(),
-		claim: JobClaim.nullish(),
+		id: z.int(),
+		claim: JobClaimSchema.nullish(),
 		claimed_at: z.preprocess(
 			(val) => (val ? new Date(val as string) : null),
 			z.date().nullable(),
@@ -149,7 +126,7 @@ export const Job = z
 			z.date().nullable(),
 		),
 		progress: z.int(),
-		steps: z.array(JobStep).nullable(),
+		steps: z.array(JobStepSchema).nullable(),
 		state: JobStateSchema,
 		user: z.object({
 			id: z.int(),
@@ -164,8 +141,8 @@ export const Job = z
 		finishedAt: finished_at,
 		state,
 	}));
-export type ServerJob = z.input<typeof Job>;
-export type Job = z.infer<typeof Job>;
+export type ServerJob = z.input<typeof JobSchema>;
+export type Job = z.infer<typeof JobSchema>;
 
 const JobCountsSchema = z
 	.record(z.string(), z.record(z.string(), z.number()))
@@ -182,11 +159,11 @@ const JobCountsSchema = z
 
 export type JobCounts = z.infer<typeof JobCountsSchema>;
 
-export const JobSearchResult = z
+export const JobSearchResultSchema = z
 	.object({
 		counts: JobCountsSchema,
 		found_count: z.number(),
-		items: z.array(JobMinimal),
+		items: z.array(JobMinimalSchema),
 		page: z.number(),
 		page_count: z.number(),
 		per_page: z.number(),
@@ -212,5 +189,5 @@ export const JobSearchResult = z
 		}),
 	);
 
-export type ServerJobSearchResult = z.input<typeof JobSearchResult>;
-export type JobSearchResult = z.infer<typeof JobSearchResult>;
+export type ServerJobSearchResult = z.input<typeof JobSearchResultSchema>;
+export type JobSearchResult = z.infer<typeof JobSearchResultSchema>;

--- a/src/routes/_authenticated/samples/$sampleId.tsx
+++ b/src/routes/_authenticated/samples/$sampleId.tsx
@@ -7,7 +7,7 @@ import ViewHeader from "@base/ViewHeader";
 import ViewHeaderAttribution from "@base/ViewHeaderAttribution";
 import ViewHeaderIcons from "@base/ViewHeaderIcons";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
-import { JobNested } from "@jobs/types";
+import { JobNestedSchema } from "@jobs/types";
 import DeleteSample from "@samples/components/Detail/DeleteSample";
 import { useCheckCanEditSample } from "@samples/hooks";
 import { sampleQueryOptions, useFetchSample } from "@samples/queries";
@@ -57,7 +57,7 @@ function SampleDetailLayout() {
 	}
 
 	const { created_at, name, user } = data;
-	const job = data.job && JobNested.parse(data.job);
+	const job = data.job && JobNestedSchema.parse(data.job);
 
 	return (
 		<>

--- a/src/samples/components/Detail/SampleDetailGeneral.tsx
+++ b/src/samples/components/Detail/SampleDetailGeneral.tsx
@@ -13,7 +13,7 @@ import { getLibraryTypeDisplayName } from "@samples/utils";
  */
 import { getRouteApi } from "@tanstack/react-router";
 import numbro from "numbro";
-import { JobNested } from "@/jobs/types";
+import { JobNestedSchema } from "@/jobs/types";
 import EditSample from "../EditSample";
 import SampleFileSizeWarning from "./SampleFileSizeWarning";
 import Sidebar from "./Sidebar";
@@ -32,7 +32,7 @@ export default function SampleDetailGeneral() {
 
 	const { quality } = data;
 
-	const job = data?.job ? JobNested.parse(data.job) : undefined;
+	const job = data?.job ? JobNestedSchema.parse(data.job) : undefined;
 
 	return (
 		<div className="flex items-stretch">

--- a/src/samples/components/Item/SampleItem.tsx
+++ b/src/samples/components/Item/SampleItem.tsx
@@ -3,7 +3,7 @@ import Box from "@base/Box";
 import Checkbox from "@base/Checkbox";
 import Link from "@base/Link";
 import type { SampleMinimal } from "@samples/types";
-import { JobNested } from "@/jobs/types";
+import { JobNestedSchema } from "@/jobs/types";
 import SampleLabel from "../Label/SampleLabel";
 import SampleLibraryTypeLabel from "../Label/SampleLibraryTypeLabel";
 import WorkflowTags from "../Tag/WorkflowTags";
@@ -39,7 +39,7 @@ export default function SampleItem({
 		setOpenQuickAnalyze(true);
 	}
 
-	const job = sample.job && JobNested.parse(sample.job);
+	const job = sample.job && JobNestedSchema.parse(sample.job);
 
 	return (
 		<Box className="flex items-stretch basis-0 gap-4">

--- a/src/subtraction/components/SubtractionItem.tsx
+++ b/src/subtraction/components/SubtractionItem.tsx
@@ -1,7 +1,7 @@
 import BoxGroupSection from "@base/BoxGroupSection";
 import Link from "@base/Link";
 import ProgressCircle from "@base/ProgressCircle";
-import { JobNested } from "@jobs/types";
+import { JobNestedSchema } from "@jobs/types";
 import type { SubtractionMinimal } from "../types";
 import { SubtractionAttribution } from "./Attribution";
 
@@ -16,7 +16,7 @@ export function SubtractionItem({
 	ready,
 	user,
 }: SubtractionMinimal) {
-	const parsedJob = job && JobNested.parse(job);
+	const parsedJob = job && JobNestedSchema.parse(job);
 
 	return (
 		<BoxGroupSection className="grid grid-cols-5 items-center">

--- a/src/subtraction/components/__tests__/SubtractionItem.test.tsx
+++ b/src/subtraction/components/__tests__/SubtractionItem.test.tsx
@@ -21,7 +21,7 @@ describe("<SubtractionItem />", () => {
 				name: "subtraction.fa.gz",
 			},
 			job: {
-				id: "foobar",
+				id: 42,
 				created_at: createdAt.toISOString(),
 				progress: 50,
 				state: "running",
@@ -43,9 +43,9 @@ describe("<SubtractionItem />", () => {
 	});
 
 	it.each([
-		"waiting",
+		"pending",
 		"running",
-		"error",
+		"failed",
 	] as const)("should render progress bar for ", async (state) => {
 		props.job.state = state;
 

--- a/src/tests/fake/jobs.ts
+++ b/src/tests/fake/jobs.ts
@@ -10,17 +10,6 @@ import type {
 import nock from "nock";
 import { createFakeUserNested } from "./user";
 
-/** V1 job states used by the server for nested jobs */
-type ServerJobState =
-	| "cancelled"
-	| "complete"
-	| "error"
-	| "preparing"
-	| "running"
-	| "terminated"
-	| "timeout"
-	| "waiting";
-
 /**
  * Creates a fake job minimal object in server response shape.
  * Use this for HTTP mocks.
@@ -29,7 +18,7 @@ export function createFakeServerJobMinimal(
 	overrides?: Partial<ServerJobMinimal>,
 ): ServerJobMinimal {
 	return {
-		id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
+		id: faker.number.int(),
 		created_at: faker.date.past().toISOString(),
 		progress: faker.number.int({ min: 0, max: 100 }),
 		state: faker.helpers.arrayElement<JobState>([
@@ -54,7 +43,7 @@ export function createFakeJobMinimal(
 ): JobMinimal {
 	return {
 		createdAt: faker.date.past(),
-		id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
+		id: faker.number.int(),
 		progress: faker.number.int({ min: 0, max: 100 }),
 		state: faker.helpers.arrayElement<JobState>([
 			"cancelled",
@@ -79,7 +68,7 @@ export function createFakeJobMinimal(
 }
 
 /**
- * Creates a fake nested job object in server response shape (V1 states).
+ * Creates a fake nested job object in server response shape.
  * Use this for HTTP mocks of resources with nested jobs (samples, analyses, etc).
  */
 export function createFakeServerJobNested(
@@ -87,17 +76,14 @@ export function createFakeServerJobNested(
 ): ServerJobNested {
 	return {
 		created_at: faker.date.past().toISOString(),
-		id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
+		id: faker.number.int(),
 		progress: faker.number.int({ min: 0, max: 100 }),
-		state: faker.helpers.arrayElement<ServerJobState>([
+		state: faker.helpers.arrayElement<JobState>([
 			"cancelled",
-			"complete",
-			"error",
-			"preparing",
+			"failed",
+			"pending",
 			"running",
-			"terminated",
-			"timeout",
-			"waiting",
+			"succeeded",
 		]),
 		user: createFakeUserNested(),
 		workflow: "pathoscope_bowtie",
@@ -106,13 +92,13 @@ export function createFakeServerJobNested(
 }
 
 /**
- * Creates a fake nested job object in client shape (transformed with V2 states).
+ * Creates a fake nested job object in client shape (transformed).
  * Use this for components that expect the transformed JobNested type.
  */
 export function createFakeJobNested(overrides?: Partial<JobNested>): JobNested {
 	return {
 		createdAt: faker.date.past(),
-		id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
+		id: faker.number.int(),
 		progress: faker.number.int({ min: 0, max: 100 }),
 		state: faker.helpers.arrayElement<JobState>([
 			"cancelled",


### PR DESCRIPTION
## Summary

- Removes the v1-to-v2 job state mapping shim that translated legacy states (e.g. `complete`, `error`, `waiting`) to v2 states — the API now returns v2 states directly
- Switches job `id` fields from `string` to `number` (`z.int()`) throughout the jobs module and all consuming components
- Renames Zod schema exports to follow the `*Schema` suffix convention (e.g. `Job` → `JobSchema`, `JobNested` → `JobNestedSchema`) to distinguish schemas from their inferred types

## Test plan

- [ ] Job list page renders jobs correctly
- [ ] Job detail page loads a job by numeric id without errors
- [ ] Sample detail and sample list items show job progress/state correctly
- [ ] Subtraction list items show job progress correctly
- [ ] Analysis list items show job state correctly
- [ ] Run `npx vitest run` — all tests pass