### PR TITLE
ci: group dependabot updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,47 @@ updates:
           interval: "weekly"
       open-pull-requests-limit: 10
       commit-message:
-          prefix: "chore"
-          include: "scope"
+          prefix: "chore(deps)"
+      groups:
+          tanstack:
+              patterns:
+                  - "@tanstack/*"
+          sentry:
+              patterns:
+                  - "@sentry/*"
+          testing:
+              patterns:
+                  - "@testing-library/*"
+                  - "@faker-js/*"
+                  - "vitest"
+                  - "@vitest/*"
+                  - "jsdom"
+          react:
+              patterns:
+                  - "react"
+                  - "react-dom"
+                  - "@types/react"
+                  - "@types/react-dom"
+                  - "babel-plugin-react-compiler"
+          tailwind:
+              patterns:
+                  - "tailwindcss"
+                  - "@tailwindcss/*"
+          vite:
+              patterns:
+                  - "vite"
+                  - "@vitejs/*"
+          react-hook-form:
+              patterns:
+                  - "react-hook-form"
+                  - "@hookform/*"
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
           interval: "monthly"
+      commit-message:
+          prefix: "chore(deps)"
+      groups:
+          actions:
+              patterns:
+                  - "*"


### PR DESCRIPTION
## Summary
- Groups dependabot npm updates into logical clusters (tanstack, sentry, testing, react, tailwind, vite, react-hook-form) to reduce PR noise
- Groups all GitHub Actions updates into a single PR
- Standardizes commit message prefix to `chore(deps)` for both npm and actions ecosystems