### PR TITLE
fix: redirect to login when account session expires

### DIFF
--- a/apps/web/src/routes/__tests__/-_authenticated.test.tsx
+++ b/apps/web/src/routes/__tests__/-_authenticated.test.tsx
@@ -1,0 +1,26 @@
+import { accountKeys } from "@account/queries";
+import { waitFor } from "@testing-library/react";
+import { renderRoute } from "@tests/setup";
+import nock from "nock";
+import { afterEach, describe, expect, it } from "vitest";
+
+describe("<AuthenticatedLayout />", () => {
+	afterEach(() => nock.cleanAll());
+
+	it("redirects to /login when the account is not authenticated", async () => {
+		nock("http://localhost").get("/api/account").reply(401, {});
+
+		const { router } = await renderRoute("/samples", {
+			seed: (queryClient) => {
+				queryClient.removeQueries({ queryKey: accountKeys.all() });
+			},
+		});
+
+		await waitFor(() => {
+			expect(router.state.location.pathname).toBe("/login");
+		});
+		expect(router.state.location.search).toMatchObject({
+			redirect: "/samples",
+		});
+	});
+});

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -80,7 +80,7 @@ export const Route = createFileRoute("/_authenticated")({
 
 function AuthenticatedLayout() {
 	const queryClient = useQueryClient();
-	const { data, isPending, isError } = useFetchAccount();
+	const { data, isPending } = useFetchAccount();
 	const location = useLocation();
 	const search = Route.useSearch();
 	const navigate = Route.useNavigate();
@@ -96,7 +96,7 @@ function AuthenticatedLayout() {
 		return <LoadingPlaceholder />;
 	}
 
-	if (isError || !data) {
+	if (!data) {
 		return (
 			<Navigate
 				to="/login"

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -14,7 +14,13 @@ import Nav from "@nav/components/Nav";
 import Sidebar from "@nav/components/Sidebar";
 import type { QueryClient } from "@tanstack/react-query";
 import { useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+import {
+	createFileRoute,
+	Navigate,
+	Outlet,
+	redirect,
+	useLocation,
+} from "@tanstack/react-router";
 import { rootKeys } from "@wall/queries";
 import { lazy, Suspense, useEffect } from "react";
 import { z } from "zod/v4";
@@ -74,7 +80,8 @@ export const Route = createFileRoute("/_authenticated")({
 
 function AuthenticatedLayout() {
 	const queryClient = useQueryClient();
-	const { data, isPending } = useFetchAccount();
+	const { data, isPending, isError } = useFetchAccount();
+	const location = useLocation();
 	const search = Route.useSearch();
 	const navigate = Route.useNavigate();
 
@@ -87,6 +94,17 @@ function AuthenticatedLayout() {
 
 	if (isPending) {
 		return <LoadingPlaceholder />;
+	}
+
+	if (isError || !data) {
+		return (
+			<Navigate
+				to="/login"
+				replace
+				// biome-ignore lint/suspicious/noExplicitAny: route search type is `AnyRoute` because tsconfig has `strict: false` (see AppRouter.tsx)
+				search={{ redirect: location.href } as any}
+			/>
+		);
 	}
 
 	return (

--- a/apps/web/src/wall/queries.ts
+++ b/apps/web/src/wall/queries.ts
@@ -1,12 +1,10 @@
 import {
-	fetchAccount,
 	type LoginResult,
 	login,
 	type ResetPasswordResult,
 	resetPassword,
 } from "@account/api";
 import { accountKeys } from "@account/queries";
-import type { Account } from "@account/types";
 import { apiClient } from "@app/api";
 import type { Root } from "@app/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -28,35 +26,6 @@ export function useRootQuery() {
 		queryKey: rootKeys.all(),
 		queryFn: () => apiClient.get("/").then((res) => res.body),
 	});
-}
-
-/**
- * Initializes a query for fetching the account document.
- *
- * @returns A query for fetching the account document
- */
-export function useAuthentication() {
-	const queryClient = useQueryClient();
-
-	const { data, isPending, isError, error, refetch, ...queryInfo } = useQuery<
-		Account,
-		ErrorResponse
-	>({
-		queryKey: accountKeys.all(),
-		queryFn: fetchAccount,
-		retry: false,
-		refetchOnWindowFocus: false,
-	});
-
-	if (isError) {
-		if (error.response?.status === 401) {
-			queryClient.setQueryData(accountKeys.all(), null);
-		}
-	}
-
-	const authenticated = Boolean(data);
-
-	return { authenticated, isPending, isError, refetch, ...queryInfo };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes a TypeError crash when the account session expires mid-session by handling the `isError` and null `data` states in `AuthenticatedLayout`
- Replaces the removed `useAuthentication` hook (which silently set account data to `null` on 401) with a `<Navigate>` redirect that sends the user to `/login` with the current path preserved as a `redirect` search param
- Removes the now-unused `useAuthentication` hook from `wall/queries.ts` to clean up dead code

## Test plan
- [ ] Verify that navigating to a protected route while unauthenticated redirects to `/login` with the original path as `?redirect=`
- [ ] Verify that after a session expires (401 from `/api/account`), the user is redirected to `/login` instead of seeing a blank or crashed page
- [ ] Run the new `AuthenticatedLayout` test: `pnpm --filter @virtool/web exec vitest run src/routes/__tests__/-_authenticated.test.tsx`