### PR TITLE
chore: clear noUnusedFunctionParameters and noArrayIndexKey warnings

### DIFF
--- a/apps/web/src/analyses/components/Charts/CoverageChart.tsx
+++ b/apps/web/src/analyses/components/Charts/CoverageChart.tsx
@@ -91,14 +91,12 @@ function draw(element, data, length, yMax, untrustworthyRanges) {
 
 interface IimiCoverageChartProps {
 	data: number[];
-	id: string;
 	yMax: number;
 	untrustworthyRanges: UntrustworthyRange[];
 }
 
 export function CoverageChart({
 	data,
-	id,
 	yMax,
 	untrustworthyRanges,
 }: IimiCoverageChartProps) {

--- a/apps/web/src/analyses/components/Iimi/IimiIsolate.tsx
+++ b/apps/web/src/analyses/components/Iimi/IimiIsolate.tsx
@@ -29,7 +29,6 @@ export function IimiIsolate({ name, sequences }: IimiIsolateProps) {
 						</p>
 						<CoverageChart
 							data={sequence.coverage}
-							id={sequence.id}
 							yMax={Math.max(sequence.maxDepth, 10)}
 							untrustworthyRanges={sequence.untrustworthy_ranges}
 						/>

--- a/apps/web/src/analyses/components/Nuvs/NuvsBlastResults.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsBlastResults.tsx
@@ -19,8 +19,8 @@ type BLASTResultsProps = {
  * Displays the results of the blast installed for the sequence
  */
 export default function NuvsBlastResults({ hits, onBlast }: BLASTResultsProps) {
-	const components = hits.map((hit, index) => (
-		<tr key={index}>
+	const components = hits.map((hit) => (
+		<tr key={hit.accession}>
 			<td>
 				<ExternalLink
 					href={`https://www.ncbi.nlm.nih.gov/nuccore/${hit.accession}`}


### PR DESCRIPTION
## Summary

- Remove unused `id` prop from `CoverageChart` component, which was triggering the `noUnusedFunctionParameters` Biome lint rule
- Replace array index keys with stable `hit.accession` values in `NuvsBlastResults`, resolving the `noArrayIndexKey` lint warning