### PR TITLE
feat: forward server logs to Sentry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,8 +322,14 @@ Pass structured fields as the first arg and the message as the second —
 never interpolate values into the message string, that defeats the
 redaction list and makes records ungreppable.
 
+When `VT_SENTRY_DSN` is set, server logs at `info` and above are
+forwarded to Sentry automatically (via a pino destination stream, not
+`Sentry.pinoIntegration()`); redaction still applies and dev does not
+forward.
+
 See [docs/logging.md](docs/logging.md) for the redaction
-defaults, `VT_LOG_LEVEL` resolution, and where the logger singleton lives.
+defaults, `VT_LOG_LEVEL` resolution, where the logger singleton lives, and
+the Sentry forwarding wiring.
 
 ## Git
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,12 +13,13 @@
 	},
 	"dependencies": {
 		"@hookform/resolvers": "^5.4.0",
-		"@sentry/react": "^10.49.0",
+		"@sentry/tanstackstart-react": "^10.55.0",
 		"@tanstack/react-query": "^5.100.9",
 		"@tanstack/react-router": "^1.170.1",
 		"@tanstack/react-start": "^1.168.0",
 		"@tanstack/react-virtual": "^3.13.24",
 		"@virtool/logger": "workspace:*",
+		"@virtool/sentry": "workspace:*",
 		"bcrypt": "^6.0.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
@@ -47,7 +48,6 @@
 	},
 	"devDependencies": {
 		"@faker-js/faker": "^10.4.0",
-		"@sentry/vite-plugin": "^5.2.1",
 		"@tailwindcss/vite": "^4.2.4",
 		"@tanstack/router-cli": "^1.167.9",
 		"@tanstack/router-devtools": "^1.166.13",

--- a/apps/web/src/client.tsx
+++ b/apps/web/src/client.tsx
@@ -1,18 +1,10 @@
 /// <reference types="vite/client" />
-import * as Sentry from "@sentry/react";
 import { StartClient } from "@tanstack/react-start/client";
 import { StrictMode, startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
 
-const sentryDsn = import.meta.env.VT_SENTRY_DSN;
-
-if (sentryDsn) {
-	Sentry.init({
-		dsn: sentryDsn,
-		integrations: [Sentry.browserTracingIntegration()],
-		tracesSampleRate: 0.3,
-	});
-}
+// Browser-side Sentry initialisation lives in `router.tsx`'s `getRouter()` so it
+// can wire `tanstackRouterBrowserTracingIntegration` to the router instance.
 
 // Reload the page if a preload error occurs. These errors happen when a new
 // version of the app bundle is deployed and a requested chunk no longer exists

--- a/apps/web/src/instrument.server.ts
+++ b/apps/web/src/instrument.server.ts
@@ -1,0 +1,13 @@
+import * as Sentry from "@sentry/tanstackstart-react";
+import { getCommonOptions } from "@virtool/sentry";
+
+// Server-side Sentry initialisation. Imported for its side effect at the top of
+// `server.ts` so the SDK is ready before any request is handled. `enableLogs`
+// (set in `getCommonOptions`) is what lets `@virtool/logger` forward records via
+// `Sentry.logger`. No DSN means no init, so dev and unconfigured deploys are
+// untouched.
+const options = getCommonOptions();
+
+if (options.dsn) {
+	Sentry.init(options);
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,5 +1,7 @@
+import * as Sentry from "@sentry/tanstackstart-react";
 import { QueryClient } from "@tanstack/react-query";
 import { createRouter } from "@tanstack/react-router";
+import { getCommonOptions } from "@virtool/sentry/browser";
 import { routeTree } from "./routeTree.gen";
 
 export function getRouter() {
@@ -19,12 +21,27 @@ export function getRouter() {
 	});
 
 	// @ts-expect-error TanStack Router requires strictNullChecks which is not enabled in this project
-	return createRouter({
+	const router = createRouter({
 		routeTree,
 		context: { queryClient },
 		defaultPendingMinMs: 0,
 		scrollRestoration: true,
 	});
+
+	if (!router.isServer) {
+		const options = getCommonOptions(import.meta.env);
+		if (options.dsn) {
+			Sentry.init({
+				...options,
+				integrations: [
+					Sentry.tanstackRouterBrowserTracingIntegration(router),
+					Sentry.replayIntegration(),
+				],
+			});
+		}
+	}
+
+	return router;
 }
 
 declare module "@tanstack/react-router" {

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,0 +1,12 @@
+import "./instrument.server";
+
+import { wrapFetchWithSentry } from "@sentry/tanstackstart-react";
+import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
+
+export default createServerEntry(
+	wrapFetchWithSentry({
+		fetch(request: Request) {
+			return handler.fetch(request);
+		},
+	}),
+);

--- a/apps/web/src/server/__tests__/sentryLog.test.ts
+++ b/apps/web/src/server/__tests__/sentryLog.test.ts
@@ -1,0 +1,78 @@
+import { createLogger } from "@virtool/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const logger = {
+	trace: vi.fn(),
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	fatal: vi.fn(),
+};
+
+vi.mock("@sentry/tanstackstart-react", () => ({ logger }));
+
+const { createSentryLogStream } = await import("../sentryLog");
+
+describe("createSentryLogStream", () => {
+	beforeEach(() => {
+		for (const fn of Object.values(logger)) {
+			fn.mockClear();
+		}
+	});
+
+	it("forwards a record to the Sentry method matching its level", () => {
+		const stream = createSentryLogStream();
+
+		stream.write(`${JSON.stringify({ level: 40, msg: "watch out" })}\n`);
+
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		const [message] = logger.warn.mock.calls[0];
+		expect(message).toBe("watch out");
+	});
+
+	it("passes structured fields as attributes and drops the pino envelope", () => {
+		const stream = createSentryLogStream();
+
+		stream.write(
+			`${JSON.stringify({
+				level: 30,
+				time: 123,
+				pid: 1,
+				hostname: "h",
+				name: "web",
+				msg: "login",
+				userId: "u1",
+			})}\n`,
+		);
+
+		const [message, attributes] = logger.info.mock.calls[0];
+		expect(message).toBe("login");
+		expect(attributes).toEqual({ userId: "u1" });
+	});
+
+	it("forwards already-redacted secret fields from a real logger", () => {
+		const stream = createSentryLogStream();
+		const log = createLogger({
+			name: "web",
+			level: "info",
+			destination: { write() {} },
+			streams: [{ level: "info", stream }],
+		});
+
+		log.info({ password: "hunter2", headers: { cookie: "s=1" } }, "sign in");
+
+		const [, attributes] = logger.info.mock.calls[0];
+		expect(attributes.password).toBe("[redacted]");
+		expect(attributes.headers).toEqual({ cookie: "[redacted]" });
+	});
+
+	it("ignores malformed lines", () => {
+		const stream = createSentryLogStream();
+
+		expect(() => stream.write("not json\n")).not.toThrow();
+		for (const fn of Object.values(logger)) {
+			expect(fn).not.toHaveBeenCalled();
+		}
+	});
+});

--- a/apps/web/src/server/logger.ts
+++ b/apps/web/src/server/logger.ts
@@ -1,3 +1,16 @@
 import { createLogger } from "@virtool/logger";
+import { readDsn } from "@virtool/sentry";
 
-export const logger = createLogger({ name: "web" });
+// Only pull in the Sentry SDK when a DSN is configured. Without one (the Vite
+// dev container, tests) the logger is stdout-only and the heavy `@sentry/node`
+// graph — and its import-in-the-middle hooks — are never loaded.
+const streams = readDsn()
+	? [
+			{
+				level: "info" as const,
+				stream: (await import("./sentryLog")).createSentryLogStream(),
+			},
+		]
+	: undefined;
+
+export const logger = createLogger({ name: "web", streams });

--- a/apps/web/src/server/sentryLog.ts
+++ b/apps/web/src/server/sentryLog.ts
@@ -1,0 +1,54 @@
+import * as Sentry from "@sentry/tanstackstart-react";
+
+type SentryLogMethod = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
+
+// pino serialises levels as numbers; map them onto Sentry's logging methods.
+const LEVEL_METHODS: Record<number, SentryLogMethod> = {
+	10: "trace",
+	20: "debug",
+	30: "info",
+	40: "warn",
+	50: "error",
+	60: "fatal",
+};
+
+const ENVELOPE_FIELDS = new Set([
+	"level",
+	"time",
+	"pid",
+	"hostname",
+	"name",
+	"msg",
+]);
+
+/**
+ * A pino destination that forwards each record to Sentry's structured logging
+ * API. pino applies redaction before any destination sees the record, so the
+ * secret-bearing fields in `DEFAULT_REDACT_PATHS` arrive here already censored.
+ * The standard pino envelope fields are dropped; everything else rides along as
+ * Sentry log attributes.
+ */
+export function createSentryLogStream(): { write(line: string): void } {
+	return {
+		write(line) {
+			let record: Record<string, unknown>;
+			try {
+				record = JSON.parse(line);
+			} catch {
+				return;
+			}
+
+			const method = LEVEL_METHODS[record.level as number] ?? "info";
+			const message = typeof record.msg === "string" ? record.msg : "";
+
+			const attributes: Record<string, unknown> = {};
+			for (const [key, value] of Object.entries(record)) {
+				if (!ENVELOPE_FIELDS.has(key)) {
+					attributes[key] = value;
+				}
+			}
+
+			Sentry.logger[method](message, attributes);
+		},
+	};
+}

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -1,5 +1,9 @@
 import { randomBytes } from "node:crypto";
 import {
+	sentryGlobalFunctionMiddleware,
+	sentryGlobalRequestMiddleware,
+} from "@sentry/tanstackstart-react";
+import {
 	createCsrfMiddleware,
 	createMiddleware,
 	createStart,
@@ -63,8 +67,13 @@ const csrfMiddleware = createCsrfMiddleware({
 	filter: (ctx) => ctx.handlerType === "serverFn",
 });
 
+// Sentry middleware go first so request and server-function spans wrap the
+// csrf/csp/auth work rather than nesting inside it.
 export const startInstance = createStart(() => ({
 	defaultSsr: false,
-	requestMiddleware: [csrfMiddleware, cspNonce],
-	functionMiddleware: [authenticationMiddleware],
+	requestMiddleware: [sentryGlobalRequestMiddleware, csrfMiddleware, cspNonce],
+	functionMiddleware: [
+		sentryGlobalFunctionMiddleware,
+		authenticationMiddleware,
+	],
 }));

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -1,4 +1,4 @@
-import { sentryVitePlugin } from "@sentry/vite-plugin";
+import { sentryTanstackStart } from "@sentry/tanstackstart-react/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import react from "@vitejs/plugin-react";
@@ -16,7 +16,7 @@ export default defineConfig(({ command }) => ({
 					groups: [
 						{
 							name: "sentry",
-							test: /node_modules[\\/]@sentry[\\/]react/,
+							test: /node_modules[\\/]@sentry[\\/]/,
 						},
 					],
 				},
@@ -72,18 +72,21 @@ export default defineConfig(({ command }) => ({
 				plugins: ["babel-plugin-react-compiler"],
 			},
 		}),
+		tailwindcss(),
+		// Build only: uploads source maps and adds route/middleware
+		// instrumentation. Kept out of dev/test so Sentry never loads there. Must
+		// come last.
 		command === "build" &&
-			sentryVitePlugin({
+			sentryTanstackStart({
 				org: "cfia-virtool",
 				project: "cloud-ui",
+				authToken: process.env.SENTRY_AUTH_TOKEN,
 			}),
-		tailwindcss(),
 	],
 	optimizeDeps: {
 		holdUntilCrawlEnd: false,
 		include: [
 			"@hookform/resolvers/zod",
-			"@sentry/react",
 			"@tanstack/react-query",
 			"@tanstack/react-router",
 			"@tanstack/react-virtual",

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -29,6 +29,34 @@ needs to censor additional fields.
 
 ## Sentry forwarding
 
-Not currently wired. When the server bootstrap registers
-`Sentry.pinoIntegration()`, logs at `info` and above will be forwarded to
-Sentry whenever a DSN is set, with no extra wiring at call sites.
+When `VT_SENTRY_DSN` is set, the server logger fans `info`-and-above
+records out to Sentry's structured logging API (`Sentry.logger`) in
+addition to stdout. There is no per-call-site wiring: every record that
+goes through `@virtool/logger` is forwarded automatically.
+
+This is a plain pino destination stream
+(`apps/web/src/server/sentryLog.ts`), **not**
+`Sentry.pinoIntegration()`. The integration patches the `pino` module at
+load time via `import-in-the-middle`, but the production server is bundled
+(Nitro inlines pino into the server chunks), so there is no module
+boundary left to patch. A destination stream needs no patching — pino
+hands it each serialised record directly.
+
+Wiring:
+
+- `apps/web/src/instrument.server.ts` calls `Sentry.init` (with
+  `enableLogs: true`, from `@virtool/sentry`'s `getCommonOptions`). It is
+  imported for its side effect at the top of `apps/web/src/server.ts`.
+- `apps/web/src/server/logger.ts` adds the Sentry stream to the logger
+  only when a DSN is present, via `@virtool/logger`'s `streams` option.
+  The `@sentry/*` SDK is loaded lazily (dynamic `import`) so it is never
+  pulled in when no DSN is configured.
+
+Redaction still applies. pino runs `DEFAULT_REDACT_PATHS` redaction before
+writing to any destination, so the records the Sentry stream receives
+already have `password` / `token` / `secret` / `authorization` / `cookie`
+(and the `req.headers.*` / `headers.*` variants) replaced with
+`[redacted]`.
+
+Dev does not forward. The Tilt dev container runs Vite with no DSN, so the
+logger stays stdout-only and the Sentry SDK is never loaded.

--- a/packages/logger/src/index.test.ts
+++ b/packages/logger/src/index.test.ts
@@ -123,4 +123,43 @@ describe("createLogger", () => {
 		expect(record.pid).toBe(process.pid);
 		expect(typeof record.hostname).toBe("string");
 	});
+
+	it("fans out to extra streams, honouring per-stream levels", () => {
+		const primary = makeSink();
+		const extra = makeSink();
+		const log = createLogger({
+			name: "web",
+			level: "debug",
+			destination: primary.stream,
+			streams: [{ level: "info", stream: extra.stream }],
+		});
+
+		log.debug("verbose");
+		log.info("noteworthy");
+
+		expect(primary.records().map((r) => r.msg)).toEqual([
+			"verbose",
+			"noteworthy",
+		]);
+		expect(extra.records().map((r) => r.msg)).toEqual(["noteworthy"]);
+	});
+
+	it("redacts secrets before they reach extra streams", () => {
+		const primary = makeSink();
+		const extra = makeSink();
+		const log = createLogger({
+			name: "web",
+			level: "info",
+			destination: primary.stream,
+			streams: [{ level: "info", stream: extra.stream }],
+		});
+
+		log.info({ password: "hunter2", headers: { cookie: "s=1" } }, "login");
+
+		const [record] = extra.records();
+		expect(record.password).toBe("[redacted]");
+		expect((record.headers as Record<string, string>).cookie).toBe(
+			"[redacted]",
+		);
+	});
 });

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -3,6 +3,7 @@ import pino, {
 	type DestinationStream,
 	type Logger,
 	type LoggerOptions,
+	type StreamEntry,
 	type TransportMultiOptions,
 	type TransportPipelineOptions,
 	type TransportSingleOptions,
@@ -35,6 +36,13 @@ export interface CreateLoggerOptions {
 	env?: Record<string, string | undefined>;
 	/** Destination stream. Ignored when `transport` is set. */
 	destination?: DestinationStream;
+	/**
+	 * Extra destinations to fan out to alongside the primary one. Each record is
+	 * written to the primary destination and to every entry here whose level it
+	 * meets. Redaction is applied before any stream sees the record. Ignored when
+	 * `transport` is set.
+	 */
+	streams?: readonly StreamEntry<LogLevel>[];
 }
 
 export function createLogger(options: CreateLoggerOptions): Logger {
@@ -61,5 +69,17 @@ export function createLogger(options: CreateLoggerOptions): Logger {
 	if (options.transport) {
 		return pino({ ...pinoOptions, transport: options.transport });
 	}
+
+	if (options.streams && options.streams.length > 0) {
+		const primary: StreamEntry<LogLevel> = {
+			level,
+			stream: options.destination ?? pino.destination(1),
+		};
+		return pino(
+			pinoOptions,
+			pino.multistream<LogLevel>([primary, ...options.streams]),
+		);
+	}
+
 	return pino(pinoOptions, options.destination);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.76.1(react@19.2.6))
-      '@sentry/react':
-        specifier: ^10.49.0
-        version: 10.53.1(react@19.2.6)
+      '@sentry/tanstackstart-react':
+        specifier: ^10.55.0
+        version: 10.55.0(react@19.2.6)
       '@tanstack/react-query':
         specifier: ^5.100.9
         version: 5.100.10(react@19.2.6)
@@ -44,6 +44,9 @@ importers:
       '@virtool/logger':
         specifier: workspace:*
         version: link:../../packages/logger
+      '@virtool/sentry':
+        specifier: workspace:*
+        version: link:../../packages/sentry
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
@@ -64,7 +67,7 @@ importers:
         version: 9.3.3(react@19.2.6)
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(postgres@3.4.9)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(postgres@3.4.9)
       es-toolkit:
         specifier: ^1.46.1
         version: 1.46.1
@@ -123,9 +126,6 @@ importers:
       '@faker-js/faker':
         specifier: ^10.4.0
         version: 10.4.0
-      '@sentry/vite-plugin':
-        specifier: ^5.2.1
-        version: 5.3.0
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.3.0(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -179,7 +179,7 @@ importers:
         version: 29.1.1(@noble/hashes@1.8.0)
       nitro:
         specifier: 3.0.260429-beta
-        version: 3.0.260429-beta(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.45.2(postgres@3.4.9))(jiti@2.7.0)(lru-cache@11.3.6)(mongodb@7.2.0)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 3.0.260429-beta(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(postgres@3.4.9))(jiti@2.7.0)(lru-cache@11.3.6)(mongodb@7.2.0)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
       nock:
         specifier: ^13.5.5
         version: 13.5.6
@@ -194,7 +194,7 @@ importers:
         version: 8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
     optionalDependencies:
       fsevents:
         specifier: ^2.3.3
@@ -204,7 +204,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/config:
     dependencies:
@@ -214,7 +214,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/contracts:
     dependencies:
@@ -234,7 +234,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/sentry: {}
 
@@ -559,6 +559,42 @@ packages:
   '@oozcitak/util@10.0.0':
     resolution: {integrity: sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==}
     engines: {node: '>=20.0'}
+
+  '@opentelemetry/api-logs@0.214.0':
+    resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.214.0':
+    resolution: {integrity: sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
 
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
@@ -1492,28 +1528,28 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@sentry-internal/browser-utils@10.53.1':
-    resolution: {integrity: sha512-X4d6y8sBMjmNhcDW4eMBU3ASsNIMz8dqaFkhyIMN/dkYr/yZKnbRZPaVuVUGvHKjnlficPpIH0/HK9KBjrYxPw==}
+  '@sentry-internal/browser-utils@10.55.0':
+    resolution: {integrity: sha512-zUvyBr13EK0evKsSTzwSimRzZ3P9kugS32dLCj3ea5gNN+/DFtU/GsMTdcIQDhusEDraIlH17AGgqJH5gUAv5w==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/feedback@10.53.1':
-    resolution: {integrity: sha512-vVpTI/aEYN5d9IgZeYJWMqVaN0+iFgidSrYNAsZTh1US5sJUzF/wrl+68KdpmCtFROrN3jiAn1oPSwL5CKvEJA==}
+  '@sentry-internal/feedback@10.55.0':
+    resolution: {integrity: sha512-32X9WW1xs5DjCRlp89QJ/PLw4kbTIX6MsBDXN2RBN1nWBjm/2WcwXqO/v/WoIS4W2kTWXcZnQwalLSI22Fp33A==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay-canvas@10.53.1':
-    resolution: {integrity: sha512-aueLaf/2prExwA76BGU5/bOXCKWqtt6jQXWA6WJQNrmKpPEtZJB4ypnpsou0McXQCF8tur2Y8U0TEkwQP13yJQ==}
+  '@sentry-internal/replay-canvas@10.55.0':
+    resolution: {integrity: sha512-lu/y7k9cK7FZ/qJpL0fBX4WqK6IFa/+bTPhedEaC5UpzjUNP7BfXt0H+R7q9CHWmp20Ffh/wGfO3j7O+Tv2MAA==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay@10.53.1':
-    resolution: {integrity: sha512-wZNzTBYkgGUPWMuUQv7L64+OJmoCnz7GQNiTrTFK6EVAjJXFBCSsPp/nhif0bLhbk8+0g4xz633uOhpXuQbFdw==}
+  '@sentry-internal/replay@10.55.0':
+    resolution: {integrity: sha512-OkQpANGwYU5UKfwLk6Y+NpESRC8nrLBjawRDLwF6cJ8HpNScOuNNJDEJEGwXHVkJPH0pcIixsH8y0Qfcltq6Xw==}
     engines: {node: '>=18'}
 
   '@sentry/babel-plugin-component-annotate@5.3.0':
     resolution: {integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==}
     engines: {node: '>= 18'}
 
-  '@sentry/browser@10.53.1':
-    resolution: {integrity: sha512-zXF373hzUOGzUOrqd8xb1U3LQi5uYC3mwv+z5OMKUUinQlu30tTWBs7ypy6YTchtix9QlYaHWlayUF8vBZ5UjA==}
+  '@sentry/browser@10.55.0':
+    resolution: {integrity: sha512-5n1kxmW1m4j16ZDV9kt+Zo5uafFnKTy7s5YyEcGnC45KnOiO1Gy+QFd3woXns1K5GNxpjF7oOOc6tXgZLuXnQQ==}
     engines: {node: '>=18'}
 
   '@sentry/bundler-plugin-core@5.3.0':
@@ -1572,12 +1608,49 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@sentry/core@10.53.1':
-    resolution: {integrity: sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==}
+  '@sentry/core@10.55.0':
+    resolution: {integrity: sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ==}
     engines: {node: '>=18'}
 
-  '@sentry/react@10.53.1':
-    resolution: {integrity: sha512-lrwNq5T/zW84l60894TpKHPcvFuc1I/Hnohecc0TfYVpIcYYuw2orCHoU4v4wgkFaJUpegVetbgdOphViyLVjA==}
+  '@sentry/node-core@10.55.0':
+    resolution: {integrity: sha512-M8XMMIk9Y0PGZoEt37Oe5dQCdqDdJlBcwLXidpz/s5k4QtJvCO/BbtcivcuKI2htw5FwxJkSrHUzRvT36tlDpg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
+
+  '@sentry/node@10.55.0':
+    resolution: {integrity: sha512-+fB/ByoHVWPLGgoafYciiMatTNyX1FHj1bsqZBN+Pw3McbuEU1nwCPLt9zuyZZiWlQtXKsyuACS4ZhXnID5l8A==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.55.0':
+    resolution: {integrity: sha512-0+YrNmVNrttki4rWP4DW+UTt5MziepwDLNBde39tgc3cGCcy5fLSdDfhb4JfTaE5TXt4kd5XrkgvS/sDgm3RZg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+
+  '@sentry/react@10.55.0':
+    resolution: {integrity: sha512-cf6wI0W1FdrL/7d5FTHXUdTN5k5uRZ9AQu5QZxUujnxWN+DBxUWtow1HDD1zTEonQsCFyYuhXVu3w+qmBBW11A==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x || 19.x
@@ -1590,6 +1663,10 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
+
+  '@sentry/tanstackstart-react@10.55.0':
+    resolution: {integrity: sha512-csTYCyIjICRSQ4icZMLi5Un6zQ+/o31reIL4iBs29H1HrCUj5IrK8//eiTumB4rha5UCqyg96EnFlBYbBgusjg==}
+    engines: {node: '>=18'}
 
   '@sentry/vite-plugin@5.3.0':
     resolution: {integrity: sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A==}
@@ -2141,6 +2218,16 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -2385,6 +2472,9 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -3061,6 +3151,10 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  import-in-the-middle@3.0.1:
+    resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
+    engines: {node: '>=18'}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
@@ -3328,6 +3422,9 @@ packages:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   mongodb-connection-string-url@7.0.1:
     resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
@@ -3720,6 +3817,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
@@ -4672,6 +4773,41 @@ snapshots:
 
   '@oozcitak/util@10.0.0': {}
 
+  '@opentelemetry/api-logs@0.214.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
+
   '@oxc-project/types@0.130.0': {}
 
   '@oxc-project/types@0.132.0': {}
@@ -5556,33 +5692,33 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@sentry-internal/browser-utils@10.53.1':
+  '@sentry-internal/browser-utils@10.55.0':
     dependencies:
-      '@sentry/core': 10.53.1
+      '@sentry/core': 10.55.0
 
-  '@sentry-internal/feedback@10.53.1':
+  '@sentry-internal/feedback@10.55.0':
     dependencies:
-      '@sentry/core': 10.53.1
+      '@sentry/core': 10.55.0
 
-  '@sentry-internal/replay-canvas@10.53.1':
+  '@sentry-internal/replay-canvas@10.55.0':
     dependencies:
-      '@sentry-internal/replay': 10.53.1
-      '@sentry/core': 10.53.1
+      '@sentry-internal/replay': 10.55.0
+      '@sentry/core': 10.55.0
 
-  '@sentry-internal/replay@10.53.1':
+  '@sentry-internal/replay@10.55.0':
     dependencies:
-      '@sentry-internal/browser-utils': 10.53.1
-      '@sentry/core': 10.53.1
+      '@sentry-internal/browser-utils': 10.55.0
+      '@sentry/core': 10.55.0
 
   '@sentry/babel-plugin-component-annotate@5.3.0': {}
 
-  '@sentry/browser@10.53.1':
+  '@sentry/browser@10.55.0':
     dependencies:
-      '@sentry-internal/browser-utils': 10.53.1
-      '@sentry-internal/feedback': 10.53.1
-      '@sentry-internal/replay': 10.53.1
-      '@sentry-internal/replay-canvas': 10.53.1
-      '@sentry/core': 10.53.1
+      '@sentry-internal/browser-utils': 10.55.0
+      '@sentry-internal/feedback': 10.55.0
+      '@sentry-internal/replay': 10.55.0
+      '@sentry-internal/replay-canvas': 10.55.0
+      '@sentry/core': 10.55.0
 
   '@sentry/bundler-plugin-core@5.3.0':
     dependencies:
@@ -5641,12 +5777,47 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/core@10.53.1': {}
+  '@sentry/core@10.55.0': {}
 
-  '@sentry/react@10.53.1(react@19.2.6)':
+  '@sentry/node-core@10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
     dependencies:
-      '@sentry/browser': 10.53.1
-      '@sentry/core': 10.53.1
+      '@sentry/core': 10.55.0
+      '@sentry/opentelemetry': 10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 3.0.1
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@sentry/node@10.55.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry/core': 10.55.0
+      '@sentry/node-core': 10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      '@sentry/opentelemetry': 10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 3.0.1
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.55.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry/core': 10.55.0
+
+  '@sentry/react@10.55.0(react@19.2.6)':
+    dependencies:
+      '@sentry/browser': 10.55.0
+      '@sentry/core': 10.55.0
       react: 19.2.6
 
   '@sentry/rollup-plugin@5.3.0':
@@ -5655,6 +5826,22 @@ snapshots:
       magic-string: 0.30.21
     transitivePeerDependencies:
       - encoding
+      - supports-color
+
+  '@sentry/tanstackstart-react@10.55.0(react@19.2.6)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry-internal/browser-utils': 10.55.0
+      '@sentry/core': 10.55.0
+      '@sentry/node': 10.55.0
+      '@sentry/react': 10.55.0(react@19.2.6)
+      '@sentry/vite-plugin': 5.3.0
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - encoding
+      - react
+      - rollup
       - supports-color
 
   '@sentry/vite-plugin@5.3.0':
@@ -6335,6 +6522,12 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -6588,6 +6781,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  cjs-module-lexer@2.2.0: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -6837,9 +7032,9 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  db0@0.3.4(drizzle-orm@0.45.2(postgres@3.4.9)):
+  db0@0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(postgres@3.4.9)):
     optionalDependencies:
-      drizzle-orm: 0.45.2(postgres@3.4.9)
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(postgres@3.4.9)
 
   debug@4.4.3:
     dependencies:
@@ -6923,8 +7118,9 @@ snapshots:
       react-is: 18.3.1
       tslib: 2.8.1
 
-  drizzle-orm@0.45.2(postgres@3.4.9):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(postgres@3.4.9):
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       postgres: 3.4.9
 
   dunder-proto@1.0.1:
@@ -7165,6 +7361,13 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  import-in-the-middle@3.0.1:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
   indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
@@ -7368,6 +7571,8 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
+  module-details-from-path@1.0.4: {}
+
   mongodb-connection-string-url@7.0.1:
     dependencies:
       '@types/whatwg-url': 13.0.0
@@ -7409,11 +7614,11 @@ snapshots:
 
   nf3@0.3.17: {}
 
-  nitro@3.0.260429-beta(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.45.2(postgres@3.4.9))(jiti@2.7.0)(lru-cache@11.3.6)(mongodb@7.2.0)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)):
+  nitro@3.0.260429-beta(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(postgres@3.4.9))(jiti@2.7.0)(lru-cache@11.3.6)(mongodb@7.2.0)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.5(srvx@0.11.15)
-      db0: 0.3.4(drizzle-orm@0.45.2(postgres@3.4.9))
+      db0: 0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(postgres@3.4.9))
       env-runner: 0.1.7
       h3: 2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15))
       hookable: 6.1.1
@@ -7424,7 +7629,7 @@ snapshots:
       rolldown: 1.0.1
       srvx: 0.11.15
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@0.45.2(postgres@3.4.9)))(lru-cache@11.3.6)(mongodb@7.2.0)(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(postgres@3.4.9)))(lru-cache@11.3.6)(mongodb@7.2.0)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 16.6.1
       jiti: 2.7.0
@@ -7813,6 +8018,13 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   retry@0.12.0: {}
 
   robust-predicates@3.0.3: {}
@@ -8167,10 +8379,10 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unstorage@2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@0.45.2(postgres@3.4.9)))(lru-cache@11.3.6)(mongodb@7.2.0)(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(postgres@3.4.9)))(lru-cache@11.3.6)(mongodb@7.2.0)(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       chokidar: 5.0.0
-      db0: 0.3.4(drizzle-orm@0.45.2(postgres@3.4.9))
+      db0: 0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(postgres@3.4.9))
       lru-cache: 11.3.6
       mongodb: 7.2.0
       ofetch: 2.0.0-alpha.3
@@ -8219,7 +8431,7 @@ snapshots:
     optionalDependencies:
       vite: 8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)
 
-  vitest@4.1.7(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -8242,6 +8454,7 @@ snapshots:
       vite: 8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.1
       jsdom: 29.1.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- Wires pino server logs to Sentry's structured logging API when `VT_SENTRY_DSN` is set, using a plain destination stream instead of `Sentry.pinoIntegration()` (which can't patch bundled modules in Nitro's output).
- Migrates from `@sentry/react` + `@sentry/vite-plugin` to `@sentry/tanstackstart-react`, wiring server-side init, Sentry middleware, and browser tracing through TanStack Router's integration.
- Extends `@virtool/logger`'s `createLogger` with a `streams` option for fan-out destinations so the Sentry stream is only loaded when a DSN is present, keeping dev and test unaffected.

## Test plan

- [ ] Confirm `pnpm check` and `pnpm typecheck` pass cleanly
- [ ] Confirm `pnpm test` passes (new tests in `sentryLog.test.ts` and `packages/logger/src/index.test.ts`)
- [ ] In a deployed environment with `VT_SENTRY_DSN` set, verify server log records appear in Sentry's Logs view with structured attributes and redacted secrets
- [ ] Confirm no Sentry SDK is loaded in dev (no DSN configured) by checking network requests or bundle output