### PR TITLE
fix: convert read selector mode picker to Dropdown and fix library type grid

### DIFF
--- a/apps/web/src/samples/components/Create/LibraryTypeSelector.tsx
+++ b/apps/web/src/samples/components/Create/LibraryTypeSelector.tsx
@@ -14,7 +14,7 @@ export default function LibraryTypeSelector({
 }: LibraryTypeSelectorProps) {
 	return (
 		<SelectBox
-			className="grid-cols-3 mb-6"
+			className="grid-cols-2 mb-6"
 			label="Library Type"
 			onValueChange={onSelect}
 			value={libraryType}

--- a/apps/web/src/samples/components/Create/ReadSelector.tsx
+++ b/apps/web/src/samples/components/Create/ReadSelector.tsx
@@ -4,6 +4,10 @@ import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
 import Button from "@base/Button";
 import CompactScrollList from "@base/CompactScrollList";
+import Dropdown from "@base/Dropdown";
+import DropdownButton from "@base/DropdownButton";
+import DropdownMenuContent from "@base/DropdownMenuContent";
+import DropdownMenuItem from "@base/DropdownMenuItem";
 import Icon from "@base/Icon";
 import InputError from "@base/InputError";
 import InputGroup from "@base/InputGroup";
@@ -11,10 +15,6 @@ import InputLabel from "@base/InputLabel";
 import InputSearch from "@base/InputSearch";
 import Link from "@base/Link";
 import NoneFoundSection from "@base/NoneFoundSection";
-import Select from "@base/Select";
-import SelectButton from "@base/SelectButton";
-import SelectContent from "@base/SelectContent";
-import SelectItem from "@base/SelectItem";
 import Toolbar from "@base/Toolbar";
 import type {
 	FetchNextPageOptions,
@@ -266,27 +266,26 @@ export default function ReadSelector({
 					<Button className="inline-flex gap-2" type="button" onClick={reset}>
 						<Icon icon={Undo} /> Reset
 					</Button>
-					<Select
-						value={mode}
-						onValueChange={(value) => setMode(value as SelectorMode)}
-					>
-						<SelectButton
-							aria-label="Read selection mode"
-							icon={ChevronDown}
-							placeholder="Selection mode"
-						/>
-						<SelectContent position="popper" align="end">
+					<Dropdown>
+						<DropdownButton className="flex items-center gap-1.5">
+							{selectorModes.find((m) => m.value === mode)?.label}
+							<ChevronDown size={16} />
+						</DropdownButton>
+						<DropdownMenuContent className="max-w-72">
 							{selectorModes.map((selectorMode) => (
-								<SelectItem
+								<DropdownMenuItem
 									key={selectorMode.value}
-									value={selectorMode.value}
-									description={selectorMode.description}
+									onSelect={() => setMode(selectorMode.value)}
+									className="flex flex-col items-start"
 								>
-									{selectorMode.label}
-								</SelectItem>
+									<span className="font-medium">{selectorMode.label}</span>
+									<span className="text-xs text-gray-500">
+										{selectorMode.description}
+									</span>
+								</DropdownMenuItem>
 							))}
-						</SelectContent>
-					</Select>
+						</DropdownMenuContent>
+					</Dropdown>
 				</Toolbar>
 				{noneFound || (
 					<>

--- a/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
@@ -27,9 +27,11 @@ async function setReadSelectorMode(
 	name: "Auto-pair" | "Manual",
 ): Promise<void> {
 	await userEvent.click(
-		screen.getByRole("combobox", { name: "Read selection mode" }),
+		screen.getByRole("button", { name: /^(Auto-pair|Manual)$/ }),
 	);
-	await userEvent.click(await screen.findByRole("option", { name }));
+	await userEvent.click(
+		await screen.findByRole("menuitem", { name: new RegExp(name) }),
+	);
 }
 
 describe("<CreateSample>", () => {

--- a/apps/web/src/samples/components/Create/__tests__/ReadSelector.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/ReadSelector.test.tsx
@@ -56,8 +56,12 @@ function rowButton(name: string): HTMLElement {
 }
 
 async function setMode(name: "Auto-pair" | "Manual"): Promise<void> {
-	await userEvent.click(screen.getByRole("combobox"));
-	await userEvent.click(await screen.findByRole("option", { name }));
+	await userEvent.click(
+		screen.getByRole("button", { name: /^(Auto-pair|Manual)$/ }),
+	);
+	await userEvent.click(
+		await screen.findByRole("menuitem", { name: new RegExp(name) }),
+	);
 }
 
 describe("<ReadSelector>", () => {
@@ -67,7 +71,9 @@ describe("<ReadSelector>", () => {
 		mockApiListFiles([]);
 		renderWithProviders(<Harness files={[createFakeFile()]} />);
 
-		expect(screen.getByRole("combobox")).toHaveTextContent("Auto-pair");
+		expect(
+			screen.getByRole("button", { name: /^(Auto-pair|Manual)$/ }),
+		).toHaveTextContent("Auto-pair");
 	});
 
 	describe("Auto-pair mode", () => {


### PR DESCRIPTION
## Summary

- Converts the read selector's mode picker from `Select` to `Dropdown`, providing explicit label display and description rendering via `DropdownMenuItem`
- Fixes the library type selector grid from 3 columns to 2 columns to match the two available library types after barcode support was removed