### PR TITLE
fix: surface real errors on primary route data instead of spinning

### DIFF
--- a/apps/web/src/administration/queries.ts
+++ b/apps/web/src/administration/queries.ts
@@ -13,6 +13,7 @@ import {
 	useMutation,
 	useQuery,
 	useQueryClient,
+	useSuspenseQuery,
 } from "@tanstack/react-query";
 import type { ErrorResponse } from "@/types/api";
 import type { AdministratorRoleName, Settings } from "./types";
@@ -40,15 +41,33 @@ export const settingsQueryKeys = {
 };
 
 /**
+ * Query options for the API settings.
+ */
+export function settingsQueryOptions() {
+	return queryOptions<Settings>({
+		queryKey: settingsQueryKeys.all(),
+		queryFn: () => apiClient.get("/settings").then((response) => response.body),
+	});
+}
+
+/**
  * Fetch the API settings.
  *
  * @returns The API settings.
  */
 export function useFetchSettings() {
-	return useQuery<Settings>({
-		queryKey: settingsQueryKeys.all(),
-		queryFn: () => apiClient.get("/settings").then((response) => response.body),
-	});
+	return useQuery(settingsQueryOptions());
+}
+
+/**
+ * Fetch the API settings, suspending until they resolve.
+ *
+ * `data` is always defined, and a failed request throws to the nearest route
+ * error boundary. Use this from components rendered under a route whose loader
+ * prefetches the settings.
+ */
+export function useSuspenseSettings() {
+	return useSuspenseQuery(settingsQueryOptions());
 }
 
 /**
@@ -203,6 +222,19 @@ export function userQueryOptions(userId: number) {
  */
 export function useFetchUser(userId: number) {
 	return useQuery(userQueryOptions(userId));
+}
+
+/**
+ * Fetches a single user, suspending until it resolves.
+ *
+ * `data` is always defined, and a failed request throws to the nearest route
+ * error boundary. Use this from components rendered under a route whose loader
+ * prefetches the user.
+ *
+ * @param userId - The id of the user to fetch
+ */
+export function useSuspenseUser(userId: number) {
+	return useSuspenseQuery(userQueryOptions(userId));
 }
 
 /** Values accepted when updating a user from the administration views. */

--- a/apps/web/src/otus/components/Detail/History/OtuHistory.tsx
+++ b/apps/web/src/otus/components/Detail/History/OtuHistory.tsx
@@ -1,5 +1,4 @@
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
-import { useFetchOtuHistory } from "@otus/queries";
+import { useSuspenseOtuHistory } from "@otus/queries";
 import { useReferenceIsArchived } from "@references/hooks";
 import { getRouteApi } from "@tanstack/react-router";
 import { groupBy } from "es-toolkit";
@@ -12,12 +11,8 @@ const routeApi = getRouteApi("/_authenticated/refs/$refId/otus/$otuId");
  */
 export default function OtuHistory() {
 	const { otuId, refId } = routeApi.useParams();
-	const { data, isPending } = useFetchOtuHistory(otuId);
+	const { data } = useSuspenseOtuHistory(otuId);
 	const archived = useReferenceIsArchived(refId);
-
-	if (isPending || !data) {
-		return <LoadingPlaceholder />;
-	}
 
 	const changes = groupBy(data, (change) =>
 		change.index.version === "unbuilt" ? "unbuilt" : "built",

--- a/apps/web/src/otus/queries.tsx
+++ b/apps/web/src/otus/queries.tsx
@@ -6,6 +6,7 @@ import {
 	useMutation,
 	useQuery,
 	useQueryClient,
+	useSuspenseQuery,
 } from "@tanstack/react-query";
 import { createContext, type ReactNode, useContext } from "react";
 import type { ErrorResponse } from "@/types/api";
@@ -101,6 +102,14 @@ export function useFetchOTU(otuId: string) {
 	});
 }
 
+export function otuHistoryQueryOptions(otuId: string) {
+	return queryOptions<OtuHistory[], ErrorResponse>({
+		queryKey: OTUQueryKeys.history(otuId),
+		queryFn: () =>
+			apiClient.get(`/otus/${otuId}/history`).then((res) => res.body),
+	});
+}
+
 /**
  * Fetches the history of changes for a single OTU
  *
@@ -108,11 +117,17 @@ export function useFetchOTU(otuId: string) {
  * @returns A history list of changes for a single OTU
  */
 export function useFetchOtuHistory(otuId: string) {
-	return useQuery<OtuHistory[], ErrorResponse>({
-		queryKey: OTUQueryKeys.history(otuId),
-		queryFn: () =>
-			apiClient.get(`/otus/${otuId}/history`).then((res) => res.body),
-	});
+	return useQuery(otuHistoryQueryOptions(otuId));
+}
+
+/**
+ * Fetch an OTU's history, suspending until it resolves.
+ *
+ * `data` is always defined, and a failed request throws to the nearest route
+ * error boundary instead of resolving to `undefined`.
+ */
+export function useSuspenseOtuHistory(otuId: string) {
+	return useSuspenseQuery(otuHistoryQueryOptions(otuId));
 }
 
 /**

--- a/apps/web/src/references/components/Detail/ReferenceSettings.tsx
+++ b/apps/web/src/references/components/Detail/ReferenceSettings.tsx
@@ -1,6 +1,5 @@
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import SectionHeader from "@base/SectionHeader";
-import { useFetchReference } from "@references/queries";
+import { useSuspenseReference } from "@references/queries";
 /**
  * The reference settings view allowing users to manage the reference
  */
@@ -15,16 +14,12 @@ const routeApi = getRouteApi("/_authenticated/refs/$refId");
 
 export default function ReferenceSettings() {
 	const { refId } = routeApi.useParams();
-	const { data, isPending } = useFetchReference(refId);
+	const { data } = useSuspenseReference(refId);
 
 	const [editUserId, setEditUserId] = useState<string>();
 	const [editGroupId, setEditGroupId] = useState<string>();
 	const [openAddUser, setOpenAddUser] = useState(false);
 	const [openAddGroup, setOpenAddGroup] = useState(false);
-
-	if (isPending || !data) {
-		return <LoadingPlaceholder />;
-	}
 
 	return (
 		<>

--- a/apps/web/src/references/components/ReferenceSettings.tsx
+++ b/apps/web/src/references/components/ReferenceSettings.tsx
@@ -1,16 +1,11 @@
-import { useFetchSettings } from "@administration/queries";
+import { useSuspenseSettings } from "@administration/queries";
 import ContainerNarrow from "@base/ContainerNarrow";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import { GlobalSourceTypes } from "./SourceTypes/GlobalSourceTypes";
 
 export default function ReferenceSettings() {
-	const { data, isPending } = useFetchSettings();
-
-	if (isPending || !data) {
-		return <LoadingPlaceholder />;
-	}
+	const { data } = useSuspenseSettings();
 
 	return (
 		<ContainerNarrow>

--- a/apps/web/src/references/components/__tests__/ReferenceSettings.test.tsx
+++ b/apps/web/src/references/components/__tests__/ReferenceSettings.test.tsx
@@ -31,12 +31,8 @@ test("GlobalSourceTypes", async () => {
 
 	renderWithProviders(<ReferenceSettings />);
 
-	// Wait for initial request to complete.
-	await waitFor(() =>
-		expect(screen.queryByLabelText("loading")).not.toBeInTheDocument(),
-	);
-
-	expect(screen.getByText("Clone")).toBeInTheDocument();
+	// Wait for the settings to load (loading is absorbed by Suspense).
+	expect(await screen.findByText("Clone")).toBeInTheDocument();
 	expect(screen.getByText("Genotype")).toBeInTheDocument();
 
 	// Delete 'Clone'.

--- a/apps/web/src/references/queries.ts
+++ b/apps/web/src/references/queries.ts
@@ -5,6 +5,7 @@ import {
 	useMutation,
 	useQuery,
 	useQueryClient,
+	useSuspenseQuery,
 } from "@tanstack/react-query";
 import { useState } from "react";
 import type { ErrorResponse } from "@/types/api";
@@ -373,6 +374,19 @@ export function referenceQueryOptions(refId: string) {
  */
 export function useFetchReference(refId: string) {
 	return useQuery(referenceQueryOptions(refId));
+}
+
+/**
+ * Fetch a reference, suspending until it resolves.
+ *
+ * `data` is always defined, and a failed request throws to the nearest route
+ * error boundary instead of resolving to `undefined`. Use this from components
+ * rendered under the `$refId` detail route, whose loader prefetches the
+ * reference — loading and errors are handled by the route's Suspense and
+ * `errorComponent` rather than inline.
+ */
+export function useSuspenseReference(refId: string) {
+	return useSuspenseQuery(referenceQueryOptions(refId));
 }
 
 /**

--- a/apps/web/src/routes/_authenticated/refs/$refId/otus/$otuId/history.tsx
+++ b/apps/web/src/routes/_authenticated/refs/$refId/otus/$otuId/history.tsx
@@ -1,8 +1,19 @@
 import OtuHistory from "@otus/components/Detail/History/OtuHistory";
-import { createFileRoute } from "@tanstack/react-router";
+import { otuHistoryQueryOptions } from "@otus/queries";
+import { createFileRoute, notFound } from "@tanstack/react-router";
 
 export const Route = createFileRoute(
 	"/_authenticated/refs/$refId/otus/$otuId/history",
 )({
+	loader: async ({ context: { queryClient }, params: { otuId } }) => {
+		try {
+			await queryClient.ensureQueryData(otuHistoryQueryOptions(otuId));
+		} catch (error) {
+			if (error?.response?.status === 404) {
+				throw notFound();
+			}
+			throw error;
+		}
+	},
 	component: OtuHistory,
 });

--- a/apps/web/src/routes/_authenticated/refs/settings.tsx
+++ b/apps/web/src/routes/_authenticated/refs/settings.tsx
@@ -1,6 +1,10 @@
+import { settingsQueryOptions } from "@administration/queries";
 import ReferenceSettings from "@references/components/ReferenceSettings";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_authenticated/refs/settings")({
+	loader: async ({ context: { queryClient } }) => {
+		await queryClient.ensureQueryData(settingsQueryOptions());
+	},
 	component: ReferenceSettings,
 });

--- a/apps/web/src/routes/_authenticated/samples/settings.tsx
+++ b/apps/web/src/routes/_authenticated/samples/settings.tsx
@@ -1,6 +1,10 @@
+import { settingsQueryOptions } from "@administration/queries";
 import SamplesSettings from "@samples/components/SampleSettings";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_authenticated/samples/settings")({
+	loader: async ({ context: { queryClient } }) => {
+		await queryClient.ensureQueryData(settingsQueryOptions());
+	},
 	component: SamplesSettings,
 });

--- a/apps/web/src/samples/components/Detail/SampleDetailGeneral.tsx
+++ b/apps/web/src/samples/components/Detail/SampleDetailGeneral.tsx
@@ -3,12 +3,11 @@ import BoxGroupHeader from "@base/BoxGroupHeader";
 import BoxGroupTable from "@base/BoxGroupTable";
 import ContainerNarrow from "@base/ContainerNarrow";
 import ContainerSide from "@base/ContainerSide";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Markdown from "@base/Markdown";
 import JobItem from "@jobs/components/JobItem";
 import { useFetchJob } from "@jobs/queries";
 import type { Label } from "@labels/types";
-import { useFetchSample } from "@samples/queries";
+import { useSuspenseSample } from "@samples/queries";
 import { getLibraryTypeDisplayName } from "@samples/utils";
 /**
  * The general view in sample details
@@ -28,12 +27,8 @@ export default function SampleDetailGeneral({
 	labels,
 }: SampleDetailGeneralProps) {
 	const { sampleId } = routeApi.useParams();
-	const { data, isPending } = useFetchSample(sampleId);
-	const { data: job } = useFetchJob(data?.job?.id ?? Number.NaN, data?.job);
-
-	if (isPending || !data) {
-		return <LoadingPlaceholder />;
-	}
+	const { data } = useSuspenseSample(sampleId);
+	const { data: job } = useFetchJob(data.job?.id ?? Number.NaN, data.job);
 
 	const { quality } = data;
 

--- a/apps/web/src/samples/components/SampleQuality.tsx
+++ b/apps/web/src/samples/components/SampleQuality.tsx
@@ -1,7 +1,6 @@
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import { Quality } from "@quality/components/Quality";
 import { getRouteApi } from "@tanstack/react-router";
-import { useFetchSample } from "../queries";
+import { useSuspenseSample } from "../queries";
 import LegacyAlert from "./SampleFilesMessage";
 
 const routeApi = getRouteApi("/_authenticated/samples/$sampleId");
@@ -11,11 +10,7 @@ const routeApi = getRouteApi("/_authenticated/samples/$sampleId");
  */
 export default function SampleQuality() {
 	const { sampleId } = routeApi.useParams();
-	const { data, isPending } = useFetchSample(sampleId);
-
-	if (isPending || !data) {
-		return <LoadingPlaceholder />;
-	}
+	const { data } = useSuspenseSample(sampleId);
 
 	return (
 		<div className="flex flex-col">

--- a/apps/web/src/samples/components/SampleSettings.tsx
+++ b/apps/web/src/samples/components/SampleSettings.tsx
@@ -1,16 +1,11 @@
-import { useFetchSettings } from "@administration/queries";
+import { useSuspenseSettings } from "@administration/queries";
 import ContainerNarrow from "@base/ContainerNarrow";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import SampleRights from "./SampleRights";
 
 export default function SamplesSettings() {
-	const { data, isPending } = useFetchSettings();
-
-	if (isPending || !data) {
-		return <LoadingPlaceholder />;
-	}
+	const { data } = useSuspenseSettings();
 
 	return (
 		<ContainerNarrow>

--- a/apps/web/src/server/users/functions.ts
+++ b/apps/web/src/server/users/functions.ts
@@ -143,7 +143,7 @@ export const createUser = createServerFn({ method: "POST" })
 			setResponseStatus(201);
 			return user;
 		} catch (err) {
-			rethrowAsHttp(err);
+			throw rethrowAsHttp(err);
 		}
 	});
 
@@ -167,7 +167,7 @@ export const updateUser = createServerFn({ method: "POST" })
 		try {
 			return await updateUserImpl(db, userId, values);
 		} catch (err) {
-			rethrowAsHttp(err);
+			throw rethrowAsHttp(err);
 		}
 	});
 
@@ -183,7 +183,7 @@ export const updateAccountHandle = createServerFn({ method: "POST" })
 				handle: data.handle,
 			});
 		} catch (err) {
-			rethrowAsHttp(err);
+			throw rethrowAsHttp(err);
 		}
 	});
 
@@ -201,6 +201,6 @@ export const setAdministratorRole = createServerFn({ method: "POST" })
 		try {
 			return await setAdministratorRoleImpl(db, data.userId, data.role);
 		} catch (err) {
-			rethrowAsHttp(err);
+			throw rethrowAsHttp(err);
 		}
 	});

--- a/apps/web/src/server/users/functions.ts
+++ b/apps/web/src/server/users/functions.ts
@@ -121,7 +121,9 @@ export const getUser = createServerFn({ method: "GET" })
 		try {
 			return await getUserImpl(db, data.userId);
 		} catch (err) {
-			rethrowAsHttp(err);
+			// `throw` keeps the handler's inferred return type `User` rather than
+			// `User | undefined`, so suspense consumers get a non-nullable user.
+			throw rethrowAsHttp(err);
 		}
 	});
 

--- a/apps/web/src/users/components/UserDetail.tsx
+++ b/apps/web/src/users/components/UserDetail.tsx
@@ -1,8 +1,7 @@
 import { useCheckAdminRole } from "@administration/hooks";
-import { useFetchUser, useUpdateUser } from "@administration/queries";
+import { useSuspenseUser, useUpdateUser } from "@administration/queries";
 import Alert from "@base/Alert";
 import InitialIcon from "@base/InitialIcon";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import { CircleAlert, ShieldUserIcon } from "lucide-react";
 import Label from "@/base/Label";
 import Handle from "./Handle";
@@ -22,16 +21,12 @@ type UserDetailProps = {
  * The detailed view of a user
  */
 export default function UserDetail({ userId }: UserDetailProps) {
-	const { data, isPending } = useFetchUser(userId);
+	const { data } = useSuspenseUser(userId);
 	const { hasPermission: canEdit } = useCheckAdminRole(
-		data?.administrator_role === null ? "users" : "full",
+		data.administrator_role === null ? "users" : "full",
 	);
 
 	const mutation = useUpdateUser();
-
-	if (isPending || !data) {
-		return <LoadingPlaceholder />;
-	}
 
 	if (!canEdit) {
 		return (


### PR DESCRIPTION
## Summary

- Adds `RouteError` as the router's `defaultErrorComponent`, replacing indefinite loading spinners with actionable error states — 401/403/404 get specific messages, everything else gets a \"Try again\" button that clears the error and reruns the loader
- Converts primary-data queries across samples, references, OTUs, settings, and user detail to `useSuspenseQuery`, letting the framework handle loading and errors declaratively and removing all `if (isPending || !data)` guards
- Documents the two-tier loading/error policy (Tier 1: suspense + route error boundary for primary data; Tier 2: inline `isError` check for secondary data) in `docs/queries.md` and `AGENTS.md`