### PR TITLE
fix: open create analysis dialog reliably

### DIFF
--- a/apps/web/src/analyses/components/AnalysisList.tsx
+++ b/apps/web/src/analyses/components/AnalysisList.tsx
@@ -6,6 +6,7 @@ import Pagination from "@base/Pagination";
 import { useListHmms } from "@hmm/queries";
 import { useCheckCanEditSample } from "@samples/hooks";
 import { useFetchSample } from "@samples/queries";
+import { useState } from "react";
 import { useListAnalyses } from "../queries";
 import type { AnalysisMinimal } from "../types";
 import AnalysisItem from "./AnalysisItem";
@@ -13,10 +14,9 @@ import CreateAnalysis from "./Create/CreateAnalysis";
 import AnalysisHMMAlert from "./HMMAlert";
 
 type AnalysesListProps = {
-	openCreateAnalysis: boolean;
+	onPageChange: (page: number) => void;
 	page: number;
 	sampleId: string;
-	setSearch: (next: { openCreateAnalysis?: boolean; page?: number }) => void;
 };
 
 function renderRow() {
@@ -30,11 +30,11 @@ function renderRow() {
  * A list of analyses with filtering options
  */
 export default function AnalysesList({
-	openCreateAnalysis,
+	onPageChange,
 	page,
 	sampleId,
-	setSearch,
 }: AnalysesListProps) {
+	const [openCreateAnalysis, setOpenCreateAnalysis] = useState(false);
 	const { data: analyses, isPending: isPendingAnalyses } = useListAnalyses(
 		sampleId,
 		page,
@@ -66,7 +66,7 @@ export default function AnalysesList({
 					<button
 						type="button"
 						className={buttonVariants({ color: "blue" })}
-						onClick={() => setSearch({ openCreateAnalysis: true })}
+						onClick={() => setOpenCreateAnalysis(true)}
 					>
 						Create
 					</button>
@@ -79,7 +79,7 @@ export default function AnalysesList({
 					storedPage={analyses.page}
 					currentPage={page}
 					pageCount={analyses.page_count}
-					onPageChange={(page) => setSearch({ page })}
+					onPageChange={onPageChange}
 				/>
 			) : (
 				<NoneFoundBox noun="analyses" />
@@ -88,7 +88,7 @@ export default function AnalysesList({
 			<CreateAnalysis
 				hmms={hmms}
 				open={openCreateAnalysis}
-				setOpen={(openCreateAnalysis) => setSearch({ openCreateAnalysis })}
+				setOpen={setOpenCreateAnalysis}
 				sampleId={sampleId}
 			/>
 		</ContainerNarrow>

--- a/apps/web/src/analyses/components/__tests__/AnalysisList.test.tsx
+++ b/apps/web/src/analyses/components/__tests__/AnalysisList.test.tsx
@@ -27,12 +27,7 @@ describe("<AnalysesToolbar />", () => {
 	function renderList() {
 		renderWithProviders(
 			<MemoryRouter>
-				<AnalysesList
-					openCreateAnalysis={false}
-					page={1}
-					sampleId={sample.id}
-					setSearch={() => {}}
-				/>
+				<AnalysesList onPageChange={() => {}} page={1} sampleId={sample.id} />
 			</MemoryRouter>,
 		);
 	}

--- a/apps/web/src/routes/_authenticated/samples/$sampleId/analyses/index.tsx
+++ b/apps/web/src/routes/_authenticated/samples/$sampleId/analyses/index.tsx
@@ -4,7 +4,6 @@ import { z } from "zod/v4";
 
 const analysesListSearchSchema = z.object({
 	page: z.number().default(1).catch(1),
-	openCreateAnalysis: z.boolean().optional().catch(undefined),
 });
 
 export const Route = createFileRoute(
@@ -16,15 +15,14 @@ export const Route = createFileRoute(
 
 function AnalysesRoute() {
 	const { sampleId } = Route.useParams();
-	const search = Route.useSearch();
+	const { page } = Route.useSearch();
 	const navigate = Route.useNavigate();
 
 	return (
 		<AnalysesList
-			openCreateAnalysis={Boolean(search.openCreateAnalysis)}
-			page={search.page}
+			onPageChange={(page) => navigate({ search: { page } })}
+			page={page}
 			sampleId={sampleId}
-			setSearch={(next) => navigate({ search: { ...search, ...next } })}
 		/>
 	);
 }


### PR DESCRIPTION
## Summary

- Switches the create analysis dialog open state from a URL search param (`openCreateAnalysis`) to local React state (`useState`), matching the same pattern used for other dialogs in recent fixes
- Removes `openCreateAnalysis` from the analyses route search schema, simplifying the URL and preventing stale dialog state from persisting across navigations
- Cleans up the `AnalysesList` component props: drops `openCreateAnalysis` and `setSearch`, adds a focused `onPageChange` callback

## Test plan

- [ ] Open a sample's analyses tab and click the Create button — the create analysis dialog should open
- [ ] Close the dialog and confirm it does not reopen on navigation
- [ ] Confirm page navigation still works via the pagination control