### PR TITLE
docs: clarify test plan rule applies to PR comments too

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,7 +384,7 @@ and make commits easier to find later.
 - Title: lowercase, no period, under 72 characters.
 - Scope is optional but preferred.
 - Don't push or create PRs unless asked.
-- Don't include a Test plan section in PR descriptions.
+- Don't include a Test plan section in pull request descriptions or comments.
 - Don't use `git -C <path>` unless necessary. It triggers permission prompts
   that aren't worth the trouble. Run git commands from the working directory
   instead.


### PR DESCRIPTION
## Summary
- Expands the AGENTS.md rule about test plans to explicitly state it applies to both pull request descriptions and review comments, not just descriptions