### PR TITLE
fix: open sample edit dialog reliably

### DIFF
--- a/apps/web/src/routes/_authenticated/samples/$sampleId.tsx
+++ b/apps/web/src/routes/_authenticated/samples/$sampleId.tsx
@@ -9,6 +9,7 @@ import ViewHeaderIcons from "@base/ViewHeaderIcons";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import { JobNestedSchema } from "@jobs/types";
 import DeleteSample from "@samples/components/Detail/DeleteSample";
+import EditSample from "@samples/components/EditSample";
 import { useCheckCanEditSample } from "@samples/hooks";
 import { sampleQueryOptions, useFetchSample } from "@samples/queries";
 import {
@@ -16,17 +17,11 @@ import {
 	notFound,
 	Outlet,
 	useLocation,
-	useNavigate,
 } from "@tanstack/react-router";
 import { Key, Pencil } from "lucide-react";
-import { z } from "zod/v4";
-
-const sampleDetailSearchSchema = z.object({
-	openEditSample: z.boolean().optional().catch(undefined),
-});
+import { useState } from "react";
 
 export const Route = createFileRoute("/_authenticated/samples/$sampleId")({
-	validateSearch: sampleDetailSearchSchema,
 	loader: async ({ context: { queryClient }, params: { sampleId } }) => {
 		try {
 			await queryClient.ensureQueryData(sampleQueryOptions(sampleId));
@@ -50,7 +45,7 @@ function SampleDetailLayout() {
 	const location = useLocation();
 	const { data, isPending } = useFetchSample(sampleId);
 	const { hasPermission: canModify } = useCheckCanEditSample(sampleId);
-	const navigate = useNavigate({ from: Route.fullPath });
+	const [editOpen, setEditOpen] = useState(false);
 
 	if (isPending || !data) {
 		return <LoadingPlaceholder />;
@@ -71,15 +66,7 @@ function SampleDetailLayout() {
 									color="grayDark"
 									IconComponent={Pencil}
 									tip="modify"
-									onClick={() =>
-										navigate({
-											search: (prev: Record<string, unknown>) => ({
-												...prev,
-												openEditSample: true,
-											}),
-											replace: true,
-										})
-									}
+									onClick={() => setEditOpen(true)}
 								/>
 								<DeleteSample
 									id={sampleId}
@@ -111,6 +98,8 @@ function SampleDetailLayout() {
 			</Tabs>
 
 			<Outlet />
+
+			<EditSample open={editOpen} sample={data} setOpen={setEditOpen} />
 		</>
 	);
 }

--- a/apps/web/src/samples/components/Detail/SampleDetailGeneral.tsx
+++ b/apps/web/src/samples/components/Detail/SampleDetailGeneral.tsx
@@ -15,7 +15,6 @@ import { getLibraryTypeDisplayName } from "@samples/utils";
  */
 import { getRouteApi } from "@tanstack/react-router";
 import numbro from "numbro";
-import EditSample from "../EditSample";
 import SampleFileSizeWarning from "./SampleFileSizeWarning";
 import Sidebar from "./Sidebar";
 
@@ -29,8 +28,6 @@ export default function SampleDetailGeneral({
 	labels,
 }: SampleDetailGeneralProps) {
 	const { sampleId } = routeApi.useParams();
-	const search = routeApi.useSearch();
-	const navigate = routeApi.useNavigate();
 	const { data, isPending } = useFetchSample(sampleId);
 	const { data: job } = useFetchJob(data?.job?.id ?? Number.NaN, data?.job);
 
@@ -135,14 +132,6 @@ export default function SampleDetailGeneral({
 					defaultSubtractions={data.subtractions}
 				/>
 			</ContainerSide>
-
-			<EditSample
-				open={Boolean(search.openEditSample)}
-				sample={data}
-				setOpen={(openEditSample) =>
-					navigate({ search: { ...search, openEditSample } })
-				}
-			/>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

- Switches the sample edit dialog from being driven by a URL search param (`openEditSample`) to local React state (`useState`)
- Moves the `EditSample` component up to the `SampleDetailLayout` level so it is always mounted alongside the layout, regardless of which sub-route is active
- Removes the `sampleDetailSearchSchema` and `validateSearch` from the route definition, eliminating the stale/inconsistent state that could prevent the dialog from opening

## Test plan

- [ ] Navigate to a sample detail page and click the pencil (edit) icon — the edit dialog should open
- [ ] Close the dialog and confirm it can be reopened without a full page reload
- [ ] Confirm the URL does not change when opening or closing the edit dialog
- [ ] Navigate between sub-tabs (General, Analyses, etc.) and verify the edit dialog can still be opened from any tab