### PR TITLE
chore: add strictNullChecks allowlist tsconfig and CI gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
             - name: tsc
               run: pnpm typecheck
             - name: tsc (strictNullChecks)
-              run: pnpm --filter @virtool/web exec tsc -p tsconfig.strictNullChecks.json
+              run: pnpm --filter @virtool/web run typecheck:strict
     test:
         name: Test
         runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,8 @@ jobs:
               run: pnpm install --frozen-lockfile
             - name: tsc
               run: pnpm typecheck
+            - name: tsc (strictNullChecks)
+              run: pnpm --filter @virtool/web exec tsc -p tsconfig.strictNullChecks.json
     test:
         name: Test
         runs-on: ubuntu-24.04

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,8 @@
 		"develop": "vite",
 		"start": "node scripts/check-api.mjs && node .output/server/index.mjs",
 		"test": "TZ=UTC vitest",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsc --noEmit",
+		"typecheck:strict": "tsc -p tsconfig.strictNullChecks.json"
 	},
 	"dependencies": {
 		"@hookform/resolvers": "^5.4.0",

--- a/apps/web/tsconfig.strictNullChecks.json
+++ b/apps/web/tsconfig.strictNullChecks.json
@@ -1,7 +1,8 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "strictNullChecks": true
+        "strictNullChecks": true,
+        "noEmit": true
     },
-    "include": ["src/app/types.ts"]
+    "include": ["src/**/*.d.ts", "src/app/types.ts"]
 }

--- a/apps/web/tsconfig.strictNullChecks.json
+++ b/apps/web/tsconfig.strictNullChecks.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "strictNullChecks": true
+    },
+    "include": ["src/app/types.ts"]
+}


### PR DESCRIPTION
## Summary

- Adds `apps/web/tsconfig.strictNullChecks.json`, a secondary tsconfig that extends the base config and enables `strictNullChecks`, with an explicit `include` allowlist starting with `src/app/types.ts`
- Adds a `typecheck:strict` script in `apps/web/package.json` for running the allowlist typecheck locally
- Adds a `tsc (strictNullChecks)` step to the CI `typecheck` job so the allowlist is enforced in every PR

## Test plan

- [ ] CI passes the new `tsc (strictNullChecks)` step
- [ ] Running `pnpm --filter @virtool/web exec tsc -p tsconfig.strictNullChecks.json` locally exits cleanly
- [ ] Adding a file to `include` that has null-check violations causes the CI step to fail

## Summary by Sourcery

Introduce a strict null-checking TypeScript configuration for the web app and enforce it via local scripts and CI.

Enhancements:
- Add a strict null-checks tsconfig for the web app with an allowlist entry point.
- Expose a typecheck:strict npm script for running the strict null-check TypeScript pass locally.

CI:
- Add a strictNullChecks TypeScript typecheck step to the CI workflow to gate pull requests.