### PR TITLE
chore: stop dependabot from filing duplicate npm PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,7 @@
 version: 2
 updates:
     - package-ecosystem: "npm"
-      directories:
-          - "/"
-          - "/apps/web"
-          - "/packages/bio"
-          - "/packages/config"
-          - "/packages/contracts"
-          - "/packages/logger"
-          - "/packages/sentry"
+      directory: "/"
       schedule:
           interval: "weekly"
       open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Consolidates the Dependabot npm configuration from per-directory entries to a single root `directory: "/"` entry, preventing duplicate PRs for the same package update across the monorepo.

## Test plan
- [ ] Verify Dependabot no longer opens multiple PRs for the same npm package update across workspace packages