### PR TITLE
fix: open edit and archive reference dialogs reliably

### DIFF
--- a/apps/web/src/references/components/Detail/ArchiveReference.tsx
+++ b/apps/web/src/references/components/Detail/ArchiveReference.tsx
@@ -6,27 +6,24 @@ import {
 	DialogFooter,
 	DialogTitle,
 } from "@base/Dialog";
+import IconButton from "@base/IconButton";
 import {
 	useArchiveReference,
 	useUnarchiveReference,
 } from "@references/queries";
 import type { Reference } from "@references/types";
 import { AlertCircle, Archive, ArchiveRestore } from "lucide-react";
+import { useState } from "react";
 
 type ArchiveReferenceProps = {
 	detail: Reference;
-	open?: boolean;
-	setOpen?: (open: boolean) => void;
 };
 
 /**
- * A dialog confirming that the user wants to archive or unarchive a reference
+ * An archive/unarchive icon button and the dialog confirming the action
  */
-export default function ArchiveReference({
-	detail,
-	open = false,
-	setOpen = () => {},
-}: ArchiveReferenceProps) {
+export default function ArchiveReference({ detail }: ArchiveReferenceProps) {
+	const [open, setOpen] = useState(false);
 	const archiveMutation = useArchiveReference(detail.id);
 	const unarchiveMutation = useUnarchiveReference(detail.id);
 
@@ -61,43 +58,51 @@ export default function ArchiveReference({
 	const Icon = detail.archived ? ArchiveRestore : Archive;
 
 	return (
-		<Dialog open={open} onOpenChange={handleOpenChange}>
-			<DialogContent>
-				<div className="flex gap-4">
-					<div className="shrink-0 inline-flex items-center justify-center w-11 h-11 rounded-full bg-gray-100 text-gray-600">
-						<Icon size={20} strokeWidth={2.25} />
-					</div>
-					<div className="min-w-0 flex-1">
-						<DialogTitle>
-							{verb} <span className="text-gray-700">{detail.name}</span>?
-						</DialogTitle>
-						<DialogDescription>
-							{detail.archived
-								? "It will return to active use and appear in the default references list."
-								: "Archived references are hidden from default views and blocked from edits and new analyses. Existing analyses will continue to resolve."}
-						</DialogDescription>
-					</div>
-				</div>
-
-				{errorMessage && (
-					<div className="mt-4 flex items-start gap-2 px-3 py-2.5 rounded border border-red-200 bg-red-50 text-red-700">
-						<AlertCircle size={16} className="mt-0.5 shrink-0" />
-						<div className="text-sm leading-snug">
-							<span className="font-semibold">
-								Cannot {verb.toLowerCase()}.
-							</span>{" "}
-							{errorMessage}
+		<>
+			<IconButton
+				color="grayDark"
+				IconComponent={Icon}
+				tip={detail.archived ? "unarchive" : "archive"}
+				onClick={() => setOpen(true)}
+			/>
+			<Dialog open={open} onOpenChange={handleOpenChange}>
+				<DialogContent>
+					<div className="flex gap-4">
+						<div className="shrink-0 inline-flex items-center justify-center w-11 h-11 rounded-full bg-gray-100 text-gray-600">
+							<Icon size={20} strokeWidth={2.25} />
+						</div>
+						<div className="min-w-0 flex-1">
+							<DialogTitle>
+								{verb} <span className="text-gray-700">{detail.name}</span>?
+							</DialogTitle>
+							<DialogDescription>
+								{detail.archived
+									? "It will return to active use and appear in the default references list."
+									: "Archived references are hidden from default views and blocked from edits and new analyses. Existing analyses will continue to resolve."}
+							</DialogDescription>
 						</div>
 					</div>
-				)}
 
-				<DialogFooter className="mt-2 gap-2">
-					<Button onClick={() => handleOpenChange(false)}>Cancel</Button>
-					<Button color="blue" onClick={handleConfirm}>
-						{verb}
-					</Button>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+					{errorMessage && (
+						<div className="mt-4 flex items-start gap-2 px-3 py-2.5 rounded border border-red-200 bg-red-50 text-red-700">
+							<AlertCircle size={16} className="mt-0.5 shrink-0" />
+							<div className="text-sm leading-snug">
+								<span className="font-semibold">
+									Cannot {verb.toLowerCase()}.
+								</span>{" "}
+								{errorMessage}
+							</div>
+						</div>
+					)}
+
+					<DialogFooter className="mt-2 gap-2">
+						<Button onClick={() => handleOpenChange(false)}>Cancel</Button>
+						<Button color="blue" onClick={handleConfirm}>
+							{verb}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
 	);
 }

--- a/apps/web/src/references/components/Detail/ArchivedReferenceDetailHeader.tsx
+++ b/apps/web/src/references/components/Detail/ArchivedReferenceDetailHeader.tsx
@@ -1,21 +1,23 @@
 import Badge from "@base/Badge";
 import Icon from "@base/Icon";
-import IconButton from "@base/IconButton";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderAttribution from "@base/ViewHeaderAttribution";
 import ViewHeaderIcons from "@base/ViewHeaderIcons";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import { useCheckReferenceRight } from "@references/hooks";
+import type { Reference } from "@references/types";
 import { useLocation } from "@tanstack/react-router";
-import { ArchiveRestore, Lock } from "lucide-react";
+import { Lock } from "lucide-react";
+import ArchiveReference from "./ArchiveReference";
 
 type ArchivedReferenceDetailHeaderProps = {
 	createdAt: string;
+	/** The reference details */
+	detail: Reference;
 	/** Whether the reference is installed remotely */
 	isRemote: boolean;
 	name: string;
 	refId: string;
-	setOpenArchiveReference?: (open: boolean) => void;
 	userHandle: string;
 };
 
@@ -25,10 +27,10 @@ type ArchivedReferenceDetailHeaderProps = {
  */
 export default function ArchivedReferenceDetailHeader({
 	createdAt,
+	detail,
 	isRemote,
 	name,
 	refId,
-	setOpenArchiveReference = () => {},
 	userHandle,
 }: ArchivedReferenceDetailHeaderProps) {
 	const { pathname: location } = useLocation();
@@ -46,14 +48,7 @@ export default function ArchivedReferenceDetailHeader({
 				{showIcons && (
 					<ViewHeaderIcons>
 						{isRemote && <Icon color="grey" icon={Lock} aria-label="lock" />}
-						{!isRemote && canModify && (
-							<IconButton
-								color="grayDark"
-								IconComponent={ArchiveRestore}
-								tip="unarchive"
-								onClick={() => setOpenArchiveReference(true)}
-							/>
-						)}
+						{!isRemote && canModify && <ArchiveReference detail={detail} />}
 					</ViewHeaderIcons>
 				)}
 			</ViewHeaderTitle>

--- a/apps/web/src/references/components/Detail/EditReference.tsx
+++ b/apps/web/src/references/components/Detail/EditReference.tsx
@@ -38,8 +38,19 @@ export default function EditReference({ detail }: EditReferenceProps) {
 	const { mutation } = useUpdateReference(detail.id);
 
 	function handleEdit({ name, description, organism }) {
-		mutation.mutate({ name, description, organism });
-		setOpen(false);
+		mutation.mutate(
+			{ name, description, organism },
+			{
+				onSuccess: () => setOpen(false),
+			},
+		);
+	}
+
+	function handleOpenChange(next: boolean) {
+		if (!next) {
+			mutation.reset();
+			setOpen(false);
+		}
 	}
 
 	return (
@@ -50,7 +61,7 @@ export default function EditReference({ detail }: EditReferenceProps) {
 				tip="modify"
 				onClick={() => setOpen(true)}
 			/>
-			<Dialog open={open} onOpenChange={() => setOpen(false)}>
+			<Dialog open={open} onOpenChange={handleOpenChange}>
 				<DialogContent>
 					<DialogTitle>Edit Reference</DialogTitle>
 					<form onSubmit={handleSubmit((values) => handleEdit({ ...values }))}>

--- a/apps/web/src/references/components/Detail/EditReference.tsx
+++ b/apps/web/src/references/components/Detail/EditReference.tsx
@@ -1,7 +1,10 @@
 import { Dialog, DialogContent, DialogFooter, DialogTitle } from "@base/Dialog";
+import IconButton from "@base/IconButton";
 import SaveButton from "@base/SaveButton";
 import { useUpdateReference } from "@references/queries";
 import type { Reference } from "@references/types";
+import { Pencil } from "lucide-react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { ReferenceForm } from "../ReferenceForm";
 
@@ -14,18 +17,13 @@ export type FormValues = {
 type EditReferenceProps = {
 	/** The reference details */
 	detail: Reference;
-	open?: boolean;
-	setOpen?: (open: boolean) => void;
 };
 
 /**
- * A dialog for editing a reference
+ * A modify icon button and the dialog it opens for editing a reference
  */
-export default function EditReference({
-	detail,
-	open = false,
-	setOpen = () => {},
-}: EditReferenceProps) {
+export default function EditReference({ detail }: EditReferenceProps) {
+	const [open, setOpen] = useState(false);
 	const {
 		formState: { errors },
 		handleSubmit,
@@ -45,16 +43,24 @@ export default function EditReference({
 	}
 
 	return (
-		<Dialog open={open} onOpenChange={() => setOpen(false)}>
-			<DialogContent>
-				<DialogTitle>Edit Reference</DialogTitle>
-				<form onSubmit={handleSubmit((values) => handleEdit({ ...values }))}>
-					<ReferenceForm errors={errors} mode="edit" register={register} />
-					<DialogFooter>
-						<SaveButton />
-					</DialogFooter>
-				</form>
-			</DialogContent>
-		</Dialog>
+		<>
+			<IconButton
+				color="grayDark"
+				IconComponent={Pencil}
+				tip="modify"
+				onClick={() => setOpen(true)}
+			/>
+			<Dialog open={open} onOpenChange={() => setOpen(false)}>
+				<DialogContent>
+					<DialogTitle>Edit Reference</DialogTitle>
+					<form onSubmit={handleSubmit((values) => handleEdit({ ...values }))}>
+						<ReferenceForm errors={errors} mode="edit" register={register} />
+						<DialogFooter>
+							<SaveButton />
+						</DialogFooter>
+					</form>
+				</DialogContent>
+			</Dialog>
+		</>
 	);
 }

--- a/apps/web/src/references/components/Detail/ReferenceDetailHeader.tsx
+++ b/apps/web/src/references/components/Detail/ReferenceDetailHeader.tsx
@@ -1,21 +1,23 @@
 import Icon from "@base/Icon";
-import IconButton from "@base/IconButton";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderAttribution from "@base/ViewHeaderAttribution";
 import ViewHeaderIcons from "@base/ViewHeaderIcons";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import { useCheckReferenceRight } from "@references/hooks";
+import type { Reference } from "@references/types";
 import { useLocation } from "@tanstack/react-router";
-import { Archive, Lock, Pencil } from "lucide-react";
+import { Lock } from "lucide-react";
+import ArchiveReference from "./ArchiveReference";
+import EditReference from "./EditReference";
 
 type ReferenceDetailHeaderProps = {
 	createdAt: string;
+	/** The reference details */
+	detail: Reference;
 	/** Whether the reference is installed remotely */
 	isRemote: boolean;
 	name: string;
 	refId: string;
-	setOpenArchiveReference?: (open: boolean) => void;
-	setOpenEditReference?: (open: boolean) => void;
 	userHandle: string;
 };
 
@@ -25,11 +27,10 @@ type ReferenceDetailHeaderProps = {
  */
 export default function ReferenceDetailHeader({
 	createdAt,
+	detail,
 	isRemote,
 	name,
 	refId,
-	setOpenArchiveReference = () => {},
-	setOpenEditReference = () => {},
 	userHandle,
 }: ReferenceDetailHeaderProps) {
 	const { pathname: location } = useLocation();
@@ -46,18 +47,8 @@ export default function ReferenceDetailHeader({
 						{isRemote && <Icon color="grey" icon={Lock} aria-label="lock" />}
 						{!isRemote && canModify && (
 							<>
-								<IconButton
-									color="grayDark"
-									IconComponent={Pencil}
-									tip="modify"
-									onClick={() => setOpenEditReference(true)}
-								/>
-								<IconButton
-									color="grayDark"
-									IconComponent={Archive}
-									tip="archive"
-									onClick={() => setOpenArchiveReference(true)}
-								/>
+								<EditReference detail={detail} />
+								<ArchiveReference detail={detail} />
 							</>
 						)}
 					</ViewHeaderIcons>

--- a/apps/web/src/references/components/Detail/__tests__/ArchiveReference.test.tsx
+++ b/apps/web/src/references/components/Detail/__tests__/ArchiveReference.test.tsx
@@ -7,18 +7,8 @@ import {
 } from "@tests/fake/references";
 import { renderWithRouter } from "@tests/setup";
 import nock from "nock";
-import { useState } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import ArchiveReference from "../ArchiveReference";
-
-function ArchiveReferenceHarness({
-	detail,
-}: {
-	detail: ReturnType<typeof createFakeReference>;
-}) {
-	const [open, setOpen] = useState(true);
-	return <ArchiveReference detail={detail} open={open} setOpen={setOpen} />;
-}
 
 function getDialogTitle(verb: "Archive" | "Unarchive", name: string) {
 	return screen.queryByRole("heading", {
@@ -34,8 +24,9 @@ describe("<ArchiveReference />", () => {
 		const archived = { ...detail, archived: true };
 		const scope = mockApiArchiveReference(detail.id, archived);
 
-		await renderWithRouter(<ArchiveReferenceHarness detail={detail} />);
+		await renderWithRouter(<ArchiveReference detail={detail} />);
 
+		await userEvent.click(screen.getByRole("button", { name: "archive" }));
 		expect(getDialogTitle("Archive", detail.name)).toBeInTheDocument();
 
 		await userEvent.click(screen.getByRole("button", { name: "Archive" }));
@@ -52,8 +43,9 @@ describe("<ArchiveReference />", () => {
 		const unarchived = { ...detail, archived: false };
 		const scope = mockApiUnarchiveReference(detail.id, unarchived);
 
-		await renderWithRouter(<ArchiveReferenceHarness detail={detail} />);
+		await renderWithRouter(<ArchiveReference detail={detail} />);
 
+		await userEvent.click(screen.getByRole("button", { name: "unarchive" }));
 		expect(getDialogTitle("Unarchive", detail.name)).toBeInTheDocument();
 
 		await userEvent.click(screen.getByRole("button", { name: "Unarchive" }));
@@ -71,8 +63,9 @@ describe("<ArchiveReference />", () => {
 			.post(`/api/refs/${detail.id}/archive`)
 			.reply(409, { message: "The official reference cannot be archived." });
 
-		await renderWithRouter(<ArchiveReferenceHarness detail={detail} />);
+		await renderWithRouter(<ArchiveReference detail={detail} />);
 
+		await userEvent.click(screen.getByRole("button", { name: "archive" }));
 		await userEvent.click(screen.getByRole("button", { name: "Archive" }));
 
 		expect(
@@ -89,8 +82,9 @@ describe("<ArchiveReference />", () => {
 			.post(`/api/refs/${detail.id}/archive`)
 			.reply(409);
 
-		await renderWithRouter(<ArchiveReferenceHarness detail={detail} />);
+		await renderWithRouter(<ArchiveReference detail={detail} />);
 
+		await userEvent.click(screen.getByRole("button", { name: "archive" }));
 		await userEvent.click(screen.getByRole("button", { name: "Archive" }));
 
 		expect(
@@ -104,8 +98,9 @@ describe("<ArchiveReference />", () => {
 		const detail = createFakeReference({ archived: false });
 		const scope = mockApiArchiveReference(detail.id, detail, 500);
 
-		await renderWithRouter(<ArchiveReferenceHarness detail={detail} />);
+		await renderWithRouter(<ArchiveReference detail={detail} />);
 
+		await userEvent.click(screen.getByRole("button", { name: "archive" }));
 		await userEvent.click(screen.getByRole("button", { name: "Archive" }));
 
 		expect(
@@ -119,8 +114,9 @@ describe("<ArchiveReference />", () => {
 		const detail = createFakeReference({ archived: false });
 		const scope = mockApiArchiveReference(detail.id, detail);
 
-		await renderWithRouter(<ArchiveReferenceHarness detail={detail} />);
+		await renderWithRouter(<ArchiveReference detail={detail} />);
 
+		await userEvent.click(screen.getByRole("button", { name: "archive" }));
 		await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
 		await waitFor(() => {

--- a/apps/web/src/references/components/Detail/__tests__/ArchivedReferenceDetailHeader.test.tsx
+++ b/apps/web/src/references/components/Detail/__tests__/ArchivedReferenceDetailHeader.test.tsx
@@ -24,6 +24,7 @@ describe("<ArchivedReferenceDetailHeader />", () => {
 		);
 		props = {
 			createdAt: reference.created_at,
+			detail: reference,
 			isRemote: false,
 			name: reference.name,
 			userHandle: reference.user.handle,

--- a/apps/web/src/references/components/Detail/__tests__/ReferenceDetailHeader.test.tsx
+++ b/apps/web/src/references/components/Detail/__tests__/ReferenceDetailHeader.test.tsx
@@ -24,6 +24,7 @@ describe("<ReferenceDetailHeaderIcon />", () => {
 		);
 		props = {
 			createdAt: reference.created_at,
+			detail: reference,
 			isRemote: false,
 			name: reference.name,
 			userHandle: reference.user.handle,

--- a/apps/web/src/routes/_authenticated/refs/$refId/route.tsx
+++ b/apps/web/src/routes/_authenticated/refs/$refId/route.tsx
@@ -1,7 +1,5 @@
 import ContainerNarrow from "@base/ContainerNarrow";
 import ArchivedReferenceDetailHeader from "@references/components/Detail/ArchivedReferenceDetailHeader";
-import ArchiveReference from "@references/components/Detail/ArchiveReference";
-import EditReference from "@references/components/Detail/EditReference";
 import ReferenceDetailHeader from "@references/components/Detail/ReferenceDetailHeader";
 import ReferenceDetailTabs from "@references/components/Detail/ReferenceDetailTabs";
 import { referenceQueryOptions, useFetchReference } from "@references/queries";
@@ -10,17 +8,9 @@ import {
 	notFound,
 	Outlet,
 	useMatches,
-	useNavigate,
 } from "@tanstack/react-router";
-import { z } from "zod/v4";
-
-const refDetailSearchSchema = z.object({
-	openArchiveReference: z.boolean().optional().catch(undefined),
-	openEditReference: z.boolean().optional().catch(undefined),
-});
 
 export const Route = createFileRoute("/_authenticated/refs/$refId")({
-	validateSearch: refDetailSearchSchema,
 	loader: async ({ context: { queryClient }, params: { refId } }) => {
 		try {
 			await queryClient.ensureQueryData(referenceQueryOptions(refId));
@@ -36,8 +26,6 @@ export const Route = createFileRoute("/_authenticated/refs/$refId")({
 
 function ReferenceDetailLayout() {
 	const { refId } = Route.useParams();
-	const search = Route.useSearch();
-	const navigate = useNavigate({ from: Route.fullPath });
 	const { data } = useFetchReference(refId);
 	const isOtuDetail = useMatches().some(
 		(match) => match.routeId === "/_authenticated/refs/$refId/otus/$otuId",
@@ -47,24 +35,6 @@ function ReferenceDetailLayout() {
 		return null;
 	}
 
-	function setOpenArchiveReference(openArchiveReference: boolean) {
-		navigate({
-			search: (prev: Record<string, unknown>) => ({
-				...prev,
-				openArchiveReference,
-			}),
-		});
-	}
-
-	function setOpenEditReference(openEditReference: boolean) {
-		navigate({
-			search: (prev: Record<string, unknown>) => ({
-				...prev,
-				openEditReference,
-			}),
-		});
-	}
-
 	return (
 		<>
 			{!isOtuDetail && (
@@ -72,19 +42,18 @@ function ReferenceDetailLayout() {
 					{data.archived ? (
 						<ArchivedReferenceDetailHeader
 							createdAt={data.created_at}
+							detail={data}
 							isRemote={Boolean(data.remotes_from)}
 							name={data.name}
-							setOpenArchiveReference={setOpenArchiveReference}
 							userHandle={data.user.handle}
 							refId={refId}
 						/>
 					) : (
 						<ReferenceDetailHeader
 							createdAt={data.created_at}
+							detail={data}
 							isRemote={Boolean(data.remotes_from)}
 							name={data.name}
-							setOpenArchiveReference={setOpenArchiveReference}
-							setOpenEditReference={setOpenEditReference}
 							userHandle={data.user.handle}
 							refId={refId}
 						/>
@@ -96,18 +65,6 @@ function ReferenceDetailLayout() {
 			<ContainerNarrow>
 				<Outlet />
 			</ContainerNarrow>
-
-			<EditReference
-				detail={data}
-				open={Boolean(search.openEditReference)}
-				setOpen={setOpenEditReference}
-			/>
-
-			<ArchiveReference
-				detail={data}
-				open={Boolean(search.openArchiveReference)}
-				setOpen={setOpenArchiveReference}
-			/>
 		</>
 	);
 }


### PR DESCRIPTION
## Summary
- Moves dialog open state for the edit reference and archive reference dialogs from URL search params to local React `useState`
- Inlines the trigger icon buttons into `EditReference` and `ArchiveReference` so each component is self-contained
- Removes the `openEditReference` and `openArchiveReference` search params from the `refs/$refId` route, simplifying the route layout component

## Test plan
- [ ] Open a reference detail page and verify the edit (pencil) and archive buttons appear in the header
- [ ] Click the edit button and confirm the edit dialog opens and saves correctly
- [ ] Click the archive button and confirm the archive/unarchive dialog opens and the action completes correctly
- [ ] Verify no stray search params appear in the URL when opening or closing either dialog