### PR TITLE
fix: import references no longer end up empty

### DIFF
--- a/apps/web/src/references/api.ts
+++ b/apps/web/src/references/api.ts
@@ -108,13 +108,13 @@ export function createReference(
  *
  * @param name - name of the reference
  * @param description - description for the reference
- * @param importFrom - the ID of the file to import from
+ * @param importFrom - the ID of the upload to import from
  * @returns A promise resolving to importing a reference
  */
 export function importReference(
 	name: string,
 	description: string,
-	importFrom: string,
+	importFrom: number,
 ) {
 	return apiClient
 		.post("/refs")

--- a/apps/web/src/references/api.ts
+++ b/apps/web/src/references/api.ts
@@ -115,7 +115,7 @@ export function importReference(
 	name: string,
 	description: string,
 	importFrom: number,
-) {
+): Promise<Reference> {
 	return apiClient
 		.post("/refs")
 		.send({

--- a/apps/web/src/references/components/ImportReference.tsx
+++ b/apps/web/src/references/components/ImportReference.tsx
@@ -15,8 +15,7 @@ export default function ImportReference() {
 	const navigate = useNavigate();
 
 	const importMutation = useImportReference();
-	const { uploadMutation, fileName, fileNameOnDisk, progress } =
-		useUploadReference();
+	const { uploadMutation, fileName, uploadId, progress } = useUploadReference();
 
 	const {
 		control,
@@ -73,8 +72,11 @@ export default function ImportReference() {
 
 			<form
 				onSubmit={handleSubmit((values) => {
+					if (uploadId === null) {
+						return;
+					}
 					importMutation.mutate(
-						{ ...values, importFrom: fileNameOnDisk },
+						{ ...values, importFrom: uploadId },
 						{ onSuccess: () => navigate({ to: "/refs", replace: true }) },
 					);
 				})}

--- a/apps/web/src/references/components/ImportReference.tsx
+++ b/apps/web/src/references/components/ImportReference.tsx
@@ -97,7 +97,7 @@ export default function ImportReference() {
 
 				<DialogFooter>
 					<SaveButton
-						disabled={progress !== 100 && progress !== 0}
+						disabled={progress > 0 && uploadId === null}
 						altText="Import"
 					/>
 				</DialogFooter>

--- a/apps/web/src/references/components/__tests__/ImportReference.test.tsx
+++ b/apps/web/src/references/components/__tests__/ImportReference.test.tsx
@@ -12,14 +12,13 @@ describe("<ImportReference />", () => {
 		scope.post("/api/uploads?name=external.json.gz&type=reference").reply(200, {
 			id: 12,
 			name: "external.json.gz",
-			name_on_disk: "12-external.json.gz",
 		});
 
 		scope
 			.post("/api/refs", {
 				name: "External",
 				description: "External reference",
-				import_from: "12-external.json.gz",
+				import_from: 12,
 			})
 			.reply(201, {
 				id: "foo",

--- a/apps/web/src/references/queries.ts
+++ b/apps/web/src/references/queries.ts
@@ -146,6 +146,11 @@ export function useUploadReference() {
 					setUploadId(response.body.id);
 				});
 		},
+		onMutate: () => {
+			setFileName("");
+			setUploadId(null);
+			setProgress(0);
+		},
 	});
 
 	return { uploadMutation, fileName, uploadId, progress };

--- a/apps/web/src/references/queries.ts
+++ b/apps/web/src/references/queries.ts
@@ -111,7 +111,7 @@ export function useImportReference() {
 		{
 			name: string;
 			description: string;
-			importFrom: string;
+			importFrom: number;
 		}
 	>({
 		mutationFn: ({ name, description, importFrom }) =>
@@ -126,7 +126,7 @@ export function useImportReference() {
  */
 export function useUploadReference() {
 	const [fileName, setFileName] = useState("");
-	const [fileNameOnDisk, setFileNameOnDisk] = useState("");
+	const [uploadId, setUploadId] = useState<number | null>(null);
 	const [progress, setProgress] = useState(0);
 
 	const uploadMutation = useMutation({
@@ -143,12 +143,12 @@ export function useUploadReference() {
 				})
 				.then((response) => {
 					setFileName(response.body.name);
-					setFileNameOnDisk(response.body.name_on_disk);
+					setUploadId(response.body.id);
 				});
 		},
 	});
 
-	return { uploadMutation, fileName, fileNameOnDisk, progress };
+	return { uploadMutation, fileName, uploadId, progress };
 }
 
 /**


### PR DESCRIPTION
## Summary
- The reference import form was passing the server-generated filename (`name_on_disk`) to the import API instead of the upload ID, causing the API to create an empty reference
- Changed `useUploadReference` to track the upload `id` (a number) instead of `name_on_disk` (a string), and updated `importReference` and `useImportReference` to use `number` for `importFrom`
- Added a guard in the form submit handler to bail out if the upload ID is not yet available

## Test plan
- [ ] Upload a reference file in the import dialog and verify the imported reference is populated with OTUs rather than empty
- [ ] Verify the existing `ImportReference` test passes with the updated assertions