### PR TITLE
fix: report the real deployed version in the web app

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,8 +135,12 @@ jobs:
               uses: actions/checkout@v6
               with:
                   ref: ${{ needs.release.outputs.git-tag }}
-            - name: Write VERSION file
-              run: echo ${{ needs.release.outputs.git-tag }} > VERSION
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v6
+              with:
+                  version: ${{ env.PNPM_VERSION }}
+            - name: Set web app version from release tag
+              run: pnpm -C apps/web version "${{ needs.release.outputs.git-tag }}" --no-git-tag-version
             - name: Login
               uses: docker/login-action@v4
               with:


### PR DESCRIPTION
## Summary
- Replaces the old `VERSION` file approach with `pnpm version` to stamp the release tag directly into the web app's `package.json` during the Docker build step
- Ensures the version shown in the UI reflects the actual deployed release rather than a separately written flat file

## Test plan
- [ ] Verify a new release triggers the CI Docker build job and the version is stamped correctly in `apps/web/package.json`
- [ ] Confirm the web app reports the correct version string in the UI after deployment