### PR TITLE
fix: open quick analyze dialog reliably

### DIFF
--- a/apps/web/src/routes/_authenticated/samples/index.tsx
+++ b/apps/web/src/routes/_authenticated/samples/index.tsx
@@ -9,7 +9,6 @@ const samplesSearchSchema = z.object({
 	page: z.number().default(1).catch(1),
 	labels: z.array(z.number()).default([]).catch([]),
 	workflows: z.array(z.string()).default([]).catch([]),
-	openQuickAnalyze: z.boolean().optional().catch(undefined),
 });
 
 export const Route = createFileRoute("/_authenticated/samples/")({
@@ -30,7 +29,6 @@ function SamplesRoute() {
 		<SamplesList
 			filterLabels={search.labels}
 			labels={labels}
-			openQuickAnalyze={Boolean(search.openQuickAnalyze)}
 			page={search.page}
 			term={search.term}
 			workflows={search.workflows}

--- a/apps/web/src/samples/components/SamplesList.tsx
+++ b/apps/web/src/samples/components/SamplesList.tsx
@@ -19,11 +19,9 @@ import SampleLabels from "./Sidebar/ManageLabels";
 type SamplesListProps = {
 	labels: Label[];
 	filterLabels?: number[];
-	openQuickAnalyze?: boolean;
 	page?: number;
 	setSearch?: (next: {
 		labels?: number[];
-		openQuickAnalyze?: boolean;
 		page?: number;
 		term?: string;
 		workflows?: string[];
@@ -38,7 +36,6 @@ type SamplesListProps = {
 export default function SamplesList({
 	labels,
 	filterLabels = [],
-	openQuickAnalyze = false,
 	page: urlPage = 1,
 	setSearch = () => {},
 	term = "",
@@ -54,6 +51,7 @@ export default function SamplesList({
 	const { isPending: isPendingIndexes } = useListIndexes({ ready: true });
 
 	const [selected, setSelected] = useState<string[]>([]);
+	const [openQuickAnalyze, setOpenQuickAnalyze] = useState(false);
 
 	if (isPendingSamples || isPendingIndexes || !samples) {
 		return <LoadingPlaceholder />;
@@ -79,9 +77,7 @@ export default function SamplesList({
 				checked={selected.includes(item.id)}
 				handleSelect={handleSelect}
 				selectOnQuickAnalyze={selectOnQuickAnalyze}
-				setOpenQuickAnalyze={(openQuickAnalyze) =>
-					setSearch({ openQuickAnalyze })
-				}
+				setOpenQuickAnalyze={setOpenQuickAnalyze}
 			/>
 		);
 	}
@@ -91,7 +87,7 @@ export default function SamplesList({
 			<QuickAnalyze
 				open={openQuickAnalyze}
 				onClear={() => setSelected([])}
-				setOpen={(openQuickAnalyze) => setSearch({ openQuickAnalyze })}
+				setOpen={setOpenQuickAnalyze}
 				samples={intersectionWith(
 					items,
 					selected,
@@ -113,9 +109,7 @@ export default function SamplesList({
 					<SampleToolbar
 						selected={selected}
 						onClear={() => setSelected([])}
-						setOpenQuickAnalyze={(openQuickAnalyze) =>
-							setSearch({ openQuickAnalyze })
-						}
+						setOpenQuickAnalyze={setOpenQuickAnalyze}
 						term={term}
 						onChange={(e) => setSearch({ term: e.target.value })}
 					/>

--- a/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
+++ b/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
@@ -23,7 +23,6 @@ import SamplesList from "../SamplesList";
 
 type SamplesListSearch = {
 	filterLabels?: number[];
-	openQuickAnalyze?: boolean;
 	page?: number;
 	term?: string;
 	workflows?: string[];


### PR DESCRIPTION
## Summary

- Moves the `openQuickAnalyze` dialog state from a URL search parameter to local React state in `SamplesList`, so the dialog opens reliably without depending on URL sync
- Removes the `openQuickAnalyze` field from the samples route search schema and cleans up all related prop threading
- Upgrades all previously-warn Biome lint rules to `error` and adds `--error-on-warnings` to the `check` script, then fixes every violation across the codebase (type annotations, array-index keys, accessibility attributes, unused variables, and more)

## Test plan

- [ ] Open the samples list, select one or more samples, and click "Quick Analyze" — confirm the dialog opens
- [ ] Close the dialog and confirm it stays closed on re-render; confirm the URL does not contain `openQuickAnalyze`
- [ ] Run `pnpm check` and confirm it exits 0
- [ ] Run `pnpm typecheck` and confirm it exits 0