### PR TITLE
fix: eliminate scrollbar layout shift in the authenticated shell

### DIFF
--- a/apps/web/src/analyses/components/Pathoscope/PathoscopeViewScroller.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/PathoscopeViewScroller.tsx
@@ -1,3 +1,4 @@
+import { getContentScrollElement } from "@app/scroll";
 import { ArrowUp } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -6,16 +7,22 @@ export function PathoscopeViewerScroller() {
 	const [show, setShow] = useState(false);
 
 	useEffect(() => {
-		const handleScroll = () => setShow(window.scrollY > 0);
-		window.addEventListener("scroll", handleScroll);
-		return () => window.removeEventListener("scroll", handleScroll);
+		const scroller = getContentScrollElement();
+		if (!scroller) {
+			return;
+		}
+		const handleScroll = () => setShow(scroller.scrollTop > 0);
+		scroller.addEventListener("scroll", handleScroll);
+		return () => scroller.removeEventListener("scroll", handleScroll);
 	}, []);
 
 	if (show) {
 		return (
 			<div
 				className="flex items-center justify-center fixed bottom-8 left-8 size-10 border border-gray-300 rounded-lg text-gray-500 cursor-pointer z-1 hover:bg-gray-100 hover:text-gray-600"
-				onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+				onClick={() =>
+					getContentScrollElement()?.scrollTo({ top: 0, behavior: "smooth" })
+				}
 			>
 				<ArrowUp />
 			</div>

--- a/apps/web/src/app/scroll.ts
+++ b/apps/web/src/app/scroll.ts
@@ -3,5 +3,8 @@ export const CONTENT_SCROLL_ID = "content-scroll";
 
 /** Returns the authenticated shell's scrolling content container, if mounted. */
 export function getContentScrollElement(): HTMLElement | null {
+	if (typeof document === "undefined") {
+		return null;
+	}
 	return document.getElementById(CONTENT_SCROLL_ID);
 }

--- a/apps/web/src/app/scroll.ts
+++ b/apps/web/src/app/scroll.ts
@@ -1,0 +1,7 @@
+/** The id of the single scrolling content container in the authenticated shell. */
+export const CONTENT_SCROLL_ID = "content-scroll";
+
+/** Returns the authenticated shell's scrolling content container, if mounted. */
+export function getContentScrollElement(): HTMLElement | null {
+	return document.getElementById(CONTENT_SCROLL_ID);
+}

--- a/apps/web/src/app/style.css
+++ b/apps/web/src/app/style.css
@@ -28,8 +28,8 @@ html {
 	font-size: 14px;
 }
 
-body {
-	height: calc(100vh - 40px);
+@utility scrollbar-gutter-stable {
+	scrollbar-gutter: stable;
 }
 
 @layer base {

--- a/apps/web/src/base/AccordionScrollingItem.tsx
+++ b/apps/web/src/base/AccordionScrollingItem.tsx
@@ -1,3 +1,4 @@
+import { getContentScrollElement } from "@app/scroll";
 import { Accordion as AccordionPrimitive } from "radix-ui";
 import { createRef, type ReactNode, useEffect } from "react";
 
@@ -6,10 +7,18 @@ function ComposedScrollingAccordionItem(props) {
 	const ref = createRef<HTMLDivElement>();
 	useEffect(() => {
 		if (props["data-state"] === "open" && ref?.current) {
-			const position = ref.current.getBoundingClientRect().top;
-			const offset = window.scrollY;
-			window.scrollTo({
-				top: position + offset - 50,
+			const scroller = getContentScrollElement();
+			if (!scroller) {
+				return;
+			}
+			// Position the opened item ~50px below the top of the scrolling
+			// content container. Both rects are viewport-relative, so the item's
+			// offset within the scroller's content is its top minus the
+			// scroller's top, plus the amount already scrolled.
+			const itemTop = ref.current.getBoundingClientRect().top;
+			const scrollerTop = scroller.getBoundingClientRect().top;
+			scroller.scrollTo({
+				top: itemTop - scrollerTop + scroller.scrollTop - 50,
 				behavior: "smooth",
 			});
 		}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/tanstackstart-react";
 import { QueryClient } from "@tanstack/react-query";
 import { createRouter } from "@tanstack/react-router";
 import { getCommonOptions } from "@virtool/sentry/browser";
+import { CONTENT_SCROLL_ID } from "./app/scroll";
 import { routeTree } from "./routeTree.gen";
 
 export function getRouter() {
@@ -43,7 +44,12 @@ export function getRouter() {
 		// the router's 30s default short-circuit preloads.
 		defaultPreload: "intent",
 		defaultPreloadStaleTime: 0,
+		// The document no longer scrolls — the authenticated shell scrolls an
+		// inner container so the navbar can stay full-bleed with a stable
+		// scrollbar gutter. Point scroll-to-top on navigation at that container;
+		// back/forward restoration of it is handled automatically by the watcher.
 		scrollRestoration: true,
+		scrollToTopSelectors: [`#${CONTENT_SCROLL_ID}`],
 	});
 
 	if (!router.isServer) {

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -108,10 +108,10 @@ function AuthenticatedLayout() {
 					id={CONTENT_SCROLL_ID}
 					className="flex flex-1 min-h-0 overflow-y-auto scrollbar-gutter-stable"
 				>
-					<aside className="sticky top-0 self-start">
+					<aside className="sticky top-0 self-start pt-18">
 						<Sidebar administratorRole={data.administrator_role} />
 					</aside>
-					<main className="flex-1 min-w-0 px-9">
+					<main className="flex-1 min-w-0 p-18">
 						<Suspense fallback={<LoadingPlaceholder />}>
 							<Outlet />
 						</Suspense>

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -1,5 +1,6 @@
 import { accountQueryOptions, useFetchAccount } from "@account/queries";
 import { apiClient } from "@app/api";
+import { CONTENT_SCROLL_ID } from "@app/scroll";
 import * as Sse from "@app/sse/SseConnection";
 import type { Root } from "@app/types";
 import Banner from "@banner/components/Banner";
@@ -91,24 +92,31 @@ function AuthenticatedLayout() {
 
 			<UpdateToast />
 
-			<div className="bg-transparent fixed top-0 w-full z-50">
-				<Banner />
-				<Nav
-					administrator_role={data.administrator_role}
-					handle={data.handle}
-					setOpenDev={(openDev) => navigate({ search: { ...search, openDev } })}
-				/>
-			</div>
+			<div className="flex flex-col h-screen">
+				<div className="shrink-0 z-50">
+					<Banner />
+					<Nav
+						administrator_role={data.administrator_role}
+						handle={data.handle}
+						setOpenDev={(openDev) =>
+							navigate({ search: { ...search, openDev } })
+						}
+					/>
+				</div>
 
-			<div className="pt-30 flex">
-				<aside className="sticky top-30 self-start">
-					<Sidebar administratorRole={data.administrator_role} />
-				</aside>
-				<main className="flex-1 min-w-0 px-9">
-					<Suspense fallback={<LoadingPlaceholder />}>
-						<Outlet />
-					</Suspense>
-				</main>
+				<div
+					id={CONTENT_SCROLL_ID}
+					className="flex flex-1 min-h-0 overflow-y-auto scrollbar-gutter-stable"
+				>
+					<aside className="sticky top-0 self-start">
+						<Sidebar administratorRole={data.administrator_role} />
+					</aside>
+					<main className="flex-1 min-w-0 px-9">
+						<Suspense fallback={<LoadingPlaceholder />}>
+							<Outlet />
+						</Suspense>
+					</main>
+				</div>
 			</div>
 
 			<Suspense fallback={null}>


### PR DESCRIPTION
## Summary

- Move page scrolling from the document body to an inner content container (`#content-scroll`) so the navbar stays full-bleed and the scrollbar gutter is always reserved
- Add a `scrollbar-gutter: stable` Tailwind utility on the content container to prevent layout shifts as content grows and shrinks
- Update `PathoscopeViewScroller`, `AccordionScrollingItem`, and TanStack Router's `scrollToTopSelectors` to target the inner container instead of `window`