### PR TITLE
feat: add health probe endpoints to the node server

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,8 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as EventsRouteImport } from './routes/events'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as AuthenticatedIndexRouteImport } from './routes/_authenticated/index'
+import { Route as HealthReadyRouteImport } from './routes/health/ready'
+import { Route as HealthLiveRouteImport } from './routes/health/live'
 import { Route as AuthenticatedSubtractionsRouteImport } from './routes/_authenticated/subtractions'
 import { Route as AuthenticatedSamplesRouteImport } from './routes/_authenticated/samples'
 import { Route as AuthenticatedJobsRouteImport } from './routes/_authenticated/jobs'
@@ -88,6 +90,16 @@ const AuthenticatedIndexRoute = AuthenticatedIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthenticatedRoute,
+} as any)
+const HealthReadyRoute = HealthReadyRouteImport.update({
+  id: '/health/ready',
+  path: '/health/ready',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const HealthLiveRoute = HealthLiveRouteImport.update({
+  id: '/health/live',
+  path: '/health/live',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AuthenticatedSubtractionsRoute =
   AuthenticatedSubtractionsRouteImport.update({
@@ -391,6 +403,8 @@ export interface FileRoutesByFullPath {
   '/jobs': typeof AuthenticatedJobsRouteWithChildren
   '/samples': typeof AuthenticatedSamplesRouteWithChildren
   '/subtractions': typeof AuthenticatedSubtractionsRouteWithChildren
+  '/health/live': typeof HealthLiveRoute
+  '/health/ready': typeof HealthReadyRoute
   '/refs/$refId': typeof AuthenticatedRefsRefIdRouteRouteWithChildren
   '/account/api': typeof AuthenticatedAccountApiRoute
   '/account/profile': typeof AuthenticatedAccountProfileRoute
@@ -439,6 +453,8 @@ export interface FileRoutesByTo {
   '/events': typeof EventsRoute
   '/login': typeof LoginRoute
   '/setup': typeof SetupRoute
+  '/health/live': typeof HealthLiveRoute
+  '/health/ready': typeof HealthReadyRoute
   '/': typeof AuthenticatedIndexRoute
   '/account/api': typeof AuthenticatedAccountApiRoute
   '/account/profile': typeof AuthenticatedAccountProfileRoute
@@ -493,6 +509,8 @@ export interface FileRoutesById {
   '/_authenticated/jobs': typeof AuthenticatedJobsRouteWithChildren
   '/_authenticated/samples': typeof AuthenticatedSamplesRouteWithChildren
   '/_authenticated/subtractions': typeof AuthenticatedSubtractionsRouteWithChildren
+  '/health/live': typeof HealthLiveRoute
+  '/health/ready': typeof HealthReadyRoute
   '/_authenticated/': typeof AuthenticatedIndexRoute
   '/_authenticated/refs/$refId': typeof AuthenticatedRefsRefIdRouteRouteWithChildren
   '/_authenticated/account/api': typeof AuthenticatedAccountApiRoute
@@ -552,6 +570,8 @@ export interface FileRouteTypes {
     | '/jobs'
     | '/samples'
     | '/subtractions'
+    | '/health/live'
+    | '/health/ready'
     | '/refs/$refId'
     | '/account/api'
     | '/account/profile'
@@ -600,6 +620,8 @@ export interface FileRouteTypes {
     | '/events'
     | '/login'
     | '/setup'
+    | '/health/live'
+    | '/health/ready'
     | '/'
     | '/account/api'
     | '/account/profile'
@@ -653,6 +675,8 @@ export interface FileRouteTypes {
     | '/_authenticated/jobs'
     | '/_authenticated/samples'
     | '/_authenticated/subtractions'
+    | '/health/live'
+    | '/health/ready'
     | '/_authenticated/'
     | '/_authenticated/refs/$refId'
     | '/_authenticated/account/api'
@@ -704,6 +728,8 @@ export interface RootRouteChildren {
   EventsRoute: typeof EventsRoute
   LoginRoute: typeof LoginRoute
   SetupRoute: typeof SetupRoute
+  HealthLiveRoute: typeof HealthLiveRoute
+  HealthReadyRoute: typeof HealthReadyRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -742,6 +768,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof AuthenticatedIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
+    }
+    '/health/ready': {
+      id: '/health/ready'
+      path: '/health/ready'
+      fullPath: '/health/ready'
+      preLoaderRoute: typeof HealthReadyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/health/live': {
+      id: '/health/live'
+      path: '/health/live'
+      fullPath: '/health/live'
+      preLoaderRoute: typeof HealthLiveRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/_authenticated/subtractions': {
       id: '/_authenticated/subtractions'
@@ -1357,6 +1397,8 @@ const rootRouteChildren: RootRouteChildren = {
   EventsRoute: EventsRoute,
   LoginRoute: LoginRoute,
   SetupRoute: SetupRoute,
+  HealthLiveRoute: HealthLiveRoute,
+  HealthReadyRoute: HealthReadyRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/health/live.ts
+++ b/apps/web/src/routes/health/live.ts
@@ -1,0 +1,13 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+function handleLive(): Response {
+	return Response.json({ status: "alive" });
+}
+
+export const Route = createFileRoute("/health/live")({
+	server: {
+		handlers: {
+			GET: handleLive,
+		},
+	},
+});

--- a/apps/web/src/routes/health/ready.ts
+++ b/apps/web/src/routes/health/ready.ts
@@ -1,0 +1,30 @@
+import { mongoose } from "@server/db/mongo";
+import { client } from "@server/db/pg";
+import {
+	checkMongo,
+	checkPostgres,
+	summarizeReadiness,
+} from "@server/health/data";
+import { createFileRoute } from "@tanstack/react-router";
+
+async function handleReady(): Promise<Response> {
+	const [mongo, postgres] = await Promise.all([
+		checkMongo(mongoose.connection),
+		checkPostgres(client),
+	]);
+
+	const report = summarizeReadiness(mongo, postgres);
+
+	return Response.json(
+		{ status: report.status, checks: report.checks },
+		{ status: report.statusCode },
+	);
+}
+
+export const Route = createFileRoute("/health/ready")({
+	server: {
+		handlers: {
+			GET: handleReady,
+		},
+	},
+});

--- a/apps/web/src/server/health/__tests__/data.test.ts
+++ b/apps/web/src/server/health/__tests__/data.test.ts
@@ -1,0 +1,93 @@
+import type { Connection } from "mongoose";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PgClient } from "../../db/pg";
+import { checkMongo, checkPostgres, summarizeReadiness } from "../data";
+
+vi.mock("../../logger", () => ({
+	logger: { warn: vi.fn(), info: vi.fn() },
+}));
+
+function fakePgClient(result: () => PromiseLike<unknown>): PgClient {
+	return (() => result()) as unknown as PgClient;
+}
+
+function fakeConnection(ping: (() => PromiseLike<unknown>) | null): Connection {
+	return {
+		db: ping ? { admin: () => ({ ping }) } : undefined,
+	} as unknown as Connection;
+}
+
+describe("checkPostgres", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("reports ok when the query resolves", async () => {
+		const client = fakePgClient(() => Promise.resolve([{ ok: 1 }]));
+		expect(await checkPostgres(client)).toEqual({ ok: true });
+	});
+
+	it("reports not ok when the query rejects", async () => {
+		const client = fakePgClient(() => Promise.reject(new Error("down")));
+		expect(await checkPostgres(client)).toEqual({ ok: false });
+	});
+
+	it("reports not ok when the query exceeds the timeout", async () => {
+		vi.useFakeTimers();
+		const client = fakePgClient(() => new Promise(() => {}));
+		const pending = checkPostgres(client);
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(await pending).toEqual({ ok: false });
+	});
+});
+
+describe("checkMongo", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("reports ok when the ping resolves", async () => {
+		const connection = fakeConnection(() => Promise.resolve({ ok: 1 }));
+		expect(await checkMongo(connection)).toEqual({ ok: true });
+	});
+
+	it("reports not ok when the connection is not ready", async () => {
+		const connection = fakeConnection(null);
+		expect(await checkMongo(connection)).toEqual({ ok: false });
+	});
+
+	it("reports not ok when the ping rejects", async () => {
+		const connection = fakeConnection(() => Promise.reject(new Error("down")));
+		expect(await checkMongo(connection)).toEqual({ ok: false });
+	});
+
+	it("reports not ok when the ping exceeds the timeout", async () => {
+		vi.useFakeTimers();
+		const connection = fakeConnection(() => new Promise(() => {}));
+		const pending = checkMongo(connection);
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(await pending).toEqual({ ok: false });
+	});
+});
+
+describe("summarizeReadiness", () => {
+	it("is ready with a 200 when both stores are ok", () => {
+		expect(summarizeReadiness({ ok: true }, { ok: true })).toEqual({
+			status: "ready",
+			statusCode: 200,
+			checks: { mongo: { ok: true }, postgres: { ok: true } },
+		});
+	});
+
+	it("is unavailable with a 503 when mongo fails", () => {
+		const report = summarizeReadiness({ ok: false }, { ok: true });
+		expect(report.status).toBe("unavailable");
+		expect(report.statusCode).toBe(503);
+	});
+
+	it("is unavailable with a 503 when postgres fails", () => {
+		const report = summarizeReadiness({ ok: true }, { ok: false });
+		expect(report.status).toBe("unavailable");
+		expect(report.statusCode).toBe(503);
+	});
+});

--- a/apps/web/src/server/health/data.ts
+++ b/apps/web/src/server/health/data.ts
@@ -1,0 +1,77 @@
+import type { Connection } from "mongoose";
+import type { PgClient } from "../db/pg";
+import { logger } from "../logger";
+
+const CHECK_TIMEOUT_MS = 5_000;
+
+/** The result of probing a single backing store. */
+export type StoreCheck = {
+	ok: boolean;
+};
+
+/** A readiness verdict over every backing store, with the HTTP status to report. */
+export type ReadyReport = {
+	status: "ready" | "unavailable";
+	statusCode: 200 | 503;
+	checks: { mongo: StoreCheck; postgres: StoreCheck };
+};
+
+/** Fold per-store checks into a single ready/unavailable verdict. */
+export function summarizeReadiness(
+	mongo: StoreCheck,
+	postgres: StoreCheck,
+): ReadyReport {
+	const ok = mongo.ok && postgres.ok;
+
+	return {
+		status: ok ? "ready" : "unavailable",
+		statusCode: ok ? 200 : 503,
+		checks: { mongo, postgres },
+	};
+}
+
+/** Reject if `promise` does not settle within `ms` milliseconds. */
+function withTimeout<T>(promise: PromiseLike<T>, ms: number): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timer = setTimeout(() => {
+			reject(new Error(`health check timed out after ${ms}ms`));
+		}, ms);
+
+		promise.then(
+			(value) => {
+				clearTimeout(timer);
+				resolve(value);
+			},
+			(err) => {
+				clearTimeout(timer);
+				reject(err);
+			},
+		);
+	});
+}
+
+/** Probe Postgres with a trivial query. Never throws. */
+export async function checkPostgres(client: PgClient): Promise<StoreCheck> {
+	try {
+		await withTimeout(client`SELECT 1`, CHECK_TIMEOUT_MS);
+		return { ok: true };
+	} catch (err) {
+		logger.warn({ err }, "postgres health check failed");
+		return { ok: false };
+	}
+}
+
+/** Probe Mongo with a server ping. Never throws. */
+export async function checkMongo(connection: Connection): Promise<StoreCheck> {
+	try {
+		const admin = connection.db?.admin();
+		if (!admin) {
+			throw new Error("mongo connection is not ready");
+		}
+		await withTimeout(admin.ping(), CHECK_TIMEOUT_MS);
+		return { ok: true };
+	} catch (err) {
+		logger.warn({ err }, "mongo health check failed");
+		return { ok: false };
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `/health/live` endpoint that returns `{ status: "alive" }` — a lightweight liveness probe requiring no dependencies
- Adds `/health/ready` endpoint that pings both Postgres and Mongo in parallel, returning `200 { status: "ready" }` when both are up and `503 { status: "unavailable" }` with per-store check details when either is down
- Both probes run outside the authentication middleware so Kubernetes can reach them without credentials

## Test plan

- [x] Unit tests for `checkPostgres`, `checkMongo`, and `summarizeReadiness` covering ok, failure, and timeout cases
- [ ] Verify `/health/live` returns `200` with `{ status: "alive" }`
- [ ] Verify `/health/ready` returns `200` when both stores are reachable
- [ ] Verify `/health/ready` returns `503` with `{ status: "unavailable", checks: { ... } }` when a store is down