### PR TITLE
fix: stop logging mongo readiness race at warn during startup

### DIFF
--- a/apps/web/src/server/health/__tests__/data.test.ts
+++ b/apps/web/src/server/health/__tests__/data.test.ts
@@ -1,6 +1,7 @@
 import type { Connection } from "mongoose";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PgClient } from "../../db/pg";
+import { logger } from "../../logger";
 import { checkMongo, checkPostgres, summarizeReadiness } from "../data";
 
 vi.mock("../../logger", () => ({
@@ -44,6 +45,7 @@ describe("checkPostgres", () => {
 describe("checkMongo", () => {
 	afterEach(() => {
 		vi.useRealTimers();
+		vi.clearAllMocks();
 	});
 
 	it("reports ok when the ping resolves", async () => {
@@ -51,9 +53,11 @@ describe("checkMongo", () => {
 		expect(await checkMongo(connection)).toEqual({ ok: true });
 	});
 
-	it("reports not ok when the connection is not ready", async () => {
+	it("logs at info, not warn, when the connection is not ready", async () => {
 		const connection = fakeConnection(null);
 		expect(await checkMongo(connection)).toEqual({ ok: false });
+		expect(logger.info).toHaveBeenCalledTimes(1);
+		expect(logger.warn).not.toHaveBeenCalled();
 	});
 
 	it("reports not ok when the ping rejects", async () => {

--- a/apps/web/src/server/health/data.ts
+++ b/apps/web/src/server/health/data.ts
@@ -63,11 +63,16 @@ export async function checkPostgres(client: PgClient): Promise<StoreCheck> {
 
 /** Probe Mongo with a server ping. Never throws. */
 export async function checkMongo(connection: Connection): Promise<StoreCheck> {
+	const admin = connection.db?.admin();
+	if (!admin) {
+		// Expected transient race on cold start: the readiness probe can fire
+		// before the Mongoose connection finishes opening. Not a failure worth
+		// warning about.
+		logger.info("mongo connection is not ready");
+		return { ok: false };
+	}
+
 	try {
-		const admin = connection.db?.admin();
-		if (!admin) {
-			throw new Error("mongo connection is not ready");
-		}
 		await withTimeout(admin.ping(), CHECK_TIMEOUT_MS);
 		return { ok: true };
 	} catch (err) {

--- a/apps/web/src/server/logger.ts
+++ b/apps/web/src/server/logger.ts
@@ -7,7 +7,7 @@ import { readDsn } from "@virtool/sentry";
 const streams = readDsn()
 	? [
 			{
-				level: "info" as const,
+				level: "warn" as const,
 				stream: (await import("./sentryLog")).createSentryLogStream(),
 			},
 		]

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -29,10 +29,12 @@ needs to censor additional fields.
 
 ## Sentry forwarding
 
-When `VT_SENTRY_DSN` is set, the server logger fans `info`-and-above
+When `VT_SENTRY_DSN` is set, the server logger fans `warn`-and-above
 records out to Sentry's structured logging API (`Sentry.logger`) in
-addition to stdout. There is no per-call-site wiring: every record that
-goes through `@virtool/logger` is forwarded automatically.
+addition to stdout. `info` and below stay stdout-only — dashboards and
+logs are the source of truth for those; Sentry is reserved for `warn`
+and worse. There is no per-call-site wiring: every record at or above
+that threshold is forwarded automatically.
 
 This is a plain pino destination stream
 (`apps/web/src/server/sentryLog.ts`), **not**


### PR DESCRIPTION
## Summary
- The readiness probe can fire before the Mongoose connection finishes opening on cold start, producing a spurious `warn`-level log that gets forwarded to Sentry
- Changed the \"not ready\" branch in `checkMongo` to log at `info` instead of throwing an error that was caught and re-logged at `warn`
- Raised the Sentry log stream threshold from `info` to `warn` so transient startup noise stays stdout-only; updated `docs/logging.md` accordingly

## Test plan
- [ ] Verify the updated test passes: `pnpm --filter @virtool/web exec vitest run src/server/health/__tests__/data.test.ts`
- [ ] Start the app cold and confirm no `warn`-level Mongo \"not ready\" entries appear in Sentry during the startup readiness probes
- [ ] Confirm Sentry still receives `warn` and above log records when `VT_SENTRY_DSN` is set