### PR TITLE
fix: repair sample name autofill in create sample view

### DIFF
--- a/apps/web/src/samples/components/Create/CreateSample.tsx
+++ b/apps/web/src/samples/components/Create/CreateSample.tsx
@@ -27,7 +27,7 @@ import ReadSelector from "./ReadSelector";
 import SampleUserGroup from "./SampleUserGroup";
 import Sidebar from "./Sidebar";
 
-const extensionRegex = /^(.*)\.f[aq](st)?[aq]?(\.gz)?$/;
+const extensionRegex = /^(.*)\.(fq|fastq|fa|fasta)(\.gz)?$/i;
 
 /**
  * Gets a filename without extension, given the file ID and an array of all available read uploads.

--- a/apps/web/src/samples/components/Create/CreateSample.tsx
+++ b/apps/web/src/samples/components/Create/CreateSample.tsx
@@ -27,7 +27,7 @@ import ReadSelector from "./ReadSelector";
 import SampleUserGroup from "./SampleUserGroup";
 import Sidebar from "./Sidebar";
 
-const extensionRegex = /^[a-z0-9]+-(.*)\.f[aq](st)?[aq]?(\.gz)?$/;
+const extensionRegex = /^(.*)\.f[aq](st)?[aq]?(\.gz)?$/;
 
 /**
  * Gets a filename without extension, given the file ID and an array of all available read uploads.
@@ -39,7 +39,7 @@ const extensionRegex = /^[a-z0-9]+-(.*)\.f[aq](st)?[aq]?(\.gz)?$/;
  */
 function getFileNameFromId(id: number, uploads: Upload[]): string {
 	const file = uploads.find((file) => file.id === id);
-	const match = file?.name_on_disk.match(extensionRegex);
+	const match = file?.name.match(extensionRegex);
 	return match ? match[1] : "";
 }
 

--- a/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
@@ -188,6 +188,46 @@ describe("<CreateSample>", () => {
 		expect(field).toHaveValue("sample_one");
 	});
 
+	it.each([
+		["sample_one.fq", "sample_one"],
+		["sample_one.fastq", "sample_one"],
+		["sample_one.fa", "sample_one"],
+		["sample_one.fasta", "sample_one"],
+		["sample_one.FASTQ.GZ", "sample_one"],
+	])("should autofill the sample name from %s", async (fileName, expected) => {
+		const file = createFakeFile({ name: fileName });
+
+		mockApiListFiles([file]);
+		mockApiGetShortlistSubtractions([{ name: "foo", ready: true, id: "test" }]);
+
+		await renderWithRouter(<CreateSample labels={labels} />);
+
+		const field = await screen.findByRole("textbox", { name: "Name" });
+		expect(field).toHaveValue("");
+
+		await userEvent.click(screen.getByText(file.name));
+		await userEvent.click(screen.getByRole("button", { name: "Auto Fill" }));
+
+		expect(field).toHaveValue(expected);
+	});
+
+	it("should not autofill the sample name when the extension is invalid", async () => {
+		const file = createFakeFile({ name: "sample_one.fqst" });
+
+		mockApiListFiles([file]);
+		mockApiGetShortlistSubtractions([{ name: "foo", ready: true, id: "test" }]);
+
+		await renderWithRouter(<CreateSample labels={labels} />);
+
+		const field = await screen.findByRole("textbox", { name: "Name" });
+		expect(field).toHaveValue("");
+
+		await userEvent.click(screen.getByText(file.name));
+		await userEvent.click(screen.getByRole("button", { name: "Auto Fill" }));
+
+		expect(field).toHaveValue("");
+	});
+
 	it("should clear selections when reset button is clicked", async () => {
 		const file = createFakeFile({ name: "large.fastq.gz" });
 

--- a/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
@@ -171,6 +171,23 @@ describe("<CreateSample>", () => {
 		expect(field).toHaveValue("14T81");
 	});
 
+	it("should autofill the sample name from a fastq.gz filename", async () => {
+		const file = createFakeFile({ name: "sample_one.fastq.gz" });
+
+		mockApiListFiles([file]);
+		mockApiGetShortlistSubtractions([{ name: "foo", ready: true, id: "test" }]);
+
+		await renderWithRouter(<CreateSample labels={labels} />);
+
+		const field = await screen.findByRole("textbox", { name: "Name" });
+		expect(field).toHaveValue("");
+
+		await userEvent.click(screen.getByText(file.name));
+		await userEvent.click(screen.getByRole("button", { name: "Auto Fill" }));
+
+		expect(field).toHaveValue("sample_one");
+	});
+
 	it("should clear selections when reset button is clicked", async () => {
 		const file = createFakeFile({ name: "large.fastq.gz" });
 

--- a/apps/web/src/tests/fake/files.ts
+++ b/apps/web/src/tests/fake/files.ts
@@ -8,14 +8,11 @@ import { createFakeUserNested } from "./user";
  */
 export function createFakeFile(overrides?: Partial<Upload>): Upload {
 	const name = overrides?.name ?? `sample_${faker.number.int()}.fastq.gz`;
-	const name_on_disk =
-		overrides?.name_on_disk ?? `${faker.number.int()}-${name}`;
 
 	return {
 		id: faker.number.int(),
 		created_at: faker.date.past().toISOString(),
 		name,
-		name_on_disk,
 		ready: true,
 		removed: false,
 		removed_at: undefined,

--- a/apps/web/src/uploads/types.ts
+++ b/apps/web/src/uploads/types.ts
@@ -11,7 +11,6 @@ export type Upload = {
 	id: number;
 	created_at: string;
 	name: string;
-	name_on_disk: string;
 	ready: boolean;
 	removed: boolean;
 	removed_at?: string;


### PR DESCRIPTION
## Summary

- Fixes the sample name autofill button in the create sample view, which was broken because the regex matched against `name_on_disk` (which has a numeric prefix like `12345-sample.fastq.gz`) rather than the user-visible `name` field
- Updates the regex to strip the FASTQ extension from any filename, removing the assumption that filenames start with a numeric ID prefix
- Removes the unused `name_on_disk` field from the `Upload` type and fake factory

## Test plan

- [ ] Open the create sample view and select a read file
- [ ] Click "Auto Fill" and confirm the sample name field is populated with the filename minus the extension
- [ ] Verify the new test case passes: `pnpm --filter @virtool/web exec vitest run src/samples/components/Create/__tests__/CreateSample.test.tsx`