### PR TITLE
chore: clear noImplicitAnyLet warnings in analyses

### DIFF
--- a/apps/web/src/administration/components/__tests__/Settings.test.tsx
+++ b/apps/web/src/administration/components/__tests__/Settings.test.tsx
@@ -9,11 +9,10 @@ import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("<Settings />", () => {
-	let path;
+	const path = "/administration/settings";
 
 	beforeEach(() => {
 		mockApiGetSettings(createFakeSettings());
-		path = "/administration/settings";
 	});
 
 	afterEach(() => nock.cleanAll());

--- a/apps/web/src/analyses/__tests__/utils.test.ts
+++ b/apps/web/src/analyses/__tests__/utils.test.ts
@@ -1,3 +1,4 @@
+import type { FormattedPathoscopeIsolate } from "@analyses/types";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
 	fillAlign,
@@ -96,7 +97,7 @@ describe("median()", () => {
 });
 
 describe("mergeCoverage()", () => {
-	let isolates;
+	let isolates: FormattedPathoscopeIsolate[];
 
 	beforeEach(() => {
 		const coverages = [
@@ -104,7 +105,9 @@ describe("mergeCoverage()", () => {
 			[7, 5, 5, 1, 1, 2, 1, 5, 6, 2, 1, 0, 0, 0, 1, 3, 2],
 			[1, 1, 2, 3, 4, 4, 4, 4, 2, 2, 2, 3, 2, 1, 0, 1, 0],
 		];
-		isolates = coverages.map((c) => ({ filled: c }));
+		isolates = coverages.map(
+			(c) => ({ filled: c }) as FormattedPathoscopeIsolate,
+		);
 	});
 
 	it("should return merged coverage when all isolates have same length", () => {

--- a/apps/web/src/analyses/__tests__/utils.test.ts
+++ b/apps/web/src/analyses/__tests__/utils.test.ts
@@ -97,7 +97,7 @@ describe("median()", () => {
 });
 
 describe("mergeCoverage()", () => {
-	let isolates: FormattedPathoscopeIsolate[];
+	let isolates: Pick<FormattedPathoscopeIsolate, "filled">[];
 
 	beforeEach(() => {
 		const coverages = [
@@ -105,9 +105,7 @@ describe("mergeCoverage()", () => {
 			[7, 5, 5, 1, 1, 2, 1, 5, 6, 2, 1, 0, 0, 0, 1, 3, 2],
 			[1, 1, 2, 3, 4, 4, 4, 4, 2, 2, 2, 3, 2, 1, 0, 1, 0],
 		];
-		isolates = coverages.map(
-			(c) => ({ filled: c }) as FormattedPathoscopeIsolate,
-		);
+		isolates = coverages.map((filled) => ({ filled }));
 	});
 
 	it("should return merged coverage when all isolates have same length", () => {

--- a/apps/web/src/analyses/components/Iimi/__tests__/IimiViewer.test.tsx
+++ b/apps/web/src/analyses/components/Iimi/__tests__/IimiViewer.test.tsx
@@ -1,4 +1,5 @@
 import { AnalysisSearchProvider } from "@analyses/components/AnalysisSearchContext";
+import type { FormattedIimiAnalysis, FormattedIimiHit } from "@analyses/types";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -23,8 +24,8 @@ function renderWithAnalysisSearch(
 }
 
 describe("<IimiViewer />", () => {
-	let formattedIimiAnalysis;
-	let predefinedHits;
+	let formattedIimiAnalysis: FormattedIimiAnalysis;
+	let predefinedHits: FormattedIimiHit[];
 
 	beforeEach(() => {
 		formattedIimiAnalysis = formatData({

--- a/apps/web/src/analyses/components/Nuvs/NuvsExportPreview.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsExportPreview.tsx
@@ -8,34 +8,20 @@ type NuVsExportPreviewProps = {
  * Displays a preview of the Nuvs being exported
  */
 export default function NuvsExportPreview({ mode }: NuVsExportPreviewProps) {
-	let previewHeader = ">sequence_1|17SP002|RNA Polymerase";
-	let previewSequence: string;
-	let indexName: string;
-	let indexExample: string;
-	let barName: string;
-	let barExample: string;
+	const isContigs = mode === "contigs";
 
-	if (mode === "contigs") {
-		indexName = "sequence index";
-		indexExample = "sequence_1";
-
-		barName = "bar-separated ORF annotations";
-		barExample = "RNA Polymerase|cg30";
-
-		previewHeader += "|cg30";
-		previewSequence =
-			"CATTTTATCAATAACAATTAAAACAAACAAACAAAAAAACCTTACCAGCAGCAACAGCAAGATGGCCAAATAGGAACAGATAGGGAC";
-	} else {
-		indexName = "sequence index + orf index";
-		indexExample = "orf_1_1";
-
-		barName = "best annotation";
-		barExample = "RNA Polymerase";
-
-		previewHeader = previewHeader.replace("sequence_1", "orf_1_1");
-		previewSequence =
-			"ELREECRSLRSRCDQLEERVSAMEDEMNEMKREGKFREKRIKRNEQSLQEIWDYVKRPNLRLIGVPESDGENGTKLENTFREKSAME";
-	}
+	const previewHeader = isContigs
+		? ">sequence_1|17SP002|RNA Polymerase|cg30"
+		: ">orf_1_1|17SP002|RNA Polymerase";
+	const previewSequence = isContigs
+		? "CATTTTATCAATAACAATTAAAACAAACAAACAAAAAAACCTTACCAGCAGCAACAGCAAGATGGCCAAATAGGAACAGATAGGGAC"
+		: "ELREECRSLRSRCDQLEERVSAMEDEMNEMKREGKFREKRIKRNEQSLQEIWDYVKRPNLRLIGVPESDGENGTKLENTFREKSAME";
+	const indexName = isContigs ? "sequence index" : "sequence index + orf index";
+	const indexExample = isContigs ? "sequence_1" : "orf_1_1";
+	const barName = isContigs
+		? "bar-separated ORF annotations"
+		: "best annotation";
+	const barExample = isContigs ? "RNA Polymerase|cg30" : "RNA Polymerase";
 
 	return (
 		<div>

--- a/apps/web/src/analyses/components/Nuvs/NuvsExportPreview.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsExportPreview.tsx
@@ -9,11 +9,11 @@ type NuVsExportPreviewProps = {
  */
 export default function NuvsExportPreview({ mode }: NuVsExportPreviewProps) {
 	let previewHeader = ">sequence_1|17SP002|RNA Polymerase";
-	let previewSequence;
-	let indexName;
-	let indexExample;
-	let barName;
-	let barExample;
+	let previewSequence: string;
+	let indexName: string;
+	let indexExample: string;
+	let barName: string;
+	let barExample: string;
 
 	if (mode === "contigs") {
 		indexName = "sequence index";

--- a/apps/web/src/analyses/components/__tests__/AnalysisList.test.tsx
+++ b/apps/web/src/analyses/components/__tests__/AnalysisList.test.tsx
@@ -12,7 +12,7 @@ import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("<AnalysesToolbar />", () => {
-	let sample;
+	let sample: ReturnType<typeof createFakeSample>;
 
 	beforeEach(() => {
 		sample = createFakeSample();

--- a/apps/web/src/analyses/utils.ts
+++ b/apps/web/src/analyses/utils.ts
@@ -146,7 +146,7 @@ export function median(values: number[]): number {
  * This is used to render a representative coverage chart for the parent OTU.
  */
 export function mergeCoverage(
-	isolates: FormattedPathoscopeIsolate[],
+	isolates: Pick<FormattedPathoscopeIsolate, "filled">[],
 ): number[] {
 	const longest = maxBy(isolates, (isolate) => isolate.filled.length);
 	if (!longest) {


### PR DESCRIPTION
## Summary

- Add explicit types to untyped `let` declarations in analysis tests (`AnalysisList`, `IimiViewer`, `utils`) and `NuvsExportPreview` to satisfy the `noImplicitAnyLet` TypeScript compiler rule
- Refactor one `let` in `Settings.test.tsx` to `const` where reassignment was unnecessary
- No logic changes — purely type annotations and a `let` → `const` cleanup