### PR TITLE
feat(sentry): add user context, profiling, and info-level log forwarding

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -14,7 +14,7 @@ reverse proxy.
 | -------------- | ------------------ | ---------------------------------------------- |
 | `-p`, `--port` | `VT_UI_PORT`       | The port the UI server should listen on        |
 | `-H`, `--host` | `VT_UI_HOST`       | The host the UI server should listen on        |
-| `--sentry-dsn` | `VT_SENTRY_DSN`    | The DSN that sentry will send logged errors to |
+| `--sentry-dsn` | `VT_SENTRY_DSN`    | The DSN that Sentry will send logged errors to |
 
 ## Development
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -14,7 +14,7 @@ reverse proxy.
 | -------------- | ------------------ | ---------------------------------------------- |
 | `-p`, `--port` | `VT_UI_PORT`       | The port the UI server should listen on        |
 | `-H`, `--host` | `VT_UI_HOST`       | The host the UI server should listen on        |
-| `--sentry-dsn` | `VT_UI_SENTRY_DSN` | The DSN that sentry will send logged errors to |
+| `--sentry-dsn` | `VT_SENTRY_DSN`    | The DSN that sentry will send logged errors to |
 
 ## Development
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
 	},
 	"dependencies": {
 		"@hookform/resolvers": "^5.4.0",
+		"@sentry/profiling-node": "10.56.0",
 		"@sentry/tanstackstart-react": "^10.56.0",
 		"@tanstack/react-query": "^5.101.0",
 		"@tanstack/react-router": "^1.170.11",

--- a/apps/web/src/account/queries.ts
+++ b/apps/web/src/account/queries.ts
@@ -2,6 +2,7 @@ import type { Account, APIKeyMinimal } from "@account/types";
 import { apiClient } from "@app/api";
 import { resetClient } from "@app/utils";
 import type { Permissions } from "@groups/types";
+import * as Sentry from "@sentry/tanstackstart-react";
 import { logoutFn } from "@server/auth/functions";
 import { updateAccountHandle } from "@server/users/functions";
 import {
@@ -198,6 +199,7 @@ export function useLogout() {
 	return useMutation<null, ErrorResponse>({
 		mutationFn: () => logoutFn(),
 		onSuccess: () => {
+			Sentry.setUser(null);
 			resetClient();
 		},
 	});

--- a/apps/web/src/instrument.server.ts
+++ b/apps/web/src/instrument.server.ts
@@ -9,5 +9,13 @@ import { getCommonOptions } from "@virtool/sentry";
 const options = getCommonOptions();
 
 if (options.dsn) {
-	Sentry.init(options);
+	// Load the profiler lazily and only when configured. `@sentry/profiling-node`
+	// pulls in a native CommonJS addon that the Vite/Nitro SSR transform can't
+	// process, so a top-level import would break dev and tests where no DSN is
+	// set. Mirrors the DSN-gated `await import` used for the pino→Sentry stream.
+	const { nodeProfilingIntegration } = await import("@sentry/profiling-node");
+	Sentry.init({
+		...options,
+		integrations: [nodeProfilingIntegration()],
+	});
 }

--- a/apps/web/src/instrument.server.ts
+++ b/apps/web/src/instrument.server.ts
@@ -9,10 +9,10 @@ import { getCommonOptions } from "@virtool/sentry";
 const options = getCommonOptions();
 
 if (options.dsn) {
-	// Load the profiler lazily and only when configured. `@sentry/profiling-node`
+	// Import the profiler lazily and only when configured. `@sentry/profiling-node`
 	// pulls in a native CommonJS addon that the Vite/Nitro SSR transform can't
-	// process, so a top-level import would break dev and tests where no DSN is
-	// set. Mirrors the DSN-gated `await import` used for the pino→Sentry stream.
+	// process, so a top-level import breaks dev and tests where no DSN is set.
+	// Mirrors the DSN-gated `await import` used for the pino→Sentry stream.
 	const { nodeProfilingIntegration } = await import("@sentry/profiling-node");
 	Sentry.init({
 		...options,

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -68,6 +68,7 @@ export function getRouter() {
 				...options,
 				integrations: [
 					Sentry.tanstackRouterBrowserTracingIntegration(router),
+					Sentry.browserProfilingIntegration(),
 					Sentry.replayIntegration(),
 				],
 			});

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -61,7 +61,11 @@ export function getRouter() {
 		scrollToTopSelectors: [`#${CONTENT_SCROLL_ID}`],
 	});
 
-	if (!router.isServer) {
+	// `import.meta.env.SSR` is a compile-time constant, so the whole block is
+	// dead-code-eliminated from the server bundle. `browserProfilingIntegration`
+	// has no server stub (unlike the replay/tracing integrations), so leaving the
+	// reference in the SSR build would warn about an undefined import.
+	if (!import.meta.env.SSR) {
 		const options = getCommonOptions(import.meta.env);
 		if (options.dsn) {
 			Sentry.init({

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -8,6 +8,7 @@ import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Nav from "@nav/components/Nav";
 import Sidebar from "@nav/components/Sidebar";
 import UpdateToast from "@nav/components/UpdateToast";
+import * as Sentry from "@sentry/tanstackstart-react";
 import type { QueryClient } from "@tanstack/react-query";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -65,6 +66,12 @@ function AuthenticatedLayout() {
 			setupSse(queryClient);
 		}
 	}, [data, queryClient]);
+
+	useEffect(() => {
+		if (data) {
+			Sentry.setUser({ id: data.id, username: data.handle });
+		}
+	}, [data]);
 
 	if (isPending) {
 		return <LoadingPlaceholder />;

--- a/apps/web/src/server/auth/functions.ts
+++ b/apps/web/src/server/auth/functions.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/tanstackstart-react";
 import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
 import { getRequest, setResponseStatus } from "@tanstack/react-start/server";
 import { z } from "zod";
@@ -67,6 +68,7 @@ export const loginFn = createServerFn({ method: "POST" })
 /** Logout server function. Requires an authenticated session. */
 export const logoutFn = createServerFn({ method: "POST" }).handler(async () => {
 	await logout(db, realCookies);
+	Sentry.setUser(null);
 	return null;
 });
 

--- a/apps/web/src/server/auth/middleware.ts
+++ b/apps/web/src/server/auth/middleware.ts
@@ -1,5 +1,6 @@
 import type { AdministratorRoleName } from "@administration/types";
 import { hasSufficientAdminRole } from "@administration/utils";
+import * as Sentry from "@sentry/tanstackstart-react";
 import { createMiddleware, createServerOnlyFn } from "@tanstack/react-start";
 import { getRequest, setResponseStatus } from "@tanstack/react-start/server";
 import { eq } from "drizzle-orm";
@@ -104,6 +105,12 @@ export function createAuthenticationMiddleware(
 		const session: AuthenticatedSession | null = exceptionPaths.has(pathname)
 			? null
 			: await requireSession();
+		// Attach the user to the request's isolation scope so errors and logs
+		// from this handler are tied to the acting user. Id-only here — the
+		// handle isn't on the session and isn't worth a per-request lookup.
+		if (session) {
+			Sentry.setUser({ id: session.userId });
+		}
 		return next({ context: { session } });
 	});
 }

--- a/apps/web/src/server/logger.ts
+++ b/apps/web/src/server/logger.ts
@@ -7,7 +7,7 @@ import { readDsn } from "@virtool/sentry";
 const streams = readDsn()
 	? [
 			{
-				level: "warn" as const,
+				level: "info" as const,
 				stream: (await import("./sentryLog")).createSentryLogStream(),
 			},
 		]

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -34,22 +34,36 @@ const cspDirectives = [
 
 // Builds one response header for served HTML documents. Each builder receives
 // the per-response CSP nonce; those that don't need it ignore the argument.
-// Adding a document header is a new entry in `documentHeaders`, not another
-// edit to the middleware body.
 type DocumentHeader = (nonce: string) => [name: string, value: string];
 
-const documentHeaders: DocumentHeader[] = [
-	(nonce) => [
+function buildContentSecurityPolicy(
+	nonce: string,
+): [name: string, value: string] {
+	return [
 		"Content-Security-Policy",
 		[...cspDirectives, `script-src 'self' 'nonce-${nonce}'`].join("; "),
-	],
-	// Opt the document into the JS Self-Profiling API so Sentry's browser
-	// profiling integration can sample. A no-op in browsers without the API
-	// (Firefox, Safari), so it is safe to send unconditionally.
-	() => ["Document-Policy", "js-profiling"],
-	// HTML documents carry a per-request nonce and authenticated state; never
-	// let a shared cache hold onto them.
-	() => ["Cache-Control", "no-store"],
+	];
+}
+
+// Opt the document into the JS Self-Profiling API so Sentry's browser profiling
+// integration can sample. A no-op in browsers without the API (Firefox, Safari),
+// so it is safe to send unconditionally.
+function buildDocumentPolicy(): [name: string, value: string] {
+	return ["Document-Policy", "js-profiling"];
+}
+
+// HTML documents carry a per-request nonce and authenticated state; never let a
+// shared cache hold onto them.
+function buildCacheControl(): [name: string, value: string] {
+	return ["Cache-Control", "no-store"];
+}
+
+// Adding a document header is a new entry here, not another edit to the
+// middleware body.
+const documentHeaders: DocumentHeader[] = [
+	buildContentSecurityPolicy,
+	buildDocumentPolicy,
+	buildCacheControl,
 ];
 
 const documentHeadersMiddleware = createMiddleware().server(
@@ -69,7 +83,12 @@ const documentHeadersMiddleware = createMiddleware().server(
 			const [name, value] = build(nonce);
 			headers.set(name, value);
 		}
+		// `response.text()` already decoded the body, so the length and any
+		// encoding headers from the original response no longer describe it.
+		// Leaving them would make clients try to decode an already-decoded body.
 		headers.delete("content-length");
+		headers.delete("content-encoding");
+		headers.delete("transfer-encoding");
 
 		return {
 			...result,
@@ -89,8 +108,9 @@ const csrfMiddleware = createCsrfMiddleware({
 	filter: (ctx) => ctx.handlerType === "serverFn",
 });
 
-// Sentry middleware go first so request and server-function spans wrap the
-// csrf/header/auth work rather than nesting inside it.
+// Sentry middleware go first in each list so the request span wraps the
+// csrf/header request middleware and the function span wraps the auth function
+// middleware, rather than nesting inside them.
 export const startInstance = createStart(() => ({
 	defaultSsr: false,
 	requestMiddleware: [

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -32,34 +32,55 @@ const cspDirectives = [
 	"style-src 'self' 'unsafe-inline'",
 ];
 
-const cspNonce = createMiddleware().server(async ({ next }) => {
-	const result = await next();
-	const { response } = result;
-	const contentType = response.headers.get("content-type") ?? "";
-	if (!contentType.includes("text/html")) {
-		return result;
-	}
+// Builds one response header for served HTML documents. Each builder receives
+// the per-response CSP nonce; those that don't need it ignore the argument.
+// Adding a document header is a new entry in `documentHeaders`, not another
+// edit to the middleware body.
+type DocumentHeader = (nonce: string) => [name: string, value: string];
 
-	const html = await response.text();
-	const nonce = randomBytes(16).toString("base64");
-	const body = html.replace(/<script(?=[\s>])/g, `<script nonce="${nonce}"`);
-	const headers = new Headers(response.headers);
-	headers.set(
+const documentHeaders: DocumentHeader[] = [
+	(nonce) => [
 		"Content-Security-Policy",
 		[...cspDirectives, `script-src 'self' 'nonce-${nonce}'`].join("; "),
-	);
-	headers.set("Cache-Control", "no-store");
-	headers.delete("content-length");
+	],
+	// Opt the document into the JS Self-Profiling API so Sentry's browser
+	// profiling integration can sample. A no-op in browsers without the API
+	// (Firefox, Safari), so it is safe to send unconditionally.
+	() => ["Document-Policy", "js-profiling"],
+	// HTML documents carry a per-request nonce and authenticated state; never
+	// let a shared cache hold onto them.
+	() => ["Cache-Control", "no-store"],
+];
 
-	return {
-		...result,
-		response: new Response(body, {
-			status: response.status,
-			statusText: response.statusText,
-			headers,
-		}),
-	};
-});
+const documentHeadersMiddleware = createMiddleware().server(
+	async ({ next }) => {
+		const result = await next();
+		const { response } = result;
+		const contentType = response.headers.get("content-type") ?? "";
+		if (!contentType.includes("text/html")) {
+			return result;
+		}
+
+		const html = await response.text();
+		const nonce = randomBytes(16).toString("base64");
+		const body = html.replace(/<script(?=[\s>])/g, `<script nonce="${nonce}"`);
+		const headers = new Headers(response.headers);
+		for (const build of documentHeaders) {
+			const [name, value] = build(nonce);
+			headers.set(name, value);
+		}
+		headers.delete("content-length");
+
+		return {
+			...result,
+			response: new Response(body, {
+				status: response.status,
+				statusText: response.statusText,
+				headers,
+			}),
+		};
+	},
+);
 
 // Server functions are same-origin RPC endpoints callable from any site.
 // Scoping CSRF checks to serverFn requests avoids blocking regular page
@@ -69,10 +90,14 @@ const csrfMiddleware = createCsrfMiddleware({
 });
 
 // Sentry middleware go first so request and server-function spans wrap the
-// csrf/csp/auth work rather than nesting inside it.
+// csrf/header/auth work rather than nesting inside it.
 export const startInstance = createStart(() => ({
 	defaultSsr: false,
-	requestMiddleware: [sentryGlobalRequestMiddleware, csrfMiddleware, cspNonce],
+	requestMiddleware: [
+		sentryGlobalRequestMiddleware,
+		csrfMiddleware,
+		documentHeadersMiddleware,
+	],
 	functionMiddleware: [
 		sentryGlobalFunctionMiddleware,
 		errorLoggingMiddleware,

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -64,7 +64,17 @@ export default defineConfig(({ command }) => ({
 				autoCodeSplitting: true,
 			},
 		}),
-		nitro(),
+		nitro({
+			// `@sentry/profiling-node` ships native `.node` addons the bundler can't
+			// inline. Tracing it (and its native helper) keeps the packages external
+			// and copies them into the server output, so the build doesn't choke on
+			// the binaries and the runtime import resolves. The dist image ships only
+			// `.output`, so the trace is what makes the package available at runtime.
+			traceDeps: [
+				"@sentry/profiling-node*",
+				"@sentry-internal/node-cpu-profiler*",
+			],
+		}),
 		react({
 			include: "**/*.tsx",
 			babel: {

--- a/packages/sentry/src/browser.ts
+++ b/packages/sentry/src/browser.ts
@@ -12,6 +12,7 @@ export type CommonBrowserSentryOptions = {
 	environment: string;
 	sendDefaultPii: boolean;
 	tracesSampleRate: number;
+	profilesSampleRate: number;
 	replaysSessionSampleRate: number;
 	replaysOnErrorSampleRate: number;
 	enableLogs: boolean;
@@ -27,6 +28,9 @@ export function getCommonOptions(
 		environment,
 		sendDefaultPii: true,
 		tracesSampleRate: isProd ? 0.1 : 1.0,
+		// Relative to traced transactions, so the effective profiling rate is
+		// tracesSampleRate * profilesSampleRate.
+		profilesSampleRate: isProd ? 0.5 : 1.0,
 		replaysSessionSampleRate: isProd ? 0.1 : 0,
 		replaysOnErrorSampleRate: 1.0,
 		enableLogs: true,

--- a/packages/sentry/src/browser.ts
+++ b/packages/sentry/src/browser.ts
@@ -7,6 +7,7 @@ export function readDsn(env: ImportMetaEnv): string | undefined {
 	return value && value.length > 0 ? value : undefined;
 }
 
+/** Shared Sentry options for browser-side SDK initialisation. */
 export type CommonBrowserSentryOptions = {
 	dsn: string | undefined;
 	environment: string;

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -5,6 +5,7 @@ export function readDsn(): string | undefined {
 	return value && value.length > 0 ? value : undefined;
 }
 
+/** Shared Sentry options for server-side SDK initialisation. */
 export type CommonSentryOptions = {
 	dsn: string | undefined;
 	environment: string;

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -10,16 +10,21 @@ export type CommonSentryOptions = {
 	environment: string;
 	sendDefaultPii: boolean;
 	tracesSampleRate: number;
+	profilesSampleRate: number;
 	enableLogs: boolean;
 };
 
 export function getCommonOptions(): CommonSentryOptions {
 	const environment = process.env.NODE_ENV ?? "development";
+	const isProd = environment === "production";
 	return {
 		dsn: readDsn(),
 		environment,
 		sendDefaultPii: true,
-		tracesSampleRate: environment === "production" ? 0.1 : 1.0,
+		tracesSampleRate: isProd ? 0.1 : 1.0,
+		// Relative to traced transactions, so the effective profiling rate is
+		// tracesSampleRate * profilesSampleRate.
+		profilesSampleRate: isProd ? 0.5 : 1.0,
 		enableLogs: true,
 	};
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.77.0(react@19.2.7))
+      '@sentry/profiling-node':
+        specifier: 10.56.0
+        version: 10.56.0
       '@sentry/tanstackstart-react':
         specifier: ^10.56.0
         version: 10.56.0(react@19.2.7)
@@ -1546,6 +1549,10 @@ packages:
     resolution: {integrity: sha512-fkRR9JroESTIlErkht3OrH4DXKd/DbPozr2KLdX7boMo31hPu4cL9fuqzwOrwyDPRq9B4j+qEgIWB8JrTbgvmg==}
     engines: {node: '>=18'}
 
+  '@sentry-internal/node-cpu-profiler@2.4.1':
+    resolution: {integrity: sha512-Wnkik+RLvRUZEB8Zx5ofgPdcC8bCSoiUUiyH6TorrLK6PBPerbjK48c2GsJf6l5Hc5GAhA3fitueVLATB0XhWQ==}
+    engines: {node: '>=18'}
+
   '@sentry-internal/replay-canvas@10.56.0':
     resolution: {integrity: sha512-SDg2K0CAZT/TnhrixQGwXoi6ZsWUB+DQy3UUk0bSQm6c/5k5zFBpGOiughQN+DYsDilKREfPKmUEEnqvUjm1HQ==}
     engines: {node: '>=18'}
@@ -1662,6 +1669,11 @@ packages:
       '@opentelemetry/core': ^1.30.1 || ^2.1.0
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
       '@opentelemetry/semantic-conventions': ^1.39.0
+
+  '@sentry/profiling-node@10.56.0':
+    resolution: {integrity: sha512-AmcUrvqJcvl39fNzoXBCPp8iGStRSmpBYqQCPz1mlDUw/n/iWpLq5+8iHecXyT5oOST4xHjNIyb7AA/fj0Pxzw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@sentry/react@10.56.0':
     resolution: {integrity: sha512-HfPLyvnrydfyjRXw9Q0GMzj7w2YtEwuC9z5RrPUfarA2qpA0/J8cfGLzyFX2v0jBmA/kkj6J1uBUoSVhCTxFHg==}
@@ -3590,6 +3602,10 @@ packages:
   nock@13.5.6:
     resolution: {integrity: sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==}
     engines: {node: '>= 10.13'}
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
 
   node-addon-api@8.7.0:
     resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
@@ -5803,6 +5819,11 @@ snapshots:
     dependencies:
       '@sentry/core': 10.56.0
 
+  '@sentry-internal/node-cpu-profiler@2.4.1':
+    dependencies:
+      detect-libc: 2.1.2
+      node-abi: 3.92.0
+
   '@sentry-internal/replay-canvas@10.56.0':
     dependencies:
       '@sentry-internal/replay': 10.56.0
@@ -5921,6 +5942,15 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry/core': 10.56.0
+
+  '@sentry/profiling-node@10.56.0':
+    dependencies:
+      '@sentry-internal/node-cpu-profiler': 2.4.1
+      '@sentry/core': 10.56.0
+      '@sentry/node': 10.56.0
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
 
   '@sentry/react@10.56.0(react@19.2.7)':
     dependencies:
@@ -8016,6 +8046,10 @@ snapshots:
       propagate: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.8.0
 
   node-addon-api@8.7.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
 minimumReleaseAge: 1440
 
 allowBuilds:
+  '@sentry-internal/node-cpu-profiler': true
   '@sentry/cli': true
   bcrypt: true
   cpu-features: true


### PR DESCRIPTION
## Summary

- Report the authenticated user to Sentry on login (via the auth middleware and authenticated layout) and clear it on logout, so errors and spans are tied to the acting user
- Enable CPU and browser profiling: add `@sentry/profiling-node` with a DSN-gated lazy import on the server and `browserProfilingIntegration` on the client, along with the `Document-Policy: js-profiling` response header required by the JS Self-Profiling API
- Lower the server-side Sentry log forwarding threshold from `warn` to `info` so informational server events reach Sentry when a DSN is configured

## Test plan

- [ ] Log in as a user and trigger a Sentry error — confirm the Sentry event shows the correct user id and handle
- [ ] Log out and trigger a Sentry error — confirm the user field is cleared (`null`)
- [ ] With `VT_SENTRY_DSN` set, confirm profiling transactions appear in Sentry for both server and browser sessions
- [ ] Confirm the `Document-Policy: js-profiling` header is present on HTML responses
- [ ] With `VT_SENTRY_DSN` set, confirm `info`-level server logs appear in Sentry breadcrumbs
- [ ] Without `VT_SENTRY_DSN` set, confirm the server starts cleanly (no native addon import errors)