### PR TITLE
fix: show a real error when a page fails to load instead of spinning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,9 +175,16 @@ into React Query hooks and `queryOptions`/`*QueryKeys` factories — there is no
 separate per-feature `api.ts` layer. Inline each `apiClient` call into the
 hook's `queryFn`/`mutationFn`; keep a module-private helper only when a request
 is shared across hooks or branches. Route loaders prefetch via the same
-`queryOptions` factories where appropriate. See
+`queryOptions` factories where appropriate.
+
+Loading and error states come in two tiers: primary route data uses
+`useSuspenseQuery` (loading via the route's `<Suspense>`, errors via the
+router's `defaultErrorComponent`, `@base/RouteError`), and secondary data
+stays on `useQuery` checking `isError` before `isPending` for an inline error.
+Never write `if (isPending || !data)` — on error it spins forever. See
 [docs/queries.md](docs/queries.md) for the query-key, `queryOptions`,
-route-loader prefetch, and mutation patterns.
+route-loader prefetch, the two-tier error/loading policy, and mutation
+patterns.
 
 ### Styling
 

--- a/apps/web/src/base/RouteError.tsx
+++ b/apps/web/src/base/RouteError.tsx
@@ -1,0 +1,61 @@
+import { useQueryErrorResetBoundary } from "@tanstack/react-query";
+import { type ErrorComponentProps, useRouter } from "@tanstack/react-router";
+import { useEffect } from "react";
+import Button from "./Button";
+import NotFound from "./NotFound";
+
+function getStatus(error: unknown): number | undefined {
+	if (
+		error != null &&
+		typeof error === "object" &&
+		"response" in error &&
+		typeof (error as { response?: unknown }).response === "object" &&
+		(error as { response: unknown }).response != null
+	) {
+		const { status } = (error as { response: { status?: unknown } }).response;
+		return typeof status === "number" ? status : undefined;
+	}
+
+	return undefined;
+}
+
+/**
+ * The router's default `errorComponent`: renders when a route loader rejects
+ * or a `useSuspenseQuery` throws, instead of leaving the route blank.
+ *
+ * A 403 reads as a permission problem, a 404 as a missing resource, and
+ * anything else as a retryable error. "Try again" clears the cached query
+ * error and re-runs the route loader, so a transient failure recovers without
+ * a full page reload.
+ */
+export default function RouteError({ error }: ErrorComponentProps) {
+	const router = useRouter();
+	const { reset } = useQueryErrorResetBoundary();
+
+	useEffect(() => {
+		// Clear React Query's error state so an invalidate-driven refetch can
+		// resolve the suspense query and unmount this boundary.
+		reset();
+	}, [reset]);
+
+	const status = getStatus(error);
+
+	if (status === 403) {
+		return (
+			<NotFound status={403} message="You don't have access to this resource" />
+		);
+	}
+
+	if (status === 404) {
+		return <NotFound />;
+	}
+
+	return (
+		<div className="flex flex-col items-center justify-center h-96 gap-4">
+			<strong className="text-base">Something went wrong</strong>
+			<Button color="blue" onClick={() => router.invalidate()}>
+				Try again
+			</Button>
+		</div>
+	);
+}

--- a/apps/web/src/base/RouteError.tsx
+++ b/apps/web/src/base/RouteError.tsx
@@ -5,6 +5,20 @@ import Button from "./Button";
 import NotFound from "./NotFound";
 
 function getStatus(error: unknown): number | undefined {
+	// TanStack Start server-function errors cross the boundary as plain
+	// `Error`s with only `name`/`message` — the status set via
+	// `setResponseStatus` is dropped — so match the auth errors by name, as
+	// the query retry logic in `router.tsx` does.
+	if (error instanceof Error) {
+		if (error.name === "ForbiddenError") {
+			return 403;
+		}
+		if (error.name === "UnauthorizedError") {
+			return 401;
+		}
+	}
+
+	// Superagent (legacy Python API) errors carry the HTTP status here.
 	if (
 		error != null &&
 		typeof error === "object" &&
@@ -23,7 +37,7 @@ function getStatus(error: unknown): number | undefined {
  * The router's default `errorComponent`: renders when a route loader rejects
  * or a `useSuspenseQuery` throws, instead of leaving the route blank.
  *
- * A 403 reads as a permission problem, a 404 as a missing resource, and
+ * A 401/403 reads as an access problem, a 404 as a missing resource, and
  * anything else as a retryable error. "Try again" clears the cached query
  * error and re-runs the route loader, so a transient failure recovers without
  * a full page reload.
@@ -39,6 +53,15 @@ export default function RouteError({ error }: ErrorComponentProps) {
 	}, [reset]);
 
 	const status = getStatus(error);
+
+	if (status === 401) {
+		return (
+			<NotFound
+				status={401}
+				message="You need to sign in to view this resource"
+			/>
+		);
+	}
 
 	if (status === 403) {
 		return (

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,3 +1,4 @@
+import RouteError from "@base/RouteError";
 import * as Sentry from "@sentry/tanstackstart-react";
 import { QueryClient } from "@tanstack/react-query";
 import { createRouter } from "@tanstack/react-router";
@@ -40,6 +41,11 @@ export function getRouter() {
 	const router = createRouter({
 		routeTree,
 		context: { queryClient },
+		// Every route inherits this error boundary unless it sets its own
+		// `errorComponent`. It catches both rejected loaders and errors thrown
+		// from `useSuspenseQuery` during render, so a failed query surfaces a
+		// real error state instead of an indefinite loading placeholder.
+		defaultErrorComponent: RouteError,
 		defaultPendingMinMs: 0,
 		// Preload routes on hover/touch/focus. Loaders back onto React Query via
 		// `ensureQueryData`, so a 0 preload stale time hands freshness decisions

--- a/apps/web/src/routes/_authenticated/samples/$sampleId.tsx
+++ b/apps/web/src/routes/_authenticated/samples/$sampleId.tsx
@@ -1,6 +1,5 @@
 import Icon from "@base/Icon";
 import IconButton from "@base/IconButton";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Tabs from "@base/Tabs";
 import TabsLink from "@base/TabsLink";
 import ViewHeader from "@base/ViewHeader";
@@ -11,7 +10,7 @@ import { JobNestedSchema } from "@jobs/types";
 import DeleteSample from "@samples/components/Detail/DeleteSample";
 import EditSample from "@samples/components/EditSample";
 import { useCheckCanEditSample } from "@samples/hooks";
-import { sampleQueryOptions, useFetchSample } from "@samples/queries";
+import { sampleQueryOptions, useSuspenseSample } from "@samples/queries";
 import {
 	createFileRoute,
 	notFound,
@@ -43,13 +42,9 @@ export const Route = createFileRoute("/_authenticated/samples/$sampleId")({
 function SampleDetailLayout() {
 	const { sampleId } = Route.useParams();
 	const location = useLocation();
-	const { data, isPending } = useFetchSample(sampleId);
+	const { data } = useSuspenseSample(sampleId);
 	const { hasPermission: canModify } = useCheckCanEditSample(sampleId);
 	const [editOpen, setEditOpen] = useState(false);
-
-	if (isPending || !data) {
-		return <LoadingPlaceholder />;
-	}
 
 	const { created_at, name, user } = data;
 	const job = data.job && JobNestedSchema.parse(data.job);

--- a/apps/web/src/samples/components/Files/SampleDetailFiles.tsx
+++ b/apps/web/src/samples/components/Files/SampleDetailFiles.tsx
@@ -1,7 +1,6 @@
 import ContainerNarrow from "@base/ContainerNarrow";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import SampleFileSizeWarning from "@samples/components/Detail/SampleFileSizeWarning";
-import { useFetchSample } from "@samples/queries";
+import { useSuspenseSample } from "@samples/queries";
 import { getRouteApi } from "@tanstack/react-router";
 import SampleFilesMessage from "../SampleFilesMessage";
 import SampleReads from "./SampleReads";
@@ -13,11 +12,7 @@ const routeApi = getRouteApi("/_authenticated/samples/$sampleId");
  */
 export default function SampleDetailFiles() {
 	const { sampleId } = routeApi.useParams();
-	const { data, isPending } = useFetchSample(sampleId);
-
-	if (isPending || !data) {
-		return <LoadingPlaceholder />;
-	}
+	const { data } = useSuspenseSample(sampleId);
 
 	return (
 		<ContainerNarrow>

--- a/apps/web/src/samples/queries.ts
+++ b/apps/web/src/samples/queries.ts
@@ -6,6 +6,7 @@ import {
 	useMutation,
 	useQuery,
 	useQueryClient,
+	useSuspenseQuery,
 } from "@tanstack/react-query";
 import { fileQueryKeys } from "@uploads/queries";
 import { union } from "es-toolkit";
@@ -89,6 +90,19 @@ export function sampleQueryOptions(sampleId: string) {
 
 export function useFetchSample(sampleId: string) {
 	return useQuery(sampleQueryOptions(sampleId));
+}
+
+/**
+ * Fetch a sample, suspending until it resolves.
+ *
+ * `data` is always defined, and a failed request throws to the nearest route
+ * error boundary instead of resolving to `undefined`. Use this from
+ * components rendered under a route whose loader prefetches the sample (the
+ * `$sampleId` detail layout and its children) — loading and errors are handled
+ * by the route's Suspense and `errorComponent` rather than inline.
+ */
+export function useSuspenseSample(sampleId: string) {
+	return useSuspenseQuery(sampleQueryOptions(sampleId));
 }
 
 /**

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -100,7 +100,73 @@ calls in parallel with `Promise.all`.
 
 For data that isn't needed on initial render (e.g. a dialog that opens
 lazily), skip the loader and call `useQuery` where the data is consumed.
-Suspense queries (`useSuspenseQuery`) are not currently used.
+
+## Loading and error states: two tiers
+
+A query has three outcomes — pending, error, success — and a consumer has to
+account for all three. Pick the tier by how central the data is to the view,
+and never collapse pending and error into one branch. The guard
+`if (isPending || !data) return <LoadingPlaceholder />` is the anti-pattern: on
+error `data` is `undefined`, so a failed request falls into the loading branch
+and spins forever instead of showing the error.
+
+### Tier 1 — primary data, via Suspense and the route error boundary
+
+For the resource a route exists to show (detail pages, the record the URL is
+"about"), let the framework handle pending and error declaratively:
+
+1. Prefetch in the route `loader` with `ensureQueryData` (above).
+2. Read it in the component with `useSuspenseQuery` — expose a
+   `useSuspense*` hook next to the `useFetch*` one:
+
+   ```ts
+   export function useSuspenseSample(sampleId: string) {
+     return useSuspenseQuery(sampleQueryOptions(sampleId));
+   }
+   ```
+
+3. In the component, destructure `data` and use it directly — **no guard**.
+   `useSuspenseQuery` guarantees `data` is defined, and a failure throws.
+
+   ```tsx
+   function SampleDetailLayout() {
+     const { sampleId } = Route.useParams();
+     const { data } = useSuspenseSample(sampleId);
+     return <ViewHeader title={data.name} />;
+   }
+   ```
+
+Loading is absorbed by the `<Suspense>` boundary already wrapping the
+authenticated `<Outlet>`. Errors are caught by the router's
+`defaultErrorComponent` (`@base/RouteError`), wired once in `router.tsx`: it
+reads the HTTP status off the error and renders a permission message for 403,
+a not-found for 404, and a retryable message otherwise. A route only needs its
+own `errorComponent` when it wants bespoke copy.
+
+Keep a loader's `404 → notFound()` mapping where it exists — that routes a
+missing record to the dedicated `notFoundComponent` rather than the error
+boundary.
+
+### Tier 2 — secondary data, handled inline with `useQuery`
+
+For data that should fail without taking over the page — paginated lists using
+`keepPreviousData`, polling, sidebar widgets, anything optional — stay on
+`useQuery` and handle the states explicitly. Check `isError` **before**
+`isPending`, and render an inline error rather than a blocking one:
+
+```tsx
+const { data, isPending, isError } = useListSamples(page, perPage);
+
+if (isError) {
+  return <Alert color="red">Couldn't load samples.</Alert>;
+}
+if (isPending) {
+  return <LoadingPlaceholder />;
+}
+```
+
+The distinction is deliberate: Tier 1 escalates a failure to a full-route
+error state; Tier 2 contains it so the rest of the page keeps working.
 
 ## Pagination keeps the previous page on screen
 


### PR DESCRIPTION
## Summary

- Adds `RouteError`, a new default error component for TanStack Router that renders a permission message for 403, a not-found for 404, and a retryable error otherwise — replacing the silent infinite loading state that appeared when a route loader or `useSuspenseQuery` rejected.
- Wires `RouteError` as the router's `defaultErrorComponent` so every route inherits it without per-route boilerplate.
- Migrates the samples detail route and its files child to `useSuspenseSample` (backed by `useSuspenseQuery`), eliminating the `if (isPending || !data)` guard that could spin forever on error.
- Documents the two-tier loading/error policy in `docs/queries.md` and `AGENTS.md`: primary route data uses `useSuspenseQuery` (errors escalate to the route boundary), secondary data uses `useQuery` with an explicit `isError` check before `isPending`.

## Test plan

- [ ] Load a sample detail page — verify it renders normally.
- [ ] With DevTools network throttling, confirm the sample detail shows a spinner while loading, then content on success.
- [ ] Simulate a 404 (navigate to a non-existent sample ID) — verify the not-found page appears instead of a spinner.
- [ ] Simulate a 500 (block the API or disconnect) — verify "Something went wrong" and a working "Try again" button appear.
- [ ] Confirm the samples files tab renders correctly and shows the same error boundary behavior on failure.