### PR TITLE
fix: return to requested page after signing in

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,17 +1,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactElement } from "react";
 import AppRouter from "./AppRouter";
-import { resetClient } from "./utils";
 
 const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
 			retry: (failureCount: number, error: any) => {
-				if ([403, 404].includes(error.response?.status)) {
+				const status = error.response?.status;
+				if ([401, 403, 404].includes(status)) {
 					return false;
-				}
-				if (error.response?.status === 401) {
-					resetClient();
 				}
 				return failureCount <= 3;
 			},

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -36,7 +36,7 @@ function setupWebSocket(queryClient: QueryClient) {
 
 export const Route = createFileRoute("/_authenticated")({
 	validateSearch: authenticatedSearchSchema,
-	beforeLoad: async ({ context }) => {
+	beforeLoad: async ({ context, location }) => {
 		const { queryClient } = context;
 
 		const rootData = await queryClient.ensureQueryData<Root>({
@@ -54,7 +54,10 @@ export const Route = createFileRoute("/_authenticated")({
 				queryFn: fetchAccount,
 			});
 		} catch {
-			throw redirect({ to: "/login" });
+			throw redirect({
+				to: "/login",
+				search: { redirect: location.href } as never,
+			});
 		}
 	},
 	component: AuthenticatedLayout,

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -56,7 +56,8 @@ export const Route = createFileRoute("/_authenticated")({
 		} catch {
 			throw redirect({
 				to: "/login",
-				search: { redirect: location.href } as never,
+				// biome-ignore lint/suspicious/noExplicitAny: route search type is `AnyRoute` because tsconfig has `strict: false` (see AppRouter.tsx)
+				search: { redirect: location.href } as any,
 			});
 		}
 	},

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,6 +1,28 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { fetchAccount } from "@account/api";
+import { accountKeys } from "@account/queries";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import LoginWall from "@wall/components/LoginWall";
+import { z } from "zod/v4";
+
+const loginSearchSchema = z.object({
+	redirect: z.string().optional().catch(undefined),
+});
 
 export const Route = createFileRoute("/login")({
+	validateSearch: loginSearchSchema,
+	beforeLoad: async ({ context, search }) => {
+		const { queryClient } = context;
+
+		try {
+			await queryClient.ensureQueryData({
+				queryKey: accountKeys.all(),
+				queryFn: fetchAccount,
+			});
+		} catch {
+			return;
+		}
+
+		throw redirect({ to: search.redirect ?? "/" });
+	},
 	component: LoginWall,
 });

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -4,8 +4,20 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 import LoginWall from "@wall/components/LoginWall";
 import { z } from "zod/v4";
 
+function isSafeRedirect(value: string): boolean {
+	return (
+		value.startsWith("/") &&
+		!value.startsWith("//") &&
+		!value.startsWith("/login")
+	);
+}
+
 const loginSearchSchema = z.object({
-	redirect: z.string().optional().catch(undefined),
+	redirect: z
+		.string()
+		.optional()
+		.refine((val) => !val || isSafeRedirect(val))
+		.catch(undefined),
 });
 
 export const Route = createFileRoute("/login")({

--- a/src/wall/components/LoginForm.tsx
+++ b/src/wall/components/LoginForm.tsx
@@ -3,19 +3,23 @@ import Checkbox from "@base/Checkbox";
 import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import InputSimple from "@base/InputSimple";
+import { useNavigate } from "@tanstack/react-router";
 import { Controller, useForm } from "react-hook-form";
 import { useLoginMutation } from "../queries";
 import { WallTitle } from "./WallTitle";
 
 type LoginFormProps = {
+	/** URL to navigate to after a successful login. Defaults to "/". */
+	redirect?: string;
 	/** Callback to set the reset code in the parent component state. */
 	setResetCode: (resetCode: string) => void;
 };
 
 /** Handles the user login process. */
-export default function LoginForm({ setResetCode }: LoginFormProps) {
+export default function LoginForm({ redirect, setResetCode }: LoginFormProps) {
 	const { control, handleSubmit, register } = useForm();
 	const loginMutation = useLoginMutation();
+	const navigate = useNavigate();
 
 	function onSubmit({ handle, password, remember }) {
 		loginMutation.mutate(
@@ -24,7 +28,9 @@ export default function LoginForm({ setResetCode }: LoginFormProps) {
 				onSuccess: (data) => {
 					if (data.body.reset_code) {
 						setResetCode(data.body.reset_code);
+						return;
 					}
+					navigate({ to: redirect ?? "/" });
 				},
 			},
 		);

--- a/src/wall/components/LoginWall.tsx
+++ b/src/wall/components/LoginWall.tsx
@@ -1,17 +1,21 @@
+import { getRouteApi } from "@tanstack/react-router";
 import { useState } from "react";
 import LoginForm from "./LoginForm";
 import ResetForm from "./ResetForm";
 import { WallContainer } from "./WallContainer";
 
+const loginRouteApi = getRouteApi("/login");
+
 export default function LoginWall() {
 	const [resetCode, setResetCode] = useState<string | null>(null);
+	const { redirect } = loginRouteApi.useSearch();
 
 	return (
 		<WallContainer>
 			{resetCode ? (
 				<ResetForm resetCode={resetCode} />
 			) : (
-				<LoginForm setResetCode={setResetCode} />
+				<LoginForm redirect={redirect} setResetCode={setResetCode} />
 			)}
 		</WallContainer>
 	);


### PR DESCRIPTION
## Summary

- Visiting a page while signed out now redirects through `/login` and lands on the originally requested page after authenticating, instead of always falling back to `/`.
- Stop the reset loop and slow login render that occurred when `/login` was visited while signed out: the QueryClient retry callback no longer calls `resetClient` on 401, and the auth-failure path is handled by route guards.
- Mid-session 401s are still handled via the websocket close-code-4000 path, so dropping the retry-callback side effect doesn't regress logout-on-expiry.