### PR TITLE
chore: clear useIterableCallbackReturn warnings in create analysis

### DIFF
--- a/apps/web/src/analyses/components/Create/CreateIimi.tsx
+++ b/apps/web/src/analyses/components/Create/CreateIimi.tsx
@@ -53,14 +53,14 @@ export default function CreateIimi({
 		}
 		const refId = index.reference.id;
 
-		sampleIds.forEach((sampleId) =>
+		for (const sampleId of sampleIds) {
 			createAnalysis.mutate({
 				mlModel,
 				refId,
 				sampleId,
 				workflow: "iimi",
-			}),
-		);
+			});
+		}
 	}
 
 	return (

--- a/apps/web/src/analyses/components/Create/CreateNuvs.tsx
+++ b/apps/web/src/analyses/components/Create/CreateNuvs.tsx
@@ -62,14 +62,14 @@ export default function CreateNuvs({
 		}
 		const refId = index.reference.id;
 
-		sampleIds.forEach((sampleId) =>
+		for (const sampleId of sampleIds) {
 			createAnalysis.mutate({
 				refId,
 				sampleId,
 				subtractionIds,
 				workflow: "nuvs",
-			}),
-		);
+			});
+		}
 	}
 
 	return (

--- a/apps/web/src/analyses/components/Create/CreatePathoscope.tsx
+++ b/apps/web/src/analyses/components/Create/CreatePathoscope.tsx
@@ -62,14 +62,14 @@ export default function CreatePathoscope({
 		}
 		const refId = index.reference.id;
 
-		sampleIds.forEach((sampleId) =>
+		for (const sampleId of sampleIds) {
 			createAnalysis.mutate({
 				refId,
 				sampleId,
 				subtractionIds,
 				workflow: "pathoscope",
-			}),
-		);
+			});
+		}
 	}
 
 	return (


### PR DESCRIPTION
## Summary
- Converts `.forEach()` arrow-function callbacks to `for...of` loops in `CreateIimi`, `CreateNuvs`, and `CreatePathoscope` components
- This satisfies the Biome `useIterableCallbackReturn` lint rule, which requires that callbacks passed to iterable methods return a value (or be written as `for...of` when no return is needed)

## Test plan
- [ ] Verify `pnpm check` passes with no lint warnings
- [ ] Confirm create-analysis workflows (iimi, nuvs, pathoscope) still submit mutations correctly for multiple selected samples