### PR TITLE
chore: add 1-day dependabot cooldown for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       open-pull-requests-limit: 10
       commit-message:
           prefix: "chore(deps)"
+      cooldown:
+          default-days: 1
       groups:
           tanstack:
               patterns:


### PR DESCRIPTION
## Summary
- Adds a 1-day cooldown to the dependabot npm configuration so that new package versions must be at least 1 day old before dependabot opens a PR
- Reduces noise from immediate version bumps that may be yanked or quickly patched

## Test plan
- [ ] Verify the dependabot.yml is valid by checking GitHub Actions / dependabot runs after merge