### PR TITLE
fix: keep indexes URL clean when opening rebuild dialog

### DIFF
--- a/apps/web/src/indexes/components/Indexes.tsx
+++ b/apps/web/src/indexes/components/Indexes.tsx
@@ -14,7 +14,8 @@ const routeApi = getRouteApi("/_authenticated/refs/$refId/indexes/");
 type IndexesProps = {
 	openRebuild: boolean;
 	page: number;
-	setSearch: (next: { openRebuild?: boolean; page?: number }) => void;
+	setOpenRebuild: (open: boolean) => void;
+	setSearch: (next: { page?: number }) => void;
 };
 
 /**
@@ -23,6 +24,7 @@ type IndexesProps = {
 export default function Indexes({
 	openRebuild,
 	page,
+	setOpenRebuild,
 	setSearch,
 }: IndexesProps) {
 	const { refId } = routeApi.useParams();
@@ -38,11 +40,7 @@ export default function Indexes({
 	return (
 		<>
 			{!archived && <RebuildAlert page={page} refId={refId} />}
-			<RebuildIndex
-				open={openRebuild}
-				setOpen={(openRebuild) => setSearch({ openRebuild })}
-				refId={refId}
-			/>
+			<RebuildIndex open={openRebuild} setOpen={setOpenRebuild} refId={refId} />
 			{items.length ? (
 				<Pagination
 					items={items}

--- a/apps/web/src/indexes/components/RebuildAlert.tsx
+++ b/apps/web/src/indexes/components/RebuildAlert.tsx
@@ -45,7 +45,7 @@ export default function RebuildAlert({ page, refId }: RebuildAlertProps) {
 					<Link
 						to="/refs/$refId/indexes"
 						params={{ refId }}
-						search={{ openRebuild: true }}
+						state={{ openRebuild: true }}
 					>
 						Rebuild the index
 					</Link>

--- a/apps/web/src/routes/_authenticated/refs/$refId/indexes/index.tsx
+++ b/apps/web/src/routes/_authenticated/refs/$refId/indexes/index.tsx
@@ -1,10 +1,16 @@
 import Indexes from "@indexes/components/Indexes";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useLocation } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
 import { z } from "zod/v4";
+
+declare module "@tanstack/react-router" {
+	interface HistoryState {
+		openRebuild?: boolean;
+	}
+}
 
 const indexesSearchSchema = z.object({
 	page: z.number().default(1).catch(1),
-	openRebuild: z.boolean().optional().catch(undefined),
 });
 
 export const Route = createFileRoute("/_authenticated/refs/$refId/indexes/")({
@@ -15,11 +21,26 @@ export const Route = createFileRoute("/_authenticated/refs/$refId/indexes/")({
 function IndexesRoute() {
 	const search = Route.useSearch();
 	const navigate = Route.useNavigate();
+	const initialOpenRebuild = useLocation({
+		select: (location) => Boolean(location.state.openRebuild),
+	});
+	const [openRebuild, setOpenRebuild] = useState(initialOpenRebuild);
+
+	// Discard the deep-link intent so a refresh doesn't reopen the dialog.
+	useEffect(() => {
+		if (initialOpenRebuild) {
+			navigate({
+				replace: true,
+				state: (prev) => ({ ...prev, openRebuild: undefined }),
+			});
+		}
+	}, [initialOpenRebuild, navigate]);
 
 	return (
 		<Indexes
-			openRebuild={Boolean(search.openRebuild)}
+			openRebuild={openRebuild}
 			page={search.page}
+			setOpenRebuild={setOpenRebuild}
 			setSearch={(next) => navigate({ search: { ...search, ...next } })}
 		/>
 	);


### PR DESCRIPTION
Closes [VIR-2512](https://linear.app/virtool/issue/VIR-2512/switch-rebuild-index-dialog-from-search-param-to-history-state)

## Summary

- `openRebuild` was a boolean search param that leaked into the URL when `RebuildAlert` linked to the indexes page to open the rebuild dialog
- Switched to browser history state as a one-time trigger: `RebuildAlert` now passes `state={{ openRebuild: true }}` on its `<Link>`, and the route seeds local React state from `useLocation().state`
- The route immediately clears the state with a `replace` navigation so a page refresh does not reopen the dialog and the URL stays clean

## Test plan

- [ ] Click "Rebuild the index" in a `RebuildAlert` and confirm the rebuild dialog opens on arrival
- [ ] Confirm the URL contains no `openRebuild` query param after the dialog opens
- [ ] Refresh the page while the dialog is open and confirm it does not reopen
- [ ] Open and close the dialog normally (without using the alert link) and confirm it still works