### PR TITLE
chore: speed up dev server HMR

### DIFF
--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -7,7 +7,7 @@ import path from "path";
 import { defineConfig } from "vite";
 import pkg from "./package.json" with { type: "json" };
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
 	build: {
 		sourcemap: true,
 		rolldownOptions: {
@@ -71,29 +71,49 @@ export default defineConfig({
 				plugins: ["babel-plugin-react-compiler"],
 			},
 		}),
-		sentryVitePlugin({
-			org: "cfia-virtool",
-			project: "cloud-ui",
-		}),
+		command === "build" &&
+			sentryVitePlugin({
+				org: "cfia-virtool",
+				project: "cloud-ui",
+			}),
 		tailwindcss(),
 	],
 	optimizeDeps: {
 		holdUntilCrawlEnd: false,
 		include: [
 			"@hookform/resolvers/zod",
+			"@sentry/react",
 			"@tanstack/react-query",
 			"@tanstack/react-router",
 			"@tanstack/react-virtual",
+			"class-variance-authority",
+			"clsx",
 			"d3",
 			"d3-transition",
+			"downshift",
+			"es-toolkit",
+			"es-toolkit/array",
+			"es-toolkit/compat",
+			"es-toolkit/math",
+			"es-toolkit/object",
+			"es-toolkit/predicate",
+			"es-toolkit/string",
+			"fuse.js",
 			"lucide-react",
+			"marked",
+			"numbro",
 			"radix-ui",
+			"react-dropzone",
 			"react-hook-form",
+			"superagent",
+			"tailwind-merge",
 			"zod",
 			"zod/v4",
+			"zustand",
+			"zustand/middleware",
 		],
 	},
 	server: {
 		allowedHosts: ["virtool.local"],
 	},
-});
+}));

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -115,5 +115,14 @@ export default defineConfig(({ command }) => ({
 	},
 	server: {
 		allowedHosts: ["virtool.local"],
+		warmup: {
+			clientFiles: [
+				"./src/routes/__root.tsx",
+				"./src/routes/_authenticated.tsx",
+				"./src/app/**/*.{ts,tsx}",
+				"./src/base/**/*.{ts,tsx}",
+				"./src/nav/**/*.{ts,tsx}",
+			],
+		},
 	},
 }));

--- a/apps/web/vitest.config.js
+++ b/apps/web/vitest.config.js
@@ -1,6 +1,8 @@
 import os from "os";
 import { defineConfig } from "vitest/config";
-import viteConfig from "./vite.config";
+import viteConfigFn from "./vite.config";
+
+const viteConfig = viteConfigFn({ command: "serve", mode: "test" });
 
 export default defineConfig({
     ...viteConfig,


### PR DESCRIPTION
## Summary

- Expands `optimizeDeps.include` in the Vite config with all common dependencies so they are pre-bundled once at startup rather than on first import, reducing initial HMR latency
- Adds `server.warmup.clientFiles` to pre-transform root, app, base, and nav modules so they are ready before the first browser request
- Skips the Sentry Vite plugin during `dev` command since it is only needed for production builds, removing unnecessary overhead from the dev server

## Test plan

- [ ] Start the dev server and confirm it starts without errors
- [ ] Verify HMR feels noticeably faster on first page load and route changes
- [ ] Run a production build and confirm Sentry plugin still runs and source maps are uploaded