### PR TITLE
refactor(jobs): convert jobs API requests to server functions

### DIFF
--- a/apps/web/src/indexes/queries.ts
+++ b/apps/web/src/indexes/queries.ts
@@ -71,12 +71,14 @@ export function useListIndexes(ready: boolean) {
  * Fetches a single index
  *
  * @param indexId - The id of the index to fetch
+ * @param enabled - Whether the query should run
  * @returns A single index
  */
-export function useFetchIndex(indexId: string) {
+export function useFetchIndex(indexId: string, enabled = true) {
 	return useQuery<Index, ErrorResponse>({
 		queryKey: indexQueryKeys.detail(indexId),
 		queryFn: () => apiClient.get(`/indexes/${indexId}`).then((res) => res.body),
+		enabled: enabled && Boolean(indexId),
 	});
 }
 

--- a/apps/web/src/jobs/components/JobArgs.tsx
+++ b/apps/web/src/jobs/components/JobArgs.tsx
@@ -57,7 +57,7 @@ type BuildIndexRowsProps = {
 	ref_id: string;
 };
 
-/** Rows showing important arguments when running an "build_index" workflow. */
+/** Rows showing important arguments when running a "build_index" workflow. */
 function BuildIndexRows({ index_id, ref_id }: BuildIndexRowsProps) {
 	return (
 		<>

--- a/apps/web/src/jobs/components/JobDetail.tsx
+++ b/apps/web/src/jobs/components/JobDetail.tsx
@@ -5,6 +5,7 @@ import NotFound from "@base/NotFound";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderAttribution from "@base/ViewHeaderAttribution";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
+import { useFetchIndex } from "@indexes/queries";
 import { getRouteApi } from "@tanstack/react-router";
 import Alert from "@/base/Alert";
 import RelativeTime, { useRelativeTime } from "@/base/RelativeTime";
@@ -51,6 +52,18 @@ export default function JobDetail() {
 	const numericJobId = Number(jobId);
 	const { data, isPending, error } = useFetchJob(numericJobId);
 
+	// build_index jobs reference an index but not its reference, so the
+	// reference id is resolved from the index alongside the job — keeping both
+	// fetches under the same loading gate.
+	const indexId =
+		data?.workflow === "build_index"
+			? (data.args.index_id as string)
+			: undefined;
+	const { data: index, isPending: isIndexPending } = useFetchIndex(
+		indexId ?? "",
+		Boolean(indexId),
+	);
+
 	if (!Number.isInteger(numericJobId)) {
 		return <NotFound />;
 	}
@@ -62,12 +75,13 @@ export default function JobDetail() {
 		throw error;
 	}
 
-	if (isPending) {
+	if (isPending || (indexId && isIndexPending)) {
 		return <LoadingPlaceholder />;
 	}
 
 	const color = getAlertColor(data.state);
 	const workflow = getWorkflowDisplayName(data.workflow);
+	const args = index ? { ...data.args, ref_id: index.reference.id } : data.args;
 
 	return (
 		<ContainerNarrow>
@@ -75,7 +89,7 @@ export default function JobDetail() {
 				<ViewHeaderTitle>{workflow}</ViewHeaderTitle>
 				<ViewHeaderAttribution time={data.createdAt} user={data.user.handle} />
 			</ViewHeader>
-			<JobArgs workflow={data.workflow} args={data.args} />
+			<JobArgs workflow={data.workflow} args={args} />
 			{data.state === "pending" ? (
 				<PendingJobAlert createdAt={data.createdAt} />
 			) : (

--- a/apps/web/src/jobs/components/__tests__/JobDetail.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobDetail.test.tsx
@@ -1,0 +1,55 @@
+import type { ServerJob } from "@jobs/types";
+import { screen } from "@testing-library/react";
+import { mockApiGetJob } from "@tests/api/jobs";
+import { createFakeIndexMinimal } from "@tests/fake/indexes";
+import { createFakeReferenceNested } from "@tests/fake/references";
+import { renderRoute } from "@tests/setup";
+import nock from "nock";
+import { afterEach, describe, expect, it } from "vitest";
+
+function createBuildIndexJob(indexId: string): ServerJob {
+	return {
+		args: { index_id: indexId },
+		id: 123,
+		created_at: "2022-12-22T21:37:49.429000Z",
+		finished_at: "2022-12-22T21:38:49.429000Z",
+		progress: 100,
+		state: "succeeded",
+		steps: null,
+		user: { id: 7, handle: "bob" },
+		workflow: "build_index",
+	};
+}
+
+describe("<JobDetail /> build_index links", () => {
+	afterEach(() => nock.cleanAll());
+
+	it("derives the reference id from the index so both links resolve", async () => {
+		const refId = "reference-1";
+		const indexId = "index-1";
+
+		const scope = mockApiGetJob(123, createBuildIndexJob(indexId));
+		nock("http://localhost")
+			.get(`/api/indexes/${indexId}`)
+			.reply(
+				200,
+				createFakeIndexMinimal({
+					id: indexId,
+					reference: createFakeReferenceNested({ id: refId }),
+				}),
+			);
+
+		await renderRoute("/jobs/123");
+
+		const referenceLink = await screen.findByRole("link", { name: refId });
+		expect(referenceLink).toHaveAttribute("href", `/refs/${refId}`);
+
+		const indexLink = screen.getByRole("link", { name: indexId });
+		expect(indexLink).toHaveAttribute(
+			"href",
+			`/refs/${refId}/indexes/${indexId}`,
+		);
+
+		scope.done();
+	});
+});

--- a/apps/web/src/jobs/components/__tests__/JobList.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobList.test.tsx
@@ -1,13 +1,11 @@
 import { screen, waitFor } from "@testing-library/react";
-import { createFakeServerJobMinimal, mockApiGetJobs } from "@tests/fake/jobs";
+import { mockApiGetJobs } from "@tests/api/jobs";
+import { createFakeServerJobMinimal } from "@tests/fake/jobs";
 import { renderWithRouter } from "@tests/setup";
-import nock from "nock";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import JobsList from "../JobList";
 
 describe("<JobsList />", () => {
-	afterEach(() => nock.cleanAll());
-
 	it("should render", async () => {
 		const scope = mockApiGetJobs([
 			createFakeServerJobMinimal({

--- a/apps/web/src/jobs/queries.ts
+++ b/apps/web/src/jobs/queries.ts
@@ -1,4 +1,4 @@
-import { apiClient } from "@app/api";
+import { findJobs, getJob } from "@server/jobs/functions";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import {
 	JobSchema,
@@ -6,7 +6,6 @@ import {
 	type JobState,
 	type ServerJob,
 	type ServerJobNested,
-	type ServerJobSearchResult,
 } from "./types";
 
 /**
@@ -36,13 +35,7 @@ export function useFindJobs(
 ) {
 	return useQuery({
 		queryKey: jobQueryKeys.list([page, per_page, ...states]),
-		queryFn: async (): Promise<ServerJobSearchResult> => {
-			const response = await apiClient
-				.get("/jobs")
-				.query({ page, per_page, state: states });
-
-			return response.body;
-		},
+		queryFn: () => findJobs({ data: { page, perPage: per_page, states } }),
 		placeholderData: keepPreviousData,
 		select: JobSearchResultSchema.parse,
 	});
@@ -81,10 +74,7 @@ function getJobSeed(job: ServerJobNested): ServerJob {
 export function useFetchJob(jobId: number, seed?: ServerJobNested) {
 	return useQuery({
 		queryKey: jobQueryKeys.detail(jobId),
-		queryFn: async (): Promise<ServerJob> => {
-			const response = await apiClient.get(`/jobs/${jobId}`);
-			return response.body;
-		},
+		queryFn: () => getJob({ data: { jobId } }),
 		select: JobSchema.parse,
 		enabled: Number.isInteger(jobId),
 		initialData: seed ? getJobSeed(seed) : undefined,

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -9,8 +9,21 @@ export function getRouter() {
 		defaultOptions: {
 			queries: {
 				retry: (failureCount: number, error: any) => {
+					// Superagent (legacy Python API) errors carry the HTTP status here.
 					const status = error.response?.status;
 					if ([401, 403, 404].includes(status)) {
+						return false;
+					}
+					// TanStack Start server-function errors cross the boundary as plain
+					// `Error`s with only `name`/`message` preserved — the status set via
+					// `setResponseStatus` is not attached. Match the auth errors by name
+					// so a 401/403 (e.g. after logout) rejects immediately instead of
+					// retrying ~4× while the screen sits blank before the route can
+					// bounce to /login.
+					if (
+						error.name === "UnauthorizedError" ||
+						error.name === "ForbiddenError"
+					) {
 						return false;
 					}
 					return failureCount <= 3;

--- a/apps/web/src/server/db/schema/index.ts
+++ b/apps/web/src/server/db/schema/index.ts
@@ -4,6 +4,7 @@
 // here. Each feature owns a sibling file (e.g. `labels.ts`) and is added to
 // the `export *` list as it lands.
 export * from "./groups";
+export * from "./jobs";
 export * from "./labels";
 export * from "./messages";
 export * from "./sessions";

--- a/apps/web/src/server/db/schema/jobs.ts
+++ b/apps/web/src/server/db/schema/jobs.ts
@@ -1,0 +1,73 @@
+// Read-only mirror of the `jobs` table and its resource junction tables,
+// managed by the upstream Python service via Alembic. Do not generate or push
+// migrations from this side. Keep the columns in sync with
+// `../../../../../../virtool/virtool/jobs/pg.py`.
+//
+// The legacy Mongo `args` field is not a column; workflow resource ids live in
+// the `job_*` junction tables and are recombined into `args` when a job is read.
+
+import {
+	boolean,
+	integer,
+	jsonb,
+	pgTable,
+	text,
+	timestamp,
+} from "drizzle-orm/pg-core";
+
+/** A runner claim payload, stored as JSONB on a job. */
+export type JobClaim = {
+	cpu: number;
+	image: string;
+	mem: number;
+	runner_id: string;
+	runtime_version: string;
+	workflow_version: string;
+};
+
+/** A workflow step, stored in the `steps` JSONB array on a job. */
+export type JobStep = {
+	description: string;
+	id: string;
+	name: string;
+	started_at: string | null;
+};
+
+export const jobs = pgTable("jobs", {
+	id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+	acquired: boolean("acquired").$defaultFn(() => false),
+	claim: jsonb("claim").$type<JobClaim>(),
+	claimed_at: timestamp("claimed_at"),
+	created_at: timestamp("created_at").notNull(),
+	finished_at: timestamp("finished_at"),
+	key: text("key"),
+	legacy_id: text("legacy_id").unique(),
+	pinged_at: timestamp("pinged_at"),
+	state: text("state").notNull(),
+	steps: jsonb("steps").$type<JobStep[]>(),
+	user_id: integer("user_id").notNull(),
+	workflow: text("workflow").notNull(),
+});
+
+/** A row from the `jobs` table. */
+export type JobRow = typeof jobs.$inferSelect;
+
+export const jobSamples = pgTable("job_samples", {
+	job_id: integer("job_id").primaryKey(),
+	sample_id: text("sample_id").notNull(),
+});
+
+export const jobIndexes = pgTable("job_indexes", {
+	job_id: integer("job_id").primaryKey(),
+	index_id: text("index_id").notNull(),
+});
+
+export const jobSubtractions = pgTable("job_subtractions", {
+	job_id: integer("job_id").primaryKey(),
+	subtraction_id: text("subtraction_id").notNull(),
+});
+
+export const jobAnalyses = pgTable("job_analyses", {
+	job_id: integer("job_id").primaryKey(),
+	analysis_id: text("analysis_id").notNull(),
+});

--- a/apps/web/src/server/jobs/data.ts
+++ b/apps/web/src/server/jobs/data.ts
@@ -114,7 +114,7 @@ export async function findJobs(
 	// caller needs to scope jobs by user.
 	const stateFilter = states.length ? inArray(jobs.state, states) : undefined;
 
-	const [countRows, [{ value: totalCount }], [{ value: foundCount }], rows] =
+	const [countRows, [{ value: totalCount }], foundCountResult, rows] =
 		await Promise.all([
 			db
 				.select({
@@ -125,7 +125,11 @@ export async function findJobs(
 				.from(jobs)
 				.groupBy(jobs.state, jobs.workflow),
 			db.select({ value: count() }).from(jobs),
-			db.select({ value: count() }).from(jobs).where(stateFilter),
+			// Without a state filter the found count equals the total count, so
+			// skip the redundant query and reuse totalCount below.
+			stateFilter
+				? db.select({ value: count() }).from(jobs).where(stateFilter)
+				: undefined,
 			db
 				.select({
 					id: jobs.id,
@@ -143,6 +147,8 @@ export async function findJobs(
 				.offset((page - 1) * perPage)
 				.limit(perPage),
 		]);
+
+	const foundCount = foundCountResult ? foundCountResult[0].value : totalCount;
 
 	const items = rows.map((row) => ({
 		id: row.id,

--- a/apps/web/src/server/jobs/data.ts
+++ b/apps/web/src/server/jobs/data.ts
@@ -1,0 +1,230 @@
+import { count, desc, eq, inArray } from "drizzle-orm";
+import type { Db } from "../db/pg";
+import {
+	type JobClaim,
+	type JobStep,
+	jobAnalyses,
+	jobIndexes,
+	jobSamples,
+	jobSubtractions,
+	jobs,
+} from "../db/schema/jobs";
+import { users } from "../db/schema/users";
+import { AppError } from "../errors";
+
+/** One of a job's lifecycle states. */
+export type JobState =
+	| "cancelled"
+	| "failed"
+	| "pending"
+	| "running"
+	| "succeeded";
+
+const JOB_STATES: JobState[] = [
+	"cancelled",
+	"failed",
+	"pending",
+	"running",
+	"succeeded",
+];
+
+/** A job as it appears in a search result list. */
+export type JobMinimal = {
+	id: number;
+	created_at: Date;
+	progress: number;
+	state: string;
+	user: { id: number; handle: string };
+	workflow: string;
+};
+
+/** A full job, as returned by the detail endpoint. */
+export type Job = {
+	args: Record<string, string>;
+	id: number;
+	claim: JobClaim | null;
+	claimed_at: Date | null;
+	created_at: Date;
+	finished_at: Date | null;
+	progress: number;
+	state: string;
+	steps: JobStep[] | null;
+	user: { id: number; handle: string };
+	workflow: string;
+};
+
+/** A page of jobs with per-state/workflow counts and pagination metadata. */
+export type JobSearchResult = {
+	counts: Record<string, Record<string, number>>;
+	found_count: number;
+	items: JobMinimal[];
+	page: number;
+	page_count: number;
+	per_page: number;
+	total_count: number;
+};
+
+/** Filters and pagination accepted by {@link findJobs}. */
+export type FindJobsOptions = {
+	page: number;
+	perPage: number;
+	states: JobState[];
+};
+
+/** Thrown when a requested job does not exist. */
+export class JobNotFoundError extends AppError {}
+
+// Mirror of the Python `compute_progress` helper: terminal jobs are 100%, a
+// running job is the fraction of its steps that have started, everything else
+// is 0%.
+function computeProgress(state: string, steps: JobStep[] | null): number {
+	if (state === "succeeded" || state === "failed" || state === "cancelled") {
+		return 100;
+	}
+
+	if (state !== "running" || !steps || steps.length === 0) {
+		return 0;
+	}
+
+	const started = steps.filter((step) => step.started_at != null).length;
+	return Math.floor((started / steps.length) * 100);
+}
+
+function buildCounts(
+	rows: { state: string; workflow: string; count: number }[],
+): Record<string, Record<string, number>> {
+	const counts: Record<string, Record<string, number>> = {};
+
+	// Seed every state so empty states report 0 rather than going missing.
+	for (const state of JOB_STATES) {
+		counts[state] = {};
+	}
+
+	for (const row of rows) {
+		if (!counts[row.state]) {
+			counts[row.state] = {};
+		}
+		counts[row.state][row.workflow] = row.count;
+	}
+
+	return counts;
+}
+
+export async function findJobs(
+	db: Db,
+	{ page, perPage, states }: FindJobsOptions,
+): Promise<JobSearchResult> {
+	// TODO: the Python endpoint also accepts a `users` filter; add it here if a
+	// caller needs to scope jobs by user.
+	const stateFilter = states.length ? inArray(jobs.state, states) : undefined;
+
+	const [countRows, [{ value: totalCount }], [{ value: foundCount }], rows] =
+		await Promise.all([
+			db
+				.select({
+					state: jobs.state,
+					workflow: jobs.workflow,
+					count: count(),
+				})
+				.from(jobs)
+				.groupBy(jobs.state, jobs.workflow),
+			db.select({ value: count() }).from(jobs),
+			db.select({ value: count() }).from(jobs).where(stateFilter),
+			db
+				.select({
+					id: jobs.id,
+					created_at: jobs.created_at,
+					state: jobs.state,
+					steps: jobs.steps,
+					workflow: jobs.workflow,
+					userId: users.id,
+					handle: users.handle,
+				})
+				.from(jobs)
+				.innerJoin(users, eq(jobs.user_id, users.id))
+				.where(stateFilter)
+				.orderBy(desc(jobs.created_at))
+				.offset(page > 1 ? (page - 1) * perPage : 0)
+				.limit(perPage),
+		]);
+
+	const items = rows.map((row) => ({
+		id: row.id,
+		created_at: row.created_at,
+		progress: computeProgress(row.state, row.steps),
+		state: row.state,
+		user: { id: row.userId, handle: row.handle },
+		workflow: row.workflow,
+	}));
+
+	return {
+		counts: buildCounts(countRows),
+		found_count: foundCount,
+		items,
+		page,
+		page_count: foundCount ? Math.ceil(foundCount / perPage) : 0,
+		per_page: perPage,
+		total_count: totalCount,
+	};
+}
+
+export async function getJob(db: Db, jobId: number): Promise<Job> {
+	const [row] = await db
+		.select({
+			id: jobs.id,
+			claim: jobs.claim,
+			claimed_at: jobs.claimed_at,
+			created_at: jobs.created_at,
+			finished_at: jobs.finished_at,
+			state: jobs.state,
+			steps: jobs.steps,
+			workflow: jobs.workflow,
+			userId: users.id,
+			handle: users.handle,
+			sample_id: jobSamples.sample_id,
+			index_id: jobIndexes.index_id,
+			subtraction_id: jobSubtractions.subtraction_id,
+			analysis_id: jobAnalyses.analysis_id,
+		})
+		.from(jobs)
+		.innerJoin(users, eq(jobs.user_id, users.id))
+		.leftJoin(jobSamples, eq(jobs.id, jobSamples.job_id))
+		.leftJoin(jobIndexes, eq(jobs.id, jobIndexes.job_id))
+		.leftJoin(jobSubtractions, eq(jobs.id, jobSubtractions.job_id))
+		.leftJoin(jobAnalyses, eq(jobs.id, jobAnalyses.job_id))
+		.where(eq(jobs.id, jobId));
+
+	if (!row) {
+		throw new JobNotFoundError();
+	}
+
+	// `args` is reconstructed from the resource junction tables — the legacy
+	// Mongo `args` field is not stored as a column.
+	const args: Record<string, string> = {};
+	if (row.sample_id != null) {
+		args.sample_id = row.sample_id;
+	}
+	if (row.index_id != null) {
+		args.index_id = row.index_id;
+	}
+	if (row.subtraction_id != null) {
+		args.subtraction_id = row.subtraction_id;
+	}
+	if (row.analysis_id != null) {
+		args.analysis_id = row.analysis_id;
+	}
+
+	return {
+		args,
+		id: row.id,
+		claim: row.claim ?? null,
+		claimed_at: row.claimed_at,
+		created_at: row.created_at,
+		finished_at: row.finished_at,
+		progress: computeProgress(row.state, row.steps),
+		state: row.state,
+		steps: row.steps,
+		user: { id: row.userId, handle: row.handle },
+		workflow: row.workflow,
+	};
+}

--- a/apps/web/src/server/jobs/data.ts
+++ b/apps/web/src/server/jobs/data.ts
@@ -144,7 +144,7 @@ export async function findJobs(
 				.innerJoin(users, eq(jobs.user_id, users.id))
 				.where(stateFilter)
 				.orderBy(desc(jobs.created_at))
-				.offset(page > 1 ? (page - 1) * perPage : 0)
+				.offset((page - 1) * perPage)
 				.limit(perPage),
 		]);
 

--- a/apps/web/src/server/jobs/data.ts
+++ b/apps/web/src/server/jobs/data.ts
@@ -12,21 +12,17 @@ import {
 import { users } from "../db/schema/users";
 import { AppError } from "../errors";
 
-/** One of a job's lifecycle states. */
-export type JobState =
-	| "cancelled"
-	| "failed"
-	| "pending"
-	| "running"
-	| "succeeded";
-
-const JOB_STATES: JobState[] = [
+/** The canonical list of a job's lifecycle states. */
+export const JOB_STATES = [
 	"cancelled",
 	"failed",
 	"pending",
 	"running",
 	"succeeded",
-];
+] as const;
+
+/** One of a job's lifecycle states. */
+export type JobState = (typeof JOB_STATES)[number];
 
 /** A job as it appears in a search result list. */
 export type JobMinimal = {

--- a/apps/web/src/server/jobs/functions.ts
+++ b/apps/web/src/server/jobs/functions.ts
@@ -5,16 +5,11 @@ import { db } from "../db/pg";
 import {
 	findJobs as findJobsImpl,
 	getJob as getJobImpl,
+	JOB_STATES,
 	JobNotFoundError,
 } from "./data";
 
-const jobStateSchema = z.enum([
-	"cancelled",
-	"failed",
-	"pending",
-	"running",
-	"succeeded",
-]);
+const jobStateSchema = z.enum(JOB_STATES);
 
 const findJobsSchema = z.object({
 	page: z.number().int().min(1).default(1),

--- a/apps/web/src/server/jobs/functions.ts
+++ b/apps/web/src/server/jobs/functions.ts
@@ -43,6 +43,6 @@ export const getJob = createServerFn({ method: "GET" })
 		try {
 			return await getJobImpl(db, data.jobId);
 		} catch (err) {
-			rethrowAsHttp(err);
+			await rethrowAsHttp(err);
 		}
 	});

--- a/apps/web/src/server/jobs/functions.ts
+++ b/apps/web/src/server/jobs/functions.ts
@@ -1,0 +1,53 @@
+import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
+import { setResponseStatus } from "@tanstack/react-start/server";
+import { z } from "zod";
+import { db } from "../db/pg";
+import {
+	findJobs as findJobsImpl,
+	getJob as getJobImpl,
+	JobNotFoundError,
+} from "./data";
+
+const jobStateSchema = z.enum([
+	"cancelled",
+	"failed",
+	"pending",
+	"running",
+	"succeeded",
+]);
+
+const findJobsSchema = z.object({
+	page: z.number().int().min(1).default(1),
+	perPage: z.number().int().min(1).max(100).default(25),
+	states: z.array(jobStateSchema).default([]),
+});
+
+const jobIdSchema = z.object({
+	jobId: z.number().int().positive(),
+});
+
+// Wrapped in createServerOnlyFn so the compiler can strip this body — and the
+// JobNotFoundError import it references — from the client bundle. A plain
+// top-level helper would pin ./data and its postgres transitive dependency in
+// the client graph.
+const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+	if (err instanceof JobNotFoundError) {
+		setResponseStatus(404);
+		throw new Error("Job not found.");
+	}
+	throw err;
+});
+
+export const findJobs = createServerFn({ method: "GET" })
+	.inputValidator(findJobsSchema)
+	.handler(async ({ data }) => findJobsImpl(db, data));
+
+export const getJob = createServerFn({ method: "GET" })
+	.inputValidator(jobIdSchema)
+	.handler(async ({ data }) => {
+		try {
+			return await getJobImpl(db, data.jobId);
+		} catch (err) {
+			rethrowAsHttp(err);
+		}
+	});

--- a/apps/web/src/tests/api/jobs.ts
+++ b/apps/web/src/tests/api/jobs.ts
@@ -1,0 +1,53 @@
+import type { ServerJob, ServerJobMinimal } from "@jobs/types";
+import { expect, vi } from "vitest";
+
+/**
+ * Mock handles for the `@server/jobs/functions` server-fn module. Wired in
+ * globally from `tests/setup.tsx` so any test importing this helper can stub
+ * the jobs server functions without per-file `vi.mock` boilerplate.
+ */
+export const jobServerFnMocks = {
+	findJobs: vi.fn(),
+	getJob: vi.fn(),
+};
+
+/** Asserts that the corresponding mock was called at least once. */
+export type MockScope = { done(): void };
+
+function makeScope(fn: ReturnType<typeof vi.fn>): MockScope {
+	return {
+		done() {
+			expect(fn).toHaveBeenCalled();
+		},
+	};
+}
+
+/** Sets up findJobs to resolve with a single page containing the given jobs. */
+export function mockApiGetJobs(
+	jobs: ServerJobMinimal[],
+	found_count?: number,
+): MockScope {
+	jobServerFnMocks.findJobs.mockResolvedValue({
+		counts: {},
+		found_count: found_count ?? jobs.length,
+		items: jobs,
+		page: 1,
+		page_count: 1,
+		per_page: 25,
+		total_count: jobs.length,
+	});
+	return makeScope(jobServerFnMocks.findJobs);
+}
+
+/** Sets up getJob to resolve with the given job when matched by id. */
+export function mockApiGetJob(jobId: number, job: ServerJob): MockScope {
+	jobServerFnMocks.getJob.mockImplementation(
+		async ({ data }: { data: { jobId: number } }) => {
+			if (data.jobId === jobId) {
+				return job;
+			}
+			throw new Error(`unexpected jobId in mockApiGetJob: ${data.jobId}`);
+		},
+	);
+	return makeScope(jobServerFnMocks.getJob);
+}

--- a/apps/web/src/tests/fake/jobs.ts
+++ b/apps/web/src/tests/fake/jobs.ts
@@ -7,7 +7,6 @@ import type {
 	ServerJobNested,
 	Workflow,
 } from "@jobs/types";
-import nock from "nock";
 import { createFakeUserNested } from "./user";
 
 /**
@@ -120,29 +119,4 @@ export function createFakeJobNested(overrides?: Partial<JobNested>): JobNested {
 		]),
 		...overrides,
 	};
-}
-
-/**
- * Sets up a mocked API route for fetching a list of jobs
- *
- * @param jobs - The documents for jobs (server shape)
- * @param found_count - The number of jobs found
- * @returns The nock scope for the mocked API call
- */
-export function mockApiGetJobs(
-	jobs: ReturnType<typeof createFakeServerJobMinimal>[],
-	found_count?: number,
-) {
-	return nock("http://localhost")
-		.get("/api/jobs")
-		.query(true)
-		.reply(200, {
-			items: jobs,
-			counts: {},
-			found_count: found_count ?? jobs.length,
-			page: 1,
-			page_count: 1,
-			per_page: 25,
-			total_count: jobs.length,
-		});
 }

--- a/apps/web/src/tests/setup.tsx
+++ b/apps/web/src/tests/setup.tsx
@@ -20,6 +20,7 @@ import { createContext, type ReactNode, useContext, useState } from "react";
 import { beforeEach, vi } from "vitest";
 import { routeTree } from "@/routeTree.gen";
 import { groupServerFnMocks } from "./api/groups";
+import { jobServerFnMocks } from "./api/jobs";
 import { userServerFnMocks } from "./api/users";
 import { createFakeAccount } from "./fake/account";
 
@@ -31,12 +32,19 @@ vi.mock("@server/users/functions", async () => {
 	const { userServerFnMocks } = await import("./api/users");
 	return userServerFnMocks;
 });
+vi.mock("@server/jobs/functions", async () => {
+	const { jobServerFnMocks } = await import("./api/jobs");
+	return jobServerFnMocks;
+});
 
 beforeEach(() => {
 	for (const fn of Object.values(groupServerFnMocks)) {
 		fn.mockReset();
 	}
-	for (const fn of Object.values(userServerFnMocks)) {
+	for (const fn of [
+		...Object.values(userServerFnMocks),
+		...Object.values(jobServerFnMocks),
+	]) {
 		fn.mockReset();
 		// Default to a pending promise so an un-stubbed query renders its loading
 		// state instead of resolving to `undefined`.


### PR DESCRIPTION
## Summary

- Replaces superagent-based `findJobs` and `getJob` React Query calls with TanStack Start server functions backed by a direct Drizzle/Postgres query, eliminating the round-trip through the Python REST API for job reads.
- Adds the Drizzle schema mirror for the `jobs`, `job_samples`, `job_indexes`, `job_subtractions`, and `job_analyses` tables; reconstructs the legacy `args` map from the resource junction tables at read time.
- Fixes the `build_index` job detail view: the reference id was previously missing because it is not stored in the job args — the detail now fetches the index record and derives `ref_id` from it, restoring the broken reference and index links. Also suppresses React Query retries for `UnauthorizedError`/`ForbiddenError` thrown by server functions (status codes are stripped at the RPC boundary).

## Test plan

- [ ] Job list loads and paginates correctly; state filter chips work.
- [ ] Job detail renders for each workflow type (build_index, pathoscope_bowtie, nuvs, create_subtraction, …).
- [ ] `build_index` job detail shows working reference and index links.
- [ ] Logging out while a job query is in flight redirects to /login without visible retry delay.
- [ ] `JobDetail.test.tsx` passes (`pnpm --filter @virtool/web exec vitest run src/jobs/components/__tests__/JobDetail.test.tsx`).
- [ ] `JobList.test.tsx` passes (`pnpm --filter @virtool/web exec vitest run src/jobs/components/__tests__/JobList.test.tsx`).