### PR TITLE
fix: open create subtraction dialog reliably

### DIFF
--- a/apps/web/src/routes/_authenticated/subtractions/index.tsx
+++ b/apps/web/src/routes/_authenticated/subtractions/index.tsx
@@ -5,7 +5,6 @@ import { z } from "zod/v4";
 const subtractionsSearchSchema = z.object({
 	find: z.string().default("").catch(""),
 	page: z.number().default(1).catch(1),
-	openCreateSubtraction: z.boolean().optional().catch(undefined),
 });
 
 export const Route = createFileRoute("/_authenticated/subtractions/")({
@@ -20,7 +19,6 @@ function SubtractionsRoute() {
 	return (
 		<SubtractionList
 			find={search.find}
-			openCreateSubtraction={Boolean(search.openCreateSubtraction)}
 			page={search.page}
 			setSearch={(next) => navigate({ search: { ...search, ...next } })}
 		/>

--- a/apps/web/src/subtraction/components/SubtractionCreate.tsx
+++ b/apps/web/src/subtraction/components/SubtractionCreate.tsx
@@ -1,9 +1,11 @@
+import { buttonVariants } from "@base/buttonVariants";
 import {
 	Dialog,
 	DialogContent,
 	DialogDescription,
 	DialogFooter,
 	DialogTitle,
+	DialogTrigger,
 } from "@base/Dialog";
 import InputError from "@base/InputError";
 import InputGroup from "@base/InputGroup";
@@ -14,6 +16,7 @@ import PseudoLabel from "@base/PseudoLabel";
 import SaveButton from "@base/SaveButton";
 import { RestoredAlert } from "@forms/components/RestoredAlert";
 import { usePersistentForm } from "@forms/hooks";
+import { useState } from "react";
 import { Controller } from "react-hook-form";
 import { useInfiniteFindFiles } from "@/uploads/queries";
 import { useCreateSubtraction } from "../queries";
@@ -25,18 +28,12 @@ type FormValues = {
 	uploadId: number[];
 };
 
-type SubtractionCreateProps = {
-	open?: boolean;
-	setOpen?: (open: boolean) => void;
-};
-
 /**
  * Displays a dialog for creating a subtraction
  */
-export default function SubtractionCreate({
-	open = false,
-	setOpen = () => {},
-}: SubtractionCreateProps) {
+export default function SubtractionCreate() {
+	const [open, setOpen] = useState(false);
+
 	const {
 		hasRestored,
 		formState: { errors },
@@ -58,20 +55,6 @@ export default function SubtractionCreate({
 
 	const mutation = useCreateSubtraction();
 
-	if (isPending || !files) {
-		return (
-			<Dialog open={open} onOpenChange={() => setOpen(false)}>
-				<DialogContent size="lg">
-					<DialogTitle>Create Subtraction</DialogTitle>
-					<DialogDescription>
-						Create a new subtraction from a FASTA file.
-					</DialogDescription>
-					<LoadingPlaceholder className="mt-9" />
-				</DialogContent>
-			</Dialog>
-		);
-	}
-
 	function onSubmit({ name, nickname, uploadId }: FormValues) {
 		mutation.mutate(
 			{ name, nickname, uploadId: uploadId[0] },
@@ -85,56 +68,63 @@ export default function SubtractionCreate({
 	}
 
 	return (
-		<Dialog open={open} onOpenChange={() => setOpen(false)}>
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger className={buttonVariants({ color: "blue" })}>
+				Create
+			</DialogTrigger>
 			<DialogContent size="lg">
 				<DialogTitle>Create Subtraction</DialogTitle>
 				<DialogDescription>
 					Create a new subtraction from a FASTA file.
 				</DialogDescription>
-				<form onSubmit={handleSubmit(onSubmit)}>
-					<RestoredAlert
-						hasRestored={hasRestored}
-						name="subtraction"
-						resetForm={reset}
-					/>
-					<InputGroup>
-						<InputLabel htmlFor="name">Name</InputLabel>
-						<InputSimple
-							id="name"
-							{...register("name", {
-								required: "A name is required",
-							})}
+				{isPending || !files ? (
+					<LoadingPlaceholder className="mt-9" />
+				) : (
+					<form onSubmit={handleSubmit(onSubmit)}>
+						<RestoredAlert
+							hasRestored={hasRestored}
+							name="subtraction"
+							resetForm={reset}
 						/>
-						<InputError>{errors.name?.message}</InputError>
-					</InputGroup>
-
-					<InputGroup>
-						<InputLabel htmlFor="nickname">Nickname</InputLabel>
-						<InputSimple id="nickname" {...register("nickname")} />
-					</InputGroup>
-
-					<PseudoLabel>Files</PseudoLabel>
-					<Controller
-						name="uploadId"
-						control={control}
-						render={({ field: { onChange, value } }) => (
-							<SubtractionFileSelector
-								onClick={onChange}
-								error={errors.uploadId?.message ?? ""}
-								files={files}
-								isFetchingNextPage={isFetchingNextPage}
-								fetchNextPage={fetchNextPage}
-								isPending={isPending}
-								foundCount={files.pages[0].found_count}
-								selected={value}
+						<InputGroup>
+							<InputLabel htmlFor="name">Name</InputLabel>
+							<InputSimple
+								id="name"
+								{...register("name", {
+									required: "A name is required",
+								})}
 							/>
-						)}
-						rules={{ required: "Please select a file" }}
-					/>
-					<DialogFooter>
-						<SaveButton />
-					</DialogFooter>
-				</form>
+							<InputError>{errors.name?.message}</InputError>
+						</InputGroup>
+
+						<InputGroup>
+							<InputLabel htmlFor="nickname">Nickname</InputLabel>
+							<InputSimple id="nickname" {...register("nickname")} />
+						</InputGroup>
+
+						<PseudoLabel>Files</PseudoLabel>
+						<Controller
+							name="uploadId"
+							control={control}
+							render={({ field: { onChange, value } }) => (
+								<SubtractionFileSelector
+									onClick={onChange}
+									error={errors.uploadId?.message ?? ""}
+									files={files}
+									isFetchingNextPage={isFetchingNextPage}
+									fetchNextPage={fetchNextPage}
+									isPending={isPending}
+									foundCount={files.pages[0].found_count}
+									selected={value}
+								/>
+							)}
+							rules={{ required: "Please select a file" }}
+						/>
+						<DialogFooter>
+							<SaveButton />
+						</DialogFooter>
+					</form>
+				)}
 			</DialogContent>
 		</Dialog>
 	);

--- a/apps/web/src/subtraction/components/SubtractionList.tsx
+++ b/apps/web/src/subtraction/components/SubtractionList.tsx
@@ -11,13 +11,8 @@ import SubtractionToolbar from "./SubtractionToolbar";
 
 type SubtractionListProps = {
 	find?: string;
-	openCreateSubtraction?: boolean;
 	page?: number;
-	setSearch?: (next: {
-		find?: string;
-		openCreateSubtraction?: boolean;
-		page?: number;
-	}) => void;
+	setSearch?: (next: { find?: string; page?: number }) => void;
 };
 
 /**
@@ -25,7 +20,6 @@ type SubtractionListProps = {
  */
 export default function SubtractionList({
 	find = "",
-	openCreateSubtraction = false,
 	page = 1,
 	setSearch = () => {},
 }: SubtractionListProps) {
@@ -50,14 +44,7 @@ export default function SubtractionList({
 				</ViewHeaderTitle>
 			</ViewHeader>
 
-			<SubtractionToolbar
-				openCreate={openCreateSubtraction}
-				setOpenCreate={(openCreateSubtraction) =>
-					setSearch({ openCreateSubtraction })
-				}
-				term={find}
-				handleChange={handleChange}
-			/>
+			<SubtractionToolbar term={find} handleChange={handleChange} />
 
 			{!items.length ? (
 				<NoneFoundBox key="subtractions" noun="subtractions" />

--- a/apps/web/src/subtraction/components/SubtractionToolbar.tsx
+++ b/apps/web/src/subtraction/components/SubtractionToolbar.tsx
@@ -1,20 +1,15 @@
 import { useCheckAdminRoleOrPermission } from "@administration/hooks";
-import Button from "@base/Button";
 import InputSearch from "@base/InputSearch";
 import Toolbar from "@base/Toolbar";
 import SubtractionCreate from "./SubtractionCreate";
 
 type SubtractionToolbarProps = {
 	handleChange: (any) => void;
-	openCreate: boolean;
-	setOpenCreate: (open: boolean) => void;
 	term: string;
 };
 
 export default function SubtractionToolbar({
 	handleChange,
-	openCreate,
-	setOpenCreate,
 	term,
 }: SubtractionToolbarProps) {
 	const { hasPermission } = useCheckAdminRoleOrPermission("modify_subtraction");
@@ -24,12 +19,7 @@ export default function SubtractionToolbar({
 			<div className="flex-grow">
 				<InputSearch value={term} onChange={handleChange} placeholder="Name" />
 			</div>
-			{hasPermission && (
-				<Button color="blue" onClick={() => setOpenCreate(true)}>
-					Create
-				</Button>
-			)}
-			<SubtractionCreate open={openCreate} setOpen={setOpenCreate} />
+			{hasPermission && <SubtractionCreate />}
 		</Toolbar>
 	);
 }

--- a/apps/web/src/subtraction/components/__tests__/CreateSubtraction.test.tsx
+++ b/apps/web/src/subtraction/components/__tests__/CreateSubtraction.test.tsx
@@ -4,8 +4,13 @@ import userEvent from "@testing-library/user-event";
 import { createFakeFile, mockApiListFiles } from "@tests/fake/files";
 import { mockApiCreateSubtraction } from "@tests/fake/subtractions";
 import { renderWithRouter } from "@tests/setup";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import SubtractionCreate from "../SubtractionCreate";
+
+async function openDialog() {
+	await renderWithRouter(<SubtractionCreate />);
+	await userEvent.click(screen.getByRole("button", { name: "Create" }));
+}
 
 describe("<SubtractionCreate />", () => {
 	afterEach(() => {
@@ -14,7 +19,7 @@ describe("<SubtractionCreate />", () => {
 
 	it("should render when no uploads available", async () => {
 		mockApiListFiles([]);
-		await renderWithRouter(<SubtractionCreate open setOpen={vi.fn()} />);
+		await openDialog();
 
 		expect(await screen.findByText(/no files found/i)).toBeInTheDocument();
 	});
@@ -25,7 +30,7 @@ describe("<SubtractionCreate />", () => {
 			type: "subtraction",
 		});
 		mockApiListFiles([file]);
-		await renderWithRouter(<SubtractionCreate open setOpen={vi.fn()} />);
+		await openDialog();
 
 		expect(await screen.findByText(file.name)).toBeInTheDocument();
 		await userEvent.click(await screen.findByText(/save/i));
@@ -49,7 +54,7 @@ describe("<SubtractionCreate />", () => {
 			file.id,
 		);
 
-		await renderWithRouter(<SubtractionCreate open setOpen={vi.fn()} />);
+		await openDialog();
 
 		await userEvent.type(await screen.findByLabelText("Name"), name);
 		await userEvent.type(screen.getByLabelText("Nickname"), nickname);
@@ -80,7 +85,7 @@ describe("<SubtractionCreate />", () => {
 		);
 		mockApiListFiles([file]);
 
-		await renderWithRouter(<SubtractionCreate open setOpen={vi.fn()} />);
+		await openDialog();
 
 		expect(await screen.findByDisplayValue(name)).toBeInTheDocument();
 		expect(await screen.findByDisplayValue(nickname)).toBeInTheDocument();
@@ -105,7 +110,7 @@ describe("<SubtractionCreate />", () => {
 			file.id,
 		);
 
-		await renderWithRouter(<SubtractionCreate open setOpen={vi.fn()} />);
+		await openDialog();
 
 		await userEvent.type(await screen.findByLabelText("Name"), name);
 		await userEvent.type(screen.getByLabelText("Nickname"), nickname);

--- a/apps/web/src/subtraction/components/__tests__/SubtractionList.test.tsx
+++ b/apps/web/src/subtraction/components/__tests__/SubtractionList.test.tsx
@@ -12,7 +12,6 @@ import SubtractionList from "../SubtractionList";
 
 type SubtractionListSearch = {
 	find?: string;
-	openCreateSubtraction?: boolean;
 	page?: number;
 };
 


### PR DESCRIPTION
## Summary
- Switches the create subtraction dialog from URL search-param-driven open state to self-managed React `useState`, matching the pattern applied to other dialogs (analysis, references, quick analyze, index rebuild, create user, sample edit)
- Embeds a `DialogTrigger` button inside `SubtractionCreate` so the component is fully self-contained; removes the now-unnecessary `open`/`setOpen` props and the `openCreateSubtraction` search param from the route schema
- Updates tests to open the dialog by clicking the trigger button rather than passing `open` as a prop

## Test plan
- [ ] Navigate to the Subtractions list page and confirm the Create button is visible (for users with `modify_subtraction` permission)
- [ ] Click Create and confirm the dialog opens correctly with the file selector and form fields
- [ ] Submit the form and confirm a subtraction is created successfully
- [ ] Confirm the dialog can be dismissed and reopened multiple times without issues