### PR TITLE
fix: allow toggling a label off in the samples list when labels are mixed

### DIFF
--- a/apps/web/src/samples/components/Sidebar/__tests__/ManageLabels.test.tsx
+++ b/apps/web/src/samples/components/Sidebar/__tests__/ManageLabels.test.tsx
@@ -1,7 +1,26 @@
 import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderWithRouter } from "@tests/setup";
-import { beforeEach, describe, expect, it } from "vitest";
+import nock from "nock";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import ManageLabels from "../ManageLabels";
+
+/**
+ * Mocks the sample-update endpoint and captures the request body so tests can
+ * assert which labels were sent for each selected sample.
+ */
+function mockApiUpdateSampleLabels(sampleId: string) {
+	const captured: { body?: { labels: number[] } } = {};
+
+	nock("http://localhost")
+		.patch(`/api/samples/${sampleId}`)
+		.reply(200, (_uri, body: { labels: number[] }) => {
+			captured.body = body;
+			return {};
+		});
+
+	return captured;
+}
 
 describe("<ManageLabels>", () => {
 	let props;
@@ -63,5 +82,77 @@ describe("<ManageLabels>", () => {
 
 		expect(screen.getByText("test")).toBeInTheDocument();
 		expect(screen.getByText("label")).toBeInTheDocument();
+	});
+
+	describe("toggling a label with mixed labels across the selection", () => {
+		afterEach(() => nock.cleanAll());
+
+		beforeEach(() => {
+			// "test" (id 1) is on both samples, "label" (id 2) is on one only, so
+			// the selection has labels in mixed states.
+			props.selectedSamples = [
+				{
+					name: "Foo Sample",
+					id: "foo_sample",
+					labels: [
+						{ color: "#C4B5FD", description: "", id: 1, name: "test" },
+						{ color: "#FCA5A5", description: "", id: 2, name: "label" },
+					],
+				},
+				{
+					name: "Bar Sample",
+					id: "bar_sample",
+					labels: [{ color: "#C4B5FD", description: "", id: 1, name: "test" }],
+				},
+			];
+		});
+
+		async function openSelectorAndClick(labelName: string) {
+			await renderWithRouter(<ManageLabels {...props} />);
+			await waitFor(() =>
+				expect(screen.queryByLabelText("loading")).not.toBeInTheDocument(),
+			);
+
+			await userEvent.click(
+				screen.getByRole("button", { name: "select labels" }),
+			);
+			await userEvent.click(screen.getByRole("button", { name: labelName }));
+		}
+
+		it("removes a fully-applied label from every sample", async () => {
+			const foo = mockApiUpdateSampleLabels("foo_sample");
+			const bar = mockApiUpdateSampleLabels("bar_sample");
+
+			await openSelectorAndClick("test");
+
+			await waitFor(() => {
+				expect(foo.body?.labels).toEqual([2]);
+				expect(bar.body?.labels).toEqual([]);
+			});
+		});
+
+		it("adds a partially-applied label to every sample", async () => {
+			const foo = mockApiUpdateSampleLabels("foo_sample");
+			const bar = mockApiUpdateSampleLabels("bar_sample");
+
+			await openSelectorAndClick("label");
+
+			await waitFor(() => {
+				expect(foo.body?.labels).toEqual([1, 2]);
+				expect(bar.body?.labels).toEqual([1, 2]);
+			});
+		});
+
+		it("adds an unapplied label to every sample", async () => {
+			const foo = mockApiUpdateSampleLabels("foo_sample");
+			const bar = mockApiUpdateSampleLabels("bar_sample");
+
+			await openSelectorAndClick("bar");
+
+			await waitFor(() => {
+				expect(foo.body?.labels).toEqual([1, 2, 3]);
+				expect(bar.body?.labels).toEqual([1, 3]);
+			});
+		});
 	});
 });

--- a/apps/web/src/samples/queries.ts
+++ b/apps/web/src/samples/queries.ts
@@ -215,14 +215,13 @@ export function useUpdateLabel(
 	});
 
 	function onUpdate(label: number) {
+		const clicked = selectedLabels.find((item) => item.id === label);
+		const allLabeled = clicked?.allLabeled === true;
+
 		selectedSamples.forEach((sample) => {
 			const sampleLabelIds = sample.labels.map((l) => l.id);
-			const labelExists = selectedLabels.some((item) => item.id === label);
-			const allLabeled = selectedLabels.every(
-				(item) => item.allLabeled === true,
-			);
 
-			if (!labelExists || !allLabeled) {
+			if (!allLabeled) {
 				mutation.mutate({
 					sampleId: sample.id,
 					update: { labels: union(sampleLabelIds, [label]) },


### PR DESCRIPTION
## Summary

- Fixes a bug where clicking a fully-applied label in the samples sidebar would not remove it when the selection had labels in a mixed state (some samples had the label, others did not).
- The bug was caused by checking whether _all_ selected label entries had `allLabeled === true` rather than checking only the specific label being clicked.
- Adds regression tests covering the three toggle cases: removing a fully-applied label, adding a partially-applied label, and adding an unapplied label.

## Test plan

- [ ] Select two or more samples where one sample has a label the other does not.
- [ ] Open the label selector in the sidebar and click the partially-applied label — it should be added to all selected samples.
- [ ] Click the now fully-applied label — it should be removed from all selected samples.
- [ ] Confirm that a label not present on any sample can still be added normally.