### PR TITLE
feat: add about dialog with version info

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,9 @@
 
 React + TypeScript single-page application for Virtool, a bioinformatics platform.
 
+> `CLAUDE.md` is a symlink to this file. Edit `AGENTS.md` — never write to
+> `CLAUDE.md` directly.
+
 ## Repository layout
 
 This is a **pnpm monorepo**:
@@ -393,7 +396,16 @@ and make commits easier to find later.
 - **Assertions:** Use explicit `expect()` assertions, not snapshots.
 - **User interaction:** Use `@testing-library/user-event` over `fireEvent`.
 - **Queries:** Prefer accessible queries (`getByRole`, `getByLabelText`) over
-  `getByTestId`.
+  `getByTestId`. Every interactive element should be reachable by an
+  accessible name (visible label, `aria-label`, or `aria-labelledby`). If a
+  query is ambiguous, give the target a name in the component rather than
+  disambiguating in the test — the test stays stable as the surrounding UI
+  changes.
+- **Don't disambiguate by index.** Reaching into `getAllByRole(...)[n]` to
+  pick between *different* controls (e.g. one of several buttons) is
+  fragile — adding or reordering controls silently picks up the wrong one.
+  Add an accessible name instead. Indexing into a list of intrinsically
+  ordered, equivalent items (rows in a table, cards in a list) is fine.
 
 ### Shared test fixtures live in their own module
 

--- a/apps/web/src/nav/components/AboutDialog.tsx
+++ b/apps/web/src/nav/components/AboutDialog.tsx
@@ -1,0 +1,62 @@
+import { Dialog, DialogContent, DialogTitle } from "@base/Dialog";
+import ExternalLink from "@base/ExternalLink";
+import { useRootQuery } from "@wall/queries";
+
+type AboutDialogProps = {
+	open: boolean;
+	setOpen: (open: boolean) => void;
+};
+
+/**
+ * Dialog showing the Virtool server and web app versions and a link to the
+ * documentation.
+ */
+export default function AboutDialog({ open, setOpen }: AboutDialogProps) {
+	const { data } = useRootQuery();
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogContent>
+				<DialogTitle>About Virtool</DialogTitle>
+				<p className="text-slate-600 pb-6">
+					Virtool runs as two pieces: a server that stores your data and runs
+					analyses, and a web app that you use in your browser to interact with
+					it. Each is released independently.
+				</p>
+
+				<section className="pb-6">
+					<h3 className="font-medium pb-3 text-lg">Versions</h3>
+					<dl className="grid grid-cols-[8rem_1fr] gap-y-3">
+						<dt className="font-medium">Server</dt>
+						<dd>
+							<div className="font-mono">{data?.version ?? "—"}</div>
+							<div className="text-slate-600 text-sm">
+								Stores data and runs analyses.
+							</div>
+						</dd>
+						<dt className="font-medium">Web app</dt>
+						<dd>
+							<div className="font-mono">{__APP_VERSION__}</div>
+							<div className="text-slate-600 text-sm">
+								The pages you see in your browser.
+							</div>
+						</dd>
+					</dl>
+				</section>
+
+				<section className="border-t border-gray-200 pt-6">
+					<h3 className="font-medium pb-2 text-lg">Documentation</h3>
+					<p className="text-slate-600 pb-2">
+						Guides for installing, configuring, and using Virtool.
+					</p>
+					<ExternalLink
+						className="text-blue-600 hover:underline"
+						href="https://virtool.ca/docs/manual/start/installation/"
+					>
+						virtool.ca/docs
+					</ExternalLink>
+				</section>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/nav/components/AboutDialog.tsx
+++ b/apps/web/src/nav/components/AboutDialog.tsx
@@ -26,21 +26,25 @@ export default function AboutDialog({ open, setOpen }: AboutDialogProps) {
 
 				<section className="pb-6">
 					<h3 className="font-medium pb-3 text-lg">Versions</h3>
-					<dl className="grid grid-cols-[8rem_1fr] gap-y-3">
-						<dt className="font-medium">Server</dt>
-						<dd>
-							<div className="font-mono">{data?.version ?? "—"}</div>
-							<div className="text-slate-600 text-sm">
-								Stores data and runs analyses.
-							</div>
-						</dd>
-						<dt className="font-medium">Web app</dt>
-						<dd>
-							<div className="font-mono">{__APP_VERSION__}</div>
-							<div className="text-slate-600 text-sm">
-								The pages you see in your browser.
-							</div>
-						</dd>
+					<dl className="space-y-3">
+						<div className="flex">
+							<dt className="font-medium w-32 shrink-0">Server</dt>
+							<dd>
+								<div className="font-mono">{data?.version ?? "—"}</div>
+								<div className="text-slate-600 text-sm">
+									Stores data and runs analyses.
+								</div>
+							</dd>
+						</div>
+						<div className="flex">
+							<dt className="font-medium w-32 shrink-0">Web app</dt>
+							<dd>
+								<div className="font-mono">{__APP_VERSION__}</div>
+								<div className="text-slate-600 text-sm">
+									The pages you see in your browser.
+								</div>
+							</dd>
+						</div>
 					</dl>
 				</section>
 

--- a/apps/web/src/nav/components/Nav.tsx
+++ b/apps/web/src/nav/components/Nav.tsx
@@ -10,7 +10,9 @@ import IconButton from "@base/IconButton";
 import InitialIcon from "@base/InitialIcon";
 import Logo from "@base/Logo";
 import { useRootQuery } from "@wall/queries";
-import { Bug } from "lucide-react";
+import { Bug, Info } from "lucide-react";
+import { useState } from "react";
+import AboutDialog from "./AboutDialog";
 import { NavLink } from "./NavLink";
 
 type NavBarProps = {
@@ -29,6 +31,7 @@ export default function Nav({
 }: NavBarProps) {
 	const mutation = useLogout();
 	const { data } = useRootQuery();
+	const [aboutOpen, setAboutOpen] = useState(false);
 
 	function onLogout() {
 		mutation.mutate();
@@ -55,6 +58,13 @@ export default function Nav({
 					/>
 				)}
 
+				<IconButton
+					onClick={() => setAboutOpen(true)}
+					IconComponent={Info}
+					tip="About"
+					color="gray"
+				/>
+
 				<Dropdown>
 					<DropdownMenuTrigger>
 						<div className="bg-transparent flex items-center">
@@ -74,20 +84,12 @@ export default function Nav({
 								Administration{" "}
 							</DropdownMenuLink>
 						)}
-						<DropdownMenuItem>
-							<a
-								target="_blank"
-								href="https://virtool.ca/docs/manual/start/installation/"
-								rel="noopener noreferrer"
-								className="text-black hover:text-black"
-							>
-								Documentation
-							</a>
-						</DropdownMenuItem>
 						<DropdownMenuItem onSelect={onLogout}>Logout</DropdownMenuItem>
 					</DropdownMenuContent>
 				</Dropdown>
 			</div>
+
+			<AboutDialog open={aboutOpen} setOpen={setAboutOpen} />
 		</nav>
 	);
 }

--- a/apps/web/src/nav/components/Nav.tsx
+++ b/apps/web/src/nav/components/Nav.tsx
@@ -66,7 +66,7 @@ export default function Nav({
 				/>
 
 				<Dropdown>
-					<DropdownMenuTrigger>
+					<DropdownMenuTrigger aria-label="User menu">
 						<div className="bg-transparent flex items-center">
 							<InitialIcon handle={handle} size="md" />
 						</div>

--- a/apps/web/src/nav/components/__tests__/Nav.test.tsx
+++ b/apps/web/src/nav/components/__tests__/Nav.test.tsx
@@ -26,9 +26,7 @@ describe("<Nav />", () => {
 			screen.getByRole("link", { name: "Subtractions" }),
 		).toBeInTheDocument();
 
-		const buttons = screen.getAllByRole("button");
-		const dropdownTrigger = buttons[buttons.length - 1];
-		await userEvent.click(dropdownTrigger);
+		await userEvent.click(screen.getByRole("button", { name: "User menu" }));
 
 		expect(
 			screen.getByRole("menuitem", { name: "Signed in as Bob" }),

--- a/apps/web/src/nav/components/__tests__/Nav.test.tsx
+++ b/apps/web/src/nav/components/__tests__/Nav.test.tsx
@@ -8,11 +8,9 @@ import Nav from "../Nav";
 describe("<Nav />", () => {
 	const props: {
 		administrator_role: AdministratorRoleName;
-		dev: boolean;
 		handle: string;
 	} = {
 		administrator_role: "full",
-		dev: false,
 		handle: "Bob",
 	};
 
@@ -28,7 +26,9 @@ describe("<Nav />", () => {
 			screen.getByRole("link", { name: "Subtractions" }),
 		).toBeInTheDocument();
 
-		await userEvent.click(screen.getByRole("button"));
+		const buttons = screen.getAllByRole("button");
+		const dropdownTrigger = buttons[buttons.length - 1];
+		await userEvent.click(dropdownTrigger);
 
 		expect(
 			screen.getByRole("menuitem", { name: "Signed in as Bob" }),
@@ -40,10 +40,28 @@ describe("<Nav />", () => {
 			screen.getByRole("menuitem", { name: "Administration" }),
 		).toBeInTheDocument();
 		expect(
-			screen.getByRole("menuitem", { name: "Documentation" }),
-		).toBeInTheDocument();
+			screen.queryByRole("menuitem", { name: "Documentation" }),
+		).not.toBeInTheDocument();
 		expect(
 			screen.getByRole("menuitem", { name: "Logout" }),
 		).toBeInTheDocument();
+	});
+
+	it("opens the About dialog when the About button is clicked", async () => {
+		await renderWithRouter(<Nav {...props} />);
+
+		await userEvent.click(screen.getByRole("button", { name: "About" }));
+
+		expect(
+			screen.getByRole("heading", { name: "About Virtool" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("heading", { name: "Documentation" }),
+		).toBeInTheDocument();
+		const docLink = screen.getByRole("link", { name: "virtool.ca/docs" });
+		expect(docLink).toHaveAttribute(
+			"href",
+			"https://virtool.ca/docs/manual/start/installation/",
+		);
 	});
 });

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;


### PR DESCRIPTION
## Summary

- Adds an About dialog accessible via an info icon button in the nav bar, showing the server version, web app version, and a link to the documentation
- Moves the Documentation link out of the user dropdown menu and into the About dialog
- Adds a `vite-env.d.ts` to declare the `__APP_VERSION__` global injected by Vite