### PR TITLE
fix: hide used read files from selector after sample creation

### DIFF
--- a/apps/web/src/samples/__tests__/queries.test.tsx
+++ b/apps/web/src/samples/__tests__/queries.test.tsx
@@ -1,0 +1,59 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { mockApiCreateSample } from "@tests/fake/samples";
+import { fileQueryKeys } from "@uploads/queries";
+import nock from "nock";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useCreateSample } from "../queries";
+
+describe("useCreateSample()", () => {
+	afterEach(() => nock.cleanAll());
+
+	it("invalidates the uploads lists on success so reserved files leave the selector", async () => {
+		const queryClient = new QueryClient();
+		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+
+		const scope = mockApiCreateSample(
+			"Sample A",
+			"",
+			"",
+			"",
+			"normal",
+			[1],
+			[],
+			[],
+			null,
+		);
+
+		function wrapper({ children }: { children: ReactNode }) {
+			return (
+				<QueryClientProvider client={queryClient}>
+					{children}
+				</QueryClientProvider>
+			);
+		}
+
+		const { result } = renderHook(() => useCreateSample(), { wrapper });
+
+		result.current.mutate({
+			name: "Sample A",
+			isolate: "",
+			host: "",
+			locale: "",
+			libraryType: "normal",
+			subtractions: [],
+			files: [1],
+			labels: [],
+			group: null,
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+		expect(invalidateQueries).toHaveBeenCalledWith({
+			queryKey: fileQueryKeys.lists(),
+		});
+
+		scope.done();
+	});
+});

--- a/apps/web/src/samples/queries.ts
+++ b/apps/web/src/samples/queries.ts
@@ -7,6 +7,7 @@ import {
 	useQuery,
 	useQueryClient,
 } from "@tanstack/react-query";
+import { fileQueryKeys } from "@uploads/queries";
 import { union } from "es-toolkit";
 import type { ErrorResponse } from "@/types/api";
 import type {
@@ -96,6 +97,8 @@ export function useFetchSample(sampleId: string) {
  * @returns A mutator for creating a sample
  */
 export function useCreateSample() {
+	const queryClient = useQueryClient();
+
 	return useMutation<
 		Sample,
 		ErrorResponse,
@@ -136,6 +139,12 @@ export function useCreateSample() {
 					group,
 				})
 				.then((res) => res.body),
+		onSuccess: () => {
+			// The created sample reserves its read files, so the server stops
+			// returning them. Refetch the uploads lists to drop them from the
+			// selector.
+			queryClient.invalidateQueries({ queryKey: fileQueryKeys.lists() });
+		},
 	});
 }
 


### PR DESCRIPTION
## Summary
- After a sample is created, the read files it uses become reserved on the server but previously remained visible in the read file selector in the UI
- Added an `onSuccess` callback to `useCreateSample` that invalidates `fileQueryKeys.lists()`, triggering a refetch so reserved files disappear from the selector immediately after creation
- Added a unit test verifying that `invalidateQueries` is called with the correct query key on a successful create