### PR TITLE
chore: use pnpm in worktrunk pre-start hook

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,4 +1,4 @@
-pre-start = "npm ci"
+pre-start = "pnpm install"
 
 [list]
 url = "http://localhost:{{ branch | hash_port }}"


### PR DESCRIPTION
## Summary
- Updates the worktrunk `pre-start` hook in `.config/wt.toml` to use `pnpm install` instead of `npm ci`, aligning with the project's use of pnpm as its package manager

## Test plan
- [ ] Verify that opening a new worktree runs `pnpm install` without errors