### PR TITLE
docs: add Linear issue conventions and GitHub PR title guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,6 +279,14 @@ constraints, mappings, or decisions that apply to your work.
 - **Issue prefix**: `VIR`
 - **Default label**: Frontend
 
+### Issue conventions
+
+- Capitalize issue titles.
+- Place issues in **Todo** by default; use **Backlog** only when explicitly
+  asked. If an issue seems like it should be Backlog, say so and ask.
+- Never assign issues to anyone.
+- Label bugs as **Bug** in addition to any other labels.
+
 ## Code style
 
 The basics:
@@ -387,6 +395,11 @@ and make commits easier to find later.
 - Don't use `git -C <path>` unless necessary. It triggers permission prompts
   that aren't worth the trouble. Run git commands from the working directory
   instead.
+
+### GitHub
+
+- PR titles must follow Conventional Commits format so they can be cleanly
+  squash-merged into a single well-formed commit.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

- Documents Linear issue conventions for agents: capitalize titles, default to Todo status, never assign issues, and label bugs as Bug
- Documents that GitHub PR titles must follow Conventional Commits format so squash merges produce well-formed commits

## Test plan

- [ ] Review the AGENTS.md changes to confirm the conventions are clearly stated and correctly placed