### PR TITLE
refactor: remove pathoscope_bowtie workflow name aliasing

### DIFF
--- a/src/account/types.ts
+++ b/src/account/types.ts
@@ -1,7 +1,7 @@
 import type { GroupMinimal, Permissions } from "@groups/types";
 import type { User } from "@users/types";
 
-export type QuickAnalyzeWorkflow = "nuvs" | "pathoscope_bowtie";
+export type QuickAnalyzeWorkflow = "nuvs" | "pathoscope";
 
 export type APIKeyMinimal = {
 	created_at?: string;

--- a/src/analyses/components/AnalysisDetail.tsx
+++ b/src/analyses/components/AnalysisDetail.tsx
@@ -43,7 +43,7 @@ export default function AnalysisDetail() {
 
 	let content: ReactNode;
 
-	if (analysis.workflow === "pathoscope_bowtie") {
+	if (analysis.workflow === "pathoscope") {
 		content = (
 			<PathoscopeViewer
 				analysis={analysis as FormattedPathoscopeAnalysis}

--- a/src/analyses/components/Create/CreateAnalysis.tsx
+++ b/src/analyses/components/Create/CreateAnalysis.tsx
@@ -50,7 +50,7 @@ export default function CreateAnalysis({
 			<CreateAnalysisDialogContent>
 				<DialogTitle>Analyze</DialogTitle>
 				<HMMAlert installed={hmms.status.task?.complete} />
-				<Tabs.Root defaultValue="pathoscope_bowtie">
+				<Tabs.Root defaultValue="pathoscope">
 					<Tabs.List
 						className={cn(
 							"bg-gray-100",
@@ -101,7 +101,7 @@ export default function CreateAnalysis({
 					<Content value="nuvs">
 						<CreateNuvs sampleCount={1} sampleIds={sampleIds} />
 					</Content>
-					<Content value="pathoscope_bowtie">
+					<Content value="pathoscope">
 						<CreatePathoscope sampleCount={1} sampleIds={sampleIds} />
 					</Content>
 				</Tabs.Root>

--- a/src/analyses/components/Create/CreatePathoscope.tsx
+++ b/src/analyses/components/Create/CreatePathoscope.tsx
@@ -63,7 +63,7 @@ export default function CreatePathoscope({
 				refId,
 				sampleId,
 				subtractionIds,
-				workflow: "pathoscope_bowtie",
+				workflow: "pathoscope",
 			}),
 		);
 	}

--- a/src/analyses/components/Create/QuickAnalyze.tsx
+++ b/src/analyses/components/Create/QuickAnalyze.tsx
@@ -66,7 +66,7 @@ export default function QuickAnalyze({
 				<DialogTitle>Quick Analyze</DialogTitle>
 				<HMMAlert installed={hmms.status.task?.complete} />
 
-				<Tabs.Root defaultValue="pathoscope_bowtie">
+				<Tabs.Root defaultValue="pathoscope">
 					<Tabs.List
 						className={cn(
 							"bg-gray-100",
@@ -137,7 +137,7 @@ export default function QuickAnalyze({
 					<Content value="nuvs">
 						<CreateNuvs sampleCount={sampleIds.length} sampleIds={sampleIds} />
 					</Content>
-					<Content value="pathoscope_bowtie">
+					<Content value="pathoscope">
 						<CreatePathoscope
 							sampleCount={sampleIds.length}
 							sampleIds={sampleIds}

--- a/src/analyses/components/Create/workflows.ts
+++ b/src/analyses/components/Create/workflows.ts
@@ -4,7 +4,7 @@ export type workflow = {
 };
 
 export const pathoscopeWorkflow = {
-	id: "pathoscope_bowtie",
+	id: "pathoscope",
 	name: "Pathoscope",
 };
 

--- a/src/analyses/types.ts
+++ b/src/analyses/types.ts
@@ -93,7 +93,7 @@ export type Analysis =
 export type FormattedPathoscopeAnalysis = AnalysisMinimal & {
 	files: AnalysisFile[];
 	results: FormattedPathoscopeResults;
-	workflow: "pathoscope_bowtie";
+	workflow: "pathoscope";
 };
 
 /** All results for a pathoscope analysis*/
@@ -287,7 +287,7 @@ export type AnalysisSearchResult = SearchResult & {
 	items: AnalysisMinimal[];
 };
 
-export type AnalysisWorkflow = "iimi" | "pathoscope_bowtie" | "nuvs";
+export type AnalysisWorkflow = "iimi" | "pathoscope" | "nuvs";
 
 /** Read depths of a sequence mapped by position to an array */
 export type PositionMappedReadDepths = number[];

--- a/src/analyses/utils.ts
+++ b/src/analyses/utils.ts
@@ -268,7 +268,7 @@ export function formatPathoscopeData(detail): FormattedPathoscopeAnalysis {
 }
 
 export function formatData(detail) {
-	if (detail?.workflow?.startsWith("pathoscope")) {
+	if (detail?.workflow === "pathoscope") {
 		return formatPathoscopeData(detail);
 	}
 
@@ -283,7 +283,7 @@ export function formatData(detail) {
 	return detail;
 }
 
-const supportedWorkflows = ["pathoscope_bowtie", "nuvs", "iimi"];
+const supportedWorkflows = ["pathoscope", "nuvs", "iimi"];
 
 export function checkSupportedWorkflow(workflow) {
 	return supportedWorkflows.includes(workflow);

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -81,13 +81,11 @@ export const workflowDisplayNames = {
 	iimi: "Iimi",
 	nuvs: "Nuvs",
 	pathoscope: "Pathoscope",
-	pathoscope_bowtie: "Pathoscope",
-	pathoscope_snap: "Pathoscope",
 	build_index: "Build Index",
 };
 
 /**
- * Transforms a plain workflow ID (eg. pathoscope_bowtie) to a human-readable name (eg. PathoscopeBowtie).
+ * Transforms a plain workflow ID (eg. pathoscope) to a human-readable name (eg. Pathoscope).
  *
  * @func
  * @param workflow plain workflow ID

--- a/src/app/websocket/reactQueryHandler.ts
+++ b/src/app/websocket/reactQueryHandler.ts
@@ -19,7 +19,7 @@ const workflowQueries = {
 	create_sample: [samplesQueryKeys.lists()],
 	iimi: [samplesQueryKeys.lists(), analysesQueryKeys.lists()],
 	nuvs: [samplesQueryKeys.lists(), analysesQueryKeys.lists()],
-	pathoscope_bowtie: [samplesQueryKeys.lists(), analysesQueryKeys.lists()],
+	pathoscope: [samplesQueryKeys.lists(), analysesQueryKeys.lists()],
 };
 
 function jobUpdater(queryClient: QueryClient, data: WsMessage["data"]) {

--- a/src/jobs/types.ts
+++ b/src/jobs/types.ts
@@ -9,19 +9,15 @@ const JobStateSchema = z.enum([
 ]);
 export type JobState = z.infer<typeof JobStateSchema>;
 
-export const Workflow = z.preprocess(
-	(val) => (val === "pathoscope_bowtie" ? "pathoscope" : val),
-	z.enum([
-		"build_index",
-		"create_sample",
-		"create_subtraction",
-		"nuvs",
-		"pathoscope",
-		"iimi",
-	]),
-);
+export const Workflow = z.literal([
+	"build_index",
+	"create_sample",
+	"create_subtraction",
+	"nuvs",
+	"pathoscope",
+	"iimi",
+]);
 export type Workflow = z.infer<typeof Workflow>;
-export type ServerWorkflow = z.input<typeof Workflow>;
 
 export const JobNestedSchema = z
 	.object({

--- a/src/tests/fake/account.ts
+++ b/src/tests/fake/account.ts
@@ -7,7 +7,7 @@ import { createFakePermissions } from "./permissions";
 import { createFakeUser } from "./user";
 
 const defaultSettings = {
-	quick_analyze_workflow: "pathoscope_bowtie",
+	quick_analyze_workflow: "pathoscope",
 	show_ids: true,
 	show_versions: true,
 	skip_quick_analyze_dialog: true,

--- a/src/tests/fake/analyses.ts
+++ b/src/tests/fake/analyses.ts
@@ -39,7 +39,7 @@ export function createFakeAnalysisMinimal(
 		subtractions: [createFakeSubtractionNested()],
 		updated_at: faker.date.past().toISOString(),
 		user: createFakeUserNested(),
-		workflow: "pathoscope_bowtie",
+		workflow: "pathoscope",
 		...overrides,
 	};
 }

--- a/src/tests/fake/jobs.ts
+++ b/src/tests/fake/jobs.ts
@@ -29,7 +29,7 @@ export function createFakeServerJobMinimal(
 			"succeeded",
 		]),
 		user: createFakeUserNested(),
-		workflow: "pathoscope_bowtie",
+		workflow: "pathoscope",
 		...overrides,
 	};
 }
@@ -86,7 +86,7 @@ export function createFakeServerJobNested(
 			"succeeded",
 		]),
 		user: createFakeUserNested(),
-		workflow: "pathoscope_bowtie",
+		workflow: "pathoscope",
 		...overrides,
 	};
 }


### PR DESCRIPTION
## Summary
- Removes the legacy `pathoscope_bowtie` workflow name alias from the Zod `Workflow` schema, replacing it with the canonical `pathoscope` identifier
- Updates all type definitions, component logic, fake data factories, and WebSocket query handlers to use `pathoscope` exclusively
- Cleans up the `workflowDisplayNames` map by removing the now-unnecessary `pathoscope_bowtie` and `pathoscope_snap` alias entries

## Test plan
- [ ] Verify creating a Pathoscope analysis still works end-to-end
- [ ] Confirm existing analyses with `workflow: "pathoscope"` display correctly in the analysis detail view
- [ ] Check the Quick Analyze dialog defaults to the Pathoscope tab correctly
- [ ] Run `npx vitest run` and confirm all tests pass