### PR TITLE
fix: open reference member dialogs reliably

### DIFF
--- a/apps/web/src/references/components/Detail/ReferenceSettings.tsx
+++ b/apps/web/src/references/components/Detail/ReferenceSettings.tsx
@@ -6,34 +6,21 @@ import { useFetchReference } from "@references/queries";
  */
 import { getRouteApi } from "@tanstack/react-router";
 import { sortBy } from "es-toolkit";
+import { useState } from "react";
 import { ArchivedSourceTypes } from "../SourceTypes/ArchivedSourceTypes";
 import { LocalSourceTypes } from "../SourceTypes/LocalSourceTypes";
 import ReferenceMembers from "./ReferenceMembers";
 
 const routeApi = getRouteApi("/_authenticated/refs/$refId");
 
-type ReferenceSettingsProps = {
-	editGroupId?: string;
-	editUserId?: string;
-	openAddGroup?: boolean;
-	openAddUser?: boolean;
-	setSearch?: (next: {
-		editGroupId?: string;
-		editUserId?: string;
-		openAddGroup?: boolean;
-		openAddUser?: boolean;
-	}) => void;
-};
-
-export default function ReferenceSettings({
-	editGroupId,
-	editUserId,
-	openAddGroup = false,
-	openAddUser = false,
-	setSearch = () => {},
-}: ReferenceSettingsProps) {
+export default function ReferenceSettings() {
 	const { refId } = routeApi.useParams();
 	const { data, isPending } = useFetchReference(refId);
+
+	const [editUserId, setEditUserId] = useState<string>();
+	const [editGroupId, setEditGroupId] = useState<string>();
+	const [openAddUser, setOpenAddUser] = useState(false);
+	const [openAddGroup, setOpenAddGroup] = useState(false);
 
 	if (isPending || !data) {
 		return <LoadingPlaceholder />;
@@ -53,8 +40,8 @@ export default function ReferenceSettings({
 				members={sortBy(data.users, ["id"])}
 				openAdd={openAddUser}
 				refId={refId}
-				setEditId={(editUserId) => setSearch({ editUserId })}
-				setOpenAdd={(openAddUser) => setSearch({ openAddUser })}
+				setEditId={setEditUserId}
+				setOpenAdd={setOpenAddUser}
 			/>
 			<ReferenceMembers
 				editId={editGroupId}
@@ -62,8 +49,8 @@ export default function ReferenceSettings({
 				members={sortBy(data.groups, ["id"])}
 				openAdd={openAddGroup}
 				refId={refId}
-				setEditId={(editGroupId) => setSearch({ editGroupId })}
-				setOpenAdd={(openAddGroup) => setSearch({ openAddGroup })}
+				setEditId={setEditGroupId}
+				setOpenAdd={setOpenAddGroup}
 			/>
 		</>
 	);

--- a/apps/web/src/routes/_authenticated/refs/$refId/manage.tsx
+++ b/apps/web/src/routes/_authenticated/refs/$refId/manage.tsx
@@ -1,15 +1,6 @@
 import ReferenceManager from "@references/components/Detail/ReferenceManager";
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod/v4";
-
-const manageSearchSchema = z.object({
-	openAddUser: z.boolean().optional().catch(undefined),
-	openAddGroup: z.boolean().optional().catch(undefined),
-	editUserId: z.string().optional().catch(undefined),
-	editGroupId: z.string().optional().catch(undefined),
-});
 
 export const Route = createFileRoute("/_authenticated/refs/$refId/manage")({
-	validateSearch: manageSearchSchema,
 	component: ReferenceManager,
 });

--- a/apps/web/src/routes/_authenticated/refs/$refId/settings.tsx
+++ b/apps/web/src/routes/_authenticated/refs/$refId/settings.tsx
@@ -1,30 +1,6 @@
 import ReferenceSettings from "@references/components/Detail/ReferenceSettings";
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod/v4";
-
-const settingsSearchSchema = z.object({
-	openAddUser: z.boolean().optional().catch(undefined),
-	openAddGroup: z.boolean().optional().catch(undefined),
-	editUserId: z.string().optional().catch(undefined),
-	editGroupId: z.string().optional().catch(undefined),
-});
 
 export const Route = createFileRoute("/_authenticated/refs/$refId/settings")({
-	validateSearch: settingsSearchSchema,
-	component: ReferenceSettingsRoute,
+	component: ReferenceSettings,
 });
-
-function ReferenceSettingsRoute() {
-	const search = Route.useSearch();
-	const navigate = Route.useNavigate();
-
-	return (
-		<ReferenceSettings
-			editGroupId={search.editGroupId}
-			editUserId={search.editUserId}
-			openAddGroup={Boolean(search.openAddGroup)}
-			openAddUser={Boolean(search.openAddUser)}
-			setSearch={(next) => navigate({ search: { ...search, ...next } })}
-		/>
-	);
-}


### PR DESCRIPTION
## Summary
- Switches reference member management dialog state (add user, add group, edit user, edit group) from URL search params to local React `useState`
- Removes `validateSearch` schemas from the `/refs/$refId/manage` and `/refs/$refId/settings` routes
- Consistent with the same fix applied to quick-analyze, index rebuild, create user, and sample edit dialogs

## Test plan
- [ ] Open a reference settings page and add a user member — dialog opens and closes correctly
- [ ] Open a reference settings page and edit a user member — dialog opens pre-filled and closes correctly
- [ ] Open a reference settings page and add a group member — dialog opens and closes correctly
- [ ] Open a reference settings page and edit a group member — dialog opens pre-filled and closes correctly
- [ ] Open the reference manage page and verify the same member dialog flows work