### PR TITLE
fix: redirect to home after creating first user

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,13 +118,46 @@ mappings, or decisions that apply to your work.
 
 ## Git
 
-Commit messages use **Conventional Commits**:
+Commit messages use **Conventional Commits**. Releases are automated with
+semantic-release: only `feat` (minor) and `fix` (patch) trigger a release.
+Anything user-visible must be one of those — never `refactor` or `chore`.
 
 ```
 type(scope): description
 ```
 
-Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`.
+### Types
+
+- `feat`: new user-facing feature or capability
+- `fix`: bug fix or correcting wrong behavior (includes UI adjustments and
+  performance improvements)
+- `chore`: internal code not yet exposed to users (e.g., new hook, data model),
+  configs, dependencies, file moves/renames, build scripts
+- `refactor`: restructuring code without changing behavior (e.g., extracting
+  functions, renaming variables, reorganizing modules)
+- `style`: formatting only — no logic changes
+- `docs`: documentation changes only
+- `test`: adding or updating tests
+- `ci`: CI/CD pipeline changes
+
+### Titles
+
+`feat` and `fix` titles are user-facing. Describe the outcome for the user, not
+the code change. Implementation details go in the body, not the title.
+
+- Bad: `fix: use shared Button component with corrected label`
+- Good: `fix: correct submit button label`
+- Bad: `feat: wrap save handler in a transaction`
+- Good: `fix: prevent rare data loss when saving`
+
+All other types are developer-facing — implementation details are helpful and
+make commits easier to find later.
+
+- Good: `refactor: extract form helpers into src/forms/`
+- Good: `chore: add csv parser`
+- Good: `test: add tests for table components and hooks`
+
+### Other rules
 
 - Title: lowercase, no period, under 72 characters.
 - Scope is optional but preferred.

--- a/src/users/queries.ts
+++ b/src/users/queries.ts
@@ -59,8 +59,5 @@ export function useCreateFirstUser() {
 		mutationFn: ({ handle, password, forceReset }) => {
 			return createFirst(handle, password, forceReset);
 		},
-		onSuccess: () => {
-			window.location.reload();
-		},
 	});
 }

--- a/src/wall/components/FirstUser.tsx
+++ b/src/wall/components/FirstUser.tsx
@@ -3,8 +3,11 @@ import InputError from "@base/InputError";
 import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import InputSimple from "@base/InputSimple";
+import { useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import { useCreateFirstUser } from "@users/queries";
 import { useForm } from "react-hook-form";
+import { rootKeys } from "../queries";
 import { WallContainer } from "./WallContainer";
 import { WallTitle } from "./WallTitle";
 
@@ -18,15 +21,25 @@ type FormValues = {
  */
 export default function FirstUser() {
 	const mutation = useCreateFirstUser();
+	const queryClient = useQueryClient();
+	const navigate = useNavigate();
 
 	const { handleSubmit, register } = useForm<FormValues>();
 
 	function onSubmit(data: FormValues) {
-		mutation.mutate({
-			handle: data.username,
-			password: data.password,
-			forceReset: false,
-		});
+		mutation.mutate(
+			{
+				handle: data.username,
+				password: data.password,
+				forceReset: false,
+			},
+			{
+				onSuccess: async () => {
+					await queryClient.invalidateQueries({ queryKey: rootKeys.all() });
+					navigate({ to: "/" });
+				},
+			},
+		);
 	}
 
 	return (

--- a/src/wall/components/__tests__/FirstUser.test.tsx
+++ b/src/wall/components/__tests__/FirstUser.test.tsx
@@ -1,25 +1,26 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { renderWithProviders } from "@tests/setup";
+import { renderWithRouter } from "@tests/setup";
 import nock from "nock";
 import { describe, expect, it } from "vitest";
 import FirstUser from "../FirstUser";
 
 describe("<FirstUser />", () => {
-	it("creates first user once form is submitted", async () => {
+	it("creates first user and redirects to / on success", async () => {
 		const usernameInput = "Username";
 		const passwordInput = "Password";
 		const scope = nock("http://localhost")
-			.post("/api/users/first", {
+			.put("/api/users/first", {
 				handle: usernameInput,
 				password: passwordInput,
+				force_reset: false,
 			})
 			.reply(201, {
 				handle: usernameInput,
 				password: passwordInput,
 			});
 
-		renderWithProviders(<FirstUser />);
+		const { router } = await renderWithRouter(<FirstUser />, "/setup");
 
 		const usernameField = screen.getByLabelText("username");
 		const passwordField = screen.getByLabelText("password");
@@ -35,6 +36,9 @@ describe("<FirstUser />", () => {
 
 		await userEvent.click(screen.getByRole("button", { name: /Create User/i }));
 
-		scope.isDone();
+		await waitFor(() => {
+			expect(router.state.location.pathname).toBe("/");
+		});
+		expect(scope.isDone()).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary
- After creating the first user, the app now invalidates the root query cache and navigates to `/` using TanStack Router instead of reloading the page via `window.location.reload()`
- The `onSuccess` handler was moved from the mutation definition in `useCreateFirstUser` to the call site in `FirstUser.tsx` so that navigation concerns stay in the component
- Clarifies conventional commit type guidelines in `AGENTS.md`, noting that only `feat` and `fix` trigger semantic-release and describing when to use each type

## Test plan
- [x] Updated test uses `renderWithRouter` and asserts `router.state.location.pathname === "/"` after form submission
- [ ] Manually verify that submitting the first-user form redirects to the home page without a full page reload