### PR TITLE
feat: remove unused barcode reference target support from the UI

### DIFF
--- a/apps/web/src/references/queries.ts
+++ b/apps/web/src/references/queries.ts
@@ -256,8 +256,17 @@ export function useCreateReference() {
 export function useUpdateReference(refId: string, onSuccess?: () => void) {
 	const queryClient = useQueryClient();
 
-	const mutation = useMutation<Reference, ErrorResponse, unknown>({
-		mutationFn: (data: { restrict_source_types?: boolean }) => {
+	const mutation = useMutation<
+		Reference,
+		ErrorResponse,
+		{
+			name?: string;
+			description?: string;
+			organism?: string;
+			restrict_source_types?: boolean;
+		}
+	>({
+		mutationFn: (data) => {
 			return apiClient
 				.patch(`/refs/${refId}`)
 				.send(data)

--- a/apps/web/src/references/queries.ts
+++ b/apps/web/src/references/queries.ts
@@ -14,7 +14,6 @@ import type {
 	ReferenceInstalled,
 	ReferenceMinimal,
 	ReferenceSearchResult,
-	ReferenceTarget,
 	ReferenceUser,
 } from "./types";
 
@@ -258,10 +257,7 @@ export function useUpdateReference(refId: string, onSuccess?: () => void) {
 	const queryClient = useQueryClient();
 
 	const mutation = useMutation<Reference, ErrorResponse, unknown>({
-		mutationFn: (data: {
-			restrict_source_types?: boolean;
-			targets?: ReferenceTarget[];
-		}) => {
+		mutationFn: (data: { restrict_source_types?: boolean }) => {
 			return apiClient
 				.patch(`/refs/${refId}`)
 				.send(data)

--- a/apps/web/src/references/types.ts
+++ b/apps/web/src/references/types.ts
@@ -61,13 +61,6 @@ export type ReferenceRelease = {
 	size: number;
 };
 
-export type ReferenceTarget = {
-	description: string;
-	length: number;
-	name: string;
-	required: boolean;
-};
-
 /** Basic reference data for nested representation */
 export type ReferenceNested = {
 	/** The unique identifier */
@@ -126,7 +119,6 @@ export type Reference = ReferenceMinimal & {
 	groups: Array<ReferenceGroup>;
 	restrict_source_types: boolean;
 	source_types: Array<string>;
-	targets: ReferenceTarget[];
 	users: Array<ReferenceUser>;
 };
 

--- a/apps/web/src/tests/fake/references.ts
+++ b/apps/web/src/tests/fake/references.ts
@@ -3,22 +3,9 @@ import type {
 	Reference,
 	ReferenceMinimal,
 	ReferenceNested,
-	ReferenceTarget,
 } from "@references/types";
 import nock from "nock";
 import { createFakeUserNested } from "./user";
-
-/**
- * Create a fake reference target
- */
-export function createFakeReferenceTarget(): ReferenceTarget {
-	return {
-		description: faker.lorem.lines(1),
-		length: faker.number.int(),
-		name: faker.word.noun({ strategy: "any-length" }),
-		required: true,
-	};
-}
 
 /**
  * Create a fake reference nested
@@ -86,7 +73,6 @@ export function createFakeReference(overrides?: Partial<Reference>): Reference {
 		groups: [],
 		restrict_source_types: false,
 		source_types: ["isolate", "strain"],
-		targets: [createFakeReferenceTarget()],
 		users: [
 			{
 				...createFakeUserNested(),


### PR DESCRIPTION
## Summary
- Removes the `ReferenceTarget` type and all related code that supported barcode reference targets in the UI
- Drops `targets` from the `Reference` type and the `useUpdateReference` mutation payload since the backend no longer exposes this feature
- Cleans up the `createFakeReferenceTarget` factory and its usage in test fakes