### PR TITLE
refactor: rename documents to items in list API responses

### DIFF
--- a/src/analyses/api.ts
+++ b/src/analyses/api.ts
@@ -30,7 +30,10 @@ export function listAnalyses(
 	return apiClient
 		.get(`/samples/${sampleId}/analyses`)
 		.query({ page, per_page, find: term })
-		.then((res) => res.body);
+		.then((res) => {
+			const { documents, ...rest } = res.body;
+			return { ...rest, items: documents };
+		});
 }
 
 /**

--- a/src/analyses/components/AnalysisList.tsx
+++ b/src/analyses/components/AnalysisList.tsx
@@ -22,8 +22,8 @@ type AnalysesListProps = {
 };
 
 function renderRow() {
-	function AnalysisRow(document: AnalysisMinimal) {
-		return <AnalysisItem key={document.id} analysis={document} />;
+	function AnalysisRow(item: AnalysisMinimal) {
+		return <AnalysisItem key={item.id} analysis={item} />;
 	}
 	return AnalysisRow;
 }
@@ -66,7 +66,7 @@ export default function AnalysesList({
 			</div>
 			{analyses.found_count ? (
 				<Pagination
-					items={analyses.documents}
+					items={analyses.items}
 					renderRow={renderRow()}
 					storedPage={analyses.page}
 					currentPage={page}

--- a/src/analyses/types.ts
+++ b/src/analyses/types.ts
@@ -284,7 +284,7 @@ export type NuvsOrf = {
 
 /** Analysis search results from the API */
 export type AnalysisSearchResult = SearchResult & {
-	documents: AnalysisMinimal[];
+	items: AnalysisMinimal[];
 };
 
 export type AnalysisWorkflow = "iimi" | "pathoscope_bowtie" | "nuvs";

--- a/src/app/websocket/updaters.ts
+++ b/src/app/websocket/updaters.ts
@@ -21,7 +21,7 @@ function taskSelector<T extends TaskObject>(cache: T): Task {
 	return cache?.task;
 }
 
-type Document = { items: TaskObject[] } | { documents: TaskObject[] };
+type ListCache = { items: TaskObject[] };
 
 /**
  * Update `Task`s in the list of items
@@ -30,15 +30,14 @@ type Document = { items: TaskObject[] } | { documents: TaskObject[] };
  * @param selector - A function that returns the task from an instance of the cached item
  * @returns A function that updates the task in the cache
  */
-function listItemUpdater<T extends Document>(
+function listItemUpdater<T extends ListCache>(
 	task: Task,
 	selector: (cache: TaskObject) => Task,
 ) {
 	return (cache: T): T => {
 		const newCache = cloneDeep(cache);
 
-		const items = "items" in newCache ? newCache.items : newCache.documents;
-		items.forEach((item: { task: Task }) => {
+		newCache.items.forEach((item: { task: Task }) => {
 			const previousTask = selector(item);
 			if (previousTask && item.task.id === task.id) {
 				Object.assign(previousTask, task);

--- a/src/hmm/api.ts
+++ b/src/hmm/api.ts
@@ -58,5 +58,8 @@ export function listHmms(
 	return apiClient
 		.get("/hmms")
 		.query({ page, per_page, find: term })
-		.then((res) => res.body);
+		.then((res) => {
+			const { documents, ...rest } = res.body;
+			return { ...rest, items: documents };
+		});
 }

--- a/src/hmm/components/HmmList.tsx
+++ b/src/hmm/components/HmmList.tsx
@@ -27,7 +27,7 @@ export default function HmmList({ find, page, setSearch }: HmmListProps) {
 	}
 
 	const {
-		documents,
+		items,
 		page: storedPage,
 		page_count,
 		found_count,
@@ -52,17 +52,17 @@ export default function HmmList({ find, page, setSearch }: HmmListProps) {
 						term={find}
 						onChange={(e) => setSearch({ find: e.target.value })}
 					/>
-					{documents.length ? (
+					{items.length ? (
 						<Pagination
-							items={documents}
+							items={items}
 							storedPage={storedPage}
 							currentPage={page}
 							pageCount={page_count}
 							onPageChange={(page) => setSearch({ page })}
 						>
 							<BoxGroup>
-								{documents.map((document) => (
-									<HmmItem key={document.id} hmm={document} />
+								{items.map((item) => (
+									<HmmItem key={item.id} hmm={item} />
 								))}
 							</BoxGroup>
 						</Pagination>

--- a/src/hmm/components/__tests__/HmmList.test.tsx
+++ b/src/hmm/components/__tests__/HmmList.test.tsx
@@ -33,7 +33,7 @@ describe("<HmmList />", () => {
 		scope.done();
 	});
 
-	it("should render correctly when no documents exist", async () => {
+	it("should render correctly when no items exist", async () => {
 		const fakeHMMData = createFakeHmmSearchResults({ documents: [] });
 		const scope = mockApiGetHmms(fakeHMMData);
 		await renderRoute(path);

--- a/src/hmm/types.ts
+++ b/src/hmm/types.ts
@@ -45,7 +45,12 @@ export type HMMInstalled = {
 /** HMM search results from the API */
 export type HmmSearchResults = SearchResult & {
 	/** Gives information about each HMM */
-	documents: HMMMinimal[];
+	items: HMMMinimal[];
 	/** The status of the HMMs */
 	status: { [key: string]: any };
+};
+
+/** Wire-shape HMM search results returned by the backend before the UI transform */
+export type ServerHmmSearchResults = Omit<HmmSearchResults, "items"> & {
+	documents: HMMMinimal[];
 };

--- a/src/indexes/api.ts
+++ b/src/indexes/api.ts
@@ -34,7 +34,10 @@ export function findIndexes(
 	return apiClient
 		.get(`/refs/${refId}/indexes`)
 		.query({ find: term, page, per_page })
-		.then((res) => res.body);
+		.then((res) => {
+			const { documents, ...rest } = res.body;
+			return { ...rest, items: documents };
+		});
 }
 
 /**
@@ -60,9 +63,10 @@ export function listIndexes({ ready, term }: { ready: boolean; term: string }) {
 export function getUnbuiltChanges(
 	refId: string,
 ): Promise<UnbuiltChangesSearchResults> {
-	return apiClient
-		.get(`/refs/${refId}/history?unbuilt=true`)
-		.then((res) => res.body);
+	return apiClient.get(`/refs/${refId}/history?unbuilt=true`).then((res) => {
+		const { documents, ...rest } = res.body;
+		return { ...rest, items: documents };
+	});
 }
 
 /**

--- a/src/indexes/components/History.tsx
+++ b/src/indexes/components/History.tsx
@@ -5,7 +5,7 @@ import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import { sortBy } from "es-toolkit";
 import type { ReactNode } from "react";
 
-type HistoryDocument = {
+type HistoryItem = {
 	id: string;
 	description: string;
 	otu: { name: string };
@@ -37,10 +37,9 @@ export default function RebuildHistory({ unbuilt }) {
 	if (unbuilt === null) {
 		content = <LoadingPlaceholder className="mt-5" />;
 	} else {
-		const historyComponents = sortBy(
-			(unbuilt.documents ?? []) as HistoryDocument[],
-			[(doc) => doc.otu.name],
-		).map((change) => (
+		const historyComponents = sortBy((unbuilt.items ?? []) as HistoryItem[], [
+			(change) => change.otu.name,
+		]).map((change) => (
 			<RebuildHistoryItem
 				key={change.id}
 				description={change.description}

--- a/src/indexes/components/Indexes.tsx
+++ b/src/indexes/components/Indexes.tsx
@@ -31,7 +31,7 @@ export default function Indexes({
 		return <LoadingPlaceholder />;
 	}
 
-	const { documents, page: storedPage, page_count } = data;
+	const { items, page: storedPage, page_count } = data;
 
 	return (
 		<>
@@ -41,22 +41,22 @@ export default function Indexes({
 				setOpen={(openRebuild) => setSearch({ openRebuild })}
 				refId={refId}
 			/>
-			{documents.length ? (
+			{items.length ? (
 				<Pagination
-					items={documents}
+					items={items}
 					storedPage={storedPage}
 					currentPage={page}
 					pageCount={page_count}
 					onPageChange={(page) => setSearch({ page })}
 				>
 					<BoxGroup>
-						{documents.map((document) => (
+						{items.map((item) => (
 							<IndexItem
-								key={document.id}
-								index={document}
+								key={item.id}
+								index={item}
 								refId={refId}
 								activeId={
-									documents.find((doc) => doc.ready && doc.has_files)?.id
+									items.find((index) => index.ready && index.has_files)?.id
 								}
 							/>
 						))}

--- a/src/indexes/types.ts
+++ b/src/indexes/types.ts
@@ -91,13 +91,13 @@ export type UnbuiltChanges = HistoryNested & {
 
 /** Unbuilt changes search results */
 export type UnbuiltChangesSearchResults = SearchResult & {
-	documents: UnbuiltChanges[];
+	items: UnbuiltChanges[];
 };
 
 /** Index search results */
 export type IndexSearchResult = SearchResult & {
 	/** Indexes relevant to the query*/
-	documents: Index[];
+	items: Index[];
 	/** The number of individual OTUs changes since the last index build */
 	modified_otu_count: number;
 	/** The number of total OTUs in the reference */

--- a/src/otus/api.ts
+++ b/src/otus/api.ts
@@ -301,7 +301,10 @@ export function listOTUs(
 	return apiClient
 		.get(`/refs/${refId}/otus`)
 		.query({ find: term, page, per_page, verified: verified || undefined })
-		.then((res) => res.body);
+		.then((res) => {
+			const { documents, ...rest } = res.body;
+			return { ...rest, items: documents };
+		});
 }
 
 /**

--- a/src/otus/components/OtuList.tsx
+++ b/src/otus/components/OtuList.tsx
@@ -47,7 +47,7 @@ export default function OtuList({
 		return <LoadingPlaceholder />;
 	}
 
-	const { documents, page: storedPage, page_count } = otus;
+	const { items, page: storedPage, page_count } = otus;
 
 	return (
 		<ContainerNarrow>
@@ -64,17 +64,17 @@ export default function OtuList({
 				refId={refId}
 			/>
 
-			{documents.length ? (
+			{items.length ? (
 				<Pagination
-					items={documents}
+					items={items}
 					storedPage={storedPage}
 					currentPage={page}
 					pageCount={page_count}
 					onPageChange={(page) => setSearch({ page })}
 				>
 					<BoxGroup>
-						{documents.map((document) => (
-							<OtuItem key={document.id} {...document} refId={refId} />
+						{items.map((item) => (
+							<OtuItem key={item.id} {...item} refId={refId} />
 						))}
 					</BoxGroup>
 				</Pagination>

--- a/src/otus/components/__tests__/OTUList.test.tsx
+++ b/src/otus/components/__tests__/OTUList.test.tsx
@@ -47,7 +47,7 @@ describe("<OTUsList />", () => {
 			scope.done();
 		});
 
-		it("should render when no documents are found", async () => {
+		it("should render when no items are found", async () => {
 			const scope = mockApiFindOtus([], reference.id);
 			await renderRoute(path);
 

--- a/src/otus/types.ts
+++ b/src/otus/types.ts
@@ -108,6 +108,6 @@ export type Otu = OtuMinimal & {
 
 /** OTU search results from API*/
 export type OtuSearchResult = SearchResult & {
-	documents: OtuMinimal[];
+	items: OtuMinimal[];
 	modified_count: number;
 };

--- a/src/references/api.ts
+++ b/src/references/api.ts
@@ -63,7 +63,10 @@ export function findReferences({
 	return apiClient
 		.get("/refs")
 		.query({ find: term, page, per_page })
-		.then((response) => response.body);
+		.then((response) => {
+			const { documents, ...rest } = response.body;
+			return { ...rest, items: documents };
+		});
 }
 
 /**

--- a/src/references/components/Detail/AddReferenceUser.tsx
+++ b/src/references/components/Detail/AddReferenceUser.tsx
@@ -39,7 +39,7 @@ export default function AddReferenceUser({
 	}
 
 	const userIds = users.map((u) => u.id);
-	const items = data.pages.flatMap((page) => page.documents);
+	const items = data.pages.flatMap((page) => page.items);
 	const filteredItems = items.filter((item) => !userIds.includes(item.id));
 
 	function renderRow(item) {

--- a/src/references/components/ReferenceList.tsx
+++ b/src/references/components/ReferenceList.tsx
@@ -42,7 +42,7 @@ export default function ReferenceList({
 	}
 
 	const {
-		documents,
+		items,
 		page: storedPage,
 		page_count,
 		total_count,
@@ -74,20 +74,20 @@ export default function ReferenceList({
 				<ReferenceOfficial officialInstalled={official_installed} />
 				{total_count !== 0 && (
 					<Pagination
-						items={documents}
+						items={items}
 						storedPage={storedPage}
 						currentPage={page}
 						pageCount={page_count}
 						onPageChange={(page) => setSearch({ page })}
 					>
 						<BoxGroup>
-							{documents.map((document) => (
+							{items.map((item) => (
 								<ReferenceItem
-									key={document.id}
+									key={item.id}
 									onClone={(cloneReferenceId) =>
 										setSearch({ cloneReferenceId })
 									}
-									reference={document}
+									reference={item}
 								/>
 							))}
 						</BoxGroup>
@@ -96,7 +96,7 @@ export default function ReferenceList({
 			</ContainerNarrow>
 			<Clone
 				cloneReferenceId={cloneReferenceId}
-				references={documents}
+				references={items}
 				unsetCloneReferenceId={() => setSearch({ cloneReferenceId: undefined })}
 			/>
 		</>

--- a/src/references/types.ts
+++ b/src/references/types.ts
@@ -130,6 +130,6 @@ export type Reference = ReferenceMinimal & {
 };
 
 export type ReferenceSearchResult = SearchResult & {
-	documents: Array<ReferenceMinimal>;
+	items: Array<ReferenceMinimal>;
 	official_installed: boolean;
 };

--- a/src/samples/api.ts
+++ b/src/samples/api.ts
@@ -20,7 +20,10 @@ export function listSamples(
 	return apiClient
 		.get("/samples")
 		.query({ page, per_page, find: term, label: labels, workflows })
-		.then((res) => res.body);
+		.then((res) => {
+			const { documents, ...rest } = res.body;
+			return { ...rest, items: documents };
+		});
 }
 
 /**

--- a/src/samples/components/SamplesList.tsx
+++ b/src/samples/components/SamplesList.tsx
@@ -58,24 +58,24 @@ export default function SamplesList({
 		return <LoadingPlaceholder />;
 	}
 
-	const { documents, page, page_count, total_count } = samples;
+	const { items, page, page_count, total_count } = samples;
 
-	function renderRow(document: SampleMinimal) {
+	function renderRow(item: SampleMinimal) {
 		function handleSelect() {
-			setSelected(xor(selected, [document.id]));
+			setSelected(xor(selected, [item.id]));
 		}
 
 		function selectOnQuickAnalyze() {
-			if (!selected.includes(document.id)) {
-				setSelected(union(selected, [document.id]));
+			if (!selected.includes(item.id)) {
+				setSelected(union(selected, [item.id]));
 			}
 		}
 
 		return (
 			<SampleItem
-				key={document.id}
-				sample={document}
-				checked={selected.includes(document.id)}
+				key={item.id}
+				sample={item}
+				checked={selected.includes(item.id)}
 				handleSelect={handleSelect}
 				selectOnQuickAnalyze={selectOnQuickAnalyze}
 				setOpenQuickAnalyze={(openQuickAnalyze) =>
@@ -92,9 +92,9 @@ export default function SamplesList({
 				onClear={() => setSelected([])}
 				setOpen={(openQuickAnalyze) => setSearch({ openQuickAnalyze })}
 				samples={intersectionWith(
-					documents,
+					items,
 					selected,
-					(document, id) => document.id === id,
+					(item, id) => item.id === id,
 				)}
 			/>
 			<div
@@ -120,11 +120,11 @@ export default function SamplesList({
 					/>
 				</div>
 				<div className="row-start-2 min-w-xl">
-					{!documents.length ? (
+					{!items.length ? (
 						<NoneFoundBox key="noSample" noun="samples" />
 					) : (
 						<Pagination
-							items={documents}
+							items={items}
 							storedPage={page}
 							currentPage={urlPage}
 							renderRow={renderRow}
@@ -137,9 +137,9 @@ export default function SamplesList({
 					<SampleLabels
 						labels={labels}
 						selectedSamples={intersectionWith(
-							documents,
+							items,
 							selected,
-							(document, id) => document.id === id,
+							(item, id) => item.id === id,
 						)}
 					/>
 				) : (

--- a/src/samples/components/Sidebar/__tests__/ManageLabels.test.tsx
+++ b/src/samples/components/Sidebar/__tests__/ManageLabels.test.tsx
@@ -8,7 +8,6 @@ describe("<ManageLabels>", () => {
 
 	beforeEach(() => {
 		props = {
-			documents: [],
 			selectedSamples: [],
 			labels: [
 				{ color: "#C4B5FD", description: "", id: 1, name: "test" },
@@ -28,8 +27,8 @@ describe("<ManageLabels>", () => {
 		expect(screen.getByText("Create one")).toBeInTheDocument();
 	});
 
-	it("should display labels of one selected document", async () => {
-		props.selectedSamples = props.documents = [
+	it("should display labels of one selected sample", async () => {
+		props.selectedSamples = [
 			{
 				name: "Foo Sample",
 				id: "foo_sample",
@@ -44,8 +43,8 @@ describe("<ManageLabels>", () => {
 		expect(screen.getByText("test")).toBeInTheDocument();
 	});
 
-	it("should display labels of two selected documents", async () => {
-		props.selectedSamples = props.documents = [
+	it("should display labels of two selected samples", async () => {
+		props.selectedSamples = [
 			{
 				name: "Foo Sample",
 				id: "foo_sample",

--- a/src/samples/types.ts
+++ b/src/samples/types.ts
@@ -113,5 +113,5 @@ export type Sample = SampleMinimal & {
 
 /* Sample search results from the API */
 export type SampleSearchResult = SearchResult & {
-	documents: Array<SampleMinimal>;
+	items: Array<SampleMinimal>;
 };

--- a/src/subtraction/api.ts
+++ b/src/subtraction/api.ts
@@ -44,7 +44,10 @@ export function findSubtractions(
 	return apiClient
 		.get("/subtractions")
 		.query({ page, per_page, find: term })
-		.then((response) => response.body);
+		.then((response) => {
+			const { documents, ...rest } = response.body;
+			return { ...rest, items: documents };
+		});
 }
 
 /**

--- a/src/subtraction/components/SubtractionList.tsx
+++ b/src/subtraction/components/SubtractionList.tsx
@@ -39,7 +39,7 @@ export default function SubtractionList({
 		setSearch({ find: e.target.value });
 	}
 
-	const { documents, total_count, page: storedPage, page_count } = data;
+	const { items, total_count, page: storedPage, page_count } = data;
 
 	return (
 		<>
@@ -59,19 +59,19 @@ export default function SubtractionList({
 				handleChange={handleChange}
 			/>
 
-			{!documents.length ? (
+			{!items.length ? (
 				<NoneFoundBox key="subtractions" noun="subtractions" />
 			) : (
 				<Pagination
-					items={documents}
+					items={items}
 					storedPage={storedPage}
 					currentPage={page}
 					pageCount={page_count}
 					onPageChange={(page) => setSearch({ page })}
 				>
 					<BoxGroup>
-						{documents.map((document) => (
-							<SubtractionItem key={document.id} {...document} />
+						{items.map((item) => (
+							<SubtractionItem key={item.id} {...item} />
 						))}
 					</BoxGroup>
 				</Pagination>

--- a/src/subtraction/types.ts
+++ b/src/subtraction/types.ts
@@ -93,5 +93,5 @@ export type SubtractionOption = SubtractionNested & {
 /** Subtraction search results from the API */
 export type SubtractionSearchResult = SearchResult & {
 	ready_count: number;
-	documents: Array<SubtractionMinimal>;
+	items: Array<SubtractionMinimal>;
 };

--- a/src/tests/fake/hmm.ts
+++ b/src/tests/fake/hmm.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import type { Hmm, HmmSearchResults } from "@hmm/types";
+import type { Hmm, ServerHmmSearchResults } from "@hmm/types";
 import nock from "nock";
 
 /**
@@ -53,8 +53,8 @@ export function createFakeHmm() {
  * @param overrides - optional properties for creating a fake Hmm search result with specific values
  */
 export function createFakeHmmSearchResults(
-	overrides?: Partial<HmmSearchResults>,
-): HmmSearchResults {
+	overrides?: Partial<ServerHmmSearchResults>,
+): ServerHmmSearchResults {
 	return {
 		documents: Array.from({ length: 5 }, createFakeHmmMinimal),
 		status: {
@@ -81,7 +81,7 @@ export function createFakeHmmSearchResults(
  * @param hmmSearchResults - The hmm search results to be returned from the mocked API call
  * @returns The nock scope for the mocked API call
  */
-export function mockApiGetHmms(hmmSearchResults: HmmSearchResults) {
+export function mockApiGetHmms(hmmSearchResults: ServerHmmSearchResults) {
 	return nock("http://localhost")
 		.get("/api/hmms")
 		.query(true)

--- a/src/uploads/hooks.ts
+++ b/src/uploads/hooks.ts
@@ -21,9 +21,9 @@ export function useValidateFiles(
 
 	useEffect(() => {
 		if (!isPending && selected.length) {
-			const documents = data.pages.flatMap((page) => page.items);
+			const items = data.pages.flatMap((page) => page.items);
 			const selectedFilesExist = selected.every((itemId) =>
-				documents.some((item) => item.id === itemId),
+				items.some((item) => item.id === itemId),
 			);
 
 			if (!selectedFilesExist) {

--- a/src/users/components/__tests__/ManageUsers.test.tsx
+++ b/src/users/components/__tests__/ManageUsers.test.tsx
@@ -25,7 +25,7 @@ describe("<ManageUsers />", () => {
 		});
 	});
 
-	it("should render correctly when documents = null", async () => {
+	it("should render correctly when items = null", async () => {
 		const account = createFakeAccount({
 			administrator_role: "full",
 		});

--- a/src/users/components/__tests__/UserDetail.test.tsx
+++ b/src/users/components/__tests__/UserDetail.test.tsx
@@ -192,7 +192,7 @@ describe("<UserDetail />", () => {
 
 			scope.done();
 		});
-		it("should render NoneFound when documents = []", async () => {
+		it("should render NoneFound when items = []", async () => {
 			const user = createFakeUser({ groups: [] });
 
 			mockApiListGroups([]);

--- a/src/users/types.ts
+++ b/src/users/types.ts
@@ -74,5 +74,5 @@ export type AdminUserResponse = SearchResult & {
 /** User search results from the API */
 export type UserResponse = SearchResult & {
 	/** The page of users */
-	documents: Array<User>;
+	items: Array<User>;
 };


### PR DESCRIPTION
## Summary
- Renames the `documents` field to `items` in all list/search result types across analyses, HMMs, indexes, OTUs, references, samples, subtractions, and users
- Adds a transform in each feature's API layer to map `documents` → `items` at the network boundary, keeping the backend wire format isolated from UI code
- Cleans up related variable names and test descriptions to use `item`/`items` instead of `document`/`documents`

## Test plan
- [ ] Run `npx vitest run` and verify all tests pass
- [ ] Manually verify list pages for samples, references, HMMs, OTUs, indexes, and subtractions render correctly
- [ ] Confirm pagination still works on all list pages