### PR TITLE
refactor: remove sequence target field from UI

### DIFF
--- a/apps/web/src/otus/queries.tsx
+++ b/apps/web/src/otus/queries.tsx
@@ -301,7 +301,6 @@ export function useCreateSequence(otuId: string) {
 			host: string;
 			sequence: string;
 			segment?: string;
-			target?: string;
 		}
 	>({
 		mutationFn: ({
@@ -311,11 +310,10 @@ export function useCreateSequence(otuId: string) {
 			host,
 			sequence,
 			segment,
-			target,
 		}) =>
 			apiClient
 				.post(`/otus/${otuId}/isolates/${isolateId}/sequences`)
-				.send({ accession, definition, host, sequence, segment, target })
+				.send({ accession, definition, host, sequence, segment })
 				.then((res) => res.body),
 
 		onSuccess: () => {
@@ -345,7 +343,6 @@ export function useEditSequence(otuId: string) {
 			host: string;
 			sequence: string;
 			segment?: string;
-			target?: string;
 		}
 	>({
 		mutationFn: ({
@@ -356,11 +353,10 @@ export function useEditSequence(otuId: string) {
 			host,
 			sequence,
 			segment,
-			target,
 		}) =>
 			apiClient
 				.patch(`/otus/${otuId}/isolates/${isolateId}/sequences/${sequenceId}`)
-				.send({ accession, definition, host, sequence, segment, target })
+				.send({ accession, definition, host, sequence, segment })
 				.then((res) => res.body),
 		onSuccess: () => {
 			queryClient.invalidateQueries({

--- a/apps/web/src/otus/types.ts
+++ b/apps/web/src/otus/types.ts
@@ -66,7 +66,6 @@ export type OtuSequence = {
 	remote?: OtuRemote;
 	segment?: string | null;
 	sequence: string;
-	target?: string | null;
 };
 
 export type OtuIsolate = {

--- a/apps/web/src/tests/fake/otus.ts
+++ b/apps/web/src/tests/fake/otus.ts
@@ -38,7 +38,6 @@ export function createFakeOTUSequence(
 		id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
 		segment: null,
 		sequence: faker.word.noun({ strategy: "any-length" }),
-		target: null,
 	};
 
 	return { ...sequence, ...overrides };
@@ -235,7 +234,6 @@ export function mockApiRemoveIsolate(otuId: string, isolateId: string) {
  * @param host - The host for the sequence
  * @param sequence - The sequence characters assigned
  * @param segment - The segment assigned
- * @param target - The target assigned
  * @returns The nock scope for the mocked API call
  */
 export function mockApiAddSequence(
@@ -246,7 +244,6 @@ export function mockApiAddSequence(
 	host: string,
 	sequence: string,
 	segment?: string,
-	target?: string,
 ) {
 	const OTUSequence = createFakeOTUSequence({
 		accession,
@@ -254,7 +251,6 @@ export function mockApiAddSequence(
 		host,
 		sequence,
 		segment,
-		target,
 	});
 
 	return nock("http://localhost")
@@ -274,7 +270,6 @@ export function mockApiAddSequence(
  * @param host - The host for the sequence
  * @param sequence - The sequence characters assigned
  * @param segment - The segment assigned
- * @param target - The target assigned
  * @returns The nock scope for the mocked API call
  */
 export function mockApiEditSequence(
@@ -286,7 +281,6 @@ export function mockApiEditSequence(
 	host: string,
 	sequence: string,
 	segment?: string | null,
-	target?: string | null,
 ) {
 	const OTUSequence = createFakeOTUSequence({
 		accession,
@@ -294,7 +288,6 @@ export function mockApiEditSequence(
 		host,
 		sequence,
 		segment,
-		target,
 	});
 
 	return nock("http://localhost")
@@ -304,7 +297,6 @@ export function mockApiEditSequence(
 			host,
 			segment,
 			sequence,
-			target,
 		})
 		.query(true)
 		.reply(201, OTUSequence);


### PR DESCRIPTION
## Summary

- Removes the `target` field from the `OtuSequence` type
- Strips `target` from the `useCreateSequence` and `useEditSequence` mutation payloads
- Cleans up `target` from test fakes and mock API helpers (`mockApiAddSequence`, `mockApiEditSequence`)

## Test plan

- [ ] Verify creating a sequence still works without a target field
- [ ] Verify editing a sequence still works without a target field
- [ ] Run `pnpm --filter @virtool/web exec vitest run src/sequences` to confirm tests pass