### PR TITLE
fix: open create API key dialog reliably

### DIFF
--- a/apps/web/src/account/components/ApiKeyCreate.tsx
+++ b/apps/web/src/account/components/ApiKeyCreate.tsx
@@ -40,6 +40,7 @@ export default function ApiKeyCreate() {
 		handleSubmit,
 		control,
 		register,
+		reset,
 	} = useForm<FormValues>({
 		defaultValues: {
 			name: "",
@@ -62,6 +63,7 @@ export default function ApiKeyCreate() {
 		if (!open) {
 			setCopied(false);
 			setNewKey("");
+			reset();
 		}
 	}
 

--- a/apps/web/src/account/components/ApiKeyCreate.tsx
+++ b/apps/web/src/account/components/ApiKeyCreate.tsx
@@ -1,11 +1,13 @@
 import { cn } from "@app/utils";
 import Button from "@base/Button";
+import { buttonVariants } from "@base/buttonVariants";
 import {
 	Dialog,
 	DialogContent,
 	DialogDescription,
 	DialogFooter,
 	DialogTitle,
+	DialogTrigger,
 } from "@base/Dialog";
 import InputError from "@base/InputError";
 import InputGroup from "@base/InputGroup";
@@ -25,18 +27,10 @@ type FormValues = {
 	permissions: Permissions;
 };
 
-type ApiKeyCreateProps = {
-	open?: boolean;
-	setOpen?: (open: boolean) => void;
-};
-
 /**
  * Displays a dialog to create an API key
  */
-export default function ApiKeyCreate({
-	open = false,
-	setOpen = () => {},
-}: ApiKeyCreateProps) {
+export default function ApiKeyCreate() {
 	const [copied, setCopied] = useState(false);
 	const [newKey, setNewKey] = useState("");
 	const mutation = useCreateAPIKey();
@@ -64,10 +58,11 @@ export default function ApiKeyCreate({
 
 	const showCreated = Boolean(newKey);
 
-	function handleHide() {
-		setCopied(false);
-		setOpen(false);
-		setNewKey("");
+	function handleOpenChange(open: boolean) {
+		if (!open) {
+			setCopied(false);
+			setNewKey("");
+		}
 	}
 
 	function onSubmit({ name, permissions }: FormValues) {
@@ -86,7 +81,10 @@ export default function ApiKeyCreate({
 	}
 
 	return (
-		<Dialog open={open} onOpenChange={handleHide}>
+		<Dialog onOpenChange={handleOpenChange}>
+			<DialogTrigger className={buttonVariants({ color: "blue" })}>
+				Create
+			</DialogTrigger>
 			<DialogContent>
 				<DialogTitle>Create API Key</DialogTitle>
 				<DialogDescription>

--- a/apps/web/src/account/components/ApiKeys.tsx
+++ b/apps/web/src/account/components/ApiKeys.tsx
@@ -1,6 +1,5 @@
 import { cn } from "@app/utils";
 import BoxGroup from "@base/BoxGroup";
-import Button from "@base/Button";
 import ExternalLink from "@base/ExternalLink";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundBox from "@base/NoneFoundBox";
@@ -8,18 +7,10 @@ import { useFetchAPIKeys } from "../queries";
 import ApiKey from "./ApiKey";
 import ApiKeyCreate from "./ApiKeyCreate";
 
-type ApiKeysProps = {
-	openCreateKey?: boolean;
-	setOpenCreateKey?: (open: boolean) => void;
-};
-
 /**
  * A component to manage and display API keys
  */
-export default function ApiKeys({
-	openCreateKey = false,
-	setOpenCreateKey = () => {},
-}: ApiKeysProps) {
+export default function ApiKeys() {
 	const { data, isPending } = useFetchAPIKeys();
 
 	if (isPending || !data) {
@@ -47,9 +38,7 @@ export default function ApiKeys({
 					</ExternalLink>
 					.
 				</h3>
-				<Button color="blue" onClick={() => setOpenCreateKey(true)}>
-					Create
-				</Button>
+				<ApiKeyCreate />
 			</header>
 
 			{keyComponents.length ? (
@@ -57,8 +46,6 @@ export default function ApiKeys({
 			) : (
 				<NoneFoundBox noun="API keys" />
 			)}
-
-			<ApiKeyCreate open={openCreateKey} setOpen={setOpenCreateKey} />
 		</div>
 	);
 }

--- a/apps/web/src/account/components/__tests__/ApiKeys.test.tsx
+++ b/apps/web/src/account/components/__tests__/ApiKeys.test.tsx
@@ -28,7 +28,7 @@ describe("<ApiKeys />", () => {
 	});
 
 	it("should render and function when loaded", async () => {
-		userEvent.setup();
+		const user = userEvent.setup();
 
 		mockApiGetAccount(
 			createFakeAccount({
@@ -50,27 +50,27 @@ describe("<ApiKeys />", () => {
 
 		expect(screen.getByText("No API keys found.")).toBeInTheDocument();
 
-		await userEvent.click(screen.getByRole("button", { name: "Create" }));
+		await user.click(screen.getByRole("button", { name: "Create" }));
 
 		const dialog = screen.getByRole("dialog", { name: "Create API Key" });
 		const input = within(dialog).getByLabelText("Name");
 
 		// Check that submission without a name fails.
-		await userEvent.click(screen.getByRole("button", { name: "Save" }));
+		await user.click(screen.getByRole("button", { name: "Save" }));
 		expect(
 			await screen.findByText("Provide a name for the key"),
 		).toBeInTheDocument();
 
-		await userEvent.type(input, "Key A");
+		await user.type(input, "Key A");
 		expect(input).toHaveValue("Key A");
 
 		const checkbox = screen.getByRole("checkbox", {
 			name: "remove_job",
 		});
-		await userEvent.click(checkbox);
+		await user.click(checkbox);
 		expect(checkbox).toBeChecked();
 
-		await userEvent.click(screen.getByRole("button", { name: "Save" }));
+		await user.click(screen.getByRole("button", { name: "Save" }));
 
 		mockApiGetApiKeys([
 			createFakeApiKey({
@@ -84,7 +84,7 @@ describe("<ApiKeys />", () => {
 		expect(screen.getByText(/Make note of it now/)).toBeInTheDocument();
 		expect(screen.getByDisplayValue("testKey")).toBeInTheDocument();
 
-		await userEvent.keyboard("{Escape}");
+		await user.keyboard("{Escape}");
 
 		// Test that the new key is displayed in the list.
 		expect(screen.getByText("Key A")).toBeInTheDocument();
@@ -157,8 +157,6 @@ describe("<ApiKeys />", () => {
 
 		await userEvent.click(createRefCheckbox);
 		await userEvent.click(uploadFileCheckbox);
-
-		screen.debug(dialog);
 
 		expect(uploadFileCheckbox).toBeChecked();
 	});

--- a/apps/web/src/account/components/__tests__/ApiKeys.test.tsx
+++ b/apps/web/src/account/components/__tests__/ApiKeys.test.tsx
@@ -10,14 +10,8 @@ import {
 import { createFakePermissions } from "@tests/fake/permissions";
 import { renderWithRouter } from "@tests/setup";
 import nock from "nock";
-import { useState } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import ApiKeys from "../ApiKeys";
-
-function ApiKeysHarness() {
-	const [open, setOpen] = useState(false);
-	return <ApiKeys openCreateKey={open} setOpenCreateKey={setOpen} />;
-}
 
 describe("<ApiKeys />", () => {
 	const basePath = "/account/api";
@@ -48,7 +42,7 @@ describe("<ApiKeys />", () => {
 			createFakePermissions({ remove_job: true }),
 		);
 
-		await renderWithRouter(<ApiKeysHarness />, "/account/api");
+		await renderWithRouter(<ApiKeys />, "/account/api");
 
 		await screen.findByRole("heading", {
 			name: /Manage API keys for accessing the/,
@@ -108,7 +102,7 @@ describe("<ApiKeys />", () => {
 		);
 		mockApiGetApiKeys([]);
 
-		await renderWithRouter(<ApiKeysHarness />, basePath);
+		await renderWithRouter(<ApiKeys />, basePath);
 
 		await userEvent.click(
 			await screen.findByRole("button", { name: "Create" }),

--- a/apps/web/src/routes/_authenticated/account/api.tsx
+++ b/apps/web/src/routes/_authenticated/account/api.tsx
@@ -1,26 +1,6 @@
 import ApiKeys from "@account/components/ApiKeys";
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod/v4";
-
-const apiSearchSchema = z.object({
-	openCreateKey: z.boolean().optional().catch(undefined),
-});
 
 export const Route = createFileRoute("/_authenticated/account/api")({
-	validateSearch: apiSearchSchema,
-	component: ApiKeysRoute,
+	component: ApiKeys,
 });
-
-function ApiKeysRoute() {
-	const search = Route.useSearch();
-	const navigate = Route.useNavigate();
-
-	return (
-		<ApiKeys
-			openCreateKey={Boolean(search.openCreateKey)}
-			setOpenCreateKey={(openCreateKey) =>
-				navigate({ search: { ...search, openCreateKey } })
-			}
-		/>
-	);
-}


### PR DESCRIPTION
## Summary
- Replaces the `openCreateKey` URL search param with a self-contained `DialogTrigger` inside `ApiKeyCreate`, matching the pattern used for other dialogs in the app
- Removes the `openCreateKey`/`setOpenCreateKey` prop-drilling through `ApiKeysRoute` → `ApiKeys` → `ApiKeyCreate`
- Simplifies the route component to a direct reference to `ApiKeys` with no search-param schema

## Test plan
- [ ] Navigate to Account → API Keys and click Create — dialog opens
- [ ] Submit the form — new key is displayed and can be copied
- [ ] Close the dialog — form resets (no stale key or copied state)
- [ ] Existing API key list renders correctly without regression