### PR TITLE
fix: hide Iimi workflow from analysis creation

### DIFF
--- a/src/analyses/components/Create/__tests__/workflows.test.ts
+++ b/src/analyses/components/Create/__tests__/workflows.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
 	getCompatibleWorkflows,
-	iimiWorkflow,
 	nuvsWorkflow,
 	pathoscopeWorkflow,
 } from "../workflows";
@@ -9,11 +8,11 @@ import {
 describe("getCompatibleWorkflows()", () => {
 	it("should not return nuvs when [hasHmm=false]", () => {
 		const result = getCompatibleWorkflows(false);
-		expect(result).toEqual([pathoscopeWorkflow, iimiWorkflow]);
+		expect(result).toEqual([pathoscopeWorkflow]);
 	});
 
 	it("should return all workflows when [hasHmm=true]", () => {
 		const result = getCompatibleWorkflows(true);
-		expect(result).toEqual([pathoscopeWorkflow, nuvsWorkflow, iimiWorkflow]);
+		expect(result).toEqual([pathoscopeWorkflow, nuvsWorkflow]);
 	});
 });

--- a/src/analyses/components/Create/workflows.ts
+++ b/src/analyses/components/Create/workflows.ts
@@ -18,11 +18,7 @@ export const iimiWorkflow = {
 	name: "Iimi",
 };
 
-export const workflows = [
-	pathoscopeWorkflow,
-	nuvsWorkflow,
-	iimiWorkflow,
-] as workflow[];
+export const workflows = [pathoscopeWorkflow, nuvsWorkflow] as workflow[];
 
 export function getCompatibleWorkflows(hasHmm: boolean): workflow[] {
 	return workflows.filter((workflow) => {


### PR DESCRIPTION
## Summary
- Removes Iimi from the list of available workflows when creating an analysis
- The Iimi Docker image is broken and the workflow is being discontinued, so users should not be able to start new Iimi analyses

Closes [VIR-2334](https://linear.app/virtool/issue/VIR-2334/disable-iimi-start-temporarily)