### PR TITLE
fix: exclude archived references from create analysis index selector

### DIFF
--- a/apps/web/src/analyses/hooks.ts
+++ b/apps/web/src/analyses/hooks.ts
@@ -88,7 +88,7 @@ type UseCompatibleIndexesResult = {
 };
 
 export function useCompatibleIndexes(): UseCompatibleIndexesResult {
-	const { data, isPending } = useListIndexes(true);
+	const { data, isPending } = useListIndexes(true, false);
 
 	const indexes = Object.values(
 		groupBy(data ?? [], (item) => item.reference.id),

--- a/apps/web/src/analyses/hooks.ts
+++ b/apps/web/src/analyses/hooks.ts
@@ -88,7 +88,7 @@ type UseCompatibleIndexesResult = {
 };
 
 export function useCompatibleIndexes(): UseCompatibleIndexesResult {
-	const { data, isPending } = useListIndexes(true, false);
+	const { data, isPending } = useListIndexes({ ready: true, archived: false });
 
 	const indexes = Object.values(
 		groupBy(data ?? [], (item) => item.reference.id),

--- a/apps/web/src/indexes/queries.ts
+++ b/apps/web/src/indexes/queries.ts
@@ -51,22 +51,29 @@ export function useFindIndexes(
 	});
 }
 
+type ListIndexesOptions = {
+	/** Only return ready indexes */
+	ready: boolean;
+
+	/** Filter indexes by their reference's archived status */
+	archived?: boolean;
+};
+
 /**
  * Gets a list of ready indexes
  *
- * @param ready - Only return ready indexes
- * @param archived - Filter indexes by their reference's archived status
+ * @param options - The ready and archived filters to apply
  * @returns A list of ready indexes
  */
-export function useListIndexes(ready: boolean, archived?: boolean) {
+export function useListIndexes({ ready, archived }: ListIndexesOptions) {
+	const params = archived === undefined ? { ready } : { ready, archived };
+
 	return useQuery<IndexMinimal[]>({
-		queryKey: indexQueryKeys.list(
-			archived === undefined ? [ready] : [ready, archived],
-		),
+		queryKey: indexQueryKeys.list(Object.values(params)),
 		queryFn: () =>
 			apiClient
 				.get("/indexes")
-				.query(archived === undefined ? { ready } : { ready, archived })
+				.query(params)
 				.then((res) => res.body),
 	});
 }

--- a/apps/web/src/indexes/queries.ts
+++ b/apps/web/src/indexes/queries.ts
@@ -54,15 +54,19 @@ export function useFindIndexes(
 /**
  * Gets a list of ready indexes
  *
+ * @param ready - Only return ready indexes
+ * @param archived - Filter indexes by their reference's archived status
  * @returns A list of ready indexes
  */
-export function useListIndexes(ready: boolean) {
+export function useListIndexes(ready: boolean, archived?: boolean) {
 	return useQuery<IndexMinimal[]>({
-		queryKey: indexQueryKeys.list([ready]),
+		queryKey: indexQueryKeys.list(
+			archived === undefined ? [ready] : [ready, archived],
+		),
 		queryFn: () =>
 			apiClient
 				.get("/indexes")
-				.query({ ready })
+				.query(archived === undefined ? { ready } : { ready, archived })
 				.then((res) => res.body),
 	});
 }

--- a/apps/web/src/samples/components/SamplesList.tsx
+++ b/apps/web/src/samples/components/SamplesList.tsx
@@ -51,7 +51,7 @@ export default function SamplesList({
 		filterLabels,
 		filterWorkflows,
 	);
-	const { isPending: isPendingIndexes } = useListIndexes(true);
+	const { isPending: isPendingIndexes } = useListIndexes({ ready: true });
 
 	const [selected, setSelected] = useState<string[]>([]);
 


### PR DESCRIPTION
## Summary

- Archived references were appearing in the index selector when creating a Pathoscope, NuVs, or IIMI analysis because `useListIndexes` only passed `?ready=true` to the API with no filter on archived status.
- Extended `useListIndexes` to accept an optional `archived` parameter that is forwarded to the API query (`?archived=false`).
- Updated `useCompatibleIndexes` to pass `archived: false`, so the API returns only indexes belonging to active (non-archived) references.

Closes VIR-2479