### PR TITLE
refactor: use user_id FK for instance messages

### DIFF
--- a/apps/web/src/server/db/schema/messages.ts
+++ b/apps/web/src/server/db/schema/messages.ts
@@ -1,7 +1,8 @@
-// Read-only mirror of the `instance_messages` table managed by the upstream
-// Python service via Alembic. Do not generate or push migrations from this
-// side. Keep the columns in sync with
-// `../../../../../../virtool/virtool/messages/sql.py`.
+// Mirror of the `instance_messages` table. Schema and migrations are owned by
+// the upstream Python service via Alembic — do not generate or push migrations
+// from this side. The legacy `"user"` VARCHAR column still exists in the DB
+// during the upstream cleanup window but is not declared here; Drizzle ignores
+// columns it does not know about.
 
 import {
 	boolean,
@@ -11,6 +12,7 @@ import {
 	text,
 	timestamp,
 } from "drizzle-orm/pg-core";
+import { users } from "./users";
 
 export const messageColor = pgEnum("messagecolor", [
 	"red",
@@ -28,7 +30,9 @@ export const instanceMessages = pgTable("instance_messages", {
 	message: text("message"),
 	createdAt: timestamp("created_at"),
 	updatedAt: timestamp("updated_at"),
-	user: text("user"),
+	userId: integer("user_id")
+		.notNull()
+		.references(() => users.id),
 });
 
 /** A row from the `instance_messages` table. */

--- a/apps/web/src/server/messages/data.ts
+++ b/apps/web/src/server/messages/data.ts
@@ -76,7 +76,7 @@ export async function findMessages(): Promise<Message[]> {
 	return rows.map(toMessage);
 }
 
-async function findMessageById(id: number): Promise<Message> {
+async function getMessageById(id: number): Promise<Message> {
 	const [row] = await db
 		.select(messageSelect)
 		.from(instanceMessages)
@@ -111,7 +111,7 @@ export async function createMessage(
 
 	await emit("messages", row.id, "create");
 
-	return findMessageById(row.id);
+	return getMessageById(row.id);
 }
 
 export async function updateMessage(
@@ -142,7 +142,7 @@ export async function updateMessage(
 
 	await emit("messages", row.id, "update");
 
-	return findMessageById(row.id);
+	return getMessageById(row.id);
 }
 
 export async function deleteMessage(id: number): Promise<void> {
@@ -180,7 +180,7 @@ export async function setActiveMessage(id: number): Promise<Message> {
 
 	await emit("messages", row.id, "update");
 
-	return findMessageById(row.id);
+	return getMessageById(row.id);
 }
 
 export async function clearActiveMessage(): Promise<void> {

--- a/apps/web/src/server/messages/data.ts
+++ b/apps/web/src/server/messages/data.ts
@@ -1,11 +1,7 @@
 import type { UserNested } from "@users/types";
-import { desc, eq, inArray } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { db } from "../db/pg";
-import {
-	type InstanceMessageRow,
-	instanceMessages,
-	type MessageColor,
-} from "../db/schema/messages";
+import { instanceMessages, type MessageColor } from "../db/schema/messages";
 import { users } from "../db/schema/users";
 import { AppError } from "../errors";
 import { emit } from "../events/emit";
@@ -24,48 +20,30 @@ export type Message = {
 /** Thrown when a requested instance message does not exist. */
 export class MessageNotFoundError extends AppError {}
 
-function parseUserId(userIdText: string | null): number | null {
-	if (userIdText === null) {
-		return null;
-	}
-	const parsed = Number.parseInt(userIdText, 10);
-	return Number.isNaN(parsed) ? null : parsed;
-}
+type MessageJoinRow = {
+	id: number;
+	active: boolean | null;
+	color: MessageColor;
+	message: string | null;
+	createdAt: Date | null;
+	updatedAt: Date | null;
+	user: UserNested;
+};
 
-async function lookupUsers(
-	userIdTexts: ReadonlyArray<string | null>,
-): Promise<Map<number, UserNested>> {
-	const ids = Array.from(
-		new Set(
-			userIdTexts.map(parseUserId).filter((id): id is number => id !== null),
-		),
-	);
+const messageSelect = {
+	id: instanceMessages.id,
+	active: instanceMessages.active,
+	color: instanceMessages.color,
+	message: instanceMessages.message,
+	createdAt: instanceMessages.createdAt,
+	updatedAt: instanceMessages.updatedAt,
+	user: {
+		id: users.id,
+		handle: users.handle,
+	},
+} as const;
 
-	if (ids.length === 0) {
-		return new Map();
-	}
-
-	const rows = await db
-		.select({ id: users.id, handle: users.handle })
-		.from(users)
-		.where(inArray(users.id, ids));
-
-	return new Map(rows.map((row) => [row.id, row]));
-}
-
-async function lookupUser(userIdText: string | null): Promise<UserNested> {
-	const map = await lookupUsers([userIdText]);
-	const id = parseUserId(userIdText);
-	if (id !== null) {
-		const user = map.get(id);
-		if (user) {
-			return user;
-		}
-	}
-	return { id: 0, handle: "" };
-}
-
-function toMessage(row: InstanceMessageRow, user: UserNested): Message {
+function toMessage(row: MessageJoinRow): Message {
 	return {
 		id: row.id,
 		active: row.active ?? false,
@@ -73,38 +51,44 @@ function toMessage(row: InstanceMessageRow, user: UserNested): Message {
 		message: row.message ?? "",
 		created_at: row.createdAt?.toISOString() ?? "",
 		updated_at: row.updatedAt?.toISOString() ?? "",
-		user,
+		user: row.user,
 	};
 }
 
 export async function findMessage(): Promise<Message | null> {
 	const [row] = await db
-		.select()
+		.select(messageSelect)
 		.from(instanceMessages)
+		.innerJoin(users, eq(users.id, instanceMessages.userId))
 		.where(eq(instanceMessages.active, true))
 		.limit(1);
 
-	if (!row) {
-		return null;
-	}
-
-	const user = await lookupUser(row.user);
-	return toMessage(row, user);
+	return row ? toMessage(row) : null;
 }
 
 export async function findMessages(): Promise<Message[]> {
 	const rows = await db
-		.select()
+		.select(messageSelect)
 		.from(instanceMessages)
+		.innerJoin(users, eq(users.id, instanceMessages.userId))
 		.orderBy(desc(instanceMessages.createdAt));
 
-	const userMap = await lookupUsers(rows.map((row) => row.user));
+	return rows.map(toMessage);
+}
 
-	return rows.map((row) => {
-		const id = parseUserId(row.user);
-		const user = (id !== null && userMap.get(id)) || { id: 0, handle: "" };
-		return toMessage(row, user);
-	});
+async function findMessageById(id: number): Promise<Message> {
+	const [row] = await db
+		.select(messageSelect)
+		.from(instanceMessages)
+		.innerJoin(users, eq(users.id, instanceMessages.userId))
+		.where(eq(instanceMessages.id, id))
+		.limit(1);
+
+	if (!row) {
+		throw new MessageNotFoundError();
+	}
+
+	return toMessage(row);
 }
 
 export async function createMessage(
@@ -121,14 +105,13 @@ export async function createMessage(
 			message,
 			createdAt: now,
 			updatedAt: now,
-			user: String(userId),
+			userId,
 		})
-		.returning();
+		.returning({ id: instanceMessages.id });
 
 	await emit("messages", row.id, "create");
 
-	const user = await lookupUser(row.user);
-	return toMessage(row, user);
+	return findMessageById(row.id);
 }
 
 export async function updateMessage(
@@ -137,7 +120,7 @@ export async function updateMessage(
 	userId: number,
 ): Promise<Message> {
 	const update: Partial<typeof instanceMessages.$inferInsert> = {
-		user: String(userId),
+		userId,
 		updatedAt: new Date(),
 	};
 	if (values.color !== undefined) {
@@ -151,7 +134,7 @@ export async function updateMessage(
 		.update(instanceMessages)
 		.set(update)
 		.where(eq(instanceMessages.id, id))
-		.returning();
+		.returning({ id: instanceMessages.id });
 
 	if (!row) {
 		throw new MessageNotFoundError();
@@ -159,8 +142,7 @@ export async function updateMessage(
 
 	await emit("messages", row.id, "update");
 
-	const user = await lookupUser(row.user);
-	return toMessage(row, user);
+	return findMessageById(row.id);
 }
 
 export async function deleteMessage(id: number): Promise<void> {
@@ -187,7 +169,7 @@ export async function setActiveMessage(id: number): Promise<Message> {
 			.update(instanceMessages)
 			.set({ active: true })
 			.where(eq(instanceMessages.id, id))
-			.returning();
+			.returning({ id: instanceMessages.id });
 
 		if (!updated) {
 			throw new MessageNotFoundError();
@@ -198,8 +180,7 @@ export async function setActiveMessage(id: number): Promise<Message> {
 
 	await emit("messages", row.id, "update");
 
-	const user = await lookupUser(row.user);
-	return toMessage(row, user);
+	return findMessageById(row.id);
 }
 
 export async function clearActiveMessage(): Promise<void> {


### PR DESCRIPTION
## Summary
- Replaces the legacy `user` VARCHAR column (which stored user IDs as strings) with a proper `user_id` integer foreign key referencing the `users` table in the `instance_messages` schema declaration
- Simplifies data access by using a single JOIN instead of a multi-step lookup: fetch rows, collect IDs, batch-fetch users, then stitch together
- All mutating operations (`create`, `update`, `setActive`) now return only the new row's `id` from `.returning()` and re-fetch via a shared `findMessageById` helper that includes the join

## Test plan
- [ ] Create an instance message and verify it is returned with the correct `user` field
- [ ] Update an existing message and confirm the user association is preserved
- [ ] Set a message as active and confirm it is returned with the correct user
- [ ] List all messages and verify each has a populated `user` object
- [ ] Fetch the active message and confirm it resolves correctly