### PR TITLE
fix: improve OTU and reference search bar and isolate URL handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,10 @@ currently configured in another repository.
   `pnpm --filter @virtool/web exec tsr generate` (or the equivalent
   `@tanstack/router-cli generate`) to regenerate
   `apps/web/src/routeTree.gen.ts` before running type checks.
+- `apps/web/src/routeTree.gen.ts` is checked in. If it shows up in
+  `git status` — even when it looks like unrelated drift from a
+  regen — commit it alongside your other changes. Never leave it
+  out of a commit.
 - Before committing: `pnpm check` and `pnpm typecheck`.
 - After changing tests: run the specific test file with
   `pnpm --filter @virtool/web exec vitest run <path>`.

--- a/apps/web/src/app/hooks.tsx
+++ b/apps/web/src/app/hooks.tsx
@@ -23,6 +23,38 @@ export function useDebouncedValue<T>(value: T, delayMs = 250): T {
 	return debounced;
 }
 
+/**
+ * Two-way binding for an input whose committed value lives in the parent (URL,
+ * store, etc.). Returns a local `draft` for the input and a setter; commits
+ * `draft` to `onChange` after it's been stable for `delayMs`, and resyncs
+ * `draft` when `value` changes externally (e.g. back/forward navigation).
+ */
+export function useDebouncedDraft<T>(
+	value: T,
+	onChange: (next: T) => void,
+	delayMs?: number,
+): [T, (next: T) => void] {
+	const [draft, setDraft] = useState(value);
+	const debouncedDraft = useDebouncedValue(draft, delayMs);
+	const lastSentRef = useRef(value);
+
+	useEffect(() => {
+		if (debouncedDraft !== value) {
+			lastSentRef.current = debouncedDraft;
+			onChange(debouncedDraft);
+		}
+	}, [debouncedDraft, onChange, value]);
+
+	useEffect(() => {
+		if (value !== lastSentRef.current) {
+			lastSentRef.current = value;
+			setDraft(value);
+		}
+	}, [value]);
+
+	return [draft, setDraft];
+}
+
 function getSize(ref) {
 	return {
 		height: ref.current ? ref.current.offsetHeight : 0,

--- a/apps/web/src/app/hooks.tsx
+++ b/apps/web/src/app/hooks.tsx
@@ -9,6 +9,20 @@ export function useNow() {
 	return useSyncExternalStore(subscribeToTime, Date.now, Date.now);
 }
 
+/**
+ * Returns `value` delayed until it has been stable for `delayMs`.
+ */
+export function useDebouncedValue<T>(value: T, delayMs = 250): T {
+	const [debounced, setDebounced] = useState(value);
+
+	useEffect(() => {
+		const id = setTimeout(() => setDebounced(value), delayMs);
+		return () => clearTimeout(id);
+	}, [value, delayMs]);
+
+	return debounced;
+}
+
 function getSize(ref) {
 	return {
 		height: ref.current ? ref.current.offsetHeight : 0,

--- a/apps/web/src/otus/components/Detail/Isolates/IsolateEditor.tsx
+++ b/apps/web/src/otus/components/Detail/Isolates/IsolateEditor.tsx
@@ -14,7 +14,7 @@ import AddIsolate from "./AddIsolate";
 import IsolateDetail from "./IsolateDetail";
 import IsolateItem from "./IsolateItem";
 
-const routeApi = getRouteApi("/_authenticated/refs/$refId/otus/$otuId");
+const routeApi = getRouteApi("/_authenticated/refs/$refId/otus/$otuId/otu");
 
 /**
  * Displays a component for managing the isolates

--- a/apps/web/src/otus/components/Detail/Isolates/IsolateItem.tsx
+++ b/apps/web/src/otus/components/Detail/Isolates/IsolateItem.tsx
@@ -5,7 +5,7 @@ import type { OtuIsolate } from "@otus/types";
 import { getRouteApi } from "@tanstack/react-router";
 import { Star } from "lucide-react";
 
-const routeApi = getRouteApi("/_authenticated/refs/$refId/otus/$otuId");
+const routeApi = getRouteApi("/_authenticated/refs/$refId/otus/$otuId/otu");
 
 type IsolateItemProps = {
 	/** Whether the Isolate is selected */

--- a/apps/web/src/otus/components/OtuList.tsx
+++ b/apps/web/src/otus/components/OtuList.tsx
@@ -49,7 +49,7 @@ export default function OtuList({ find, page, setSearch }: OtuListProps) {
 			<RebuildAlert page={page} refId={refId} />
 			<OtuToolbar
 				term={find}
-				setTerm={(find) => setSearch({ find }, { replace: true })}
+				setTerm={(find) => setSearch({ find, page: 1 }, { replace: true })}
 				onCreate={() => setOpenCreate(true)}
 				refId={refId}
 				remotesFrom={reference.remotes_from}

--- a/apps/web/src/otus/components/OtuList.tsx
+++ b/apps/web/src/otus/components/OtuList.tsx
@@ -17,7 +17,10 @@ const routeApi = getRouteApi("/_authenticated/refs/$refId/otus/");
 type OtuListProps = {
 	find: string;
 	page: number;
-	setSearch: (next: { find?: string; page?: number }) => void;
+	setSearch: (
+		next: { find?: string; page?: number },
+		options?: { replace?: boolean },
+	) => void;
 };
 
 /**
@@ -46,7 +49,7 @@ export default function OtuList({ find, page, setSearch }: OtuListProps) {
 			<RebuildAlert page={page} refId={refId} />
 			<OtuToolbar
 				term={find}
-				onChange={(e) => setSearch({ find: e.target.value })}
+				setTerm={(find) => setSearch({ find }, { replace: true })}
 				onCreate={() => setOpenCreate(true)}
 				refId={refId}
 				remotesFrom={reference.remotes_from}

--- a/apps/web/src/otus/components/OtuToolbar.tsx
+++ b/apps/web/src/otus/components/OtuToolbar.tsx
@@ -1,4 +1,4 @@
-import { useDebouncedValue } from "@app/hooks";
+import { useDebouncedDraft } from "@app/hooks";
 import Button from "@base/Button";
 import InputSearch from "@base/InputSearch";
 import Toolbar from "@base/Toolbar";
@@ -7,7 +7,6 @@ import {
 	useReferenceIsArchived,
 } from "@references/hooks";
 import type { ReferenceRemotesFrom } from "@references/types";
-import { useEffect, useState } from "react";
 
 type OtuToolbarProps = {
 	/** Current search term used for filtering */
@@ -42,14 +41,7 @@ export default function OtuToolbar({
 	);
 	const archived = useReferenceIsArchived(refId);
 
-	const [draft, setDraft] = useState(term);
-	const debouncedDraft = useDebouncedValue(draft);
-
-	useEffect(() => {
-		if (debouncedDraft !== term) {
-			setTerm(debouncedDraft);
-		}
-	}, [debouncedDraft, setTerm, term]);
+	const [draft, setDraft] = useDebouncedDraft(term, setTerm);
 
 	return (
 		<Toolbar>

--- a/apps/web/src/otus/components/OtuToolbar.tsx
+++ b/apps/web/src/otus/components/OtuToolbar.tsx
@@ -1,3 +1,4 @@
+import { useDebouncedValue } from "@app/hooks";
 import Button from "@base/Button";
 import InputSearch from "@base/InputSearch";
 import Toolbar from "@base/Toolbar";
@@ -6,14 +7,14 @@ import {
 	useReferenceIsArchived,
 } from "@references/hooks";
 import type { ReferenceRemotesFrom } from "@references/types";
-import type { ChangeEvent } from "react";
+import { useEffect, useState } from "react";
 
 type OtuToolbarProps = {
 	/** Current search term used for filtering */
 	term: string;
 
-	/** A callback function to handle changes in search input */
-	onChange: (term: ChangeEvent<HTMLInputElement>) => void;
+	/** Update the search term in the url */
+	setTerm: (term: string) => void;
 
 	/** Called when the user clicks the Create button */
 	onCreate: () => void;
@@ -30,7 +31,7 @@ type OtuToolbarProps = {
  */
 export default function OtuToolbar({
 	term,
-	onChange,
+	setTerm,
 	onCreate,
 	refId,
 	remotesFrom,
@@ -41,13 +42,22 @@ export default function OtuToolbar({
 	);
 	const archived = useReferenceIsArchived(refId);
 
+	const [draft, setDraft] = useState(term);
+	const debouncedDraft = useDebouncedValue(draft);
+
+	useEffect(() => {
+		if (debouncedDraft !== term) {
+			setTerm(debouncedDraft);
+		}
+	}, [debouncedDraft, setTerm, term]);
+
 	return (
 		<Toolbar>
 			<div className="flex-grow">
 				<InputSearch
 					placeholder="Name or abbreviation"
-					value={term}
-					onChange={onChange}
+					value={draft}
+					onChange={(e) => setDraft(e.target.value)}
 				/>
 			</div>
 

--- a/apps/web/src/otus/components/__tests__/OtuToolbar.test.tsx
+++ b/apps/web/src/otus/components/__tests__/OtuToolbar.test.tsx
@@ -25,7 +25,7 @@ describe("<OtuToolbar />", () => {
 		renderWithProviders(
 			<OtuToolbar
 				term=""
-				onChange={vi.fn()}
+				setTerm={vi.fn()}
 				onCreate={vi.fn()}
 				refId={reference.id}
 				remotesFrom={null}
@@ -43,7 +43,7 @@ describe("<OtuToolbar />", () => {
 		renderWithProviders(
 			<OtuToolbar
 				term=""
-				onChange={vi.fn()}
+				setTerm={vi.fn()}
 				onCreate={vi.fn()}
 				refId={reference.id}
 				remotesFrom={null}

--- a/apps/web/src/otus/hooks.ts
+++ b/apps/web/src/otus/hooks.ts
@@ -1,7 +1,7 @@
 import { getRouteApi } from "@tanstack/react-router";
 import type { Otu } from "./types";
 
-const routeApi = getRouteApi("/_authenticated/refs/$refId/otus/$otuId");
+const routeApi = getRouteApi("/_authenticated/refs/$refId/otus/$otuId/otu");
 
 /**
  * A hook to get the active isolate id

--- a/apps/web/src/references/components/ReferenceList.tsx
+++ b/apps/web/src/references/components/ReferenceList.tsx
@@ -19,13 +19,16 @@ type ReferenceListProps = {
 	createReferenceType?: string;
 	find?: string;
 	page?: number;
-	setSearch?: (next: {
-		archived?: boolean;
-		cloneReferenceId?: string;
-		createReferenceType?: string;
-		find?: string;
-		page?: number;
-	}) => void;
+	setSearch?: (
+		next: {
+			archived?: boolean;
+			cloneReferenceId?: string;
+			createReferenceType?: string;
+			find?: string;
+			page?: number;
+		},
+		options?: { replace?: boolean },
+	) => void;
 };
 
 /**
@@ -69,7 +72,7 @@ export default function ReferenceList({
 					setCreateReferenceType={(createReferenceType) =>
 						setSearch({ createReferenceType })
 					}
-					setFind={(find) => setSearch({ find })}
+					setFind={(find) => setSearch({ find }, { replace: true })}
 				/>
 				<CreateReference
 					createReferenceType={createReferenceType}

--- a/apps/web/src/references/components/ReferenceList.tsx
+++ b/apps/web/src/references/components/ReferenceList.tsx
@@ -72,7 +72,7 @@ export default function ReferenceList({
 					setCreateReferenceType={(createReferenceType) =>
 						setSearch({ createReferenceType })
 					}
-					setFind={(find) => setSearch({ find }, { replace: true })}
+					setFind={(find) => setSearch({ find, page: 1 }, { replace: true })}
 				/>
 				<CreateReference
 					createReferenceType={createReferenceType}

--- a/apps/web/src/references/components/ReferenceToolbar.tsx
+++ b/apps/web/src/references/components/ReferenceToolbar.tsx
@@ -1,9 +1,11 @@
 import { useCheckAdminRoleOrPermission } from "@administration/hooks";
+import { useDebouncedValue } from "@app/hooks";
 import Button from "@base/Button";
 import InputSearch from "@base/InputSearch";
 import ToggleGroup from "@base/ToggleGroup";
 import ToggleGroupItem from "@base/ToggleGroupItem";
 import Toolbar from "@base/Toolbar";
+import { useEffect, useState } from "react";
 
 type ReferenceToolbarProps = {
 	archived: boolean;
@@ -26,13 +28,22 @@ export default function ReferenceToolbar({
 	const { hasPermission: canCreate } =
 		useCheckAdminRoleOrPermission("create_ref");
 
+	const [draft, setDraft] = useState(find);
+	const debouncedDraft = useDebouncedValue(draft);
+
+	useEffect(() => {
+		if (debouncedDraft !== find) {
+			setFind(debouncedDraft);
+		}
+	}, [debouncedDraft, setFind, find]);
+
 	return (
 		<Toolbar>
 			<div className="flex-grow">
 				<InputSearch
 					placeholder="Reference name"
-					value={find}
-					onChange={(e) => setFind(e.target.value)}
+					value={draft}
+					onChange={(e) => setDraft(e.target.value)}
 				/>
 			</div>
 			<ToggleGroup

--- a/apps/web/src/references/components/ReferenceToolbar.tsx
+++ b/apps/web/src/references/components/ReferenceToolbar.tsx
@@ -1,11 +1,10 @@
 import { useCheckAdminRoleOrPermission } from "@administration/hooks";
-import { useDebouncedValue } from "@app/hooks";
+import { useDebouncedDraft } from "@app/hooks";
 import Button from "@base/Button";
 import InputSearch from "@base/InputSearch";
 import ToggleGroup from "@base/ToggleGroup";
 import ToggleGroupItem from "@base/ToggleGroupItem";
 import Toolbar from "@base/Toolbar";
-import { useEffect, useState } from "react";
 
 type ReferenceToolbarProps = {
 	archived: boolean;
@@ -28,14 +27,7 @@ export default function ReferenceToolbar({
 	const { hasPermission: canCreate } =
 		useCheckAdminRoleOrPermission("create_ref");
 
-	const [draft, setDraft] = useState(find);
-	const debouncedDraft = useDebouncedValue(draft);
-
-	useEffect(() => {
-		if (debouncedDraft !== find) {
-			setFind(debouncedDraft);
-		}
-	}, [debouncedDraft, setFind, find]);
+	const [draft, setDraft] = useDebouncedDraft(find, setFind);
 
 	return (
 		<Toolbar>

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -1384,3 +1384,13 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { startInstance } from './start.ts'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
+  }
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -1384,13 +1384,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { startInstance } from './start.ts'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>
-  }
-}

--- a/apps/web/src/routes/_authenticated/refs/$refId/otus/$otuId/otu.tsx
+++ b/apps/web/src/routes/_authenticated/refs/$refId/otus/$otuId/otu.tsx
@@ -1,8 +1,14 @@
 import OtuSection from "@otus/components/Detail/OtuSection";
 import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod/v4";
+
+const otuTabSearchSchema = z.object({
+	activeIsolate: z.string().optional().catch(undefined),
+});
 
 export const Route = createFileRoute(
 	"/_authenticated/refs/$refId/otus/$otuId/otu",
 )({
+	validateSearch: otuTabSearchSchema,
 	component: OtuSection,
 });

--- a/apps/web/src/routes/_authenticated/refs/$refId/otus/$otuId/route.tsx
+++ b/apps/web/src/routes/_authenticated/refs/$refId/otus/$otuId/route.tsx
@@ -10,15 +10,9 @@ import { otuQueryOptions, useFetchOTU } from "@otus/queries";
 import { useReferenceIsArchived } from "@references/hooks";
 import { referenceQueryOptions, useFetchReference } from "@references/queries";
 import { createFileRoute, notFound, Outlet } from "@tanstack/react-router";
-import { z } from "zod/v4";
-
-const otuDetailSearchSchema = z.object({
-	activeIsolate: z.string().optional().catch(undefined),
-});
 
 export const Route = createFileRoute("/_authenticated/refs/$refId/otus/$otuId")(
 	{
-		validateSearch: otuDetailSearchSchema,
 		loader: async ({ context: { queryClient }, params: { refId, otuId } }) => {
 			try {
 				await Promise.all([

--- a/apps/web/src/routes/_authenticated/refs/$refId/otus/index.tsx
+++ b/apps/web/src/routes/_authenticated/refs/$refId/otus/index.tsx
@@ -20,7 +20,12 @@ function OtusRoute() {
 		<OtuList
 			find={search.find}
 			page={search.page}
-			setSearch={(next) => navigate({ search: { ...search, ...next } })}
+			setSearch={(next, options) =>
+				navigate({
+					search: { ...search, ...next },
+					replace: options?.replace,
+				})
+			}
 		/>
 	);
 }

--- a/apps/web/src/routes/_authenticated/refs/index.tsx
+++ b/apps/web/src/routes/_authenticated/refs/index.tsx
@@ -26,7 +26,12 @@ function ReferencesRoute() {
 			createReferenceType={search.createReferenceType}
 			find={search.find}
 			page={search.page}
-			setSearch={(next) => navigate({ search: { ...search, ...next } })}
+			setSearch={(next, options) =>
+				navigate({
+					search: { ...search, ...next },
+					replace: options?.replace,
+				})
+			}
 		/>
 	);
 }

--- a/apps/web/src/users/api.ts
+++ b/apps/web/src/users/api.ts
@@ -37,8 +37,5 @@ export async function findUsers(
 	return apiClient
 		.get("/users")
 		.query({ page, per_page, term })
-		.then((res) => {
-			const { documents, ...rest } = res.body;
-			return { ...rest, items: documents };
-		});
+		.then((res) => res.body);
 }


### PR DESCRIPTION
## Summary
- Debounce search input in OTU and reference toolbars to avoid spamming browser history on each keystroke, using a new shared `useDebouncedValue` hook and `replace: true` navigation
- Move `activeIsolate` search param validation to the `otu` child route so the selected isolate is preserved correctly in the URL on the OTU detail page
- Fix a crash on the reference settings page and clean up a stale route registration block from `routeTree.gen.ts`

## Test plan
- [ ] Type in the OTU list search bar and verify history is not spammed (back button should not step through each keystroke)
- [ ] Type in the reference list search bar and verify the same debounce behaviour
- [ ] Navigate to an OTU detail page, select an isolate, and confirm the `activeIsolate` param stays in the URL on refresh
- [ ] Open the reference settings page and verify it loads without crashing