### PR TITLE
feat: allow users and administrators to edit user handles

### DIFF
--- a/apps/web/src/account/components/AccountHandle.tsx
+++ b/apps/web/src/account/components/AccountHandle.tsx
@@ -6,6 +6,7 @@ import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import InputSimple from "@base/InputSimple";
 import SaveButton from "@base/SaveButton";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { useUpdateHandle } from "../queries";
 
@@ -26,8 +27,15 @@ export default function AccountHandle({ handle }: HandleProps) {
 		formState: { errors },
 		handleSubmit,
 		register,
+		reset,
 	} = useForm<FormValues>({ defaultValues: { handle } });
 	const mutation = useUpdateHandle();
+
+	// Keep the input in sync when the handle prop changes after a successful
+	// update and refetch.
+	useEffect(() => {
+		reset({ handle });
+	}, [handle, reset]);
 
 	function onSubmit(values: FormValues) {
 		mutation.mutate({ handle: values.handle });

--- a/apps/web/src/account/components/AccountHandle.tsx
+++ b/apps/web/src/account/components/AccountHandle.tsx
@@ -1,0 +1,64 @@
+import BoxGroup from "@base/BoxGroup";
+import BoxGroupHeader from "@base/BoxGroupHeader";
+import BoxGroupSection from "@base/BoxGroupSection";
+import InputError from "@base/InputError";
+import InputGroup from "@base/InputGroup";
+import InputLabel from "@base/InputLabel";
+import InputSimple from "@base/InputSimple";
+import SaveButton from "@base/SaveButton";
+import { useForm } from "react-hook-form";
+import { useUpdateHandle } from "../queries";
+
+type FormValues = {
+	handle: string;
+};
+
+type HandleProps = {
+	/** The users current handle */
+	handle: string;
+};
+
+/**
+ * A component to update the account's handle
+ */
+export default function AccountHandle({ handle }: HandleProps) {
+	const {
+		formState: { errors },
+		handleSubmit,
+		register,
+	} = useForm<FormValues>({ defaultValues: { handle } });
+	const mutation = useUpdateHandle();
+
+	function onSubmit(values: FormValues) {
+		mutation.mutate({ handle: values.handle });
+	}
+
+	return (
+		<BoxGroup>
+			<BoxGroupHeader>
+				<h2>Handle</h2>
+			</BoxGroupHeader>
+			<form onSubmit={handleSubmit(onSubmit)}>
+				<BoxGroupSection>
+					<InputGroup>
+						<InputLabel htmlFor="handle">Username</InputLabel>
+						<InputSimple
+							id="handle"
+							autoComplete="off"
+							{...register("handle", {
+								required: "Please specify a username",
+							})}
+						/>
+						<InputError>
+							{errors.handle?.message ||
+								(mutation.isError ? mutation.error.message : "")}
+						</InputError>
+					</InputGroup>
+					<footer className="flex items-center justify-end mb-4">
+						<SaveButton altText="Change" />
+					</footer>
+				</BoxGroupSection>
+			</form>
+		</BoxGroup>
+	);
+}

--- a/apps/web/src/account/components/AccountProfile.tsx
+++ b/apps/web/src/account/components/AccountProfile.tsx
@@ -5,6 +5,7 @@ import { ShieldUser } from "lucide-react";
 import { useFetchAccount } from "../queries";
 import AccountEmail from "./AccountEmail";
 import AccountGroups from "./AccountGroups";
+import AccountHandle from "./AccountHandle";
 import AccountPassword from "./AccountPassword";
 
 /**
@@ -42,6 +43,7 @@ export default function AccountProfile() {
 				</div>
 			</div>
 
+			<AccountHandle handle={handle} />
 			<AccountPassword lastPasswordChange={last_password_change} />
 			<AccountEmail email={email} />
 			<AccountGroups groups={groups} />

--- a/apps/web/src/account/components/__tests__/AccountProfile.test.tsx
+++ b/apps/web/src/account/components/__tests__/AccountProfile.test.tsx
@@ -1,6 +1,7 @@
 import AccountProfile from "@account/components/AccountProfile";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { mockApiUpdateAccountHandle } from "@tests/api/users";
 import {
 	createFakeAccount,
 	mockApiChangePassword,
@@ -60,7 +61,7 @@ describe("<AccountProfile />", () => {
 		const input = screen.getByLabelText("Email Address");
 		expect(input).toHaveValue("");
 
-		const button = screen.getAllByRole("button", { name: "Change" })[1];
+		const button = screen.getAllByRole("button", { name: "Change" })[2];
 
 		await userEvent.type(input, "invalid");
 		await userEvent.click(button);
@@ -75,6 +76,57 @@ describe("<AccountProfile />", () => {
 		await userEvent.click(button);
 	});
 
+	it("should render with the current handle", async () => {
+		const account = createFakeAccount({ handle: "current_handle" });
+
+		mockApiGetAccount(account);
+		renderWithProviders(<AccountProfile />);
+
+		await screen.findByText("Handle");
+		expect(screen.getByLabelText("Username")).toHaveValue("current_handle");
+	});
+
+	it("should change the handle", async () => {
+		const account = createFakeAccount({ handle: "old_handle" });
+
+		mockApiGetAccount(account);
+		const scope = mockApiUpdateAccountHandle({
+			...account,
+			handle: "new_handle",
+		});
+		renderWithProviders(<AccountProfile />);
+
+		await screen.findByText("Handle");
+		const input = screen.getByLabelText("Username");
+		const button = screen.getAllByRole("button", { name: "Change" })[0];
+
+		await userEvent.clear(input);
+		await userEvent.type(input, "new_handle");
+		await userEvent.click(button);
+
+		await waitFor(() => scope.done());
+	});
+
+	it("should show a conflict error when the handle is taken", async () => {
+		const account = createFakeAccount({ handle: "old_handle" });
+
+		mockApiGetAccount(account);
+		mockApiUpdateAccountHandle(undefined, 409, "User already exists.");
+		renderWithProviders(<AccountProfile />);
+
+		await screen.findByText("Handle");
+		const input = screen.getByLabelText("Username");
+		const button = screen.getAllByRole("button", { name: "Change" })[0];
+
+		await userEvent.clear(input);
+		await userEvent.type(input, "taken_handle");
+		await userEvent.click(button);
+
+		await waitFor(() =>
+			expect(screen.getByText("User already exists.")).toBeInTheDocument(),
+		);
+	});
+
 	it("should handle password changes", async () => {
 		const account = createFakeAccount({
 			administrator_role: "full",
@@ -84,7 +136,7 @@ describe("<AccountProfile />", () => {
 
 		expect(await screen.findByText("Password")).toBeInTheDocument();
 
-		const button = screen.getAllByRole("button", { name: "Change" })[0];
+		const button = screen.getAllByRole("button", { name: "Change" })[1];
 
 		const oldPasswordInput = screen.getByLabelText("Old Password");
 		const newPasswordInput = screen.getByLabelText("New Password");
@@ -122,7 +174,7 @@ describe("<AccountProfile />", () => {
 
 		await screen.findByText("Password");
 
-		const button = screen.getAllByRole("button", { name: "Change" })[0];
+		const button = screen.getAllByRole("button", { name: "Change" })[1];
 		const oldPasswordInput = screen.getByLabelText("Old Password");
 		const newPasswordInput = screen.getByLabelText("New Password");
 

--- a/apps/web/src/account/components/__tests__/AccountProfile.test.tsx
+++ b/apps/web/src/account/components/__tests__/AccountProfile.test.tsx
@@ -1,7 +1,10 @@
 import AccountProfile from "@account/components/AccountProfile";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { mockApiUpdateAccountHandle } from "@tests/api/users";
+import {
+	mockApiUpdateAccountHandle,
+	userServerFnMocks,
+} from "@tests/api/users";
 import {
 	createFakeAccount,
 	mockApiChangePassword,
@@ -90,19 +93,21 @@ describe("<AccountProfile />", () => {
 		const account = createFakeAccount({ handle: "old_handle" });
 
 		mockApiGetAccount(account);
-		const scope = mockApiUpdateAccountHandle({
-			...account,
-			handle: "new_handle",
-		});
+		const scope = mockApiUpdateAccountHandle(
+			{ ...account, handle: "new_handle" },
+			200,
+			undefined,
+			"new_handle",
+		);
 		renderWithProviders(<AccountProfile />);
 
 		await screen.findByText("Handle");
 		const input = screen.getByLabelText("Username");
-		const button = screen.getAllByRole("button", { name: "Change" })[0];
+		const form = input.closest("form") as HTMLElement;
 
 		await userEvent.clear(input);
 		await userEvent.type(input, "new_handle");
-		await userEvent.click(button);
+		await userEvent.click(within(form).getByRole("button", { name: "Change" }));
 
 		await waitFor(() => scope.done());
 	});
@@ -116,15 +121,57 @@ describe("<AccountProfile />", () => {
 
 		await screen.findByText("Handle");
 		const input = screen.getByLabelText("Username");
-		const button = screen.getAllByRole("button", { name: "Change" })[0];
+		const form = input.closest("form") as HTMLElement;
 
 		await userEvent.clear(input);
 		await userEvent.type(input, "taken_handle");
-		await userEvent.click(button);
+		await userEvent.click(within(form).getByRole("button", { name: "Change" }));
 
 		await waitFor(() =>
 			expect(screen.getByText("User already exists.")).toBeInTheDocument(),
 		);
+	});
+
+	it("should show an error when the handle is reserved", async () => {
+		const account = createFakeAccount({ handle: "old_handle" });
+
+		mockApiGetAccount(account);
+		mockApiUpdateAccountHandle(undefined, 400, "Reserved user name: virtool");
+		renderWithProviders(<AccountProfile />);
+
+		await screen.findByText("Handle");
+		const input = screen.getByLabelText("Username");
+		const form = input.closest("form") as HTMLElement;
+
+		await userEvent.clear(input);
+		await userEvent.type(input, "virtool");
+		await userEvent.click(within(form).getByRole("button", { name: "Change" }));
+
+		await waitFor(() =>
+			expect(
+				screen.getByText("Reserved user name: virtool"),
+			).toBeInTheDocument(),
+		);
+	});
+
+	it("should not submit an empty handle", async () => {
+		const account = createFakeAccount({ handle: "old_handle" });
+
+		mockApiGetAccount(account);
+		mockApiUpdateAccountHandle({ ...account });
+		renderWithProviders(<AccountProfile />);
+
+		await screen.findByText("Handle");
+		const input = screen.getByLabelText("Username");
+		const form = input.closest("form") as HTMLElement;
+
+		await userEvent.clear(input);
+		await userEvent.click(within(form).getByRole("button", { name: "Change" }));
+
+		expect(
+			await screen.findByText("Please specify a username"),
+		).toBeInTheDocument();
+		expect(userServerFnMocks.updateAccountHandle).not.toHaveBeenCalled();
 	});
 
 	it("should handle password changes", async () => {

--- a/apps/web/src/account/queries.ts
+++ b/apps/web/src/account/queries.ts
@@ -3,6 +3,7 @@ import { apiClient } from "@app/api";
 import { resetClient } from "@app/utils";
 import type { Permissions } from "@groups/types";
 import { logoutFn } from "@server/auth/functions";
+import { updateAccountHandle } from "@server/users/functions";
 import {
 	queryOptions,
 	useMutation,
@@ -61,6 +62,26 @@ export function useUpdateAccount() {
 				.patch("/account")
 				.send({ update })
 				.then((res) => res.body),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: accountKeys.all() });
+		},
+	});
+}
+
+/**
+ * Initializes a mutator for changing the current account's handle
+ *
+ * @returns A mutator for changing the account handle
+ */
+export function useUpdateHandle() {
+	const queryClient = useQueryClient();
+
+	return useMutation<
+		Awaited<ReturnType<typeof updateAccountHandle>>,
+		Error,
+		{ handle: string }
+	>({
+		mutationFn: ({ handle }) => updateAccountHandle({ data: { handle } }),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: accountKeys.all() });
 		},

--- a/apps/web/src/administration/queries.ts
+++ b/apps/web/src/administration/queries.ts
@@ -209,6 +209,7 @@ export function useFetchUser(userId: number) {
 export type UserUpdate = {
 	active?: boolean;
 	force_reset?: boolean;
+	handle?: string;
 	password?: string;
 	groups?: number[];
 	primary_group?: number | null;

--- a/apps/web/src/server/users/data.ts
+++ b/apps/web/src/server/users/data.ts
@@ -73,6 +73,7 @@ export type CreateUserValues = {
 export type UserUpdateValues = {
 	active?: boolean;
 	force_reset?: boolean;
+	handle?: string;
 	password?: string;
 	groups?: number[];
 	primary_group?: number | null;
@@ -398,6 +399,9 @@ export async function updateUser(
 		patch.forceReset = values.force_reset;
 		patch.invalidateSessions = true;
 	}
+	if (values.handle !== undefined) {
+		patch.handle = values.handle;
+	}
 	if (values.password !== undefined) {
 		patch.password = await hashPassword(values.password);
 		patch.lastPasswordChange = new Date();
@@ -406,7 +410,14 @@ export async function updateUser(
 
 	await db.transaction(async (tx) => {
 		if (Object.keys(patch).length > 0) {
-			await tx.update(usersTable).set(patch).where(eq(usersTable.id, userId));
+			try {
+				await tx.update(usersTable).set(patch).where(eq(usersTable.id, userId));
+			} catch (error) {
+				if (isUniqueViolation(error)) {
+					throw new UserConflictError();
+				}
+				throw error;
+			}
 		}
 
 		if (values.groups !== undefined) {

--- a/apps/web/src/server/users/functions.ts
+++ b/apps/web/src/server/users/functions.ts
@@ -39,7 +39,7 @@ const findUsersSchema = z
 	.optional();
 
 const createUserSchema = z.object({
-	handle: z.string().min(1),
+	handle: z.string().trim().min(1),
 	password: z.string().min(1),
 	forceReset: z.boolean().default(false),
 });
@@ -48,20 +48,22 @@ const updateUserSchema = z.object({
 	userId: z.number().int().positive(),
 	active: z.boolean().optional(),
 	force_reset: z.boolean().optional(),
-	handle: z.string().min(1).optional(),
+	handle: z.string().trim().min(1).optional(),
 	password: z.string().min(1).optional(),
 	groups: z.array(z.number().int().positive()).optional(),
 	primary_group: z.number().int().positive().nullable().optional(),
 });
 
 const accountHandleSchema = z.object({
-	handle: z.string().min(1),
+	handle: z.string().trim().min(1),
 });
 
 // Reserved handle the Python service forbids; rejected before hitting the
 // database so we return a clear message rather than a unique-constraint error.
+// Trim defensively so whitespace-padded variants like " virtool" can't slip
+// past the check even if a caller skips the schema's trim.
 function checkReservedHandle(handle: string): void {
-	if (handle.toLowerCase() === "virtool") {
+	if (handle.trim().toLowerCase() === "virtool") {
 		setResponseStatus(400);
 		throw new Error("Reserved user name: virtool");
 	}

--- a/apps/web/src/server/users/functions.ts
+++ b/apps/web/src/server/users/functions.ts
@@ -48,10 +48,24 @@ const updateUserSchema = z.object({
 	userId: z.number().int().positive(),
 	active: z.boolean().optional(),
 	force_reset: z.boolean().optional(),
+	handle: z.string().min(1).optional(),
 	password: z.string().min(1).optional(),
 	groups: z.array(z.number().int().positive()).optional(),
 	primary_group: z.number().int().positive().nullable().optional(),
 });
+
+const accountHandleSchema = z.object({
+	handle: z.string().min(1),
+});
+
+// Reserved handle the Python service forbids; rejected before hitting the
+// database so we return a clear message rather than a unique-constraint error.
+function checkReservedHandle(handle: string): void {
+	if (handle.toLowerCase() === "virtool") {
+		setResponseStatus(400);
+		throw new Error("Reserved user name: virtool");
+	}
+}
 
 const setAdministratorRoleSchema = z.object({
 	userId: z.number().int().positive(),
@@ -68,7 +82,7 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 		throw new Error("User not found.");
 	}
 	if (err instanceof UserConflictError) {
-		setResponseStatus(400);
+		setResponseStatus(409);
 		throw new Error("User already exists.");
 	}
 	if (err instanceof GroupMembershipError) {
@@ -114,10 +128,7 @@ export const createUser = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		await requireAdminRole(await requireSession(), "users");
 
-		if (data.handle.toLowerCase() === "virtool") {
-			setResponseStatus(400);
-			throw new Error("Reserved user name: virtool");
-		}
+		checkReservedHandle(data.handle);
 
 		try {
 			const user = await createUserImpl(db, {
@@ -146,8 +157,27 @@ export const updateUser = createServerFn({ method: "POST" })
 		}
 
 		const { userId, ...values } = data;
+		if (values.handle !== undefined) {
+			checkReservedHandle(values.handle);
+		}
 		try {
 			return await updateUserImpl(db, userId, values);
+		} catch (err) {
+			rethrowAsHttp(err);
+		}
+	});
+
+export const updateAccountHandle = createServerFn({ method: "POST" })
+	.inputValidator(accountHandleSchema)
+	.handler(async ({ data }) => {
+		const session = await requireSession();
+
+		checkReservedHandle(data.handle);
+
+		try {
+			return await updateUserImpl(db, session.userId, {
+				handle: data.handle,
+			});
 		} catch (err) {
 			rethrowAsHttp(err);
 		}

--- a/apps/web/src/tests/api/users.ts
+++ b/apps/web/src/tests/api/users.ts
@@ -12,6 +12,7 @@ export const userServerFnMocks = {
 	getUser: vi.fn(),
 	createUser: vi.fn(),
 	updateUser: vi.fn(),
+	updateAccountHandle: vi.fn(),
 	setAdministratorRole: vi.fn(),
 	listAdministratorRoles: vi.fn(),
 };
@@ -82,6 +83,23 @@ export function mockApiEditUser(
 		userServerFnMocks.updateUser.mockResolvedValue({ ...user, ...update });
 	}
 	return makeScope(userServerFnMocks.updateUser);
+}
+
+/**
+ * Sets up updateAccountHandle to resolve with the updated user (or reject on a
+ * 4xx code, e.g. 409 for a duplicate handle).
+ */
+export function mockApiUpdateAccountHandle(
+	user?: User,
+	statusCode = 200,
+	message = "User already exists.",
+): MockScope {
+	if (statusCode >= 400) {
+		userServerFnMocks.updateAccountHandle.mockRejectedValue(new Error(message));
+	} else {
+		userServerFnMocks.updateAccountHandle.mockResolvedValue(user ?? {});
+	}
+	return makeScope(userServerFnMocks.updateAccountHandle);
 }
 
 /** Sets up listAdministratorRoles to resolve with the given roles. */

--- a/apps/web/src/tests/api/users.ts
+++ b/apps/web/src/tests/api/users.ts
@@ -88,16 +88,27 @@ export function mockApiEditUser(
 /**
  * Sets up updateAccountHandle to resolve with the updated user (or reject on a
  * 4xx code, e.g. 409 for a duplicate handle).
+ *
+ * When `expectedHandle` is given, the resolved variant also asserts the payload
+ * carried the expected handle so callers can verify the value actually sent.
  */
 export function mockApiUpdateAccountHandle(
 	user?: User,
 	statusCode = 200,
 	message = "User already exists.",
+	expectedHandle?: string,
 ): MockScope {
 	if (statusCode >= 400) {
 		userServerFnMocks.updateAccountHandle.mockRejectedValue(new Error(message));
 	} else {
-		userServerFnMocks.updateAccountHandle.mockResolvedValue(user ?? {});
+		userServerFnMocks.updateAccountHandle.mockImplementation(
+			async ({ data }: { data: { handle: string } }) => {
+				if (expectedHandle !== undefined) {
+					expect(data.handle).toBe(expectedHandle);
+				}
+				return user ?? {};
+			},
+		);
 	}
 	return makeScope(userServerFnMocks.updateAccountHandle);
 }

--- a/apps/web/src/users/components/Handle.tsx
+++ b/apps/web/src/users/components/Handle.tsx
@@ -7,6 +7,7 @@ import InputError from "@base/InputError";
 import InputGroup from "@base/InputGroup";
 import InputSimple from "@base/InputSimple";
 import SaveButton from "@base/SaveButton";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 
 type HandleProps = {
@@ -29,7 +30,14 @@ export default function Handle({ id, handle }: HandleProps) {
 		formState: { errors },
 		handleSubmit,
 		register,
+		reset,
 	} = useForm<FormValues>({ defaultValues: { handle } });
+
+	// Keep the input in sync when the handle prop changes after a successful
+	// update and refetch.
+	useEffect(() => {
+		reset({ handle });
+	}, [handle, reset]);
 
 	return (
 		<BoxGroup>

--- a/apps/web/src/users/components/Handle.tsx
+++ b/apps/web/src/users/components/Handle.tsx
@@ -1,0 +1,73 @@
+import { useUpdateUser } from "@administration/queries";
+import BoxGroup from "@base/BoxGroup";
+import BoxGroupHeader from "@base/BoxGroupHeader";
+import BoxGroupSection from "@base/BoxGroupSection";
+import InputContainer from "@base/InputContainer";
+import InputError from "@base/InputError";
+import InputGroup from "@base/InputGroup";
+import InputSimple from "@base/InputSimple";
+import SaveButton from "@base/SaveButton";
+import { useForm } from "react-hook-form";
+
+type HandleProps = {
+	/** The users unique id */
+	id: number;
+	/** The users current handle */
+	handle: string;
+};
+
+type FormValues = {
+	handle: string;
+};
+
+/**
+ * The handle view to change a user's handle
+ */
+export default function Handle({ id, handle }: HandleProps) {
+	const mutation = useUpdateUser();
+	const {
+		formState: { errors },
+		handleSubmit,
+		register,
+	} = useForm<FormValues>({ defaultValues: { handle } });
+
+	return (
+		<BoxGroup>
+			<BoxGroupHeader>
+				<h2>Change Handle</h2>
+				<p>The username this person signs in with.</p>
+			</BoxGroupHeader>
+			<BoxGroupSection>
+				<form
+					onSubmit={handleSubmit((values) =>
+						mutation.mutate({
+							userId: id,
+							update: { handle: values.handle },
+						}),
+					)}
+				>
+					<InputGroup>
+						<InputContainer>
+							<InputSimple
+								aria-label="handle"
+								id="handle"
+								autoComplete="off"
+								{...register("handle", {
+									required: "Please specify a username",
+								})}
+							/>
+							<InputError>
+								{errors.handle?.message ||
+									(mutation.isError ? mutation.error.message : "")}
+							</InputError>
+						</InputContainer>
+					</InputGroup>
+
+					<div className="flex items-center justify-end">
+						<SaveButton />
+					</div>
+				</form>
+			</BoxGroupSection>
+		</BoxGroup>
+	);
+}

--- a/apps/web/src/users/components/UserDetail.tsx
+++ b/apps/web/src/users/components/UserDetail.tsx
@@ -5,6 +5,7 @@ import InitialIcon from "@base/InitialIcon";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import { CircleAlert, ShieldUserIcon } from "lucide-react";
 import Label from "@/base/Label";
+import Handle from "./Handle";
 import Password from "./Password";
 import PrimaryGroup from "./PrimaryGroup";
 import { UserActivationBanner } from "./UserActivationBanner";
@@ -71,6 +72,8 @@ export default function UserDetail({ userId }: UserDetailProps) {
 			</header>
 
 			<UserAdministratorRole id={id} role={administrator_role} />
+
+			<Handle key={`handle-${id}`} id={id} handle={handle} />
 
 			<Password
 				key={id}

--- a/apps/web/src/users/components/__tests__/UserDetail.test.tsx
+++ b/apps/web/src/users/components/__tests__/UserDetail.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mockApiListGroups } from "@tests/api/groups";
 import {
@@ -187,6 +187,56 @@ describe("<UserDetail />", () => {
 		});
 	});
 
+	describe("<Handle />", () => {
+		it("should render with the current handle", async () => {
+			mockApiListGroups(groups);
+			const scope = mockApiGetUser(user.id, user);
+
+			renderWithProviders(<UserDetail userId={user.id} />);
+
+			expect(await screen.findByText("Change Handle")).toBeInTheDocument();
+			expect(screen.getByLabelText("handle")).toHaveValue(user.handle);
+
+			scope.done();
+		});
+
+		it("should submit a new handle", async () => {
+			mockApiListGroups(groups);
+			mockApiGetUser(user.id, user);
+			const scope = mockApiEditUser(user.id, 200, { handle: "new_handle" });
+
+			renderWithProviders(<UserDetail userId={user.id} />);
+
+			const input = await screen.findByLabelText("handle");
+			await userEvent.clear(input);
+			await userEvent.type(input, "new_handle");
+
+			const form = input.closest("form") as HTMLElement;
+			await userEvent.click(within(form).getByRole("button", { name: "Save" }));
+
+			await waitFor(() => scope.done());
+		});
+
+		it("should show a conflict error when the handle is taken", async () => {
+			mockApiListGroups(groups);
+			mockApiGetUser(user.id, user);
+			mockApiEditUser(user.id, 409, { message: "User already exists." });
+
+			renderWithProviders(<UserDetail userId={user.id} />);
+
+			const input = await screen.findByLabelText("handle");
+			await userEvent.clear(input);
+			await userEvent.type(input, "taken_handle");
+
+			const form = input.closest("form") as HTMLElement;
+			await userEvent.click(within(form).getByRole("button", { name: "Save" }));
+
+			await waitFor(() =>
+				expect(screen.getByText("User already exists.")).toBeInTheDocument(),
+			);
+		});
+	});
+
 	describe("<Password />", () => {
 		it("should render correctly", async () => {
 			mockApiListGroups(groups);
@@ -200,7 +250,12 @@ describe("<UserDetail />", () => {
 				screen.getByText("Force user to reset password on next login"),
 			).toBeInTheDocument();
 			expect(screen.getByLabelText("password")).toBeInTheDocument();
-			expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+			const passwordForm = screen
+				.getByLabelText("password")
+				.closest("form") as HTMLElement;
+			expect(
+				within(passwordForm).getByRole("button", { name: "Save" }),
+			).toBeInTheDocument();
 
 			scope.done();
 		});
@@ -214,8 +269,12 @@ describe("<UserDetail />", () => {
 
 			expect(await screen.findByText("Change Password")).toBeInTheDocument();
 
-			await userEvent.type(screen.getByLabelText("password"), "newPassword");
-			await userEvent.click(screen.getByRole("button", { name: "Save" }));
+			const passwordInput = screen.getByLabelText("password");
+			await userEvent.type(passwordInput, "newPassword");
+			const passwordForm = passwordInput.closest("form") as HTMLElement;
+			await userEvent.click(
+				within(passwordForm).getByRole("button", { name: "Save" }),
+			);
 
 			scope.done();
 		});
@@ -232,7 +291,12 @@ describe("<UserDetail />", () => {
 
 			expect(await screen.findByText("Change Password")).toBeInTheDocument();
 
-			await userEvent.click(screen.getByRole("button", { name: "Save" }));
+			const passwordForm = screen
+				.getByLabelText("password")
+				.closest("form") as HTMLElement;
+			await userEvent.click(
+				within(passwordForm).getByRole("button", { name: "Save" }),
+			);
 
 			await waitFor(() =>
 				expect(

--- a/apps/web/src/users/components/__tests__/UserDetail.test.tsx
+++ b/apps/web/src/users/components/__tests__/UserDetail.test.tsx
@@ -235,6 +235,29 @@ describe("<UserDetail />", () => {
 				expect(screen.getByText("User already exists.")).toBeInTheDocument(),
 			);
 		});
+
+		it("should show an error when the handle is reserved", async () => {
+			mockApiListGroups(groups);
+			mockApiGetUser(user.id, user);
+			mockApiEditUser(user.id, 400, {
+				message: "Reserved user name: virtool",
+			});
+
+			renderWithProviders(<UserDetail userId={user.id} />);
+
+			const input = await screen.findByLabelText("handle");
+			await userEvent.clear(input);
+			await userEvent.type(input, "virtool");
+
+			const form = input.closest("form") as HTMLElement;
+			await userEvent.click(within(form).getByRole("button", { name: "Save" }));
+
+			await waitFor(() =>
+				expect(
+					screen.getByText("Reserved user name: virtool"),
+				).toBeInTheDocument(),
+			);
+		});
 	});
 
 	describe("<Password />", () => {


### PR DESCRIPTION
## Summary
- Users can now change their own handle (username) from the Account Profile page
- Administrators can change any user's handle from the User Detail admin page
- Duplicate handle conflicts return a 409 with a clear error message; the reserved handle "virtool" is rejected before hitting the database

## Test plan
- [ ] Log in as a regular user, navigate to Account → Profile, and verify the Handle section appears with the current handle pre-filled
- [ ] Change the handle to a new unique value and confirm the change saves without error
- [ ] Attempt to set the handle to one already taken by another user and confirm the "User already exists." error appears
- [ ] Attempt to set the handle to "virtool" (any case) and confirm the reserved-name error appears
- [ ] Log in as an admin, navigate to a user's detail page, and verify the "Change Handle" section appears
- [ ] Change another user's handle as an admin and confirm it saves
- [ ] Confirm existing password-change and email-change flows on both pages still work correctly