### PR TITLE
fix: open create user dialog reliably

### DIFF
--- a/apps/web/src/routes/_authenticated/administration/users/index.tsx
+++ b/apps/web/src/routes/_authenticated/administration/users/index.tsx
@@ -6,7 +6,6 @@ import { z } from "zod";
 const searchSchema = z.object({
 	status: z.string().default("active").catch("active"),
 	page: z.number().default(1).catch(1),
-	openCreateUser: z.boolean().optional().catch(undefined),
 });
 
 export const Route = createFileRoute("/_authenticated/administration/users/")({
@@ -25,7 +24,6 @@ function UsersRoute() {
 
 	return (
 		<ManageUsers
-			openCreateUser={Boolean(search.openCreateUser)}
 			page={search.page}
 			setSearch={(next) => navigate({ search: { ...search, ...next } })}
 			status={search.status}

--- a/apps/web/src/users/components/CreateUser.tsx
+++ b/apps/web/src/users/components/CreateUser.tsx
@@ -6,6 +6,7 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@base/Dialog";
+import { useState } from "react";
 import { CreateUserForm } from "./CreateUserForm";
 
 type NewUser = {
@@ -17,18 +18,11 @@ type NewUser = {
 	forceReset: boolean;
 };
 
-type CreateUserProps = {
-	open?: boolean;
-	setOpen?: (open: boolean) => void;
-};
-
 /**
  * A dialog for creating a new user
  */
-export default function CreateUser({
-	open = false,
-	setOpen = () => {},
-}: CreateUserProps) {
+export default function CreateUser() {
+	const [open, setOpen] = useState(false);
 	const mutation = useCreateUser();
 
 	function handleSubmit({ handle, password, forceReset }: NewUser) {

--- a/apps/web/src/users/components/ManageUsers.tsx
+++ b/apps/web/src/users/components/ManageUsers.tsx
@@ -11,13 +11,8 @@ import CreateUser from "./CreateUser";
 import UsersList from "./UsersList";
 
 type ManageUsersProps = {
-	openCreateUser?: boolean;
 	page?: number;
-	setSearch?: (next: {
-		openCreateUser?: boolean;
-		page?: number;
-		status?: string;
-	}) => void;
+	setSearch?: (next: { page?: number; status?: string }) => void;
 	status?: string;
 };
 
@@ -25,7 +20,6 @@ type ManageUsersProps = {
  * Displays a list of editable users and tools for sorting through and creating users
  */
 export function ManageUsers({
-	openCreateUser = false,
 	page = 1,
 	setSearch = () => {},
 	status = "active",
@@ -56,10 +50,7 @@ export function ManageUsers({
 						<ToggleGroupItem value="active">Active</ToggleGroupItem>
 						<ToggleGroupItem value="deactivated">Deactivated</ToggleGroupItem>
 					</ToggleGroup>
-					<CreateUser
-						open={openCreateUser}
-						setOpen={(openCreateUser) => setSearch({ openCreateUser })}
-					/>
+					<CreateUser />
 				</Toolbar>
 
 				<UsersList

--- a/apps/web/src/users/components/__tests__/CreateUser.test.tsx
+++ b/apps/web/src/users/components/__tests__/CreateUser.test.tsx
@@ -3,22 +3,15 @@ import userEvent from "@testing-library/user-event";
 import { mockApiCreateUser } from "@tests/api/users";
 import { createFakeUser } from "@tests/fake/user";
 import { renderWithRouter } from "@tests/setup";
-import { useState } from "react";
 import { describe, expect, it } from "vitest";
 import CreateUser from "../CreateUser";
-
-function CreateUserHarness() {
-	const [open, setOpen] = useState(false);
-
-	return <CreateUser open={open} setOpen={setOpen} />;
-}
 
 describe("<CreateUser />", () => {
 	it("creates user once form is submitted", async () => {
 		const usernameInput = "Username";
 		const passwordInput = "Password";
 		const scope = mockApiCreateUser(createFakeUser({ handle: usernameInput }));
-		await renderWithRouter(<CreateUserHarness />);
+		await renderWithRouter(<CreateUser />);
 
 		await userEvent.click(screen.getByRole("button"));
 
@@ -36,7 +29,7 @@ describe("<CreateUser />", () => {
 	});
 
 	it("should render correct username error message", async () => {
-		await renderWithRouter(<CreateUserHarness />);
+		await renderWithRouter(<CreateUser />);
 		await userEvent.click(screen.getByRole("button"));
 
 		await userEvent.click(screen.getByRole("button", { name: "Save" }));


### PR DESCRIPTION
## Summary
- Moves the create user dialog open/close state from a URL search param (`openCreateUser`) to local React state (`useState`) inside the `CreateUser` component
- Removes the `open` and `setOpen` props from `CreateUser` and `openCreateUser` from `ManageUsers`, simplifying their interfaces
- Cleans up tests by removing the `CreateUserHarness` wrapper that was needed to manage the external open state

## Test plan
- [ ] Navigate to Administration > Users and verify the "Create User" button opens the dialog
- [ ] Submit the form to create a new user and confirm the dialog closes on success
- [ ] Confirm the URL does not change when opening/closing the create user dialog