### PR TITLE
chore(biome): enforce zero warnings in CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,9 +95,11 @@ currently configured in another repository.
 - After changing tests: run the specific test file with
   `pnpm --filter @virtool/web exec vitest run <path>`.
 - Full test suite only when asked or when changes are cross-cutting.
-- Always fix all lint errors and warnings. The main branch is guaranteed to
-  pass `pnpm check` cleanly, so any issues are caused by your changes — never
-  dismiss them as pre-existing.
+- Always fix all lint errors. Biome's lint rules are all set to `error` in
+  `biome.json` (there are no warn-level rules), and CI's `check-biome` job runs
+  `pnpm check` — so `pnpm check` must exit 0 before merging. The main branch is
+  guaranteed to pass `pnpm check` cleanly, so any issues are caused by your
+  changes — never dismiss them as pre-existing.
 - Always assume tests pass on `main` — CI enforces it. Any test failures you
   see locally are caused by your changes, never pre-existing. Do **not** use
   `git stash` (or any other working-tree-modifying command) to "check what

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,8 @@
 		"react-dom": "^19.2.7",
 		"react-dropzone": "^15.0.0",
 		"react-hook-form": "^7.77.0",
+		"react-markdown": "^10.1.0",
+		"remark-gfm": "^4.0.1",
 		"superagent": "^8.0.9",
 		"tailwind-merge": "^3.5.0",
 		"zod": "^4.3.5",

--- a/apps/web/src/analyses/components/AnalysisList.tsx
+++ b/apps/web/src/analyses/components/AnalysisList.tsx
@@ -56,7 +56,11 @@ export default function AnalysesList({
 
 	return (
 		<ContainerNarrow>
-			<AnalysisHMMAlert installed={Boolean(hmms.status.task?.complete)} />
+			<AnalysisHMMAlert
+				installed={Boolean(
+					hmms.status.installed?.ready ?? hmms.status.task?.complete,
+				)}
+			/>
 			<div className="flex justify-end pb-4">
 				{canCreate && (
 					<button

--- a/apps/web/src/analyses/components/AnalysisList.tsx
+++ b/apps/web/src/analyses/components/AnalysisList.tsx
@@ -56,7 +56,7 @@ export default function AnalysesList({
 
 	return (
 		<ContainerNarrow>
-			<AnalysisHMMAlert installed={hmms.status.task?.complete} />
+			<AnalysisHMMAlert installed={Boolean(hmms.status.task?.complete)} />
 			<div className="flex justify-end pb-4">
 				{canCreate && (
 					<button

--- a/apps/web/src/analyses/components/Create/CreateAnalysis.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysis.tsx
@@ -49,7 +49,7 @@ export default function CreateAnalysis({
 		<Dialog open={open} onOpenChange={setOpen}>
 			<CreateAnalysisDialogContent>
 				<DialogTitle>Analyze</DialogTitle>
-				<HMMAlert installed={hmms.status.task?.complete} />
+				<HMMAlert installed={Boolean(hmms.status.task?.complete)} />
 				<Tabs.Root defaultValue="pathoscope">
 					<Tabs.List
 						className={cn(

--- a/apps/web/src/analyses/components/Create/QuickAnalyze.tsx
+++ b/apps/web/src/analyses/components/Create/QuickAnalyze.tsx
@@ -64,7 +64,7 @@ export default function QuickAnalyze({
 		<Dialog open={open} onOpenChange={setOpen}>
 			<CreateAnalysisDialogContent>
 				<DialogTitle>Quick Analyze</DialogTitle>
-				<HMMAlert installed={hmms.status.task?.complete} />
+				<HMMAlert installed={Boolean(hmms.status.task?.complete)} />
 
 				<Tabs.Root defaultValue="pathoscope">
 					<Tabs.List

--- a/apps/web/src/analyses/components/Nuvs/NuvsOrf.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsOrf.tsx
@@ -40,13 +40,7 @@ function draw(element, maxLength, pos, strand) {
 	group.append("path").attr("d", d).attr("stroke-width", 1);
 }
 
-export default function NuvsOrf({
-	hits,
-	index,
-	maxSequenceLength,
-	pos,
-	strand,
-}) {
+export default function NuvsOrf({ hits, maxSequenceLength, pos, strand }) {
 	const chartEl = useRef(null);
 
 	useEffect(

--- a/apps/web/src/analyses/components/Nuvs/__tests__/NuVsViewer.test.tsx
+++ b/apps/web/src/analyses/components/Nuvs/__tests__/NuVsViewer.test.tsx
@@ -27,9 +27,9 @@ function renderWithAnalysisSearch(
 }
 
 describe("<NuvsViewer />", () => {
-	let props;
-	let sample;
-	let nuvs;
+	let sample: ReturnType<typeof createFakeSample>;
+	let nuvs: ReturnType<typeof createFakeFormattedNuVsAnalysis>;
+	let props: { detail: typeof nuvs; sample: typeof sample };
 
 	beforeEach(() => {
 		sample = createFakeSample();
@@ -60,7 +60,10 @@ describe("<NuvsViewer />", () => {
 		});
 
 		it("should render blast when clicked", async () => {
-			const scope = mockApiBlastNuVs(nuvs.id, nuvs.results.hits[0].index);
+			const scope = mockApiBlastNuVs(
+				nuvs.id,
+				String(nuvs.results.hits[0].index),
+			);
 			renderWithAnalysisSearch(<NuvsViewer {...props} />, {
 				activeHit: String(nuvs.results.hits[0].id),
 			});

--- a/apps/web/src/analyses/components/Pathoscope/PathoscopeSequence.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/PathoscopeSequence.tsx
@@ -98,7 +98,6 @@ export default function PathoscopeSequence({
 	accession,
 	data,
 	definition,
-	id,
 	length,
 	maxGenomeLength,
 	ratio,

--- a/apps/web/src/analyses/components/Pathoscope/PathoscopeViewScroller.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/PathoscopeViewScroller.tsx
@@ -18,14 +18,16 @@ export function PathoscopeViewerScroller() {
 
 	if (show) {
 		return (
-			<div
+			<button
+				type="button"
+				aria-label="Scroll to top"
 				className="flex items-center justify-center fixed bottom-8 left-8 size-10 border border-gray-300 rounded-lg text-gray-500 cursor-pointer z-1 hover:bg-gray-100 hover:text-gray-600"
 				onClick={() =>
 					getContentScrollElement()?.scrollTo({ top: 0, behavior: "smooth" })
 				}
 			>
 				<ArrowUp />
-			</div>
+			</button>
 		);
 	}
 

--- a/apps/web/src/analyses/types.ts
+++ b/apps/web/src/analyses/types.ts
@@ -79,7 +79,7 @@ export type GenericAnalysis = AnalysisMinimal & {
 	files: Array<AnalysisFile>;
 
 	/** The results of the analysis that will be presented to the user */
-	results?: { [key: string]: any };
+	results?: { [key: string]: unknown };
 
 	workflow: AnalysisWorkflow;
 };
@@ -207,7 +207,7 @@ export type FormattedNuvsResults = {
 /** Mapping data for a single Nuvs hit */
 export type FormattedNuvsHit = {
 	annotatedOrfCount: number;
-	blast: Blast;
+	blast: Blast | null;
 	e: number;
 	families: string[];
 	id: number;

--- a/apps/web/src/app/style.css
+++ b/apps/web/src/app/style.css
@@ -1,3 +1,6 @@
+@import "tailwindcss";
+@import "./animations.css";
+
 @font-face {
 	font-family: "Inter";
 	src: url("../fonts/Inter-VariableFont_opsz,wght.ttf")
@@ -15,9 +18,6 @@
 	font-style: italic;
 	font-display: swap;
 }
-
-@import "tailwindcss";
-@import "./animations.css";
 
 @theme {
 	--font-sans: "Inter", sans-serif, "Apple Color Emoji", "Segoe UI Emoji";

--- a/apps/web/src/base/Box.tsx
+++ b/apps/web/src/base/Box.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@app/utils";
-import type { ReactNode } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 
 type BoxProps = {
 	children: ReactNode;
@@ -8,6 +8,20 @@ type BoxProps = {
 };
 
 function Box({ children, className = "", onClick, ...rest }: BoxProps) {
+	const interactiveProps = onClick
+		? {
+				onClick,
+				onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+					if (event.key === "Enter" || event.key === " ") {
+						event.preventDefault();
+						onClick();
+					}
+				},
+				role: "button",
+				tabIndex: 0,
+			}
+		: {};
+
 	return (
 		<div
 			className={cn(
@@ -22,7 +36,7 @@ function Box({ children, className = "", onClick, ...rest }: BoxProps) {
 				"rounded-sm",
 				className,
 			)}
-			onClick={onClick}
+			{...interactiveProps}
 			{...rest}
 		>
 			{children}

--- a/apps/web/src/base/Button.tsx
+++ b/apps/web/src/base/Button.tsx
@@ -1,10 +1,10 @@
 import { cn } from "@app/utils";
-import type { ComponentType, ReactNode } from "react";
+import type { ElementType, ReactNode } from "react";
 import { buttonVariants } from "./buttonVariants";
 
 export type ButtonProps = {
 	active?: boolean;
-	as?: string | ComponentType<any>;
+	as?: ElementType;
 	children: ReactNode;
 	className?: string;
 	color?: "blue" | "green" | "gray" | "purple" | "red";

--- a/apps/web/src/base/Circle.tsx
+++ b/apps/web/src/base/Circle.tsx
@@ -25,6 +25,7 @@ export default function Circle({
 }: CircleProps) {
 	return (
 		<svg
+			aria-hidden="true"
 			width={size}
 			height={size}
 			viewBox="0 0 10 10"

--- a/apps/web/src/base/InitialIcon.tsx
+++ b/apps/web/src/base/InitialIcon.tsx
@@ -39,6 +39,8 @@ export default function InitialIcon({
 
 	return (
 		<svg
+			role="img"
+			aria-label={handle}
 			className={cn("overflow-visible", className)}
 			style={{ height: sizeValue, width: sizeValue }}
 		>

--- a/apps/web/src/base/Input.tsx
+++ b/apps/web/src/base/Input.tsx
@@ -22,7 +22,7 @@ export interface InputProps {
 	name?: string;
 	placeholder?: string;
 	readOnly?: boolean;
-	ref?: Ref<any>;
+	ref?: Ref<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>;
 	register?: UseFormRegisterReturn;
 	step?: number;
 	type?: string;

--- a/apps/web/src/base/InputSearch.tsx
+++ b/apps/web/src/base/InputSearch.tsx
@@ -4,11 +4,6 @@ import Input from "./Input";
 import InputContainer from "./InputContainer";
 import InputIcon from "./InputIcon";
 
-type InputHandle = {
-	blur: () => void;
-	focus: () => void;
-};
-
 interface InputSearchProps {
 	"aria-label"?: string;
 	autoFocus?: boolean;
@@ -22,7 +17,7 @@ interface InputSearchProps {
 	name?: string;
 	placeholder?: string;
 	readOnly?: boolean;
-	ref?: Ref<InputHandle>;
+	ref?: Ref<HTMLInputElement>;
 	step?: number;
 	type?: string;
 	value: string | number;

--- a/apps/web/src/base/Logo.tsx
+++ b/apps/web/src/base/Logo.tsx
@@ -56,7 +56,14 @@ export default function Logo({ className, height = 30, color }: LogoProps) {
 				className,
 			)}
 		>
-			<svg id="svg2" viewBox="0 0 512 512" height={height}>
+			<svg
+				id="svg2"
+				role="img"
+				aria-label="Virtool"
+				viewBox="0 0 512 512"
+				height={height}
+			>
+				<title>Virtool</title>
 				<defs id="defs125">
 					<clipPath id="clipPath4140">
 						<path d={clipPath} />

--- a/apps/web/src/base/Markdown.tsx
+++ b/apps/web/src/base/Markdown.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@app/utils";
-import { marked } from "marked";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import NoneFound from "./NoneFound";
 
 type MarkdownProps = {
@@ -10,33 +11,15 @@ type MarkdownProps = {
  * A styled component that parses, formats, and displays markdown content
  */
 export default function Markdown({ markdown = "" }: MarkdownProps) {
-	marked.use({
-		gfm: true,
-		async: false,
-	});
-
-	if (markdown) {
-		return (
-			<div
-				className={cn(
-					"overflow-y-scroll",
-					"max-h-96",
-					"mb-0",
-					"py-2.5",
-					"px-4",
-				)}
-				dangerouslySetInnerHTML={{
-					__html: marked.parse(markdown) as string,
-				}}
-			/>
-		);
-	}
-
 	return (
 		<div
 			className={cn("overflow-y-scroll", "max-h-96", "mb-0", "py-2.5", "px-4")}
 		>
-			<NoneFound noun="notes" />
+			{markdown ? (
+				<ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
+			) : (
+				<NoneFound noun="notes" />
+			)}
 		</div>
 	);
 }

--- a/apps/web/src/base/NoneFoundSection.tsx
+++ b/apps/web/src/base/NoneFoundSection.tsx
@@ -15,11 +15,7 @@ export default function NoneFoundSection({
 	noun,
 	className,
 }: NoneFoundSectionProps) {
-	let childrenContainer;
-
-	if (children) {
-		childrenContainer = <span>. {children}.</span>;
-	}
+	const childrenContainer = children ? <span>. {children}.</span> : null;
 
 	return (
 		<BoxGroupSection

--- a/apps/web/src/base/PseudoLabel.tsx
+++ b/apps/web/src/base/PseudoLabel.tsx
@@ -7,7 +7,5 @@ type PseudoLabelProps = {
 };
 
 export default function PseudoLabel({ children, className }: PseudoLabelProps) {
-	return (
-		<label className={cn("font-medium", "mb-2", className)}>{children}</label>
-	);
+	return <div className={cn("font-medium", "mb-2", className)}>{children}</div>;
 }

--- a/apps/web/src/base/__tests__/RelativeTime.test.tsx
+++ b/apps/web/src/base/__tests__/RelativeTime.test.tsx
@@ -4,7 +4,6 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import RelativeTime from "../RelativeTime";
 
 const fakeTime = "2019-02-10T17:11:00.000000Z";
-const RealDate = Date;
 
 describe("<RelativeTime />", () => {
 	beforeAll(() => {
@@ -45,6 +44,5 @@ describe("<RelativeTime />", () => {
 
 	afterAll(() => {
 		vi.useRealTimers();
-		Date = RealDate;
 	});
 });

--- a/apps/web/src/forms/components/__tests__/RestoredAlert.test.tsx
+++ b/apps/web/src/forms/components/__tests__/RestoredAlert.test.tsx
@@ -2,10 +2,10 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@tests/setup";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { RestoredAlert } from "../RestoredAlert";
+import { RestoredAlert, type RestoredAlertProps } from "../RestoredAlert";
 
 describe("<Alert />", () => {
-	let props;
+	let props: RestoredAlertProps;
 	beforeEach(() => {
 		props = {
 			hasRestored: true,

--- a/apps/web/src/hmm/components/HmmInstall.tsx
+++ b/apps/web/src/hmm/components/HmmInstall.tsx
@@ -22,7 +22,10 @@ export function HmmInstall() {
 	const installMutation = useInstallHmm();
 
 	const seedTask = data?.status?.task;
-	const { data: task } = useFetchTask(seedTask?.id ?? Number.NaN, seedTask);
+	const { data: task } = useFetchTask(
+		seedTask?.id ?? Number.NaN,
+		seedTask ?? undefined,
+	);
 
 	const taskComplete = task?.complete;
 

--- a/apps/web/src/hmm/components/HmmItem.tsx
+++ b/apps/web/src/hmm/components/HmmItem.tsx
@@ -18,7 +18,7 @@ export default function HmmItem({ hmm }: HmmItemProps) {
 
 	const labelComponents = filteredFamilies
 		.slice(0, 3)
-		.map((family, i) => <Label key={i}>{family}</Label>);
+		.map((family) => <Label key={family}>{family}</Label>);
 
 	return (
 		<BoxGroupSection className="flex text-lg">

--- a/apps/web/src/hmm/components/HmmToolbar.tsx
+++ b/apps/web/src/hmm/components/HmmToolbar.tsx
@@ -5,7 +5,7 @@ type HmmToolbarProps = {
 	/** Current search term used for filtering */
 	term: string;
 	/** A callback function to handle changes in search input */
-	onChange: (term: any) => void;
+	onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 /**

--- a/apps/web/src/hmm/components/__tests__/HmmList.test.tsx
+++ b/apps/web/src/hmm/components/__tests__/HmmList.test.tsx
@@ -7,7 +7,7 @@ import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("<HmmList />", () => {
-	let fakeHMMData;
+	let fakeHMMData: ReturnType<typeof createFakeHmmSearchResults>;
 	let path: string;
 
 	beforeEach(() => {
@@ -92,6 +92,8 @@ describe("<HmmList />", () => {
 				documents: [],
 				total_count: 0,
 				status: {
+					errors: [],
+					installed: null,
 					task: createFakeTask({
 						complete: false,
 						id: 21,

--- a/apps/web/src/hmm/types.ts
+++ b/apps/web/src/hmm/types.ts
@@ -1,3 +1,4 @@
+import type { ServerTask } from "@tasks/types";
 import type { UserNested } from "@users/types";
 
 import type { SearchResult } from "../types/api";
@@ -47,7 +48,11 @@ export type HmmSearchResults = SearchResult & {
 	/** Gives information about each HMM */
 	items: HMMMinimal[];
 	/** The status of the HMMs */
-	status: { [key: string]: any };
+	status: {
+		errors: string[];
+		installed: { ready: boolean } | null;
+		task: ServerTask | null;
+	};
 };
 
 /** Wire-shape HMM search results returned by the backend before the UI transform */

--- a/apps/web/src/indexes/components/RebuildIndex.tsx
+++ b/apps/web/src/indexes/components/RebuildIndex.tsx
@@ -42,9 +42,7 @@ export default function RebuildIndex({
 			<DialogContent>
 				<DialogTitle>Rebuild Index</DialogTitle>
 				<form onSubmit={handleSubmit}>
-					<RebuildIndexError
-						error={mutation.isError && mutation.error.response.body.message}
-					/>
+					<RebuildIndexError error={mutation.error?.response?.body?.message} />
 					<RebuildHistory unbuilt={data} />
 					<DialogFooter>
 						<Button type="submit" color="blue">

--- a/apps/web/src/jobs/components/JobStep.tsx
+++ b/apps/web/src/jobs/components/JobStep.tsx
@@ -24,6 +24,7 @@ export default function JobStepItem({ step, state }: JobStepProps) {
 			<div className="">
 				<h4 className="font-medium text-lg">{step.name}</h4>
 				<p
+					// biome-ignore lint/security/noDangerouslySetInnerHtml: step.description is a trusted, backend-defined workflow string rendered through marked's markdown parser, not user input
 					dangerouslySetInnerHTML={{
 						__html: marked.parseInline(step.description),
 					}}

--- a/apps/web/src/otus/components/Detail/History/HistoryList.tsx
+++ b/apps/web/src/otus/components/Detail/History/HistoryList.tsx
@@ -24,9 +24,9 @@ export default function HistoryList({
 }: HistoryListProps) {
 	const changes = sortBy(history, [(h) => h.otu.version]).reverse();
 
-	const changeComponents = changes.map((change, index) => (
+	const changeComponents = changes.map((change) => (
 		<Change
-			key={index}
+			key={change.id}
 			id={change.id}
 			archived={archived}
 			methodName={change.method_name}

--- a/apps/web/src/otus/components/Detail/Isolates/__tests__/AddIsolate.test.tsx
+++ b/apps/web/src/otus/components/Detail/Isolates/__tests__/AddIsolate.test.tsx
@@ -3,11 +3,12 @@ import userEvent from "@testing-library/user-event";
 import { mockApiCreateIsolate } from "@tests/fake/otus";
 import { renderWithProviders } from "@tests/setup";
 import nock from "nock";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AddIsolate from "../AddIsolate";
 
 describe("<AddIsolate />", () => {
-	let props;
+	let props: ComponentProps<typeof AddIsolate>;
 
 	beforeEach(() => {
 		props = {

--- a/apps/web/src/otus/components/Detail/Isolates/__tests__/RemoveIsolate.test.tsx
+++ b/apps/web/src/otus/components/Detail/Isolates/__tests__/RemoveIsolate.test.tsx
@@ -2,11 +2,12 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mockApiRemoveIsolate } from "@tests/fake/otus";
 import { renderWithProviders } from "@tests/setup";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import RemoveIsolate from "../RemoveIsolate";
 
 describe("<RemoveIsolate />", () => {
-	let props;
+	let props: ComponentProps<typeof RemoveIsolate>;
 
 	beforeEach(() => {
 		props = {

--- a/apps/web/src/otus/components/Detail/Schema/__tests__/RemoveSegment.test.tsx
+++ b/apps/web/src/otus/components/Detail/Schema/__tests__/RemoveSegment.test.tsx
@@ -7,8 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import RemoveSegment from "../RemoveSegment";
 
 describe("<RemoveSegment />", () => {
-	let otu;
-	let segmentName;
+	let otu: ReturnType<typeof createFakeOtu>;
+	let segmentName: string;
 
 	beforeEach(() => {
 		otu = createFakeOtu();

--- a/apps/web/src/otus/components/OtuCreate.tsx
+++ b/apps/web/src/otus/components/OtuCreate.tsx
@@ -36,7 +36,7 @@ export default function OtuCreate({ open, refId, setOpen }: CreateOTUProps) {
 				<DialogTitle>Create OTU</DialogTitle>
 				<OtuForm
 					onSubmit={handleSubmit}
-					error={mutation.isError && mutation.error.response?.body?.message}
+					error={mutation.error?.response?.body?.message}
 				/>
 			</DialogContent>
 		</Dialog>

--- a/apps/web/src/otus/components/OtuEdit.tsx
+++ b/apps/web/src/otus/components/OtuEdit.tsx
@@ -45,7 +45,7 @@ export default function OtuEdit({
 				<OtuForm
 					name={name}
 					abbreviation={abbreviation}
-					error={mutation.isError && mutation.error.response.body.message}
+					error={mutation.error?.response?.body?.message}
 					onSubmit={handleSubmit}
 				/>
 			</DialogContent>

--- a/apps/web/src/otus/components/OtuForm.tsx
+++ b/apps/web/src/otus/components/OtuForm.tsx
@@ -14,7 +14,7 @@ type FormValues = {
 type OTUFormProps = {
 	abbreviation?: string;
 	/** Error message to be displayed */
-	error: string;
+	error?: string;
 	name?: string;
 	/** A callback function to be called when the form is submitted */
 	onSubmit: (values: FormValues) => void;

--- a/apps/web/src/otus/components/OtuIssues.tsx
+++ b/apps/web/src/otus/components/OtuIssues.tsx
@@ -1,13 +1,13 @@
 import { formatIsolateName } from "@app/utils";
 import Alert from "@base/Alert";
 import type { ReactNode } from "react";
-import type { OtuIsolate } from "../types";
+import type { OtuIsolate, OtuIssueReport } from "../types";
 
 type OtuIssuesProps = {
 	/** The isolates associated with the OTU */
 	isolates: OtuIsolate[];
 	/** The issues that occurred */
-	issues: { [key: string]: any } | boolean;
+	issues: OtuIssueReport | boolean;
 };
 
 /**
@@ -35,12 +35,12 @@ export default function OtuIssues({ isolates, issues }: OtuIssuesProps) {
 	// One or more isolates have no sequences associated with them.
 	if (typeof issues === "object" && issues.empty_isolate) {
 		// The empty_isolate property is an array of isolate_ids of empty isolates.
-		const emptyIsolates = issues.empty_isolate.map((isolateId, index) => {
+		const emptyIsolates = issues.empty_isolate.map((isolateId) => {
 			// Get the entire isolate identified by isolate_id from the detail data.
 			const isolate = isolates.find((i) => i.id === isolateId);
 
 			return (
-				<li key={index}>
+				<li key={isolateId}>
 					{isolate ? formatIsolateName(isolate) : "Unknown isolate"}
 				</li>
 			);
@@ -57,11 +57,11 @@ export default function OtuIssues({ isolates, issues }: OtuIssuesProps) {
 	// One or more sequence documents have no sequence field.
 	if (typeof issues === "object" && issues.empty_sequence) {
 		// Make a list of sequences that have no defined sequence field.
-		const emptySequences = issues.empty_sequence.map((errorObject, index) => {
+		const emptySequences = issues.empty_sequence.map((errorObject) => {
 			// Get the entire isolate object identified by the isolate_id.
 			const isolate = isolates.find((i) => i.id === errorObject.isolate_id);
 			return (
-				<li key={index}>
+				<li key={errorObject._id}>
 					<span>
 						<em>{errorObject._id}</em> in isolate{" "}
 						<em>{isolate ? formatIsolateName(isolate) : "Unknown isolate"}</em>

--- a/apps/web/src/otus/components/OtuIssues.tsx
+++ b/apps/web/src/otus/components/OtuIssues.tsx
@@ -7,7 +7,7 @@ type OtuIssuesProps = {
 	/** The isolates associated with the OTU */
 	isolates: OtuIsolate[];
 	/** The issues that occurred */
-	issues: OtuIssueReport | boolean;
+	issues: OtuIssueReport | boolean | null;
 };
 
 /**
@@ -17,14 +17,14 @@ export default function OtuIssues({ isolates, issues }: OtuIssuesProps) {
 	const errors: ReactNode[] = [];
 
 	// The OTU has no isolates associated with it.
-	if (typeof issues === "object" && issues.empty_otu) {
+	if (issues && typeof issues === "object" && issues.empty_otu) {
 		errors.push(
 			<li key="emptyOTU">There are no isolates associated with this OTU</li>,
 		);
 	}
 
 	// The OTU has an inconsistent number of sequences between isolates.
-	if (typeof issues === "object" && issues.isolate_inconsistency) {
+	if (issues && typeof issues === "object" && issues.isolate_inconsistency) {
 		errors.push(
 			<li key="isolateInconsistency">
 				Some isolates have different numbers of sequences than other isolates
@@ -33,7 +33,7 @@ export default function OtuIssues({ isolates, issues }: OtuIssuesProps) {
 	}
 
 	// One or more isolates have no sequences associated with them.
-	if (typeof issues === "object" && issues.empty_isolate) {
+	if (issues && typeof issues === "object" && issues.empty_isolate) {
 		// The empty_isolate property is an array of isolate_ids of empty isolates.
 		const emptyIsolates = issues.empty_isolate.map((isolateId) => {
 			// Get the entire isolate identified by isolate_id from the detail data.
@@ -55,7 +55,7 @@ export default function OtuIssues({ isolates, issues }: OtuIssuesProps) {
 	}
 
 	// One or more sequence documents have no sequence field.
-	if (typeof issues === "object" && issues.empty_sequence) {
+	if (issues && typeof issues === "object" && issues.empty_sequence) {
 		// Make a list of sequences that have no defined sequence field.
 		const emptySequences = issues.empty_sequence.map((errorObject) => {
 			// Get the entire isolate object identified by the isolate_id.

--- a/apps/web/src/otus/components/__tests__/CreateOTU.test.tsx
+++ b/apps/web/src/otus/components/__tests__/CreateOTU.test.tsx
@@ -11,7 +11,7 @@ import { mockApiCreateOTU } from "../../../tests/fake/otus";
 import OtuCreate from "../OtuCreate";
 
 describe("<OtuCreate />", () => {
-	let reference;
+	let reference: ReturnType<typeof createFakeReference>;
 
 	beforeEach(() => {
 		reference = createFakeReference();

--- a/apps/web/src/otus/components/__tests__/OtuIssues.test.tsx
+++ b/apps/web/src/otus/components/__tests__/OtuIssues.test.tsx
@@ -1,13 +1,12 @@
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@tests/setup";
+import type { ComponentProps } from "react";
 import { describe, expect, it } from "vitest";
 import OtuIssues from "../OtuIssues";
 
 describe("<OTUIssues />", () => {
-	let props;
-
 	it("renders correctly without issues", () => {
-		props = {
+		const props: ComponentProps<typeof OtuIssues> = {
 			issues: {
 				empty_otu: false,
 				isolate_inconsistency: false,
@@ -26,7 +25,7 @@ describe("<OTUIssues />", () => {
 	});
 
 	it("renders correctly with issues", () => {
-		props = {
+		const props = {
 			issues: {
 				empty_otu: true,
 				isolate_inconsistency: true,
@@ -40,7 +39,9 @@ describe("<OTUIssues />", () => {
 			},
 			isolates: [
 				{
+					default: false,
 					id: "test-isolate",
+					sequences: [],
 					source_type: "isolate",
 					source_name: "test",
 				},

--- a/apps/web/src/otus/components/__tests__/OtuIssues.test.tsx
+++ b/apps/web/src/otus/components/__tests__/OtuIssues.test.tsx
@@ -25,7 +25,7 @@ describe("<OTUIssues />", () => {
 	});
 
 	it("renders correctly with issues", () => {
-		const props = {
+		const props: ComponentProps<typeof OtuIssues> = {
 			issues: {
 				empty_otu: true,
 				isolate_inconsistency: true,

--- a/apps/web/src/otus/components/__tests__/OtuRemove.test.tsx
+++ b/apps/web/src/otus/components/__tests__/OtuRemove.test.tsx
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import OtuRemove from "../OtuRemove";
 
 describe("<OtuRemove />", () => {
-	let otu;
+	let otu: ReturnType<typeof createFakeOtu>;
 
 	beforeEach(() => {
 		otu = createFakeOtu();

--- a/apps/web/src/otus/components/__tests__/OtuToolbar.test.tsx
+++ b/apps/web/src/otus/components/__tests__/OtuToolbar.test.tsx
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import OtuToolbar from "../OtuToolbar";
 
 describe("<OtuToolbar />", () => {
-	let reference;
+	let reference: ReturnType<typeof createFakeReference>;
 
 	beforeEach(() => {
 		reference = createFakeReference();

--- a/apps/web/src/otus/types.ts
+++ b/apps/web/src/otus/types.ts
@@ -88,6 +88,24 @@ export type OtuNested = {
 	version: number;
 };
 
+/** A sequence record reported as missing its sequence field */
+export type OtuEmptySequence = {
+	_id: string;
+	isolate_id: string;
+};
+
+/** Validation issues that must be resolved before an OTU can be built into an index */
+export type OtuIssueReport = {
+	/** The ids of isolates that have no sequences, or false when there are none */
+	empty_isolate?: string[] | false;
+	/** Whether the OTU has no isolates associated with it */
+	empty_otu?: boolean;
+	/** Sequence records that have no defined sequence field, or false when there are none */
+	empty_sequence?: OtuEmptySequence[] | false;
+	/** Whether isolates have inconsistent numbers of sequences */
+	isolate_inconsistency?: boolean;
+};
+
 /** Basic data for list representations */
 export type OtuMinimal = OtuNested & {
 	abbreviation: string;
@@ -98,7 +116,7 @@ export type OtuMinimal = OtuNested & {
 /** A complete OTU */
 export type Otu = OtuMinimal & {
 	isolates: Array<OtuIsolate>;
-	issues?: { [key: string]: any } | boolean | null;
+	issues?: OtuIssueReport | boolean | null;
 	last_indexed_version?: number | null;
 	most_recent_change: HistoryNested;
 	schema: Array<OtuSegment>;

--- a/apps/web/src/references/components/Detail/__tests__/ArchivedReferenceDetailHeader.test.tsx
+++ b/apps/web/src/references/components/Detail/__tests__/ArchivedReferenceDetailHeader.test.tsx
@@ -5,13 +5,14 @@ import {
 	mockApiGetReferenceDetail,
 } from "@tests/fake/references";
 import { renderWithRouter } from "@tests/setup";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import ArchivedReferenceDetailHeader from "../ArchivedReferenceDetailHeader";
 
 describe("<ArchivedReferenceDetailHeader />", () => {
-	let props;
-	let reference;
-	let path;
+	let props: ComponentProps<typeof ArchivedReferenceDetailHeader>;
+	let reference: ReturnType<typeof createFakeReference>;
+	let path: string;
 
 	beforeEach(() => {
 		reference = createFakeReference({ archived: true });

--- a/apps/web/src/references/components/Detail/__tests__/MemberRight.test.tsx
+++ b/apps/web/src/references/components/Detail/__tests__/MemberRight.test.tsx
@@ -1,11 +1,12 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@tests/setup";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ReferenceRight } from "../ReferenceRight";
 
 describe("<ReferenceRight />", () => {
-	let props;
+	let props: ComponentProps<typeof ReferenceRight>;
 
 	beforeEach(() => {
 		props = {

--- a/apps/web/src/references/components/Detail/__tests__/ReferenceDetailHeader.test.tsx
+++ b/apps/web/src/references/components/Detail/__tests__/ReferenceDetailHeader.test.tsx
@@ -5,13 +5,14 @@ import {
 	mockApiGetReferenceDetail,
 } from "@tests/fake/references";
 import { renderWithRouter } from "@tests/setup";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import ReferenceDetailHeader from "../ReferenceDetailHeader";
 
 describe("<ReferenceDetailHeaderIcon />", () => {
-	let props;
-	let reference;
-	let path;
+	let props: ComponentProps<typeof ReferenceDetailHeader>;
+	let reference: ReturnType<typeof createFakeReference>;
+	let path: string;
 
 	beforeEach(() => {
 		reference = createFakeReference();

--- a/apps/web/src/references/components/Detail/__tests__/ReferenceManager.test.tsx
+++ b/apps/web/src/references/components/Detail/__tests__/ReferenceManager.test.tsx
@@ -12,7 +12,9 @@ describe("<ReferenceManager />", () => {
 	let path: string;
 
 	beforeEach(() => {
-		reference = createFakeReference();
+		reference = createFakeReference({
+			cloned_from: { id: "source-ref", name: "Source Reference Name" },
+		});
 		path = `/refs/${reference.id}/manage`;
 		mockApiGetReferenceDetail(reference);
 	});
@@ -38,13 +40,11 @@ describe("<ReferenceManager />", () => {
 		expect(screen.queryByText("Remote Reference")).toBeNull();
 	});
 
-	it("should render when [cloned_from={ Bar: 'Bee' }]", async () => {
+	it("should render clone source when [cloned_from] is set", async () => {
 		await renderRoute(path);
 
 		expect(await screen.findByText("Clone Reference")).toBeInTheDocument();
 		expect(screen.getByText("Source Reference"));
-		expect(
-			screen.getByText(reference.cloned_from?.name ?? ""),
-		).toBeInTheDocument();
+		expect(screen.getByText("Source Reference Name")).toBeInTheDocument();
 	});
 });

--- a/apps/web/src/references/components/Detail/__tests__/ReferenceManager.test.tsx
+++ b/apps/web/src/references/components/Detail/__tests__/ReferenceManager.test.tsx
@@ -8,8 +8,8 @@ import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("<ReferenceManager />", () => {
-	let reference;
-	let path;
+	let reference: ReturnType<typeof createFakeReference>;
+	let path: string;
 
 	beforeEach(() => {
 		reference = createFakeReference();
@@ -43,6 +43,8 @@ describe("<ReferenceManager />", () => {
 
 		expect(await screen.findByText("Clone Reference")).toBeInTheDocument();
 		expect(screen.getByText("Source Reference"));
-		expect(screen.getByText(reference.cloned_from.name)).toBeInTheDocument();
+		expect(
+			screen.getByText(reference.cloned_from?.name ?? ""),
+		).toBeInTheDocument();
 	});
 });

--- a/apps/web/src/references/components/ReferenceForm.tsx
+++ b/apps/web/src/references/components/ReferenceForm.tsx
@@ -26,16 +26,13 @@ type ReferenceFormProps = {
  * Form input fields for organism, name and description
  */
 export function ReferenceForm({ errors, mode, register }: ReferenceFormProps) {
-	let organismComponent;
-
-	if (mode === "empty" || mode === "edit") {
-		organismComponent = (
+	const organismComponent =
+		mode === "empty" || mode === "edit" ? (
 			<InputGroup>
 				<InputLabel htmlFor="organism">Organism</InputLabel>
 				<InputSimple id="organism" {...register("organism")} />
 			</InputGroup>
-		);
-	}
+		) : null;
 
 	return (
 		<>

--- a/apps/web/src/references/components/__tests__/ReferenceForm.test.tsx
+++ b/apps/web/src/references/components/__tests__/ReferenceForm.test.tsx
@@ -1,16 +1,17 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@tests/setup";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ReferenceForm } from "../ReferenceForm";
+import { ReferenceForm, type ReferenceFormMode } from "../ReferenceForm";
 
 describe("<ReferenceForm />", () => {
-	let props;
+	let props: ComponentProps<typeof ReferenceForm>;
 
 	beforeEach(() => {
 		props = {
-			errors: { name: { message: "Required Field" } },
-			mode: "clone",
+			errors: { name: { type: "required", message: "Required Field" } },
+			mode: "clone" as unknown as ReferenceFormMode,
 			register: vi.fn(),
 		};
 	});

--- a/apps/web/src/references/components/__tests__/ReferenceForm.test.tsx
+++ b/apps/web/src/references/components/__tests__/ReferenceForm.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@tests/setup";
 import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ReferenceForm, type ReferenceFormMode } from "../ReferenceForm";
+import { ReferenceForm } from "../ReferenceForm";
 
 describe("<ReferenceForm />", () => {
 	let props: ComponentProps<typeof ReferenceForm>;
@@ -11,19 +11,9 @@ describe("<ReferenceForm />", () => {
 	beforeEach(() => {
 		props = {
 			errors: { name: { type: "required", message: "Required Field" } },
-			mode: "clone" as unknown as ReferenceFormMode,
+			mode: "empty",
 			register: vi.fn(),
 		};
-	});
-
-	it("should render", () => {
-		renderWithProviders(<ReferenceForm {...props} />);
-
-		expect(screen.getByRole("textbox", { name: "Name" })).toBeInTheDocument();
-		expect(
-			screen.getByRole("textbox", { name: "Description" }),
-		).toBeInTheDocument();
-		expect(screen.queryByRole("textbox", { name: "Organism" })).toBeNull();
 	});
 
 	it("should render Organism when [mode=edit]", () => {

--- a/apps/web/src/references/components/__tests__/ReferenceItem.test.tsx
+++ b/apps/web/src/references/components/__tests__/ReferenceItem.test.tsx
@@ -3,16 +3,17 @@ import { createFakeAccount, mockApiGetAccount } from "@tests/fake/account";
 import { createFakePermissions } from "@tests/fake/permissions";
 import { createFakeReferenceMinimal } from "@tests/fake/references";
 import { renderWithRouter } from "@tests/setup";
-import { beforeEach, describe, expect, it } from "vitest";
+import type { ComponentProps } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ReferenceItem } from "../ReferenceItem";
 
 describe("<ReferenceItem />", () => {
-	let props;
+	let props: ComponentProps<typeof ReferenceItem>;
 
 	beforeEach(() => {
 		props = {
-			reference: {},
-			task: {},
+			onClone: vi.fn(),
+			reference: createFakeReferenceMinimal(),
 		};
 	});
 

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -9,10 +9,13 @@ export function getRouter() {
 	const queryClient = new QueryClient({
 		defaultOptions: {
 			queries: {
-				retry: (failureCount: number, error: any) => {
+				retry: (
+					failureCount: number,
+					error: Error & { response?: { status?: number } },
+				) => {
 					// Superagent (legacy Python API) errors carry the HTTP status here.
 					const status = error.response?.status;
-					if ([401, 403, 404].includes(status)) {
+					if (status !== undefined && [401, 403, 404].includes(status)) {
 						return false;
 					}
 					// TanStack Start server-function errors cross the boundary as plain

--- a/apps/web/src/samples/components/Create/__tests__/SampleUserGroup.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/SampleUserGroup.test.tsx
@@ -1,14 +1,16 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { createFakeGroupMinimal } from "@tests/fake/groups";
 import { renderWithProviders } from "@tests/setup";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import SampleUserGroup from "../SampleUserGroup";
 
 describe("SampleUserGroup", () => {
-	let props;
+	let props: ComponentProps<typeof SampleUserGroup>;
 	beforeEach(() => {
 		props = {
-			groups: [{ name: "bar", id: "bar_id" }],
+			groups: [createFakeGroupMinimal({ name: "bar" })],
 			onChange: vi.fn(),
 			selected: "",
 		};

--- a/apps/web/src/samples/components/Detail/__tests__/DeleteSample.test.tsx
+++ b/apps/web/src/samples/components/Detail/__tests__/DeleteSample.test.tsx
@@ -1,12 +1,14 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { createFakeJobNested } from "@tests/fake/jobs";
 import { mockApiRemoveSample } from "@tests/fake/samples";
 import { renderWithRouter } from "@tests/setup";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import DeleteSample from "../DeleteSample";
 
 describe("<DeleteSample />", () => {
-	let props;
+	let props: ComponentProps<typeof DeleteSample>;
 
 	beforeEach(() => {
 		props = {
@@ -24,7 +26,11 @@ describe("<DeleteSample />", () => {
 
 	it("should render delete button when sample has failed job", async () => {
 		await renderWithRouter(
-			<DeleteSample {...props} job={{ state: "failed" }} ready={false} />,
+			<DeleteSample
+				{...props}
+				job={createFakeJobNested({ state: "failed" })}
+				ready={false}
+			/>,
 		);
 
 		expect(screen.getByRole("button")).toBeInTheDocument();
@@ -32,7 +38,11 @@ describe("<DeleteSample />", () => {
 
 	it("does not render when sample has running job", async () => {
 		await renderWithRouter(
-			<DeleteSample {...props} ready={false} job={{ state: "running" }} />,
+			<DeleteSample
+				{...props}
+				ready={false}
+				job={createFakeJobNested({ state: "running" })}
+			/>,
 		);
 
 		expect(screen.queryByRole("button")).toBeNull();

--- a/apps/web/src/samples/components/Detail/__tests__/SampleFileSizeWarning.test.tsx
+++ b/apps/web/src/samples/components/Detail/__tests__/SampleFileSizeWarning.test.tsx
@@ -1,11 +1,12 @@
 import { screen } from "@testing-library/react";
 import { createFakeSampleRead } from "@tests/fake/samples";
 import { renderWithRouter } from "@tests/setup";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import SampleFileSizeWarning from "../SampleFileSizeWarning";
 
 describe("<SampleFileSizeWarning />", () => {
-	let props;
+	let props: ComponentProps<typeof SampleFileSizeWarning>;
 
 	beforeEach(() => {
 		props = {

--- a/apps/web/src/samples/components/Detail/__tests__/SampleRights.test.tsx
+++ b/apps/web/src/samples/components/Detail/__tests__/SampleRights.test.tsx
@@ -14,8 +14,8 @@ import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("<SampleRights />", () => {
-	let sample;
-	let group;
+	let sample: ReturnType<typeof createFakeSample>;
+	let group: ReturnType<typeof createFakeGroup>;
 
 	beforeEach(() => {
 		sample = createFakeSample({

--- a/apps/web/src/samples/components/Item/SampleItem.tsx
+++ b/apps/web/src/samples/components/Item/SampleItem.tsx
@@ -43,8 +43,12 @@ export default function SampleItem({
 
 	return (
 		<Box className="flex items-stretch basis-0 gap-4">
-			<div className="cursor-pointer flex" onClick={handleSelect}>
-				<Checkbox checked={checked} id={`SampleCheckbox${sample.id}`} />
+			<div className="flex">
+				<Checkbox
+					checked={checked}
+					id={`SampleCheckbox${sample.id}`}
+					onClick={handleSelect}
+				/>
 			</div>
 
 			<div className="flex flex-1 flex-col min-w-0">

--- a/apps/web/src/samples/components/SampleRights.tsx
+++ b/apps/web/src/samples/components/SampleRights.tsx
@@ -37,8 +37,8 @@ export default function SampleRights({ settings }: SampleRightsProps) {
 		(sample_group_read ? "r" : "") + (sample_group_write ? "w" : "");
 	const all = (sample_all_read ? "r" : "") + (sample_all_write ? "w" : "");
 
-	const options = rights.map((entry, index) => (
-		<option key={index} value={entry.value}>
+	const options = rights.map((entry) => (
+		<option key={entry.value} value={entry.value}>
 			{entry.label}
 		</option>
 	));

--- a/apps/web/src/samples/components/Sidebar/__tests__/ManageLabels.test.tsx
+++ b/apps/web/src/samples/components/Sidebar/__tests__/ManageLabels.test.tsx
@@ -1,7 +1,9 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { createFakeSampleMinimal } from "@tests/fake/samples";
 import { renderWithRouter } from "@tests/setup";
 import nock from "nock";
+import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import ManageLabels from "../ManageLabels";
 
@@ -23,15 +25,15 @@ function mockApiUpdateSampleLabels(sampleId: string) {
 }
 
 describe("<ManageLabels>", () => {
-	let props;
+	let props: ComponentProps<typeof ManageLabels>;
 
 	beforeEach(() => {
 		props = {
 			selectedSamples: [],
 			labels: [
-				{ color: "#C4B5FD", description: "", id: 1, name: "test" },
-				{ color: "#FCA5A5", description: "", id: 2, name: "label" },
-				{ color: "#1D4ED8", description: "", id: 3, name: "bar" },
+				{ color: "#C4B5FD", count: 0, description: "", id: 1, name: "test" },
+				{ color: "#FCA5A5", count: 0, description: "", id: 2, name: "label" },
+				{ color: "#1D4ED8", count: 0, description: "", id: 3, name: "bar" },
 			],
 		};
 	});
@@ -48,11 +50,11 @@ describe("<ManageLabels>", () => {
 
 	it("should display labels of one selected sample", async () => {
 		props.selectedSamples = [
-			{
+			createFakeSampleMinimal({
 				name: "Foo Sample",
 				id: "foo_sample",
 				labels: [{ color: "#C4B5FD", description: "", id: 1, name: "test" }],
-			},
+			}),
 		];
 		await renderWithRouter(<ManageLabels {...props} />);
 		await waitFor(() =>
@@ -64,16 +66,16 @@ describe("<ManageLabels>", () => {
 
 	it("should display labels of two selected samples", async () => {
 		props.selectedSamples = [
-			{
+			createFakeSampleMinimal({
 				name: "Foo Sample",
 				id: "foo_sample",
 				labels: [{ color: "#C4B5FD", description: "", id: 1, name: "test" }],
-			},
-			{
+			}),
+			createFakeSampleMinimal({
 				name: "Sample",
 				id: "sample",
 				labels: [{ color: "#FCA5A5", description: "", id: 2, name: "label" }],
-			},
+			}),
 		];
 		await renderWithRouter(<ManageLabels {...props} />);
 		await waitFor(() =>
@@ -91,19 +93,19 @@ describe("<ManageLabels>", () => {
 			// "test" (id 1) is on both samples, "label" (id 2) is on one only, so
 			// the selection has labels in mixed states.
 			props.selectedSamples = [
-				{
+				createFakeSampleMinimal({
 					name: "Foo Sample",
 					id: "foo_sample",
 					labels: [
 						{ color: "#C4B5FD", description: "", id: 1, name: "test" },
 						{ color: "#FCA5A5", description: "", id: 2, name: "label" },
 					],
-				},
-				{
+				}),
+				createFakeSampleMinimal({
 					name: "Bar Sample",
 					id: "bar_sample",
 					labels: [{ color: "#C4B5FD", description: "", id: 1, name: "test" }],
-				},
+				}),
 			];
 		});
 

--- a/apps/web/src/samples/components/__tests__/EditSample.test.tsx
+++ b/apps/web/src/samples/components/__tests__/EditSample.test.tsx
@@ -2,12 +2,13 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeSample, mockApiEditSample } from "@tests/fake/samples";
 import { renderWithRouter } from "@tests/setup";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import EditSample from "../EditSample";
 
 describe("<Editsample />", () => {
-	let sample;
-	let props;
+	let sample: ReturnType<typeof createFakeSample>;
+	let props: ComponentProps<typeof EditSample>;
 
 	beforeEach(() => {
 		sample = createFakeSample();

--- a/apps/web/src/sequences/components/Sequences.tsx
+++ b/apps/web/src/sequences/components/Sequences.tsx
@@ -57,14 +57,14 @@ export default function Sequences({
 
 	return (
 		<>
-			<label className="flex items-center font-medium">
+			<div className="flex items-center font-medium">
 				<strong className="text-base pr-1">Sequences</strong>
 				<Badge>{sequences.length}</Badge>
 				<CreateSequenceLink
 					onCreate={() => setOpenCreate(true)}
 					refId={reference.id}
 				/>
-			</label>
+			</div>
 
 			<BoxGroup>{sequenceComponents}</BoxGroup>
 

--- a/apps/web/src/sequences/components/__tests__/CreateSequence.test.tsx
+++ b/apps/web/src/sequences/components/__tests__/CreateSequence.test.tsx
@@ -8,8 +8,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import CreateSequence from "../CreateSequence";
 
 describe("<CreateSequence>", () => {
-	let otu;
-	let reference;
+	let otu: ReturnType<typeof createFakeOtu>;
+	let reference: ReturnType<typeof createFakeReference>;
 
 	function renderCreateSequence(setOpen = vi.fn()) {
 		return renderWithProviders(

--- a/apps/web/src/sequences/components/__tests__/EditSequence.test.tsx
+++ b/apps/web/src/sequences/components/__tests__/EditSequence.test.tsx
@@ -10,7 +10,7 @@ describe("<SequenceEdit>", () => {
 	const isolateId = "test_isolate_id";
 	const otuId = "test_otu_id";
 	const refId = "test_ref_id";
-	let activeSequence;
+	let activeSequence: ReturnType<typeof createFakeOTUSequence>;
 
 	function renderSequenceEdit(setOpen = vi.fn()) {
 		return renderWithProviders(

--- a/apps/web/src/sequences/components/__tests__/RemoveSequence.test.tsx
+++ b/apps/web/src/sequences/components/__tests__/RemoveSequence.test.tsx
@@ -7,10 +7,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import RemoveSequence from "../RemoveSequence";
 
 describe("<RemoveSequence />", () => {
-	let otu;
-	let isolate;
-	let sequence;
-	let isolateName;
+	let otu: ReturnType<typeof createFakeOtu>;
+	let isolate: ReturnType<typeof createFakeOtu>["isolates"][number];
+	let sequence: (typeof isolate)["sequences"][number];
+	let isolateName: string;
 
 	beforeEach(() => {
 		otu = createFakeOtu();

--- a/apps/web/src/subtraction/components/Detail/EditSubtraction.tsx
+++ b/apps/web/src/subtraction/components/Detail/EditSubtraction.tsx
@@ -8,7 +8,7 @@ import { useUpdateSubtraction } from "@subtraction/queries";
 import type { Subtraction } from "@subtraction/types";
 import { useForm } from "react-hook-form";
 
-type EditSubtractionProps = {
+export type EditSubtractionProps = {
 	/** The subtraction data */
 	subtraction: Subtraction;
 	/** Indicates whether the modal for editing a subtraction is visible */

--- a/apps/web/src/subtraction/components/Detail/RemoveSubtraction.tsx
+++ b/apps/web/src/subtraction/components/Detail/RemoveSubtraction.tsx
@@ -3,7 +3,7 @@ import { useRemoveSubtraction } from "@subtraction/queries";
 import type { Subtraction } from "@subtraction/types";
 import { useNavigate } from "@tanstack/react-router";
 
-type RemoveSubtractionProps = {
+export type RemoveSubtractionProps = {
 	/** The subtraction data */
 	subtraction: Subtraction;
 	/** Indicates whether the modal for removing a subtraction is visible */

--- a/apps/web/src/subtraction/components/Detail/__tests__/EditSubtraction.test.tsx
+++ b/apps/web/src/subtraction/components/Detail/__tests__/EditSubtraction.test.tsx
@@ -6,11 +6,11 @@ import {
 } from "@tests/fake/subtractions";
 import { renderWithProviders } from "@tests/setup";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import EditSubtraction from "../EditSubtraction";
+import EditSubtraction, { type EditSubtractionProps } from "../EditSubtraction";
 
 describe("<EditSubtraction />", () => {
 	const subtraction = createFakeSubtraction();
-	let props;
+	let props: EditSubtractionProps;
 
 	beforeEach(() => {
 		props = {

--- a/apps/web/src/subtraction/components/Detail/__tests__/EditSubtraction.test.tsx
+++ b/apps/web/src/subtraction/components/Detail/__tests__/EditSubtraction.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
 	createFakeSubtraction,
@@ -79,7 +79,7 @@ describe("<EditSubtraction />", () => {
 	it("should call onHide() when closed", async () => {
 		renderWithProviders(<EditSubtraction {...props} />);
 
-		fireEvent.keyDown(document, { key: "Escape" });
+		await userEvent.keyboard("{Escape}");
 
 		await waitFor(() => expect(props.onHide).toHaveBeenCalled());
 	});

--- a/apps/web/src/subtraction/components/Detail/__tests__/RemoveSubtraction.test.tsx
+++ b/apps/web/src/subtraction/components/Detail/__tests__/RemoveSubtraction.test.tsx
@@ -6,11 +6,13 @@ import {
 } from "@tests/fake/subtractions";
 import { renderWithRouter } from "@tests/setup";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import RemoveSubtraction from "../RemoveSubtraction";
+import RemoveSubtraction, {
+	type RemoveSubtractionProps,
+} from "../RemoveSubtraction";
 
 describe("<RemoveSubtraction />", () => {
 	const subtraction = createFakeSubtraction();
-	let props;
+	let props: RemoveSubtractionProps;
 
 	beforeEach(() => {
 		props = {

--- a/apps/web/src/subtraction/components/Detail/__tests__/SubtractionDetail.test.tsx
+++ b/apps/web/src/subtraction/components/Detail/__tests__/SubtractionDetail.test.tsx
@@ -15,8 +15,8 @@ function formatSubtractionPath(subtraction: SubtractionMinimal) {
 }
 
 describe("<SubtractionDetail />", () => {
-	let subtraction;
-	let path;
+	let subtraction: ReturnType<typeof createFakeSubtraction>;
+	let path: string;
 
 	beforeEach(() => {
 		subtraction = createFakeSubtraction();

--- a/apps/web/src/subtraction/components/SubtractionFileItem.tsx
+++ b/apps/web/src/subtraction/components/SubtractionFileItem.tsx
@@ -24,7 +24,6 @@ type SubtractionFileItemProps = {
  */
 export function SubtractionFileItem({
 	active,
-	error,
 	id,
 	name,
 	onClick,

--- a/apps/web/src/tests/fake/analyses.ts
+++ b/apps/web/src/tests/fake/analyses.ts
@@ -2,7 +2,7 @@ import type {
 	Analysis,
 	AnalysisMinimal,
 	Blast,
-	FormattedNuvsResults,
+	FormattedNuvsAnalysis,
 	IimiAnalysis,
 	IimiCoverage,
 	IimiHit,
@@ -44,19 +44,15 @@ export function createFakeAnalysisMinimal(
 	};
 }
 
-type FakeFormattedNuVsAnalysis = FakeFormattedNuVsHit & {
-	results?: FormattedNuvsResults;
-};
-
 /**
  * Create a fake formatted nuvs analysis object
  *
  * @param overrides - optional properties for creating an fake formatted nuvs analysis with specific values
  */
 export function createFakeFormattedNuVsAnalysis(
-	overrides?: FakeFormattedNuVsAnalysis,
-) {
-	const defaultAnalysis = {
+	overrides?: Partial<FormattedNuvsAnalysis>,
+): FormattedNuvsAnalysis {
+	const defaultAnalysis: FormattedNuvsAnalysis = {
 		...createFakeAnalysisMinimal(),
 		files: [],
 		maxSequenceLength: faker.number.int({ min: 800, max: 20000 }),

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -5,7 +5,7 @@ export type ErrorResponse = {
 		statusText: string;
 		badRequest: boolean;
 		statusCode: number;
-		body: { [key: string]: any };
+		body: { message?: string; [key: string]: unknown };
 	};
 };
 

--- a/apps/web/src/uploads/components/__tests__/FileManager.test.tsx
+++ b/apps/web/src/uploads/components/__tests__/FileManager.test.tsx
@@ -10,7 +10,7 @@ import { FileManager, type FileManagerProps } from "../FileManager";
 
 describe("<FileManager>", () => {
 	let props: FileManagerProps;
-	let path;
+	let path: string;
 
 	afterEach(() => {
 		vi.restoreAllMocks();

--- a/apps/web/src/uploads/uploader.ts
+++ b/apps/web/src/uploads/uploader.ts
@@ -101,7 +101,7 @@ export function upload(file: File, fileType: UploadType) {
 	apiClient
 		.post("/uploads")
 		.query({ name: file.name, type: fileType })
-		.attach("file", file as any)
+		.attach("file", file)
 		.on("progress", onProgress)
 		.then(() => useUploaderStore.getState().removeUpload(localId))
 		.catch(() => useUploaderStore.getState().setFailure(localId));

--- a/apps/web/src/users/components/PrimaryGroup.tsx
+++ b/apps/web/src/users/components/PrimaryGroup.tsx
@@ -5,7 +5,7 @@ import InputSelect from "@base/InputSelect";
 import type { GroupMinimal } from "@groups/types";
 import { capitalize } from "es-toolkit/string";
 
-type PrimaryGroupProps = {
+export type PrimaryGroupProps = {
 	/** The groups associated with the user */
 	groups: GroupMinimal[];
 	/** The users unique id */

--- a/apps/web/src/users/components/UserGroup.tsx
+++ b/apps/web/src/users/components/UserGroup.tsx
@@ -1,7 +1,7 @@
 import Checkbox from "@base/Checkbox";
 import SelectBoxGroupSection from "@base/SelectBoxGroupSection";
 
-type UserGroupTypes = {
+export type UserGroupTypes = {
 	/** The group unique id */
 	id: string | number;
 

--- a/apps/web/src/users/components/__tests__/PrimaryGroup.test.tsx
+++ b/apps/web/src/users/components/__tests__/PrimaryGroup.test.tsx
@@ -4,20 +4,20 @@ import { mockApiEditUser } from "@tests/api/users";
 import { createFakeUser } from "@tests/fake/user";
 import { renderWithProviders } from "@tests/setup";
 import { beforeEach, describe, expect, it } from "vitest";
-import PrimaryGroup from "../PrimaryGroup";
+import PrimaryGroup, { type PrimaryGroupProps } from "../PrimaryGroup";
 
 describe("<PrimaryGroup />", () => {
-	let props;
+	let props: PrimaryGroupProps;
 
 	beforeEach(() => {
 		props = {
 			groups: [
-				{ id: "1", name: "foo" },
-				{ id: "2", name: "bar" },
-				{ id: "3", name: "baz" },
+				{ id: 1, legacy_id: null, name: "foo" },
+				{ id: 2, legacy_id: null, name: "bar" },
+				{ id: 3, legacy_id: null, name: "baz" },
 			],
-			id: "bob",
-			primaryGroup: { id: "2", name: "bar" },
+			id: 1,
+			primaryGroup: { id: 2, legacy_id: null, name: "bar" },
 		};
 	});
 

--- a/apps/web/src/users/components/__tests__/PrimaryGroup.test.tsx
+++ b/apps/web/src/users/components/__tests__/PrimaryGroup.test.tsx
@@ -66,7 +66,7 @@ describe("<PrimaryGroup />", () => {
 		const scope = mockApiEditUser(
 			props.id,
 			200,
-			{ primary_group: { id: "1", name: "foo" } },
+			{ primary_group: { id: 1, name: "foo" } },
 			userDetails,
 		);
 		renderWithProviders(<PrimaryGroup {...props} />);

--- a/apps/web/src/users/components/__tests__/UserGroup.test.tsx
+++ b/apps/web/src/users/components/__tests__/UserGroup.test.tsx
@@ -2,10 +2,10 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@tests/setup";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { UserGroup } from "../UserGroup";
+import { UserGroup, type UserGroupTypes } from "../UserGroup";
 
 describe("<UserGroup />", () => {
-	let props;
+	let props: UserGroupTypes;
 
 	beforeEach(() => {
 		props = {

--- a/biome.json
+++ b/biome.json
@@ -27,31 +27,31 @@
 						}
 					}
 				},
-				"useLiteralEnumMembers": "warn"
+				"useLiteralEnumMembers": "error"
 			},
 			"suspicious": {
-				"noImplicitAnyLet": "warn",
-				"noExplicitAny": "warn",
-				"noArrayIndexKey": "warn",
-				"useIterableCallbackReturn": "warn",
-				"noShadowRestrictedNames": "warn",
-				"noGlobalAssign": "warn"
+				"noImplicitAnyLet": "error",
+				"noExplicitAny": "error",
+				"noArrayIndexKey": "error",
+				"useIterableCallbackReturn": "error",
+				"noShadowRestrictedNames": "error",
+				"noGlobalAssign": "error"
 			},
 			"correctness": {
-				"noUnusedVariables": "warn",
-				"noUnusedFunctionParameters": "warn",
-				"noInvalidPositionAtImportRule": "warn"
+				"noUnusedVariables": "error",
+				"noUnusedFunctionParameters": "error",
+				"noInvalidPositionAtImportRule": "error"
 			},
 			"security": {
-				"noDangerouslySetInnerHtml": "warn"
+				"noDangerouslySetInnerHtml": "error"
 			},
 			"a11y": {
-				"noLabelWithoutControl": "warn",
-				"noSvgWithoutTitle": "warn",
-				"noStaticElementInteractions": "warn",
-				"useValidAnchor": "warn",
-				"useKeyWithClickEvents": "warn",
-				"useHtmlLang": "warn"
+				"noLabelWithoutControl": "error",
+				"noSvgWithoutTitle": "error",
+				"noStaticElementInteractions": "error",
+				"useValidAnchor": "error",
+				"useKeyWithClickEvents": "error",
+				"useHtmlLang": "error"
 			}
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"packageManager": "pnpm@11.1.3",
 	"scripts": {
 		"build": "pnpm --filter @virtool/web build",
-		"check": "biome check apps/web/src packages",
+		"check": "biome check --error-on-warnings apps/web/src packages",
 		"develop": "pnpm --filter @virtool/web develop",
 		"format": "biome check --write apps/web/src packages",
 		"test": "pnpm -r test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,12 @@ importers:
       react-hook-form:
         specifier: ^7.77.0
         version: 7.77.0(react@19.2.7)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.16)(react@19.2.7)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       superagent:
         specifier: ^8.0.9
         version: 8.1.2
@@ -2109,6 +2115,9 @@ packages:
   '@types/d3@7.4.3':
     resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -2118,14 +2127,26 @@ packages:
   '@types/dockerode@4.0.1':
     resolution: {integrity: sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
@@ -2155,6 +2176,15 @@ packages:
 
   '@types/superagent@8.1.9':
     resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@vitejs/plugin-react@6.0.2':
     resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
@@ -2303,6 +2333,9 @@ packages:
   babel-plugin-react-compiler@1.0.0:
     resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2416,9 +2449,24 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -2451,6 +2499,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -2683,6 +2734,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
@@ -2700,6 +2754,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -2892,6 +2949,13 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -2912,6 +2976,9 @@ packages:
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
@@ -3032,6 +3099,12 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   history@5.3.0:
     resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
 
@@ -3041,6 +3114,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -3067,13 +3143,32 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -3219,6 +3314,9 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -3249,6 +3347,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marked@18.0.5:
     resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
     engines: {node: '>= 20'}
@@ -3258,12 +3359,141 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -3427,6 +3657,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
@@ -3511,6 +3744,9 @@ packages:
     resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
     engines: {node: '>=18'}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   protobufjs@7.6.1:
     resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
     engines: {node: '>=12.0.0'}
@@ -3570,6 +3806,12 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -3633,6 +3875,18 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3753,6 +4007,9 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   split-ca@1.0.1:
     resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
 
@@ -3800,6 +4057,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -3811,6 +4071,12 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   superagent@8.1.2:
     resolution: {integrity: sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==}
@@ -3893,6 +4159,12 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -3923,6 +4195,24 @@ packages:
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   unplugin@3.0.0:
     resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
@@ -4035,6 +4325,12 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -4233,6 +4529,9 @@ packages:
         optional: true
       use-sync-external-store:
         optional: true
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -6167,6 +6466,10 @@ snapshots:
       '@types/d3-transition': 3.0.9
       '@types/d3-zoom': 3.0.8
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/docker-modem@3.0.6':
@@ -6180,11 +6483,25 @@ snapshots:
       '@types/node': 25.9.1
       '@types/ssh2': 1.15.5
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
   '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/methods@1.1.4': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@18.19.130':
     dependencies:
@@ -6225,6 +6542,12 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/node': 25.8.0
       form-data: 4.0.5
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.1': {}
 
   '@vitejs/plugin-react@6.0.2(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
@@ -6373,6 +6696,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -6479,7 +6804,17 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chokidar@5.0.0:
     dependencies:
@@ -6510,6 +6845,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@7.2.0: {}
 
@@ -6736,6 +7073,10 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   delaunator@5.1.0:
     dependencies:
       robust-predicates: 3.0.3
@@ -6747,6 +7088,10 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dezalgo@1.0.4:
     dependencies:
@@ -6852,6 +7197,10 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -6869,6 +7218,8 @@ snapshots:
   expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
+
+  extend@3.0.2: {}
 
   fast-fifo@1.3.2: {}
 
@@ -6984,6 +7335,30 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   history@5.3.0:
     dependencies:
       '@babel/runtime': 7.29.2
@@ -6995,6 +7370,8 @@ snapshots:
       '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-url-attributes@3.0.1: {}
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -7022,9 +7399,24 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   internmap@2.0.3: {}
 
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-hexadecimal@2.0.1: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -7145,6 +7537,8 @@ snapshots:
 
   long@5.3.2: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -7169,13 +7563,359 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   marked@18.0.5: {}
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   mdn-data@2.27.1: {}
 
   methods@1.1.2: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   mime-db@1.52.0: {}
 
@@ -7323,6 +8063,16 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
@@ -7411,6 +8161,8 @@ snapshots:
       mkdirp: 3.0.1
     transitivePeerDependencies:
       - supports-color
+
+  property-information@7.2.0: {}
 
   protobufjs@7.6.1:
     dependencies:
@@ -7527,6 +8279,24 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-markdown@10.1.0(@types/react@19.2.16)(react@19.2.7):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.16
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.7
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.16)(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -7594,6 +8364,40 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 
@@ -7728,6 +8532,8 @@ snapshots:
 
   source-map@0.7.6: {}
 
+  space-separated-tokens@2.0.2: {}
+
   split-ca@1.0.1: {}
 
   split2@4.2.0: {}
@@ -7782,6 +8588,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -7793,6 +8604,14 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   superagent@8.1.2:
     dependencies:
@@ -7924,6 +8743,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   tslib@2.8.1: {}
 
   tweetnacl@0.14.5: {}
@@ -7943,6 +8766,39 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   unplugin@3.0.0:
     dependencies:
@@ -7983,6 +8839,16 @@ snapshots:
       react: 19.2.7
 
   util-deprecate@1.0.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
@@ -8122,3 +8988,5 @@ snapshots:
       '@types/react': 19.2.16
       react: 19.2.7
       use-sync-external-store: 1.6.0(react@19.2.7)
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

- Promote all warn-level Biome lint rules to `error` in `biome.json` so the `check-biome` CI step hard-fails on any violation instead of silently passing
- Add `--error-on-warnings` to the `pnpm check` invocation as an extra safety net
- Fix all existing warnings across the codebase (type safety, array index keys, accessibility gaps, XSS via `dangerouslySetInnerHTML`) to bring the check clean — replace `marked` + `dangerouslySetInnerHTML` in `Markdown.tsx` with `react-markdown` + `remark-gfm`, tighten `any` types to `unknown`, add proper ARIA roles/labels to SVG and interactive elements, and swap index-based React keys for stable IDs
- Update `AGENTS.md` to document that all Biome rules are now `error`-level and `pnpm check` must exit 0 before merging