### PR TITLE
chore: enable noUncheckedIndexedAccess

### DIFF
--- a/apps/web/src/account/components/__tests__/AccountProfile.test.tsx
+++ b/apps/web/src/account/components/__tests__/AccountProfile.test.tsx
@@ -64,10 +64,8 @@ describe("<AccountProfile />", () => {
 		const input = screen.getByLabelText("Email Address");
 		expect(input).toHaveValue("");
 
-		const button = screen.getAllByRole("button", { name: "Change" })[2];
-		if (!button) {
-			throw new Error("expected button");
-		}
+		const form = input.closest("form") as HTMLElement;
+		const button = within(form).getByRole("button", { name: "Change" });
 
 		await userEvent.type(input, "invalid");
 		await userEvent.click(button);
@@ -186,13 +184,10 @@ describe("<AccountProfile />", () => {
 
 		expect(await screen.findByText("Password")).toBeInTheDocument();
 
-		const button = screen.getAllByRole("button", { name: "Change" })[1];
-		if (!button) {
-			throw new Error("expected button");
-		}
-
 		const oldPasswordInput = screen.getByLabelText("Old Password");
 		const newPasswordInput = screen.getByLabelText("New Password");
+		const form = oldPasswordInput.closest("form") as HTMLElement;
+		const button = within(form).getByRole("button", { name: "Change" });
 
 		// Try without providing old password.
 		await userEvent.type(newPasswordInput, "long_enough_password");
@@ -227,12 +222,10 @@ describe("<AccountProfile />", () => {
 
 		await screen.findByText("Password");
 
-		const button = screen.getAllByRole("button", { name: "Change" })[1];
-		if (!button) {
-			throw new Error("expected button");
-		}
 		const oldPasswordInput = screen.getByLabelText("Old Password");
 		const newPasswordInput = screen.getByLabelText("New Password");
+		const form = oldPasswordInput.closest("form") as HTMLElement;
+		const button = within(form).getByRole("button", { name: "Change" });
 
 		await userEvent.type(oldPasswordInput, "old_password_123");
 		await userEvent.type(newPasswordInput, "new_password_123");

--- a/apps/web/src/account/components/__tests__/AccountProfile.test.tsx
+++ b/apps/web/src/account/components/__tests__/AccountProfile.test.tsx
@@ -65,6 +65,9 @@ describe("<AccountProfile />", () => {
 		expect(input).toHaveValue("");
 
 		const button = screen.getAllByRole("button", { name: "Change" })[2];
+		if (!button) {
+			throw new Error("expected button");
+		}
 
 		await userEvent.type(input, "invalid");
 		await userEvent.click(button);
@@ -184,6 +187,9 @@ describe("<AccountProfile />", () => {
 		expect(await screen.findByText("Password")).toBeInTheDocument();
 
 		const button = screen.getAllByRole("button", { name: "Change" })[1];
+		if (!button) {
+			throw new Error("expected button");
+		}
 
 		const oldPasswordInput = screen.getByLabelText("Old Password");
 		const newPasswordInput = screen.getByLabelText("New Password");
@@ -222,6 +228,9 @@ describe("<AccountProfile />", () => {
 		await screen.findByText("Password");
 
 		const button = screen.getAllByRole("button", { name: "Change" })[1];
+		if (!button) {
+			throw new Error("expected button");
+		}
 		const oldPasswordInput = screen.getByLabelText("Old Password");
 		const newPasswordInput = screen.getByLabelText("New Password");
 

--- a/apps/web/src/analyses/__tests__/utils.test.ts
+++ b/apps/web/src/analyses/__tests__/utils.test.ts
@@ -114,9 +114,9 @@ describe("mergeCoverage()", () => {
 	});
 
 	it("should return merged coverage when isolate lengths differ", () => {
-		isolates[0].filled.push(3);
-		isolates[0].filled.push(5);
-		isolates[2].filled.push(1);
+		isolates[0]?.filled.push(3);
+		isolates[0]?.filled.push(5);
+		isolates[2]?.filled.push(1);
 		const merged = mergeCoverage(isolates);
 		expect(merged).toEqual([
 			7, 5, 5, 6, 6, 7, 9, 5, 6, 2, 2, 3, 2, 1, 1, 3, 2, 3, 5,

--- a/apps/web/src/analyses/__tests__/utils.test.ts
+++ b/apps/web/src/analyses/__tests__/utils.test.ts
@@ -1,4 +1,5 @@
 import type { FormattedPathoscopeIsolate } from "@analyses/types";
+import { at } from "@tests/setup";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
 	fillAlign,
@@ -114,9 +115,9 @@ describe("mergeCoverage()", () => {
 	});
 
 	it("should return merged coverage when isolate lengths differ", () => {
-		isolates[0]?.filled.push(3);
-		isolates[0]?.filled.push(5);
-		isolates[2]?.filled.push(1);
+		at(isolates, 0).filled.push(3);
+		at(isolates, 0).filled.push(5);
+		at(isolates, 2).filled.push(1);
 		const merged = mergeCoverage(isolates);
 		expect(merged).toEqual([
 			7, 5, 5, 6, 6, 7, 9, 5, 6, 2, 2, 3, 2, 1, 1, 3, 2, 3, 5,

--- a/apps/web/src/analyses/components/Iimi/IimiCondensedCoverage.tsx
+++ b/apps/web/src/analyses/components/Iimi/IimiCondensedCoverage.tsx
@@ -13,8 +13,8 @@ export function IimiCondensedCoverage({
 		[(seqs) => seqs[0]?.length],
 	);
 
-	const charts = sequences.map((seqs) => {
-		return <SummaryChart key={seqs[0].id} seqs={seqs} />;
+	const charts = sequences.map((seqs, index) => {
+		return <SummaryChart key={seqs[0]?.id ?? index} seqs={seqs} />;
 	});
 
 	return <div>{charts}</div>;

--- a/apps/web/src/analyses/components/Iimi/IimiViewer.tsx
+++ b/apps/web/src/analyses/components/Iimi/IimiViewer.tsx
@@ -14,8 +14,13 @@ type SortConfig = {
 	order: "desc" | "asc";
 };
 
+const probabilityConfig: SortConfig = {
+	getValue: (item) => item.probability,
+	order: "desc",
+};
+
 const sortConfigs: Record<string, SortConfig> = {
-	probability: { getValue: (item) => item.probability, order: "desc" },
+	probability: probabilityConfig,
 	coverage: { getValue: (item) => item.coverage, order: "desc" },
 	name: { getValue: (item) => item.name, order: "asc" },
 };
@@ -38,11 +43,9 @@ export function IimiViewer({ detail }: { detail: FormattedIimiAnalysis }) {
 		(item) => item.probability && item.probability >= minimumProbability,
 	);
 
-	const sortedHits = orderBy(
-		hits,
-		[sortConfigs[sort].getValue],
-		[sortConfigs[sort].order],
-	);
+	const sortConfig = sortConfigs[sort] ?? probabilityConfig;
+
+	const sortedHits = orderBy(hits, [sortConfig.getValue], [sortConfig.order]);
 
 	return (
 		<>

--- a/apps/web/src/analyses/components/Iimi/__tests__/IimiViewer.test.tsx
+++ b/apps/web/src/analyses/components/Iimi/__tests__/IimiViewer.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeIimiAnalysis } from "@tests/fake/analyses";
+import { at } from "@tests/setup";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { formatData } from "../../../utils";
 import { IimiViewer } from "../IimiViewer";
@@ -35,15 +36,11 @@ describe("<IimiViewer />", () => {
 			workflow: "iimi",
 		});
 
-		const [baseHit] = formattedIimiAnalysis.results.hits;
-		if (!baseHit) {
-			throw new Error("expected fake analysis to contain at least one hit");
-		}
-		firstHit = baseHit;
+		firstHit = at(formattedIimiAnalysis.results.hits, 0);
 
 		predefinedHits = [
 			{
-				...baseHit,
+				...firstHit,
 				id: "high-prob",
 				name: "High Probability Virus",
 				abbreviation: "HPV",
@@ -51,7 +48,7 @@ describe("<IimiViewer />", () => {
 				coverage: 0.3,
 			},
 			{
-				...baseHit,
+				...firstHit,
 				id: "med-prob",
 				name: "Medium Probability Virus",
 				abbreviation: "MPV",
@@ -59,7 +56,7 @@ describe("<IimiViewer />", () => {
 				coverage: 0.8,
 			},
 			{
-				...baseHit,
+				...firstHit,
 				id: "low-prob",
 				name: "Low Probability Virus",
 				abbreviation: "LPV",
@@ -153,10 +150,7 @@ describe("<IimiViewer />", () => {
 		});
 		await userEvent.click(otu);
 
-		const isolate = firstHit.isolates[0];
-		if (!isolate) {
-			throw new Error("expected first hit to contain at least one isolate");
-		}
+		const isolate = at(firstHit.isolates, 0);
 		const expectedIsolateName = `${isolate.source_type} ${isolate.source_name}`;
 		expect(
 			screen.getByText(new RegExp(expectedIsolateName, "i")),

--- a/apps/web/src/analyses/components/Iimi/__tests__/IimiViewer.test.tsx
+++ b/apps/web/src/analyses/components/Iimi/__tests__/IimiViewer.test.tsx
@@ -25,6 +25,7 @@ function renderWithAnalysisSearch(
 
 describe("<IimiViewer />", () => {
 	let formattedIimiAnalysis: FormattedIimiAnalysis;
+	let firstHit: FormattedIimiHit;
 	let predefinedHits: FormattedIimiHit[];
 
 	beforeEach(() => {
@@ -34,9 +35,15 @@ describe("<IimiViewer />", () => {
 			workflow: "iimi",
 		});
 
+		const [baseHit] = formattedIimiAnalysis.results.hits;
+		if (!baseHit) {
+			throw new Error("expected fake analysis to contain at least one hit");
+		}
+		firstHit = baseHit;
+
 		predefinedHits = [
 			{
-				...formattedIimiAnalysis.results.hits[0],
+				...baseHit,
 				id: "high-prob",
 				name: "High Probability Virus",
 				abbreviation: "HPV",
@@ -44,7 +51,7 @@ describe("<IimiViewer />", () => {
 				coverage: 0.3,
 			},
 			{
-				...formattedIimiAnalysis.results.hits[0],
+				...baseHit,
 				id: "med-prob",
 				name: "Medium Probability Virus",
 				abbreviation: "MPV",
@@ -52,7 +59,7 @@ describe("<IimiViewer />", () => {
 				coverage: 0.8,
 			},
 			{
-				...formattedIimiAnalysis.results.hits[0],
+				...baseHit,
 				id: "low-prob",
 				name: "Low Probability Virus",
 				abbreviation: "LPV",
@@ -80,9 +87,7 @@ describe("<IimiViewer />", () => {
 		expect(screen.getByDisplayValue("0.500")).toBeInTheDocument();
 		expect(screen.getByText("Sort: PScore")).toBeInTheDocument();
 
-		expect(
-			screen.getByText(formattedIimiAnalysis.results.hits[0].name),
-		).toBeInTheDocument();
+		expect(screen.getByText(firstHit.name)).toBeInTheDocument();
 	});
 
 	it.each([
@@ -141,16 +146,17 @@ describe("<IimiViewer />", () => {
 			<IimiViewer detail={formattedIimiAnalysis} />,
 		);
 
-		expect(
-			screen.getByText(formattedIimiAnalysis.results.hits[0].name),
-		).toBeInTheDocument();
+		expect(screen.getByText(firstHit.name)).toBeInTheDocument();
 
 		const otu = screen.getByRole("button", {
-			name: new RegExp(formattedIimiAnalysis.results.hits[0].name),
+			name: new RegExp(firstHit.name),
 		});
 		await userEvent.click(otu);
 
-		const isolate = formattedIimiAnalysis.results.hits[0].isolates[0];
+		const isolate = firstHit.isolates[0];
+		if (!isolate) {
+			throw new Error("expected first hit to contain at least one isolate");
+		}
 		const expectedIsolateName = `${isolate.source_type} ${isolate.source_name}`;
 		expect(
 			screen.getByText(new RegExp(expectedIsolateName, "i")),

--- a/apps/web/src/analyses/components/Nuvs/NuvsList.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsList.tsx
@@ -35,12 +35,18 @@ export default function NuvsList({ detail }: NuVsListProps) {
 
 		if (windowIndex > 0) {
 			previousIndex = windowIndex - 1;
-			previousId = String(sortedHits[previousIndex].id);
+			const previousHit = sortedHits[previousIndex];
+			if (previousHit) {
+				previousId = String(previousHit.id);
+			}
 		}
 
 		if (windowIndex < sortedHits.length - 1) {
 			nextIndex = windowIndex + 1;
-			nextId = String(sortedHits[nextIndex].id);
+			const nextHit = sortedHits[nextIndex];
+			if (nextHit) {
+				nextId = String(nextHit.id);
+			}
 		}
 	}
 

--- a/apps/web/src/analyses/components/Nuvs/__tests__/NuVsViewer.test.tsx
+++ b/apps/web/src/analyses/components/Nuvs/__tests__/NuVsViewer.test.tsx
@@ -8,6 +8,7 @@ import {
 	mockApiBlastNuVs,
 } from "@tests/fake/analyses";
 import { createFakeSample } from "@tests/fake/samples";
+import { at } from "@tests/setup";
 import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -36,11 +37,7 @@ describe("<NuvsViewer />", () => {
 		sample = createFakeSample();
 		nuvs = createFakeFormattedNuVsAnalysis();
 
-		const [hit] = nuvs.results.hits;
-		if (!hit) {
-			throw new Error("expected fake analysis to contain at least one hit");
-		}
-		firstHit = hit;
+		firstHit = at(nuvs.results.hits, 0);
 
 		props = {
 			detail: nuvs,

--- a/apps/web/src/analyses/components/Nuvs/__tests__/NuVsViewer.test.tsx
+++ b/apps/web/src/analyses/components/Nuvs/__tests__/NuVsViewer.test.tsx
@@ -29,11 +29,19 @@ function renderWithAnalysisSearch(
 describe("<NuvsViewer />", () => {
 	let sample: ReturnType<typeof createFakeSample>;
 	let nuvs: ReturnType<typeof createFakeFormattedNuVsAnalysis>;
+	let firstHit: (typeof nuvs.results.hits)[number];
 	let props: { detail: typeof nuvs; sample: typeof sample };
 
 	beforeEach(() => {
 		sample = createFakeSample();
 		nuvs = createFakeFormattedNuVsAnalysis();
+
+		const [hit] = nuvs.results.hits;
+		if (!hit) {
+			throw new Error("expected fake analysis to contain at least one hit");
+		}
+		firstHit = hit;
+
 		props = {
 			detail: nuvs,
 			sample: sample,
@@ -45,7 +53,7 @@ describe("<NuvsViewer />", () => {
 	describe("<NuVsDetail />", () => {
 		it("should render correctly", async () => {
 			renderWithAnalysisSearch(<NuvsViewer {...props} />, {
-				activeHit: String(nuvs.results.hits[0].id),
+				activeHit: String(firstHit.id),
 			});
 
 			expect(
@@ -60,12 +68,9 @@ describe("<NuvsViewer />", () => {
 		});
 
 		it("should render blast when clicked", async () => {
-			const scope = mockApiBlastNuVs(
-				nuvs.id,
-				String(nuvs.results.hits[0].index),
-			);
+			const scope = mockApiBlastNuVs(nuvs.id, String(firstHit.index));
 			renderWithAnalysisSearch(<NuvsViewer {...props} />, {
-				activeHit: String(nuvs.results.hits[0].id),
+				activeHit: String(firstHit.id),
 			});
 
 			await userEvent.click(
@@ -78,7 +83,7 @@ describe("<NuvsViewer />", () => {
 	describe("<NuVsExport />", () => {
 		it("should render export dialog when exporting", async () => {
 			renderWithAnalysisSearch(<NuvsViewer {...props} />, {
-				activeHit: String(nuvs.results.hits[0].id),
+				activeHit: String(firstHit.id),
 			});
 
 			await userEvent.click(screen.getByRole("button", { name: "Export" }));

--- a/apps/web/src/analyses/components/__tests__/AnalysisList.test.tsx
+++ b/apps/web/src/analyses/components/__tests__/AnalysisList.test.tsx
@@ -7,7 +7,7 @@ import {
 } from "@tests/fake/analyses";
 import { createFakeHmmSearchResults, mockApiGetHmms } from "@tests/fake/hmm";
 import { createFakeSample, mockApiGetSampleDetail } from "@tests/fake/samples";
-import { MemoryRouter, renderWithProviders } from "@tests/setup";
+import { at, MemoryRouter, renderWithProviders } from "@tests/setup";
 import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -57,7 +57,7 @@ describe("<AnalysesToolbar />", () => {
 
 	it("should show analysis creation when user is in the correct group and write is enabled", async () => {
 		const account = createFakeAccount({ administrator_role: null });
-		sample.group = account.groups[0] ?? null;
+		sample.group = at(account.groups, 0);
 		sample.group_write = true;
 		mockApiGetAccount(account);
 		mockApiGetSampleDetail(sample);

--- a/apps/web/src/analyses/components/__tests__/AnalysisList.test.tsx
+++ b/apps/web/src/analyses/components/__tests__/AnalysisList.test.tsx
@@ -57,7 +57,7 @@ describe("<AnalysesToolbar />", () => {
 
 	it("should show analysis creation when user is in the correct group and write is enabled", async () => {
 		const account = createFakeAccount({ administrator_role: null });
-		sample.group = account.groups[0];
+		sample.group = account.groups[0] ?? null;
 		sample.group_write = true;
 		mockApiGetAccount(account);
 		mockApiGetSampleDetail(sample);

--- a/apps/web/src/analyses/hooks.ts
+++ b/apps/web/src/analyses/hooks.ts
@@ -124,7 +124,7 @@ export function useSubtractionOptions(
 		isPending: isPendingSubtractionShortlist,
 	} = useFetchSubtractionsShortlist(true);
 
-	const sampleId = sampleIds[0];
+	const sampleId = sampleIds[0] ?? "";
 
 	const { data: sample, isPending: isPendingSample } = useFetchSample(sampleId);
 

--- a/apps/web/src/analyses/utils.ts
+++ b/apps/web/src/analyses/utils.ts
@@ -126,18 +126,24 @@ export function formatNuvsData(detail) {
  * @param values - an array of numbers
  */
 export function median(values: number[]): number {
+	if (values.length === 0) {
+		return 0;
+	}
+
 	const sorted = values.slice().sort((a, b) => a - b);
 
 	const midIndex = (sorted.length - 1) / 2;
 
 	if (midIndex % 1 === 0) {
-		return sorted[midIndex];
+		// midIndex is an in-range integer index because the array is non-empty.
+		return sorted[midIndex] ?? 0;
 	}
 
-	const lowerIndex = Math.floor(midIndex);
-	const upperIndex = Math.ceil(midIndex);
+	// floor and ceil of midIndex are both in-range indices of the non-empty array.
+	const lower = sorted[Math.floor(midIndex)] ?? 0;
+	const upper = sorted[Math.ceil(midIndex)] ?? 0;
 
-	return Math.round((sorted[lowerIndex] + sorted[upperIndex]) / 2);
+	return Math.round((lower + upper) / 2);
 }
 
 /**
@@ -446,16 +452,18 @@ export function combineUntrustworthyRegions(
 		.flat()
 		.sort((a, b) => a[0] - b[0]);
 
-	if (sortedUntrustworthyRanges.length === 0) {
+	const first = sortedUntrustworthyRanges.shift();
+
+	if (first === undefined) {
 		return [];
 	}
 
-	const combined = [sortedUntrustworthyRanges.shift()] as [number, number][];
+	const combined: UntrustworthyRange[] = [first];
 
 	sortedUntrustworthyRanges.forEach((range) => {
 		const last = combined[combined.length - 1];
 
-		if (range[0] <= last[1]) {
+		if (last && range[0] <= last[1]) {
 			last[1] = range[1];
 		} else {
 			combined.push(range);

--- a/apps/web/src/app/useMatchPartialPath.ts
+++ b/apps/web/src/app/useMatchPartialPath.ts
@@ -7,7 +7,7 @@ export function useMatchPartialPath(path: string, exclude?: string[]): boolean {
 		return false;
 	}
 
-	const normalizedPath = path.split("?")[0].replace(/\/+$/, "") || "/";
+	const normalizedPath = (path.split("?")[0] ?? "").replace(/\/+$/, "") || "/";
 	return (
 		pathname === normalizedPath || pathname.startsWith(`${normalizedPath}/`)
 	);

--- a/apps/web/src/app/utils.ts
+++ b/apps/web/src/app/utils.ts
@@ -105,7 +105,7 @@ export function toThousand(num: number): string {
 export function toScientificNotation(num: number): string {
 	if (num < 0.01 || num > 1000) {
 		const [coefficient, exponent] = num.toExponential().split("e");
-		return `${numbro(coefficient).format("0.00")}E${exponent.replace("+", "")}`;
+		return `${numbro(coefficient).format("0.00")}E${(exponent ?? "").replace("+", "")}`;
 	}
 
 	return numbro(num).format("0.000");

--- a/apps/web/src/base/ProgressCircle.tsx
+++ b/apps/web/src/base/ProgressCircle.tsx
@@ -15,7 +15,7 @@ const colorToHex: Record<string, string> = {
 	redLightest: "#FDE1D3",
 };
 
-const progressCircleSizes: Record<string, number> = {
+const progressCircleSizes: Record<sizes, number> = {
 	xs: 12,
 	sm: 16,
 	md: 20,
@@ -73,7 +73,7 @@ export default function ProgressCircle({
 	size = "md",
 	state = "pending",
 }: ProgressCircleProps) {
-	const circleSize = progressCircleSizes[size] ?? 20;
+	const circleSize = progressCircleSizes[size];
 	const color = getProgressColor(state);
 	const radius = calculateRadius(circleSize);
 	const strokeWidth = calculateStrokeWidth(circleSize);

--- a/apps/web/src/base/ProgressCircle.tsx
+++ b/apps/web/src/base/ProgressCircle.tsx
@@ -54,10 +54,12 @@ function getProgressColor(state: JobState): string {
 }
 
 function getTrackColor(color: string): string {
+	const fallback = colorToHex.greyLight ?? "#CBD5E0";
+
 	if (color === "grey") {
-		return colorToHex.greyLight;
+		return fallback;
 	}
-	return colorToHex[`${color}Lightest`] || colorToHex.greyLight;
+	return colorToHex[`${color}Lightest`] ?? fallback;
 }
 
 type ProgressCircleProps = {
@@ -71,7 +73,7 @@ export default function ProgressCircle({
 	size = "md",
 	state = "pending",
 }: ProgressCircleProps) {
-	const circleSize = progressCircleSizes[size];
+	const circleSize = progressCircleSizes[size] ?? 20;
 	const color = getProgressColor(state);
 	const radius = calculateRadius(circleSize);
 	const strokeWidth = calculateStrokeWidth(circleSize);

--- a/apps/web/src/hmm/components/HmmDetail.tsx
+++ b/apps/web/src/hmm/components/HmmDetail.tsx
@@ -46,7 +46,7 @@ export default function HmmDetail() {
 		</Label>
 	));
 
-	const title = data.names[0];
+	const title = data.names[0] ?? "";
 
 	return (
 		<div>

--- a/apps/web/src/hmm/components/__tests__/HmmDetail.test.tsx
+++ b/apps/web/src/hmm/components/__tests__/HmmDetail.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import { createFakeHmm, mockApiGetHmmDetail } from "@tests/fake/hmm";
-import { renderRoute } from "@tests/setup";
+import { at, renderRoute } from "@tests/setup";
 import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -57,11 +57,8 @@ describe("<HmmDetail />", () => {
 			expect(await screen.findByText("Cluster Members")).toBeInTheDocument();
 			expect(screen.getByText(hmmDetail.entries.length)).toBeInTheDocument();
 
-			const firstEntry = hmmDetail.entries[0];
-			const secondEntry = hmmDetail.entries[1];
-			if (!firstEntry || !secondEntry) {
-				throw new Error("expected at least two entries");
-			}
+			const firstEntry = at(hmmDetail.entries, 0);
+			const secondEntry = at(hmmDetail.entries, 1);
 
 			expect(screen.getByText("Accession")).toBeInTheDocument();
 			expect(screen.getByText(firstEntry.accession)).toBeInTheDocument();

--- a/apps/web/src/hmm/components/__tests__/HmmDetail.test.tsx
+++ b/apps/web/src/hmm/components/__tests__/HmmDetail.test.tsx
@@ -57,25 +57,23 @@ describe("<HmmDetail />", () => {
 			expect(await screen.findByText("Cluster Members")).toBeInTheDocument();
 			expect(screen.getByText(hmmDetail.entries.length)).toBeInTheDocument();
 
+			const firstEntry = hmmDetail.entries[0];
+			const secondEntry = hmmDetail.entries[1];
+			if (!firstEntry || !secondEntry) {
+				throw new Error("expected at least two entries");
+			}
+
 			expect(screen.getByText("Accession")).toBeInTheDocument();
-			expect(
-				screen.getByText(hmmDetail.entries[0].accession),
-			).toBeInTheDocument();
-			expect(
-				screen.getByText(hmmDetail.entries[1].accession),
-			).toBeInTheDocument();
+			expect(screen.getByText(firstEntry.accession)).toBeInTheDocument();
+			expect(screen.getByText(secondEntry.accession)).toBeInTheDocument();
 
 			expect(screen.getByText("Name")).toBeInTheDocument();
-			expect(screen.getByText(hmmDetail.entries[0].name)).toBeInTheDocument();
-			expect(screen.getByText(hmmDetail.entries[1].name)).toBeInTheDocument();
+			expect(screen.getByText(firstEntry.name)).toBeInTheDocument();
+			expect(screen.getByText(secondEntry.name)).toBeInTheDocument();
 
 			expect(screen.getByText("Organism")).toBeInTheDocument();
-			expect(
-				screen.queryByText(hmmDetail.entries[0].organism),
-			).toBeInTheDocument();
-			expect(
-				screen.queryByText(hmmDetail.entries[1].organism),
-			).toBeInTheDocument();
+			expect(screen.queryByText(firstEntry.organism)).toBeInTheDocument();
+			expect(screen.queryByText(secondEntry.organism)).toBeInTheDocument();
 
 			scope.done();
 		});

--- a/apps/web/src/hmm/components/__tests__/HmmList.test.tsx
+++ b/apps/web/src/hmm/components/__tests__/HmmList.test.tsx
@@ -23,12 +23,14 @@ describe("<HmmList />", () => {
 
 		expect(await screen.findByPlaceholderText("Name")).toBeInTheDocument();
 
-		expect(
-			screen.getByText(fakeHMMData.documents[0].cluster),
-		).toBeInTheDocument();
-		expect(
-			screen.getByText(fakeHMMData.documents[0].names[0]),
-		).toBeInTheDocument();
+		const document = fakeHMMData.documents[0];
+		const name = document?.names[0];
+		if (!document || !name) {
+			throw new Error("expected a document with a name");
+		}
+
+		expect(screen.getByText(document.cluster)).toBeInTheDocument();
+		expect(screen.getByText(name)).toBeInTheDocument();
 
 		scope.done();
 	});

--- a/apps/web/src/hmm/components/__tests__/HmmList.test.tsx
+++ b/apps/web/src/hmm/components/__tests__/HmmList.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import { createFakeAccount } from "@tests/fake/account";
 import { createFakeHmmSearchResults, mockApiGetHmms } from "@tests/fake/hmm";
 import { createFakeTask } from "@tests/fake/tasks";
-import { renderRoute } from "@tests/setup";
+import { at, renderRoute } from "@tests/setup";
 import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -23,11 +23,8 @@ describe("<HmmList />", () => {
 
 		expect(await screen.findByPlaceholderText("Name")).toBeInTheDocument();
 
-		const document = fakeHMMData.documents[0];
-		const name = document?.names[0];
-		if (!document || !name) {
-			throw new Error("expected a document with a name");
-		}
+		const document = at(fakeHMMData.documents, 0);
+		const name = at(document.names, 0);
 
 		expect(screen.getByText(document.cluster)).toBeInTheDocument();
 		expect(screen.getByText(name)).toBeInTheDocument();

--- a/apps/web/src/jobs/types.ts
+++ b/apps/web/src/jobs/types.ts
@@ -144,8 +144,8 @@ const JobCountsSchema = z
 	.record(z.string(), z.record(z.string(), z.number()))
 	.transform((counts) => {
 		const result: Partial<Record<JobState, number>> = {};
-		for (const state of Object.keys(counts) as JobState[]) {
-			result[state] = Object.values(counts[state]).reduce(
+		for (const [state, stateCounts] of Object.entries(counts)) {
+			result[state as JobState] = Object.values(stateCounts).reduce(
 				(sum, count) => sum + count,
 				0,
 			);

--- a/apps/web/src/nav/components/SidebarLink.tsx
+++ b/apps/web/src/nav/components/SidebarLink.tsx
@@ -43,7 +43,7 @@ export default function SidebarLink({
 	exclude,
 }: SidebarItemProps) {
 	const isActive = useMatchPartialPath(link, exclude);
-	const to = link.split("?")[0];
+	const to = link.split("?")[0] ?? link;
 	const search = parseLinkSearch(link);
 
 	return (

--- a/apps/web/src/otus/components/Detail/Schema/Schema.tsx
+++ b/apps/web/src/otus/components/Detail/Schema/Schema.tsx
@@ -40,19 +40,25 @@ export default function Schema() {
 
 	function handleMoveUp(index: number) {
 		const updatedSchema = schema.slice();
-		[updatedSchema[index], updatedSchema[index - 1]] = [
-			updatedSchema[index - 1],
-			updatedSchema[index],
-		];
+		const current = updatedSchema[index];
+		const previous = updatedSchema[index - 1];
+		if (!current || !previous) {
+			return;
+		}
+		updatedSchema[index] = previous;
+		updatedSchema[index - 1] = current;
 		handleUpdate(updatedSchema);
 	}
 
 	function handleMoveDown(index: number) {
 		const updatedSchema = schema.slice();
-		[updatedSchema[index], updatedSchema[index + 1]] = [
-			updatedSchema[index + 1],
-			updatedSchema[index],
-		];
+		const current = updatedSchema[index];
+		const next = updatedSchema[index + 1];
+		if (!current || !next) {
+			return;
+		}
+		updatedSchema[index] = next;
+		updatedSchema[index + 1] = current;
 		handleUpdate(updatedSchema);
 	}
 

--- a/apps/web/src/otus/components/Detail/Schema/__tests__/RemoveSegment.test.tsx
+++ b/apps/web/src/otus/components/Detail/Schema/__tests__/RemoveSegment.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeOtu, mockApiEditOTU } from "@tests/fake/otus";
-import { renderWithProviders } from "@tests/setup";
+import { at, renderWithProviders } from "@tests/setup";
 import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import RemoveSegment from "../RemoveSegment";
@@ -12,11 +12,7 @@ describe("<RemoveSegment />", () => {
 
 	beforeEach(() => {
 		otu = createFakeOtu();
-		const segment = otu.schema[0];
-		if (!segment) {
-			throw new Error("expected a schema segment");
-		}
-		segmentName = segment.name;
+		segmentName = at(otu.schema, 0).name;
 	});
 
 	afterEach(() => nock.cleanAll());

--- a/apps/web/src/otus/components/Detail/Schema/__tests__/RemoveSegment.test.tsx
+++ b/apps/web/src/otus/components/Detail/Schema/__tests__/RemoveSegment.test.tsx
@@ -12,7 +12,11 @@ describe("<RemoveSegment />", () => {
 
 	beforeEach(() => {
 		otu = createFakeOtu();
-		segmentName = otu.schema[0].name;
+		const segment = otu.schema[0];
+		if (!segment) {
+			throw new Error("expected a schema segment");
+		}
+		segmentName = segment.name;
 	});
 
 	afterEach(() => nock.cleanAll());

--- a/apps/web/src/quality/components/Nucleotides.ts
+++ b/apps/web/src/quality/components/Nucleotides.ts
@@ -34,13 +34,17 @@ export function drawNucleotidesChart(
 
 	// Append the four plot lines to the SVG.
 	unzip(data).forEach((set: number[], index: number) => {
+		const serie = series[index];
+		if (!serie) {
+			return;
+		}
 		svg
 			.append("path")
 			.attr("class", "graph-line")
 			.attr("d", () => lineDrawer(set))
-			.attr("data-legend", () => series[index].label)
+			.attr("data-legend", () => serie.label)
 			.attr("fill", "none")
-			.attr("stroke", () => series[index].color);
+			.attr("stroke", () => serie.color);
 	});
 
 	// Append x-axis and label.

--- a/apps/web/src/references/components/ImportReference.tsx
+++ b/apps/web/src/references/components/ImportReference.tsx
@@ -31,7 +31,12 @@ export default function ImportReference() {
 	});
 
 	function handleDrop(acceptedFiles: File[]) {
-		uploadMutation.mutate(acceptedFiles[0]);
+		const file = acceptedFiles[0];
+		if (file === undefined) {
+			return;
+		}
+
+		uploadMutation.mutate(file);
 	}
 
 	const uploadBarMessage =
@@ -57,7 +62,10 @@ export default function ImportReference() {
 							message={uploadBarMessage}
 							onDrop={(acceptedFiles) => {
 								handleDrop(acceptedFiles);
-								onChange(acceptedFiles[0].name);
+								const file = acceptedFiles[0];
+								if (file) {
+									onChange(file.name);
+								}
 							}}
 							multiple={false}
 						/>

--- a/apps/web/src/references/components/__tests__/ReferenceSettings.test.tsx
+++ b/apps/web/src/references/components/__tests__/ReferenceSettings.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@tests/setup";
 import nock from "nock";
@@ -51,13 +51,12 @@ test("GlobalSourceTypes", async () => {
 		.get("/api/settings")
 		.reply(200, { ...settings, default_source_types: ["Genotype"] });
 
-	const removeButton = (
-		await screen.findAllByRole("button", { name: "remove" })
-	)[0];
-	if (!removeButton) {
-		throw new Error("expected remove button");
-	}
-	await userEvent.click(removeButton);
+	const cloneRow = (await screen.findByText("Clone")).closest(
+		"div",
+	) as HTMLElement;
+	await userEvent.click(
+		within(cloneRow).getByRole("button", { name: "remove" }),
+	);
 
 	await waitFor(() => {
 		expect(

--- a/apps/web/src/references/components/__tests__/ReferenceSettings.test.tsx
+++ b/apps/web/src/references/components/__tests__/ReferenceSettings.test.tsx
@@ -51,9 +51,13 @@ test("GlobalSourceTypes", async () => {
 		.get("/api/settings")
 		.reply(200, { ...settings, default_source_types: ["Genotype"] });
 
-	await userEvent.click(
-		(await screen.findAllByRole("button", { name: "remove" }))[0],
-	);
+	const removeButton = (
+		await screen.findAllByRole("button", { name: "remove" })
+	)[0];
+	if (!removeButton) {
+		throw new Error("expected remove button");
+	}
+	await userEvent.click(removeButton);
 
 	await waitFor(() => {
 		expect(

--- a/apps/web/src/references/hooks.ts
+++ b/apps/web/src/references/hooks.ts
@@ -56,7 +56,7 @@ export function useUpdateSourceTypes(
 			const updatedSourceTypes = data.body[key];
 
 			if (sourceTypes.length > updatedSourceTypes) {
-				setLastRemoved(difference(sourceTypes, updatedSourceTypes)[0]);
+				setLastRemoved(difference(sourceTypes, updatedSourceTypes)[0] ?? "");
 			} else {
 				setLastRemoved("");
 			}

--- a/apps/web/src/samples/components/Create/CreateSample.tsx
+++ b/apps/web/src/samples/components/Create/CreateSample.tsx
@@ -39,7 +39,7 @@ const extensionRegex = /^(.*)\.(fq|fastq|fa|fasta)(\.gz)?$/i;
 function getFileNameFromId(id: number, uploads: Upload[]): string {
 	const file = uploads.find((file) => file.id === id);
 	const match = file?.name.match(extensionRegex);
-	return match ? match[1] : "";
+	return match?.[1] ?? "";
 }
 
 type FormValues = {
@@ -116,7 +116,12 @@ export default function CreateSample({ labels }: CreateSampleProps) {
 	const reads = readsResponse.pages.flatMap((page) => page.items);
 
 	function autofill(selected: number[]) {
-		const fileName = getFileNameFromId(selected[0], reads);
+		const id = selected[0];
+		if (id === undefined) {
+			return;
+		}
+
+		const fileName = getFileNameFromId(id, reads);
 		if (fileName) {
 			setValue("name", fileName);
 		}

--- a/apps/web/src/samples/components/Create/ReadSelector.tsx
+++ b/apps/web/src/samples/components/Create/ReadSelector.tsx
@@ -110,7 +110,7 @@ export default function ReadSelector({
 
 	useValidateFiles("reads", selected, onSelect, handleCleared);
 
-	const { total_count } = data.pages[0];
+	const total_count = data.pages[0]?.total_count;
 	const items = data.pages.flatMap((page) => page.items);
 
 	const loweredFilter = term.toLowerCase();

--- a/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
@@ -124,6 +124,16 @@ describe("<CreateSample>", () => {
 
 	it("should submit when all form fields complete", async () => {
 		const files = [createFakeFile(), createFakeFile()];
+		const [firstFile, secondFile] = files;
+		const [firstLabel] = labels;
+
+		if (!firstFile || !secondFile) {
+			throw new Error("expected two files");
+		}
+
+		if (!firstLabel) {
+			throw new Error("expected a label");
+		}
 
 		mockApiListFiles(files);
 		mockApiGetShortlistSubtractions([subtractionShortlist]);
@@ -134,8 +144,8 @@ describe("<CreateSample>", () => {
 			"Apple",
 			"Earth",
 			"normal",
-			[files[0].id, files[1].id],
-			[labels[0].id],
+			[firstFile.id, secondFile.id],
+			[firstLabel.id],
 			[subtractionShortlist.id],
 			null,
 		);
@@ -159,14 +169,14 @@ describe("<CreateSample>", () => {
 
 		// Select Files
 		await setReadSelectorMode("Manual");
-		await userEvent.click(screen.getByText(files[0].name));
-		await userEvent.click(screen.getByText(files[1].name));
+		await userEvent.click(screen.getByText(firstFile.name));
+		await userEvent.click(screen.getByText(secondFile.name));
 
 		// Select Labels
 		await userEvent.click(
 			screen.getByRole("button", { name: "select labels" }),
 		);
-		await userEvent.click(screen.getByText(labels[0].name));
+		await userEvent.click(screen.getByText(firstLabel.name));
 
 		// Select Subtractions
 		await userEvent.click(
@@ -306,6 +316,11 @@ describe("<CreateSample>", () => {
 			createFakeFile({ name: "alpha.fastq.gz" }),
 			createFakeFile({ name: "beta.fastq.gz" }),
 		];
+		const [firstFile, secondFile] = files;
+
+		if (!firstFile || !secondFile) {
+			throw new Error("expected two files");
+		}
 
 		mockApiListFiles(files);
 		mockApiGetShortlistSubtractions([]);
@@ -315,18 +330,18 @@ describe("<CreateSample>", () => {
 		expect(await screen.findByText("Create Sample")).toBeInTheDocument();
 
 		await setReadSelectorMode("Manual");
-		await userEvent.click(screen.getByText(files[0].name));
-		await userEvent.click(screen.getByText(files[1].name));
+		await userEvent.click(screen.getByText(firstFile.name));
+		await userEvent.click(screen.getByText(secondFile.name));
 
 		expect(screen.getByText("Paired")).toBeInTheDocument();
 		expect(
-			within(readRowButton(files[0].name)).getByText("LEFT"),
+			within(readRowButton(firstFile.name)).getByText("LEFT"),
 		).toBeVisible();
 
 		await userEvent.click(screen.getByRole("button", { name: /swap reads/i }));
 
 		expect(
-			within(readRowButton(files[0].name)).getByText("RIGHT"),
+			within(readRowButton(firstFile.name)).getByText("RIGHT"),
 		).toBeVisible();
 	});
 
@@ -335,6 +350,11 @@ describe("<CreateSample>", () => {
 			createFakeFile({ name: "alpha.fastq.gz" }),
 			createFakeFile({ name: "beta.fastq.gz" }),
 		];
+		const [firstFile, secondFile] = files;
+
+		if (!firstFile || !secondFile) {
+			throw new Error("expected two files");
+		}
 
 		mockApiListFiles(files);
 		mockApiGetShortlistSubtractions([{ name: "foo", ready: true, id: "test" }]);
@@ -344,17 +364,17 @@ describe("<CreateSample>", () => {
 		await userEvent.type(await screen.findByLabelText("Name"), "Sample B");
 
 		await setReadSelectorMode("Manual");
-		await userEvent.click(screen.getByText(files[0].name));
+		await userEvent.click(screen.getByText(firstFile.name));
 
 		expect(
-			within(readRowButton(files[0].name)).getByText("LEFT"),
+			within(readRowButton(firstFile.name)).getByText("LEFT"),
 		).toBeVisible();
 		expect(screen.getByText(/Unpaired/)).toBeInTheDocument();
 
-		await userEvent.click(screen.getByText(files[1].name));
+		await userEvent.click(screen.getByText(secondFile.name));
 
 		expect(
-			within(readRowButton(files[1].name)).getByText("RIGHT"),
+			within(readRowButton(secondFile.name)).getByText("RIGHT"),
 		).toBeVisible();
 		expect(screen.getByText(/Paired/)).toBeInTheDocument();
 	});

--- a/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
@@ -35,7 +35,8 @@ async function setReadSelectorMode(
 }
 
 describe("<CreateSample>", () => {
-	const labels = [createFakeLabel()];
+	const firstLabel = createFakeLabel();
+	const labels = [firstLabel];
 	const subtractionShortlist = createFakeShortlistSubtraction();
 
 	beforeEach(() => {
@@ -123,17 +124,9 @@ describe("<CreateSample>", () => {
 	});
 
 	it("should submit when all form fields complete", async () => {
-		const files = [createFakeFile(), createFakeFile()];
-		const [firstFile, secondFile] = files;
-		const [firstLabel] = labels;
-
-		if (!firstFile || !secondFile) {
-			throw new Error("expected two files");
-		}
-
-		if (!firstLabel) {
-			throw new Error("expected a label");
-		}
+		const firstFile = createFakeFile();
+		const secondFile = createFakeFile();
+		const files = [firstFile, secondFile];
 
 		mockApiListFiles(files);
 		mockApiGetShortlistSubtractions([subtractionShortlist]);
@@ -312,15 +305,9 @@ describe("<CreateSample>", () => {
 	});
 
 	it("should be able to swap read orientation", async () => {
-		const files = [
-			createFakeFile({ name: "alpha.fastq.gz" }),
-			createFakeFile({ name: "beta.fastq.gz" }),
-		];
-		const [firstFile, secondFile] = files;
-
-		if (!firstFile || !secondFile) {
-			throw new Error("expected two files");
-		}
+		const firstFile = createFakeFile({ name: "alpha.fastq.gz" });
+		const secondFile = createFakeFile({ name: "beta.fastq.gz" });
+		const files = [firstFile, secondFile];
 
 		mockApiListFiles(files);
 		mockApiGetShortlistSubtractions([]);
@@ -346,15 +333,9 @@ describe("<CreateSample>", () => {
 	});
 
 	it("should show correct read orientations", async () => {
-		const files = [
-			createFakeFile({ name: "alpha.fastq.gz" }),
-			createFakeFile({ name: "beta.fastq.gz" }),
-		];
-		const [firstFile, secondFile] = files;
-
-		if (!firstFile || !secondFile) {
-			throw new Error("expected two files");
-		}
+		const firstFile = createFakeFile({ name: "alpha.fastq.gz" });
+		const secondFile = createFakeFile({ name: "beta.fastq.gz" });
+		const files = [firstFile, secondFile];
 
 		mockApiListFiles(files);
 		mockApiGetShortlistSubtractions([{ name: "foo", ready: true, id: "test" }]);

--- a/apps/web/src/samples/components/Create/__tests__/ReadSelector.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/ReadSelector.test.tsx
@@ -78,15 +78,9 @@ describe("<ReadSelector>", () => {
 
 	describe("Auto-pair mode", () => {
 		it("replaces the selection with a single file on click", async () => {
-			const files = [
-				createFakeFile({ name: "alpha.fastq.gz" }),
-				createFakeFile({ name: "beta.fastq.gz" }),
-			];
-			const [firstFile, secondFile] = files;
-
-			if (!firstFile || !secondFile) {
-				throw new Error("expected two files");
-			}
+			const firstFile = createFakeFile({ name: "alpha.fastq.gz" });
+			const secondFile = createFakeFile({ name: "beta.fastq.gz" });
+			const files = [firstFile, secondFile];
 
 			mockApiListFiles(files);
 
@@ -155,16 +149,10 @@ describe("<ReadSelector>", () => {
 
 	describe("Manual mode", () => {
 		it("toggles up to two files, ignoring a third and supporting unselect", async () => {
-			const files = [
-				createFakeFile({ name: "alpha.fastq.gz" }),
-				createFakeFile({ name: "beta.fastq.gz" }),
-				createFakeFile({ name: "gamma.fastq.gz" }),
-			];
-			const [firstFile, secondFile, thirdFile] = files;
-
-			if (!firstFile || !secondFile || !thirdFile) {
-				throw new Error("expected three files");
-			}
+			const firstFile = createFakeFile({ name: "alpha.fastq.gz" });
+			const secondFile = createFakeFile({ name: "beta.fastq.gz" });
+			const thirdFile = createFakeFile({ name: "gamma.fastq.gz" });
+			const files = [firstFile, secondFile, thirdFile];
 
 			mockApiListFiles(files);
 
@@ -206,15 +194,9 @@ describe("<ReadSelector>", () => {
 		});
 
 		it("swaps the LEFT and RIGHT reads", async () => {
-			const files = [
-				createFakeFile({ name: "alpha.fastq.gz" }),
-				createFakeFile({ name: "beta.fastq.gz" }),
-			];
-			const [firstFile, secondFile] = files;
-
-			if (!firstFile || !secondFile) {
-				throw new Error("expected two files");
-			}
+			const firstFile = createFakeFile({ name: "alpha.fastq.gz" });
+			const secondFile = createFakeFile({ name: "beta.fastq.gz" });
+			const files = [firstFile, secondFile];
 
 			mockApiListFiles(files);
 
@@ -283,15 +265,9 @@ describe("<ReadSelector>", () => {
 
 		it("shows a hand-picked pair as two badged rows back in Auto-pair", async () => {
 			// Two files that do not auto-pair.
-			const files = [
-				createFakeFile({ name: "alpha.fastq.gz" }),
-				createFakeFile({ name: "beta.fastq.gz" }),
-			];
-			const [firstFile, secondFile] = files;
-
-			if (!firstFile || !secondFile) {
-				throw new Error("expected two files");
-			}
+			const firstFile = createFakeFile({ name: "alpha.fastq.gz" });
+			const secondFile = createFakeFile({ name: "beta.fastq.gz" });
+			const files = [firstFile, secondFile];
 
 			mockApiListFiles(files);
 
@@ -322,15 +298,9 @@ describe("<ReadSelector>", () => {
 	});
 
 	it("resets the selection and search term", async () => {
-		const files = [
-			createFakeFile({ name: "alpha.fastq.gz" }),
-			createFakeFile({ name: "beta.fastq.gz" }),
-		];
-		const [firstFile, secondFile] = files;
-
-		if (!firstFile || !secondFile) {
-			throw new Error("expected two files");
-		}
+		const firstFile = createFakeFile({ name: "alpha.fastq.gz" });
+		const secondFile = createFakeFile({ name: "beta.fastq.gz" });
+		const files = [firstFile, secondFile];
 
 		mockApiListFiles(files);
 

--- a/apps/web/src/samples/components/Create/__tests__/ReadSelector.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/ReadSelector.test.tsx
@@ -82,18 +82,29 @@ describe("<ReadSelector>", () => {
 				createFakeFile({ name: "alpha.fastq.gz" }),
 				createFakeFile({ name: "beta.fastq.gz" }),
 			];
+			const [firstFile, secondFile] = files;
+
+			if (!firstFile || !secondFile) {
+				throw new Error("expected two files");
+			}
+
 			mockApiListFiles(files);
 
 			renderWithProviders(<Harness files={files} />);
 
-			await userEvent.click(rowButton(files[0].name));
-			expect(within(rowButton(files[0].name)).getByText("LEFT")).toBeVisible();
+			await userEvent.click(rowButton(firstFile.name));
+			expect(within(rowButton(firstFile.name)).getByText("LEFT")).toBeVisible();
 			expect(screen.getByText("Unpaired")).toBeInTheDocument();
 
 			// A second click replaces rather than accumulates.
-			await userEvent.click(rowButton(files[1].name));
-			expect(rowButton(files[0].name)).toHaveAttribute("aria-pressed", "false");
-			expect(within(rowButton(files[1].name)).getByText("LEFT")).toBeVisible();
+			await userEvent.click(rowButton(secondFile.name));
+			expect(rowButton(firstFile.name)).toHaveAttribute(
+				"aria-pressed",
+				"false",
+			);
+			expect(
+				within(rowButton(secondFile.name)).getByText("LEFT"),
+			).toBeVisible();
 			expect(screen.getByText("Unpaired")).toBeInTheDocument();
 		});
 
@@ -149,25 +160,37 @@ describe("<ReadSelector>", () => {
 				createFakeFile({ name: "beta.fastq.gz" }),
 				createFakeFile({ name: "gamma.fastq.gz" }),
 			];
+			const [firstFile, secondFile, thirdFile] = files;
+
+			if (!firstFile || !secondFile || !thirdFile) {
+				throw new Error("expected three files");
+			}
+
 			mockApiListFiles(files);
 
 			renderWithProviders(<Harness files={files} />);
 			await setMode("Manual");
 
-			await userEvent.click(rowButton(files[0].name));
-			await userEvent.click(rowButton(files[1].name));
+			await userEvent.click(rowButton(firstFile.name));
+			await userEvent.click(rowButton(secondFile.name));
 			expect(screen.getByText("Paired")).toBeInTheDocument();
 
 			// The third click is a quiet no-op — the file stays unselected.
-			await userEvent.click(rowButton(files[2].name));
-			expect(rowButton(files[2].name)).toHaveAttribute("aria-pressed", "false");
+			await userEvent.click(rowButton(thirdFile.name));
+			expect(rowButton(thirdFile.name)).toHaveAttribute(
+				"aria-pressed",
+				"false",
+			);
 			expect(screen.getByText("Paired")).toBeInTheDocument();
 
 			// Unselecting frees a slot for the third file.
-			await userEvent.click(rowButton(files[1].name));
-			expect(rowButton(files[1].name)).toHaveAttribute("aria-pressed", "false");
-			await userEvent.click(rowButton(files[2].name));
-			expect(rowButton(files[2].name)).toHaveAttribute("aria-pressed", "true");
+			await userEvent.click(rowButton(secondFile.name));
+			expect(rowButton(secondFile.name)).toHaveAttribute(
+				"aria-pressed",
+				"false",
+			);
+			await userEvent.click(rowButton(thirdFile.name));
+			expect(rowButton(thirdFile.name)).toHaveAttribute("aria-pressed", "true");
 		});
 
 		it("does not collapse detected pairs into a single row", async () => {
@@ -187,23 +210,35 @@ describe("<ReadSelector>", () => {
 				createFakeFile({ name: "alpha.fastq.gz" }),
 				createFakeFile({ name: "beta.fastq.gz" }),
 			];
+			const [firstFile, secondFile] = files;
+
+			if (!firstFile || !secondFile) {
+				throw new Error("expected two files");
+			}
+
 			mockApiListFiles(files);
 
 			renderWithProviders(<Harness files={files} />);
 			await setMode("Manual");
 
-			await userEvent.click(rowButton(files[0].name));
-			await userEvent.click(rowButton(files[1].name));
+			await userEvent.click(rowButton(firstFile.name));
+			await userEvent.click(rowButton(secondFile.name));
 
-			expect(within(rowButton(files[0].name)).getByText("LEFT")).toBeVisible();
-			expect(within(rowButton(files[1].name)).getByText("RIGHT")).toBeVisible();
+			expect(within(rowButton(firstFile.name)).getByText("LEFT")).toBeVisible();
+			expect(
+				within(rowButton(secondFile.name)).getByText("RIGHT"),
+			).toBeVisible();
 
 			await userEvent.click(
 				screen.getByRole("button", { name: /swap reads/i }),
 			);
 
-			expect(within(rowButton(files[0].name)).getByText("RIGHT")).toBeVisible();
-			expect(within(rowButton(files[1].name)).getByText("LEFT")).toBeVisible();
+			expect(
+				within(rowButton(firstFile.name)).getByText("RIGHT"),
+			).toBeVisible();
+			expect(
+				within(rowButton(secondFile.name)).getByText("LEFT"),
+			).toBeVisible();
 		});
 
 		it("warns, without blocking, when a file sits in the wrong slot by name", async () => {
@@ -252,25 +287,36 @@ describe("<ReadSelector>", () => {
 				createFakeFile({ name: "alpha.fastq.gz" }),
 				createFakeFile({ name: "beta.fastq.gz" }),
 			];
+			const [firstFile, secondFile] = files;
+
+			if (!firstFile || !secondFile) {
+				throw new Error("expected two files");
+			}
+
 			mockApiListFiles(files);
 
 			renderWithProviders(<Harness files={files} />);
 			await setMode("Manual");
 
-			await userEvent.click(rowButton(files[0].name));
-			await userEvent.click(rowButton(files[1].name));
+			await userEvent.click(rowButton(firstFile.name));
+			await userEvent.click(rowButton(secondFile.name));
 
 			await setMode("Auto-pair");
 
 			// They render as two separate single rows, each keeping its badge, and
 			// the slots stay filled.
-			expect(within(rowButton(files[0].name)).getByText("LEFT")).toBeVisible();
-			expect(within(rowButton(files[1].name)).getByText("RIGHT")).toBeVisible();
+			expect(within(rowButton(firstFile.name)).getByText("LEFT")).toBeVisible();
+			expect(
+				within(rowButton(secondFile.name)).getByText("RIGHT"),
+			).toBeVisible();
 			expect(screen.getByText("Paired")).toBeInTheDocument();
 
 			// The first Auto-pair click applies replace and collapses to one.
-			await userEvent.click(rowButton(files[0].name));
-			expect(rowButton(files[1].name)).toHaveAttribute("aria-pressed", "false");
+			await userEvent.click(rowButton(firstFile.name));
+			expect(rowButton(secondFile.name)).toHaveAttribute(
+				"aria-pressed",
+				"false",
+			);
 			expect(screen.getByText("Unpaired")).toBeInTheDocument();
 		});
 	});
@@ -280,13 +326,19 @@ describe("<ReadSelector>", () => {
 			createFakeFile({ name: "alpha.fastq.gz" }),
 			createFakeFile({ name: "beta.fastq.gz" }),
 		];
+		const [firstFile, secondFile] = files;
+
+		if (!firstFile || !secondFile) {
+			throw new Error("expected two files");
+		}
+
 		mockApiListFiles(files);
 
 		renderWithProviders(<Harness files={files} />);
 		await setMode("Manual");
 
-		await userEvent.click(rowButton(files[0].name));
-		await userEvent.click(rowButton(files[1].name));
+		await userEvent.click(rowButton(firstFile.name));
+		await userEvent.click(rowButton(secondFile.name));
 		expect(screen.getByText("Paired")).toBeInTheDocument();
 
 		await userEvent.click(screen.getByRole("button", { name: /reset/i }));

--- a/apps/web/src/samples/components/Files/SampleReads.tsx
+++ b/apps/web/src/samples/components/Files/SampleReads.tsx
@@ -14,8 +14,8 @@ type SampleReadsProps = {
  * Extract the read side (1 or 2) from a read filename like "reads_1.fq.gz"
  */
 function extractReadSide(name: string): number {
-	const match = name.match(/reads_(\d+)/);
-	return match ? parseInt(match[1], 10) : 1;
+	const digit = name.match(/reads_(\d+)/)?.[1];
+	return digit ? parseInt(digit, 10) : 1;
 }
 
 /**

--- a/apps/web/src/samples/components/Sidebar/ManageLabels.tsx
+++ b/apps/web/src/samples/components/Sidebar/ManageLabels.tsx
@@ -13,11 +13,21 @@ function getSelectedLabels(document: SampleMinimal[]) {
 	const allLabels = document.flatMap((d) => d.labels);
 	const grouped = groupBy(allLabels, (label) => label.id);
 
-	return Object.values(grouped).map((labels) => ({
-		...labels[0],
-		count: labels.length,
-		allLabeled: labels.length === document.length,
-	}));
+	return Object.values(grouped).flatMap((labels) => {
+		const [first] = labels;
+
+		if (!first) {
+			return [];
+		}
+
+		return [
+			{
+				...first,
+				count: labels.length,
+				allLabeled: labels.length === document.length,
+			},
+		];
+	});
 }
 
 type ManageLabelsProps = {

--- a/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
+++ b/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
@@ -16,7 +16,7 @@ import {
 	createFakeShortlistSubtraction,
 	mockApiGetShortlistSubtractions,
 } from "@tests/fake/subtractions";
-import { renderWithRouter } from "@tests/setup";
+import { at, renderWithRouter } from "@tests/setup";
 import { useState } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import SamplesList from "../SamplesList";
@@ -63,13 +63,7 @@ describe("<SamplesList />", () => {
 		await renderWithRouter(<SamplesList labels={labels} />, path);
 		expect(await screen.findByText("Samples")).toBeInTheDocument();
 
-		const [firstSample] = samples;
-
-		if (!firstSample) {
-			throw new Error("expected a sample");
-		}
-
-		expect(screen.getByText(firstSample.name)).toBeInTheDocument();
+		expect(screen.getByText(at(samples, 0).name)).toBeInTheDocument();
 		expect(screen.getByText("Labels")).toBeInTheDocument();
 	});
 

--- a/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
+++ b/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
@@ -63,7 +63,13 @@ describe("<SamplesList />", () => {
 		await renderWithRouter(<SamplesList labels={labels} />, path);
 		expect(await screen.findByText("Samples")).toBeInTheDocument();
 
-		expect(screen.getByText(samples[0].name)).toBeInTheDocument();
+		const [firstSample] = samples;
+
+		if (!firstSample) {
+			throw new Error("expected a sample");
+		}
+
+		expect(screen.getByText(firstSample.name)).toBeInTheDocument();
 		expect(screen.getByText("Labels")).toBeInTheDocument();
 	});
 

--- a/apps/web/src/sequences/components/Sequences.tsx
+++ b/apps/web/src/sequences/components/Sequences.tsx
@@ -47,7 +47,7 @@ export default function Sequences({
 	));
 
 	let isolateName = `${activeIsolate.source_type} ${activeIsolate.source_name}`;
-	isolateName = isolateName[0].toUpperCase() + isolateName.slice(1);
+	isolateName = (isolateName[0] ?? "").toUpperCase() + isolateName.slice(1);
 
 	if (!sequenceComponents.length) {
 		sequenceComponents = [

--- a/apps/web/src/sequences/components/__tests__/CreateSequence.test.tsx
+++ b/apps/web/src/sequences/components/__tests__/CreateSequence.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeOtu, mockApiAddSequence } from "@tests/fake/otus";
 import { createFakeReference } from "@tests/fake/references";
-import { renderWithProviders } from "@tests/setup";
+import { at, renderWithProviders } from "@tests/setup";
 import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import CreateSequence from "../CreateSequence";
@@ -12,10 +12,7 @@ describe("<CreateSequence>", () => {
 	let reference: ReturnType<typeof createFakeReference>;
 
 	function renderCreateSequence(setOpen = vi.fn()) {
-		const isolate = otu.isolates[0];
-		if (!isolate) {
-			throw new Error("expected an isolate");
-		}
+		const isolate = at(otu.isolates, 0);
 		return renderWithProviders(
 			<CreateSequence
 				isolateId={isolate.id}
@@ -40,11 +37,8 @@ describe("<CreateSequence>", () => {
 	});
 
 	it("should update fields on typing", async () => {
-		const isolate = otu.isolates[0];
-		const segment = otu.schema[0];
-		if (!isolate || !segment) {
-			throw new Error("expected an isolate and a schema segment");
-		}
+		const isolate = at(otu.isolates, 0);
+		const segment = at(otu.schema, 0);
 
 		const scope = mockApiAddSequence(
 			otu.id,
@@ -121,11 +115,8 @@ describe("<CreateSequence>", () => {
 	});
 
 	it("should clear form cache after submitting", async () => {
-		const isolate = otu.isolates[0];
-		const segment = otu.schema[0];
-		if (!isolate || !segment) {
-			throw new Error("expected an isolate and a schema segment");
-		}
+		const isolate = at(otu.isolates, 0);
+		const segment = at(otu.schema, 0);
 
 		const scope = mockApiAddSequence(
 			otu.id,

--- a/apps/web/src/sequences/components/__tests__/CreateSequence.test.tsx
+++ b/apps/web/src/sequences/components/__tests__/CreateSequence.test.tsx
@@ -12,14 +12,18 @@ describe("<CreateSequence>", () => {
 	let reference: ReturnType<typeof createFakeReference>;
 
 	function renderCreateSequence(setOpen = vi.fn()) {
+		const isolate = otu.isolates[0];
+		if (!isolate) {
+			throw new Error("expected an isolate");
+		}
 		return renderWithProviders(
 			<CreateSequence
-				isolateId={otu.isolates[0].id}
+				isolateId={isolate.id}
 				open
 				otuId={otu.id}
 				refId={reference.id}
 				schema={otu.schema}
-				sequences={otu.isolates[0].sequences}
+				sequences={isolate.sequences}
 				setOpen={setOpen}
 			/>,
 		);
@@ -36,14 +40,20 @@ describe("<CreateSequence>", () => {
 	});
 
 	it("should update fields on typing", async () => {
+		const isolate = otu.isolates[0];
+		const segment = otu.schema[0];
+		if (!isolate || !segment) {
+			throw new Error("expected an isolate and a schema segment");
+		}
+
 		const scope = mockApiAddSequence(
 			otu.id,
-			otu.isolates[0].id,
+			isolate.id,
 			"user_typed_accession",
 			"user_typed_host",
 			"user_typed_definition",
 			"ATGRYKM",
-			otu.schema[0].name,
+			segment.name,
 		);
 
 		renderCreateSequence();
@@ -63,7 +73,7 @@ describe("<CreateSequence>", () => {
 
 		await userEvent.click(screen.getByRole("combobox"));
 		await userEvent.click(
-			await screen.findByRole("option", { name: otu.schema[0].name }),
+			await screen.findByRole("option", { name: segment.name }),
 		);
 		await userEvent.type(
 			screen.getByRole("textbox", { name: "Accession (ID)" }),
@@ -111,21 +121,27 @@ describe("<CreateSequence>", () => {
 	});
 
 	it("should clear form cache after submitting", async () => {
+		const isolate = otu.isolates[0];
+		const segment = otu.schema[0];
+		if (!isolate || !segment) {
+			throw new Error("expected an isolate and a schema segment");
+		}
+
 		const scope = mockApiAddSequence(
 			otu.id,
-			otu.isolates[0].id,
+			isolate.id,
 			"user_typed_accession",
 			"user_typed_host",
 			"user_typed_definition",
 			"ATGRYKM",
-			otu.schema[0].name,
+			segment.name,
 		);
 
 		renderCreateSequence();
 
 		await userEvent.click(await screen.findByRole("combobox"));
 		await userEvent.click(
-			await screen.findByRole("option", { name: otu.schema[0].name }),
+			await screen.findByRole("option", { name: segment.name }),
 		);
 		await userEvent.type(
 			screen.getByRole("textbox", { name: "Accession (ID)" }),

--- a/apps/web/src/sequences/components/__tests__/RemoveSequence.test.tsx
+++ b/apps/web/src/sequences/components/__tests__/RemoveSequence.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeOtu, mockApiRemoveSequence } from "@tests/fake/otus";
-import { renderWithProviders } from "@tests/setup";
+import { at, renderWithProviders } from "@tests/setup";
 import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import RemoveSequence from "../RemoveSequence";
@@ -14,22 +14,11 @@ describe("<RemoveSequence />", () => {
 
 	beforeEach(() => {
 		otu = createFakeOtu();
-		const firstIsolate = otu.isolates[0];
-		if (!firstIsolate) {
-			throw new Error("expected an isolate");
-		}
-		isolate = firstIsolate;
-		const firstSequence = isolate.sequences[0];
-		if (!firstSequence) {
-			throw new Error("expected a sequence");
-		}
-		sequence = firstSequence;
-		const sourceTypeInitial = isolate.source_type[0];
-		if (!sourceTypeInitial) {
-			throw new Error("expected a source type");
-		}
+		isolate = at(otu.isolates, 0);
+		sequence = at(isolate.sequences, 0);
 		const sourceType =
-			sourceTypeInitial.toUpperCase() + isolate.source_type.slice(1);
+			isolate.source_type.charAt(0).toUpperCase() +
+			isolate.source_type.slice(1);
 		isolateName = `${sourceType} ${isolate.source_name}`;
 	});
 

--- a/apps/web/src/sequences/components/__tests__/RemoveSequence.test.tsx
+++ b/apps/web/src/sequences/components/__tests__/RemoveSequence.test.tsx
@@ -14,10 +14,22 @@ describe("<RemoveSequence />", () => {
 
 	beforeEach(() => {
 		otu = createFakeOtu();
-		isolate = otu.isolates[0];
-		sequence = isolate.sequences[0];
+		const firstIsolate = otu.isolates[0];
+		if (!firstIsolate) {
+			throw new Error("expected an isolate");
+		}
+		isolate = firstIsolate;
+		const firstSequence = isolate.sequences[0];
+		if (!firstSequence) {
+			throw new Error("expected a sequence");
+		}
+		sequence = firstSequence;
+		const sourceTypeInitial = isolate.source_type[0];
+		if (!sourceTypeInitial) {
+			throw new Error("expected a source type");
+		}
 		const sourceType =
-			isolate.source_type[0].toUpperCase() + isolate.source_type.slice(1);
+			sourceTypeInitial.toUpperCase() + isolate.source_type.slice(1);
 		isolateName = `${sourceType} ${isolate.source_name}`;
 	});
 

--- a/apps/web/src/server/__tests__/sentryLog.test.ts
+++ b/apps/web/src/server/__tests__/sentryLog.test.ts
@@ -27,8 +27,7 @@ describe("createSentryLogStream", () => {
 		stream.write(`${JSON.stringify({ level: 40, msg: "watch out" })}\n`);
 
 		expect(logger.warn).toHaveBeenCalledTimes(1);
-		const [message] = logger.warn.mock.calls[0] ?? [];
-		expect(message).toBe("watch out");
+		expect(logger.warn).toHaveBeenCalledWith("watch out", expect.anything());
 	});
 
 	it("passes structured fields as attributes and drops the pino envelope", () => {
@@ -46,9 +45,7 @@ describe("createSentryLogStream", () => {
 			})}\n`,
 		);
 
-		const [message, attributes] = logger.info.mock.calls[0] ?? [];
-		expect(message).toBe("login");
-		expect(attributes).toEqual({ userId: "u1" });
+		expect(logger.info).toHaveBeenCalledWith("login", { userId: "u1" });
 	});
 
 	it("forwards already-redacted secret fields from a real logger", () => {
@@ -62,9 +59,13 @@ describe("createSentryLogStream", () => {
 
 		log.info({ password: "hunter2", headers: { cookie: "s=1" } }, "sign in");
 
-		const [, attributes] = logger.info.mock.calls[0] ?? [];
-		expect(attributes.password).toBe("[redacted]");
-		expect(attributes.headers).toEqual({ cookie: "[redacted]" });
+		expect(logger.info).toHaveBeenCalledWith(
+			"sign in",
+			expect.objectContaining({
+				password: "[redacted]",
+				headers: { cookie: "[redacted]" },
+			}),
+		);
 	});
 
 	it("ignores malformed lines", () => {

--- a/apps/web/src/server/__tests__/sentryLog.test.ts
+++ b/apps/web/src/server/__tests__/sentryLog.test.ts
@@ -27,7 +27,7 @@ describe("createSentryLogStream", () => {
 		stream.write(`${JSON.stringify({ level: 40, msg: "watch out" })}\n`);
 
 		expect(logger.warn).toHaveBeenCalledTimes(1);
-		const [message] = logger.warn.mock.calls[0];
+		const [message] = logger.warn.mock.calls[0] ?? [];
 		expect(message).toBe("watch out");
 	});
 
@@ -46,7 +46,7 @@ describe("createSentryLogStream", () => {
 			})}\n`,
 		);
 
-		const [message, attributes] = logger.info.mock.calls[0];
+		const [message, attributes] = logger.info.mock.calls[0] ?? [];
 		expect(message).toBe("login");
 		expect(attributes).toEqual({ userId: "u1" });
 	});
@@ -62,7 +62,7 @@ describe("createSentryLogStream", () => {
 
 		log.info({ password: "hunter2", headers: { cookie: "s=1" } }, "sign in");
 
-		const [, attributes] = logger.info.mock.calls[0];
+		const [, attributes] = logger.info.mock.calls[0] ?? [];
 		expect(attributes.password).toBe("[redacted]");
 		expect(attributes.headers).toEqual({ cookie: "[redacted]" });
 	});

--- a/apps/web/src/server/auth/session.ts
+++ b/apps/web/src/server/auth/session.ts
@@ -3,6 +3,7 @@ import { randomBytes } from "node:crypto";
 import { eq } from "drizzle-orm";
 
 import type { Db } from "../db/pg";
+import { takeFirstOrThrow } from "../db/rows";
 import { type SessionRow, sessions } from "../db/schema/sessions";
 import { hashToken, newSessionId, newSessionToken } from "./tokens";
 
@@ -43,18 +44,20 @@ export async function createAuthenticatedSession(
 		: SESSION_LIFETIME_NO_REMEMBER_MS;
 	const expiresAt = new Date(now.getTime() + lifetime);
 
-	const [row] = await db
-		.insert(sessions)
-		.values({
-			sessionId,
-			userId,
-			ip,
-			createdAt: now,
-			expiresAt,
-			tokenHash,
-			sessionType: "authenticated",
-		})
-		.returning();
+	const row = takeFirstOrThrow(
+		await db
+			.insert(sessions)
+			.values({
+				sessionId,
+				userId,
+				ip,
+				createdAt: now,
+				expiresAt,
+				tokenHash,
+				sessionType: "authenticated",
+			})
+			.returning(),
+	);
 
 	return { sessionId, token, row };
 }
@@ -82,19 +85,21 @@ export async function createResetSession(
 	const now = new Date();
 	const expiresAt = new Date(now.getTime() + RESET_LIFETIME_MS);
 
-	const [row] = await db
-		.insert(sessions)
-		.values({
-			sessionId,
-			userId,
-			ip,
-			createdAt: now,
-			expiresAt,
-			resetCode,
-			resetRemember: remember,
-			sessionType: "reset",
-		})
-		.returning();
+	const row = takeFirstOrThrow(
+		await db
+			.insert(sessions)
+			.values({
+				sessionId,
+				userId,
+				ip,
+				createdAt: now,
+				expiresAt,
+				resetCode,
+				resetRemember: remember,
+				sessionType: "reset",
+			})
+			.returning(),
+	);
 
 	return { sessionId, resetCode, row };
 }

--- a/apps/web/src/server/db/rows.ts
+++ b/apps/web/src/server/db/rows.ts
@@ -1,0 +1,19 @@
+/**
+ * Return the first row, throwing when the result set is empty. Use for
+ * insert/update `.returning()` paths where a row is guaranteed on success.
+ */
+export function takeFirstOrThrow<T>(rows: T[]): T {
+	const [row] = rows;
+	if (row === undefined) {
+		throw new Error("Expected at least one row but the result set was empty");
+	}
+	return row;
+}
+
+/**
+ * Return the first row or `undefined` when the result set is empty. Use where
+ * the caller already handles the missing-row case.
+ */
+export function takeFirst<T>(rows: T[]): T | undefined {
+	return rows[0];
+}

--- a/apps/web/src/server/events/emit.test.ts
+++ b/apps/web/src/server/events/emit.test.ts
@@ -22,7 +22,7 @@ describe("emit", () => {
 		await emit("labels", 7, "create");
 
 		expect(notify).toHaveBeenCalledTimes(1);
-		const [channel, payload] = notify.mock.calls[0];
+		const [channel, payload] = notify.mock.calls[0] ?? [];
 		expect(channel).toBe("client_events");
 		expect(JSON.parse(payload)).toEqual({
 			domain: "labels",
@@ -34,14 +34,14 @@ describe("emit", () => {
 	it("publishes a delete event", async () => {
 		await emit("labels", 12, "delete");
 
-		const [, payload] = notify.mock.calls[0];
+		const [, payload] = notify.mock.calls[0] ?? [];
 		expect(JSON.parse(payload).operation).toBe("delete");
 	});
 
 	it("accepts string resource ids", async () => {
 		await emit("samples", "abc123", "update");
 
-		const [, payload] = notify.mock.calls[0];
+		const [, payload] = notify.mock.calls[0] ?? [];
 		expect(JSON.parse(payload).resource_id).toBe("abc123");
 	});
 });

--- a/apps/web/src/server/events/emit.test.ts
+++ b/apps/web/src/server/events/emit.test.ts
@@ -22,26 +22,39 @@ describe("emit", () => {
 		await emit("labels", 7, "create");
 
 		expect(notify).toHaveBeenCalledTimes(1);
-		const [channel, payload] = notify.mock.calls[0] ?? [];
-		expect(channel).toBe("client_events");
-		expect(JSON.parse(payload)).toEqual({
-			domain: "labels",
-			resource_id: 7,
-			operation: "create",
-		});
+		expect(notify).toHaveBeenCalledWith(
+			"client_events",
+			JSON.stringify({
+				domain: "labels",
+				resource_id: 7,
+				operation: "create",
+			}),
+		);
 	});
 
 	it("publishes a delete event", async () => {
 		await emit("labels", 12, "delete");
 
-		const [, payload] = notify.mock.calls[0] ?? [];
-		expect(JSON.parse(payload).operation).toBe("delete");
+		expect(notify).toHaveBeenCalledWith(
+			"client_events",
+			JSON.stringify({
+				domain: "labels",
+				resource_id: 12,
+				operation: "delete",
+			}),
+		);
 	});
 
 	it("accepts string resource ids", async () => {
 		await emit("samples", "abc123", "update");
 
-		const [, payload] = notify.mock.calls[0] ?? [];
-		expect(JSON.parse(payload).resource_id).toBe("abc123");
+		expect(notify).toHaveBeenCalledWith(
+			"client_events",
+			JSON.stringify({
+				domain: "samples",
+				resource_id: "abc123",
+				operation: "update",
+			}),
+		);
 	});
 });

--- a/apps/web/src/server/groups/data.ts
+++ b/apps/web/src/server/groups/data.ts
@@ -1,6 +1,7 @@
 import { asc, count, eq, ilike } from "drizzle-orm";
 import type { PostgresError } from "postgres";
 import { db } from "../db/pg";
+import { takeFirstOrThrow } from "../db/rows";
 import {
 	type GroupPermissions,
 	type GroupRow,
@@ -159,14 +160,16 @@ export async function getGroup(groupId: number): Promise<Group> {
 
 export async function createGroup(name: string): Promise<Group> {
 	try {
-		const [row] = await db
-			.insert(groupsTable)
-			.values({
-				name,
-				legacyId: null,
-				permissions: generateBasePermissions(),
-			})
-			.returning();
+		const row = takeFirstOrThrow(
+			await db
+				.insert(groupsTable)
+				.values({
+					name,
+					legacyId: null,
+					permissions: generateBasePermissions(),
+				})
+				.returning(),
+		);
 
 		await emit("groups", row.id, "create");
 

--- a/apps/web/src/server/jobs/data.ts
+++ b/apps/web/src/server/jobs/data.ts
@@ -1,5 +1,6 @@
 import { count, desc, eq, inArray } from "drizzle-orm";
 import type { Db } from "../db/pg";
+import { takeFirstOrThrow } from "../db/rows";
 import {
 	type JobClaim,
 	type JobStep,
@@ -97,10 +98,9 @@ function buildCounts(
 	}
 
 	for (const row of rows) {
-		if (!counts[row.state]) {
-			counts[row.state] = {};
-		}
-		counts[row.state][row.workflow] = row.count;
+		const workflowCounts = counts[row.state] ?? {};
+		counts[row.state] = workflowCounts;
+		workflowCounts[row.workflow] = row.count;
 	}
 
 	return counts;
@@ -114,41 +114,43 @@ export async function findJobs(
 	// caller needs to scope jobs by user.
 	const stateFilter = states.length ? inArray(jobs.state, states) : undefined;
 
-	const [countRows, [{ value: totalCount }], foundCountResult, rows] =
-		await Promise.all([
-			db
-				.select({
-					state: jobs.state,
-					workflow: jobs.workflow,
-					count: count(),
-				})
-				.from(jobs)
-				.groupBy(jobs.state, jobs.workflow),
-			db.select({ value: count() }).from(jobs),
-			// Without a state filter the found count equals the total count, so
-			// skip the redundant query and reuse totalCount below.
-			stateFilter
-				? db.select({ value: count() }).from(jobs).where(stateFilter)
-				: undefined,
-			db
-				.select({
-					id: jobs.id,
-					created_at: jobs.created_at,
-					state: jobs.state,
-					steps: jobs.steps,
-					workflow: jobs.workflow,
-					userId: users.id,
-					handle: users.handle,
-				})
-				.from(jobs)
-				.innerJoin(users, eq(jobs.user_id, users.id))
-				.where(stateFilter)
-				.orderBy(desc(jobs.created_at))
-				.offset((page - 1) * perPage)
-				.limit(perPage),
-		]);
+	const [countRows, totalCountRows, foundCountRows, rows] = await Promise.all([
+		db
+			.select({
+				state: jobs.state,
+				workflow: jobs.workflow,
+				count: count(),
+			})
+			.from(jobs)
+			.groupBy(jobs.state, jobs.workflow),
+		db.select({ value: count() }).from(jobs),
+		// Without a state filter the found count equals the total count, so
+		// skip the redundant query and reuse totalCount below.
+		stateFilter
+			? db.select({ value: count() }).from(jobs).where(stateFilter)
+			: undefined,
+		db
+			.select({
+				id: jobs.id,
+				created_at: jobs.created_at,
+				state: jobs.state,
+				steps: jobs.steps,
+				workflow: jobs.workflow,
+				userId: users.id,
+				handle: users.handle,
+			})
+			.from(jobs)
+			.innerJoin(users, eq(jobs.user_id, users.id))
+			.where(stateFilter)
+			.orderBy(desc(jobs.created_at))
+			.offset((page - 1) * perPage)
+			.limit(perPage),
+	]);
 
-	const foundCount = foundCountResult ? foundCountResult[0].value : totalCount;
+	const totalCount = takeFirstOrThrow(totalCountRows).value;
+	const foundCount = foundCountRows
+		? takeFirstOrThrow(foundCountRows).value
+		: totalCount;
 
 	const items = rows.map((row) => ({
 		id: row.id,

--- a/apps/web/src/server/labels/data.ts
+++ b/apps/web/src/server/labels/data.ts
@@ -1,6 +1,7 @@
 import { asc, eq, ilike } from "drizzle-orm";
 import type { PostgresError } from "postgres";
 import type { Db } from "../db/pg";
+import { takeFirstOrThrow } from "../db/rows";
 import { type LabelRow, labels as labelsTable } from "../db/schema/labels";
 import { AppError } from "../errors";
 import { emit } from "../events/emit";
@@ -80,7 +81,9 @@ export async function getLabel(db: Db, labelId: number): Promise<Label> {
 export async function createLabel(db: Db, values: LabelValues): Promise<Label> {
 	let row: LabelRow;
 	try {
-		[row] = await db.insert(labelsTable).values(values).returning();
+		row = takeFirstOrThrow(
+			await db.insert(labelsTable).values(values).returning(),
+		);
 	} catch (error) {
 		if (isUniqueViolation(error)) {
 			throw new LabelConflictError();

--- a/apps/web/src/server/messages/data.ts
+++ b/apps/web/src/server/messages/data.ts
@@ -1,6 +1,7 @@
 import type { UserNested } from "@users/types";
 import { desc, eq } from "drizzle-orm";
 import { db } from "../db/pg";
+import { takeFirstOrThrow } from "../db/rows";
 import { instanceMessages, type MessageColor } from "../db/schema/messages";
 import { users } from "../db/schema/users";
 import { AppError } from "../errors";
@@ -97,17 +98,19 @@ export async function createMessage(
 	userId: number,
 ): Promise<Message> {
 	const now = new Date();
-	const [row] = await db
-		.insert(instanceMessages)
-		.values({
-			active: false,
-			color,
-			message,
-			createdAt: now,
-			updatedAt: now,
-			userId,
-		})
-		.returning({ id: instanceMessages.id });
+	const row = takeFirstOrThrow(
+		await db
+			.insert(instanceMessages)
+			.values({
+				active: false,
+				color,
+				message,
+				createdAt: now,
+				updatedAt: now,
+				userId,
+			})
+			.returning({ id: instanceMessages.id }),
+	);
 
 	await emit("messages", row.id, "create");
 

--- a/apps/web/src/server/users/data.ts
+++ b/apps/web/src/server/users/data.ts
@@ -14,6 +14,7 @@ import {
 import type { PostgresError } from "postgres";
 import { hashPassword } from "../auth/password";
 import type { Db } from "../db/pg";
+import { takeFirstOrThrow } from "../db/rows";
 import {
 	type GroupPermissions,
 	groups as groupsTable,
@@ -325,8 +326,7 @@ export async function getUser(db: Db, userId: number): Promise<User> {
 		throw new UserNotFoundError();
 	}
 
-	const [user] = await assembleUsers(db, [row]);
-	return user;
+	return takeFirstOrThrow(await assembleUsers(db, [row]));
 }
 
 /** Read a user's administrator role without assembling the full user. */
@@ -350,17 +350,19 @@ export async function createUser(
 	const password = await hashPassword(values.password);
 
 	try {
-		const [row] = await db
-			.insert(usersTable)
-			.values({
-				handle: values.handle,
-				password,
-				forceReset: values.forceReset,
-				lastPasswordChange: new Date(),
-				legacyId: null,
-				settings: DEFAULT_USER_SETTINGS,
-			})
-			.returning({ id: usersTable.id });
+		const row = takeFirstOrThrow(
+			await db
+				.insert(usersTable)
+				.values({
+					handle: values.handle,
+					password,
+					forceReset: values.forceReset,
+					lastPasswordChange: new Date(),
+					legacyId: null,
+					settings: DEFAULT_USER_SETTINGS,
+				})
+				.returning({ id: usersTable.id }),
+		);
 
 		await emit("users", row.id, "create");
 

--- a/apps/web/src/subtraction/components/Detail/__tests__/SubtractionDetail.test.tsx
+++ b/apps/web/src/subtraction/components/Detail/__tests__/SubtractionDetail.test.tsx
@@ -35,9 +35,11 @@ describe("<SubtractionDetail />", () => {
 		expect(
 			await screen.findByText(subtraction.linked_samples.length),
 		).toBeInTheDocument();
-		expect(
-			await screen.findByText(subtraction.files[0].name),
-		).toBeInTheDocument();
+		const file = subtraction.files[0];
+		if (!file) {
+			throw new Error("expected a file");
+		}
+		expect(await screen.findByText(file.name)).toBeInTheDocument();
 
 		scope.done();
 	});

--- a/apps/web/src/subtraction/components/Detail/__tests__/SubtractionDetail.test.tsx
+++ b/apps/web/src/subtraction/components/Detail/__tests__/SubtractionDetail.test.tsx
@@ -35,11 +35,9 @@ describe("<SubtractionDetail />", () => {
 		expect(
 			await screen.findByText(subtraction.linked_samples.length),
 		).toBeInTheDocument();
-		const file = subtraction.files[0];
-		if (!file) {
-			throw new Error("expected a file");
+		for (const file of subtraction.files) {
+			expect(await screen.findByText(file.name)).toBeInTheDocument();
 		}
-		expect(await screen.findByText(file.name)).toBeInTheDocument();
 
 		scope.done();
 	});

--- a/apps/web/src/subtraction/components/SubtractionCreate.tsx
+++ b/apps/web/src/subtraction/components/SubtractionCreate.tsx
@@ -73,8 +73,13 @@ export default function SubtractionCreate({
 	}
 
 	function onSubmit({ name, nickname, uploadId }: FormValues) {
+		const id = uploadId[0];
+		if (id === undefined) {
+			return;
+		}
+
 		mutation.mutate(
-			{ name, nickname, uploadId: uploadId[0] },
+			{ name, nickname, uploadId: id },
 			{
 				onSuccess: () => {
 					setOpen(false);
@@ -125,7 +130,7 @@ export default function SubtractionCreate({
 								isFetchingNextPage={isFetchingNextPage}
 								fetchNextPage={fetchNextPage}
 								isPending={isPending}
-								foundCount={files.pages[0].found_count}
+								foundCount={files.pages[0]?.found_count ?? 0}
 								selected={value}
 							/>
 						)}

--- a/apps/web/src/tests/fake/analyses.ts
+++ b/apps/web/src/tests/fake/analyses.ts
@@ -118,8 +118,12 @@ export function createFakeFormattedNuVsHit(overrides?: FakeFormattedNuVsHit) {
  * @returns The nock scope for the mocked API call
  */
 export function mockApiGetAnalyses(analyses: AnalysisMinimal[]) {
+	const [firstAnalysis] = analyses;
+	if (!firstAnalysis) {
+		throw new Error("expected at least one analysis");
+	}
 	return nock("http://localhost")
-		.get(`/api/samples/${analyses[0].sample.id}/analyses`)
+		.get(`/api/samples/${firstAnalysis.sample.id}/analyses`)
 		.query(true)
 		.reply(200, {
 			page: 1,

--- a/apps/web/src/tests/fake/ml.ts
+++ b/apps/web/src/tests/fake/ml.ts
@@ -48,7 +48,7 @@ export function createFakeMLModel(overrides?: Partial<MlModel>): MlModel {
 
 	return {
 		...createFakeMLModelMinimal(overrides),
-		latest_release: releases[0],
+		latest_release: releases[0] ?? null,
 		releases,
 		...overrides,
 	};

--- a/apps/web/src/tests/fake/user.ts
+++ b/apps/web/src/tests/fake/user.ts
@@ -38,7 +38,8 @@ export function createFakeUser(overrides?: Partial<User>): User {
 		groups,
 		last_password_change: faker.date.past().toISOString(),
 		permissions: createFakePermissions(permissions),
-		primary_group: primary_group === undefined ? groups[0] : primary_group,
+		primary_group:
+			primary_group === undefined ? (groups[0] ?? null) : primary_group,
 		...rest,
 	};
 }

--- a/apps/web/src/tests/setup.tsx
+++ b/apps/web/src/tests/setup.tsx
@@ -56,6 +56,20 @@ process.env.TZ = "UTC";
 
 faker.seed(1);
 
+/**
+ * Return the element at `index`, throwing if the array has no such element.
+ *
+ * Lets tests index into fixture data they built without a non-null assertion,
+ * which `noUncheckedIndexedAccess` would otherwise require.
+ */
+export function at<T>(items: readonly T[], index: number): T {
+	const item = items[index];
+	if (item === undefined) {
+		throw new Error(`expected an element at index ${index}`);
+	}
+	return item;
+}
+
 export function wrapWithProviders(ui: ReactNode) {
 	const queryClient = new QueryClient();
 

--- a/apps/web/src/uploads/pairing.ts
+++ b/apps/web/src/uploads/pairing.ts
@@ -42,8 +42,14 @@ export function detectMate(name: string): Mate | null {
 		const match = pattern.exec(name);
 
 		if (match) {
-			const side = Number(match[1]) as 1 | 2;
-			const digitIndex = match.index + match[0].indexOf(match[1]);
+			const full = match[0];
+			const digit = match[1];
+			if (full === undefined || digit === undefined) {
+				continue;
+			}
+
+			const side = Number(digit) as 1 | 2;
+			const digitIndex = match.index + full.indexOf(digit);
 			const stem =
 				name.slice(0, digitIndex) + MATE_TOKEN + name.slice(digitIndex + 1);
 
@@ -87,6 +93,10 @@ export function buildReadRows(files: Upload[]): ReadRow[] {
 		}
 
 		const [first, second] = group;
+		if (first === undefined || second === undefined) {
+			continue;
+		}
+
 		const firstSide = mates.get(first.id)?.side;
 		const secondSide = mates.get(second.id)?.side;
 

--- a/apps/web/src/uploads/uploader.ts
+++ b/apps/web/src/uploads/uploader.ts
@@ -129,12 +129,13 @@ function watchUploadTiming(): void {
 
 	const newSamples = [...samples.slice(-9), loaded];
 
+	const last = newSamples[newSamples.length - 1];
+	const first = newSamples[0];
+
 	let speed: number;
 
-	if (newSamples.length > 1) {
-		speed =
-			Math.abs(newSamples[newSamples.length - 1] - newSamples[0]) /
-			newSamples.length;
+	if (newSamples.length > 1 && last !== undefined && first !== undefined) {
+		speed = Math.abs(last - first) / newSamples.length;
 	} else {
 		speed = 0;
 	}

--- a/apps/web/src/users/components/__tests__/ManageUsers.test.tsx
+++ b/apps/web/src/users/components/__tests__/ManageUsers.test.tsx
@@ -9,7 +9,11 @@ import { ManageUsers } from "../ManageUsers";
 describe("<ManageUsers />", () => {
 	it("should render correctly with 3 users", async () => {
 		const users = createFakeUsers(3);
-		users[0].administrator_role = "full";
+		const [firstUser] = users;
+		if (!firstUser) {
+			throw new Error("expected user");
+		}
+		firstUser.administrator_role = "full";
 		await mockApiFindUsers(users);
 		const account = createFakeAccount({
 			administrator_role: "full",
@@ -42,6 +46,10 @@ describe("<ManageUsers />", () => {
 
 	it("should render correctly if account has insufficient permissions", async () => {
 		const users = createFakeUsers(3);
+		const [firstUser] = users;
+		if (!firstUser) {
+			throw new Error("expected user");
+		}
 
 		mockApiFindUsers(users);
 		mockApiGetAccount(createFakeAccount({ administrator_role: null }));
@@ -52,7 +60,7 @@ describe("<ManageUsers />", () => {
 			await screen.findByText("You do not have permission to manage users."),
 		).toBeInTheDocument();
 		expect(screen.getByText("Contact an administrator.")).toBeInTheDocument();
-		expect(screen.queryByText(users[0].handle)).not.toBeInTheDocument();
+		expect(screen.queryByText(firstUser.handle)).not.toBeInTheDocument();
 		expect(
 			screen.queryByRole("button", { name: "Create" }),
 		).not.toBeInTheDocument();

--- a/apps/web/src/users/components/__tests__/ManageUsers.test.tsx
+++ b/apps/web/src/users/components/__tests__/ManageUsers.test.tsx
@@ -2,18 +2,14 @@ import { screen } from "@testing-library/react";
 import { mockApiFindUsers } from "@tests/api/users";
 import { createFakeAccount, mockApiGetAccount } from "@tests/fake/account";
 import { createFakeUsers } from "@tests/fake/user";
-import { renderWithRouter } from "@tests/setup";
+import { at, renderWithRouter } from "@tests/setup";
 import { describe, expect, it } from "vitest";
 import { ManageUsers } from "../ManageUsers";
 
 describe("<ManageUsers />", () => {
 	it("should render correctly with 3 users", async () => {
 		const users = createFakeUsers(3);
-		const [firstUser] = users;
-		if (!firstUser) {
-			throw new Error("expected user");
-		}
-		firstUser.administrator_role = "full";
+		at(users, 0).administrator_role = "full";
 		await mockApiFindUsers(users);
 		const account = createFakeAccount({
 			administrator_role: "full",
@@ -46,10 +42,6 @@ describe("<ManageUsers />", () => {
 
 	it("should render correctly if account has insufficient permissions", async () => {
 		const users = createFakeUsers(3);
-		const [firstUser] = users;
-		if (!firstUser) {
-			throw new Error("expected user");
-		}
 
 		mockApiFindUsers(users);
 		mockApiGetAccount(createFakeAccount({ administrator_role: null }));
@@ -60,7 +52,9 @@ describe("<ManageUsers />", () => {
 			await screen.findByText("You do not have permission to manage users."),
 		).toBeInTheDocument();
 		expect(screen.getByText("Contact an administrator.")).toBeInTheDocument();
-		expect(screen.queryByText(firstUser.handle)).not.toBeInTheDocument();
+		for (const user of users) {
+			expect(screen.queryByText(user.handle)).not.toBeInTheDocument();
+		}
 		expect(
 			screen.queryByRole("button", { name: "Create" }),
 		).not.toBeInTheDocument();

--- a/apps/web/src/wall/components/__tests__/LoginForm.test.tsx
+++ b/apps/web/src/wall/components/__tests__/LoginForm.test.tsx
@@ -43,12 +43,14 @@ describe("<LoginForm />", () => {
 		await userEvent.click(screen.getByRole("button", { name: "Login" }));
 
 		await waitFor(() => expect(loginMock).toHaveBeenCalledTimes(1));
-		const [loginArgs] = loginMock.mock.calls[0] ?? [];
-		expect(loginArgs).toEqual({
-			handle,
-			password,
-			remember: true,
-		});
+		expect(loginMock).toHaveBeenCalledWith(
+			{
+				handle,
+				password,
+				remember: true,
+			},
+			expect.anything(),
+		);
 	});
 
 	it("displays the thrown error message on login failure", async () => {

--- a/apps/web/src/wall/components/__tests__/LoginForm.test.tsx
+++ b/apps/web/src/wall/components/__tests__/LoginForm.test.tsx
@@ -43,7 +43,8 @@ describe("<LoginForm />", () => {
 		await userEvent.click(screen.getByRole("button", { name: "Login" }));
 
 		await waitFor(() => expect(loginMock).toHaveBeenCalledTimes(1));
-		expect(loginMock.mock.calls[0][0]).toEqual({
+		const [loginArgs] = loginMock.mock.calls[0] ?? [];
+		expect(loginArgs).toEqual({
 			handle,
 			password,
 			remember: true,

--- a/apps/web/src/wall/components/__tests__/ResetForm.test.tsx
+++ b/apps/web/src/wall/components/__tests__/ResetForm.test.tsx
@@ -36,8 +36,10 @@ describe("<ResetForm />", () => {
 		await userEvent.click(screen.getByRole("button", { name: "Reset" }));
 
 		await waitFor(() => expect(resetPasswordMock).toHaveBeenCalledTimes(1));
-		const [resetArgs] = resetPasswordMock.mock.calls[0] ?? [];
-		expect(resetArgs).toEqual({ password, resetCode });
+		expect(resetPasswordMock).toHaveBeenCalledWith(
+			{ password, resetCode },
+			expect.anything(),
+		);
 	});
 
 	it("displays the thrown error message on reset failure", async () => {

--- a/apps/web/src/wall/components/__tests__/ResetForm.test.tsx
+++ b/apps/web/src/wall/components/__tests__/ResetForm.test.tsx
@@ -36,7 +36,8 @@ describe("<ResetForm />", () => {
 		await userEvent.click(screen.getByRole("button", { name: "Reset" }));
 
 		await waitFor(() => expect(resetPasswordMock).toHaveBeenCalledTimes(1));
-		expect(resetPasswordMock.mock.calls[0][0]).toEqual({ password, resetCode });
+		const [resetArgs] = resetPasswordMock.mock.calls[0] ?? [];
+		expect(resetArgs).toEqual({ password, resetCode });
 	});
 
 	it("displays the thrown error message on reset failure", async () => {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -39,6 +39,7 @@
 		"module": "ESNext",
 		"moduleResolution": "bundler",
 		"noEmit": true,
+		"noUncheckedIndexedAccess": true,
 		"outDir": "./build/",
 		"rootDir": "./src",
 		"skipLibCheck": true,


### PR DESCRIPTION
## Summary
- Enables the `noUncheckedIndexedAccess` TypeScript compiler option, which makes array and object index access return `T | undefined` instead of `T`, catching a class of potential runtime errors at compile time.
- Fixes all resulting type errors across the codebase by adding null checks, optional chaining (`?.`), and fallback values where index access results were previously assumed to be defined.
- Also enforces zero Biome warnings and fixes two dialog open-reliability issues found during the work.

## Test plan
- [ ] CI type check passes with `noUncheckedIndexedAccess` enabled
- [ ] CI lint check passes (`pnpm check`)
- [ ] All existing tests continue to pass