### PR TITLE
ci: stabilize docker build with pinned pnpm and frozen lockfile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ permissions:
 env:
     REGISTRY: ghcr.io
     NODE_VERSION: 22
-    PNPM_VERSION: 10
+    PNPM_VERSION: 11.1.3
 
 jobs:
     build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY packages/config/package.json ./packages/config/
 COPY packages/contracts/package.json ./packages/contracts/
 COPY packages/logger/package.json ./packages/logger/
 COPY packages/sentry/package.json ./packages/sentry/
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 COPY biome.json ./
 COPY packages ./packages
 COPY apps/web ./apps/web

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "virtool-ui",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@11.1.3",
   "scripts": {
     "build": "pnpm --filter @virtool/web build",
     "check": "biome check apps/web/src packages",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,10 @@ packages:
   - 'apps/*'
   - 'packages/*'
 
+# Reject lockfile entries published less than 24h ago. Guards against
+# brand-new supply-chain attacks that target popular packages.
+minimumReleaseAge: 1440
+
 allowBuilds:
   '@sentry/cli': true
   bcrypt: true


### PR DESCRIPTION
## Summary

- The Docker build ran `pnpm install` (non-frozen), which re-resolved transitive deps to the newest published versions and then tripped pnpm's `minimumReleaseAge` supply-chain check on packages published less than 24 h ago
- Switch to `--frozen-lockfile` so installs always match the committed lockfile, pin `packageManager` in `package.json` so corepack enforces a single pnpm version (11.1.3), align `PNPM_VERSION` in CI, and set `minimumReleaseAge: 1440` explicitly in `pnpm-workspace.yaml`