### PR TITLE
chore: ignore superagent, @types/superagent, and nock in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
           prefix: "chore(deps)"
       cooldown:
           default-days: 1
+      ignore:
+          - dependency-name: "superagent"
+          - dependency-name: "@types/superagent"
+          - dependency-name: "nock"
       groups:
           tanstack:
               patterns:


### PR DESCRIPTION
## Summary
- Adds `superagent`, `@types/superagent`, and `nock` to the Dependabot ignore list to suppress noisy automated dependency bump PRs for packages that are being phased out or managed manually.

## Test plan
- [ ] Verify no Dependabot PRs are created for `superagent`, `@types/superagent`, or `nock` after merging.