### PR TITLE
fix: show inline errors for secondary data instead of spinning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,8 +180,11 @@ is shared across hooks or branches. Route loaders prefetch via the same
 Loading and error states come in two tiers: primary route data uses
 `useSuspenseQuery` (loading via the route's `<Suspense>`, errors via the
 router's `defaultErrorComponent`, `@base/RouteError`), and secondary data
-stays on `useQuery` checking `isError` before `isPending` for an inline error.
-Never write `if (isPending || !data)` — on error it spins forever. See
+stays on `useQuery`, gating an inline `@base/QueryError` on `isError && !data`
+(error only when there's nothing to show, so stale data survives a failed
+background refetch) before checking `isPending`. Never write
+`if (isPending || !data)` — that puts `!data` in the loading branch, so an
+initial-load failure spins forever. See
 [docs/queries.md](docs/queries.md) for the query-key, `queryOptions`,
 route-loader prefetch, the two-tier error/loading policy, and mutation
 patterns.

--- a/apps/web/src/account/components/AccountProfile.tsx
+++ b/apps/web/src/account/components/AccountProfile.tsx
@@ -1,6 +1,7 @@
 import InitialIcon from "@base/InitialIcon";
 import Label from "@base/Label";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import { ShieldUser } from "lucide-react";
 import { useFetchAccount } from "../queries";
 import AccountEmail from "./AccountEmail";
@@ -12,9 +13,13 @@ import AccountPassword from "./AccountPassword";
  * Displays information related to the users account with options to reset password and email
  */
 export default function AccountProfile() {
-	const { data, isPending } = useFetchAccount();
+	const { data, isPending, isError } = useFetchAccount();
 
-	if (isPending || !data) {
+	if (isError && !data) {
+		return <QueryError noun="your account" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/account/components/ApiKeyPermissions.tsx
+++ b/apps/web/src/account/components/ApiKeyPermissions.tsx
@@ -8,6 +8,7 @@ import BoxGroup from "@base/BoxGroup";
 import BoxGroupSection from "@base/BoxGroupSection";
 import Checkbox from "@base/Checkbox";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import type { Permissions } from "@groups/types";
 import { sortBy } from "es-toolkit";
 
@@ -28,9 +29,13 @@ export default function ApiKeyPermissions({
 	keyPermissions,
 	onChange,
 }: APIPermissionsProps) {
-	const { data: account, isPending } = useFetchAccount();
+	const { data: account, isPending, isError } = useFetchAccount();
 
-	if (isPending || !account) {
+	if (isError && !account) {
+		return <QueryError noun="your account" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/account/components/ApiKeys.tsx
+++ b/apps/web/src/account/components/ApiKeys.tsx
@@ -3,6 +3,7 @@ import BoxGroup from "@base/BoxGroup";
 import ExternalLink from "@base/ExternalLink";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundBox from "@base/NoneFoundBox";
+import QueryError from "@base/QueryError";
 import { useFetchAPIKeys } from "../queries";
 import ApiKey from "./ApiKey";
 import ApiKeyCreate from "./ApiKeyCreate";
@@ -11,9 +12,13 @@ import ApiKeyCreate from "./ApiKeyCreate";
  * A component to manage and display API keys
  */
 export default function ApiKeys() {
-	const { data, isPending } = useFetchAPIKeys();
+	const { data, isPending, isError } = useFetchAPIKeys();
 
-	if (isPending || !data) {
+	if (isError && !data) {
+		return <QueryError noun="API keys" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder className="mt-36" />;
 	}
 

--- a/apps/web/src/administration/components/Banners.tsx
+++ b/apps/web/src/administration/components/Banners.tsx
@@ -10,6 +10,7 @@ import BoxGroup from "@base/BoxGroup";
 import BoxGroupSection from "@base/BoxGroupSection";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundSection from "@base/NoneFoundSection";
+import QueryError from "@base/QueryError";
 import { RadioGroup, RadioGroupItem } from "@base/RadioGroup";
 import SectionHeader from "@base/SectionHeader";
 import BannerItem from "./BannerItem";
@@ -20,14 +21,18 @@ import CreateBanner from "./CreateBanner";
  * deactivate, and delete entries; the active row is shown to all users.
  */
 export default function Banners() {
-	const { data, isPending } = useFetchBanners();
+	const { data, isPending, isError } = useFetchBanners();
 	const createMutation = useCreateBanner();
 	const updateMutation = useUpdateBanner();
 	const deleteMutation = useDeleteBanner();
 	const setActiveMutation = useSetActiveBanner();
 	const clearActiveMutation = useClearActiveBanner();
 
-	if (isPending || !data) {
+	if (isError && !data) {
+		return <QueryError noun="banners" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/administration/components/ServerSettings.tsx
+++ b/apps/web/src/administration/components/ServerSettings.tsx
@@ -1,13 +1,22 @@
 import ContainerNarrow from "@base/ContainerNarrow";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import { useFetchSettings } from "../queries";
 import Api from "./Api";
 import Banners from "./Banners";
 
 export default function ServerSettings() {
-	const { data: settings, isPending: isPendingSettings } = useFetchSettings();
+	const {
+		data: settings,
+		isPending: isPendingSettings,
+		isError: isErrorSettings,
+	} = useFetchSettings();
 
-	if (isPendingSettings || !settings) {
+	if (isErrorSettings && !settings) {
+		return <QueryError noun="server settings" />;
+	}
+
+	if (isPendingSettings) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/analyses/components/AnalysisDetail.tsx
+++ b/apps/web/src/analyses/components/AnalysisDetail.tsx
@@ -2,6 +2,7 @@ import NuvsViewer from "@analyses/components/Nuvs/NuvsViewer";
 import { getWorkflowDisplayName } from "@app/utils";
 import Box from "@base/Box";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import RelativeTime from "@base/RelativeTime";
 import SubviewHeader from "@base/SubviewHeader";
 import SubviewHeaderAttribution from "@base/SubviewHeaderAttribution";
@@ -26,10 +27,18 @@ const routeApi = getRouteApi(
 /** Base component viewing all supported analysis */
 export default function AnalysisDetail() {
 	const { analysisId, sampleId } = routeApi.useParams();
-	const { data: analysis, isPending } = useGetAnalysis(analysisId);
-	const { data: sample, isPending: isPendingSample } = useFetchSample(sampleId);
+	const { data: analysis, isPending, isError } = useGetAnalysis(analysisId);
+	const {
+		data: sample,
+		isPending: isPendingSample,
+		isError: isSampleError,
+	} = useFetchSample(sampleId);
 
-	if (isPending || isPendingSample || !sample) {
+	if ((isError || isSampleError) && (!analysis || !sample)) {
+		return <QueryError noun="analysis" />;
+	}
+
+	if (isPending || isPendingSample) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/analyses/components/AnalysisDetail.tsx
+++ b/apps/web/src/analyses/components/AnalysisDetail.tsx
@@ -34,7 +34,7 @@ export default function AnalysisDetail() {
 		isError: isSampleError,
 	} = useFetchSample(sampleId);
 
-	if ((isError || isSampleError) && (!analysis || !sample)) {
+	if ((isError && !analysis) || (isSampleError && !sample)) {
 		return <QueryError noun="analysis" />;
 	}
 

--- a/apps/web/src/analyses/components/Create/CreateIimi.tsx
+++ b/apps/web/src/analyses/components/Create/CreateIimi.tsx
@@ -1,6 +1,7 @@
 import { useCompatibleIndexes } from "@analyses/hooks";
 import { useCreateAnalysis } from "@analyses/queries";
 import Button from "@base/Button";
+import QueryError from "@base/QueryError";
 import { useFindModels } from "@ml/queries";
 import { Controller, useForm } from "react-hook-form";
 import { CreateAnalysisFooter } from "./CreateAnalysisFooter";
@@ -29,8 +30,16 @@ export default function CreateIimi({
 	sampleCount,
 	sampleIds,
 }: CreateIimiProps) {
-	const { indexes, isPending: isPendingIndexes } = useCompatibleIndexes();
-	const { data: mlModels, isPending: isPendingMlModels } = useFindModels();
+	const {
+		indexes,
+		isPending: isPendingIndexes,
+		isError: isErrorIndexes,
+	} = useCompatibleIndexes();
+	const {
+		data: mlModels,
+		isPending: isPendingMlModels,
+		isError: isErrorMlModels,
+	} = useFindModels();
 
 	const createAnalysis = useCreateAnalysis();
 
@@ -40,7 +49,11 @@ export default function CreateIimi({
 		formState: { errors },
 	} = useForm<CreateIimiFormValues>();
 
-	if (isPendingIndexes || isPendingMlModels || !indexes || !mlModels) {
+	if (isErrorIndexes || isErrorMlModels) {
+		return <QueryError noun="analysis options" />;
+	}
+
+	if (isPendingIndexes || isPendingMlModels) {
 		return null;
 	}
 

--- a/apps/web/src/analyses/components/Create/CreateIimi.tsx
+++ b/apps/web/src/analyses/components/Create/CreateIimi.tsx
@@ -49,7 +49,7 @@ export default function CreateIimi({
 		formState: { errors },
 	} = useForm<CreateIimiFormValues>();
 
-	if (isErrorIndexes || isErrorMlModels) {
+	if (isErrorIndexes || (isErrorMlModels && !mlModels)) {
 		return <QueryError noun="analysis options" />;
 	}
 

--- a/apps/web/src/analyses/components/Create/CreateNuvs.tsx
+++ b/apps/web/src/analyses/components/Create/CreateNuvs.tsx
@@ -1,6 +1,7 @@
 import { useCompatibleIndexes, useSubtractionOptions } from "@analyses/hooks";
 import { useCreateAnalysis } from "@analyses/queries";
 import Button from "@base/Button";
+import QueryError from "@base/QueryError";
 import { Controller, useForm } from "react-hook-form";
 import { CreateAnalysisFooter } from "./CreateAnalysisFooter";
 import { CreateAnalysisInputError } from "./CreateAnalysisInputError";
@@ -28,12 +29,17 @@ export default function CreateNuvs({
 	sampleCount,
 	sampleIds,
 }: CreateNuvsProps) {
-	const { indexes, isPending: isPendingIndexes } = useCompatibleIndexes();
+	const {
+		indexes,
+		isPending: isPendingIndexes,
+		isError: isErrorIndexes,
+	} = useCompatibleIndexes();
 
 	const {
 		defaultSubtractions,
 		subtractions,
 		isPending: isPendingSubtractions,
+		isError: isErrorSubtractions,
 	} = useSubtractionOptions(sampleIds);
 
 	const createAnalysis = useCreateAnalysis();
@@ -49,7 +55,11 @@ export default function CreateNuvs({
 		},
 	});
 
-	if (isPendingIndexes || isPendingSubtractions || !indexes) {
+	if (isErrorIndexes || isErrorSubtractions) {
+		return <QueryError noun="analysis options" />;
+	}
+
+	if (isPendingIndexes || isPendingSubtractions) {
 		return null;
 	}
 

--- a/apps/web/src/analyses/components/Create/CreatePathoscope.tsx
+++ b/apps/web/src/analyses/components/Create/CreatePathoscope.tsx
@@ -1,6 +1,7 @@
 import { useCompatibleIndexes, useSubtractionOptions } from "@analyses/hooks";
 import { useCreateAnalysis } from "@analyses/queries";
 import Button from "@base/Button";
+import QueryError from "@base/QueryError";
 import { Controller, useForm } from "react-hook-form";
 import { CreateAnalysisFooter } from "./CreateAnalysisFooter";
 import { CreateAnalysisInputError } from "./CreateAnalysisInputError";
@@ -28,12 +29,17 @@ export default function CreatePathoscope({
 	sampleCount,
 	sampleIds,
 }: CreatePathoscopeProps) {
-	const { indexes, isPending: isPendingIndexes } = useCompatibleIndexes();
+	const {
+		indexes,
+		isPending: isPendingIndexes,
+		isError: isErrorIndexes,
+	} = useCompatibleIndexes();
 
 	const {
 		defaultSubtractions,
 		subtractions,
 		isPending: isPendingSubtractions,
+		isError: isErrorSubtractions,
 	} = useSubtractionOptions(sampleIds);
 
 	const createAnalysis = useCreateAnalysis();
@@ -49,7 +55,11 @@ export default function CreatePathoscope({
 		},
 	});
 
-	if (isPendingIndexes || isPendingSubtractions || !indexes) {
+	if (isErrorIndexes || isErrorSubtractions) {
+		return <QueryError noun="analysis options" />;
+	}
+
+	if (isPendingIndexes || isPendingSubtractions) {
 		return null;
 	}
 

--- a/apps/web/src/analyses/components/Create/QuickAnalyze.tsx
+++ b/apps/web/src/analyses/components/Create/QuickAnalyze.tsx
@@ -2,6 +2,7 @@ import { cn } from "@app/utils";
 import Badge from "@base/Badge";
 import BoxGroupSection from "@base/BoxGroupSection";
 import { Dialog, DialogTitle } from "@base/Dialog";
+import QueryError from "@base/QueryError";
 import { useListHmms } from "@hmm/queries";
 import type { SampleMinimal } from "@samples/types";
 import { Tabs } from "radix-ui";
@@ -43,7 +44,7 @@ export default function QuickAnalyze({
 	samples,
 	setOpen,
 }: QuickAnalyzeProps) {
-	const { data: hmms, isPending } = useListHmms(1, 1, "");
+	const { data: hmms, isPending, isError } = useListHmms(1, 1, "");
 
 	// The dialog should close when all selected samples have been analyzed and deselected.
 	useEffect(() => {
@@ -52,7 +53,18 @@ export default function QuickAnalyze({
 		}
 	}, [open, samples, setOpen]);
 
-	if (isPending || !hmms) {
+	if (isError && !hmms) {
+		return (
+			<Dialog open={open} onOpenChange={setOpen}>
+				<CreateAnalysisDialogContent>
+					<DialogTitle>Quick Analyze</DialogTitle>
+					<QueryError noun="HMMs" />
+				</CreateAnalysisDialogContent>
+			</Dialog>
+		);
+	}
+
+	if (isPending) {
 		return null;
 	}
 

--- a/apps/web/src/analyses/hooks.ts
+++ b/apps/web/src/analyses/hooks.ts
@@ -85,10 +85,14 @@ export function useGetActiveHit(matches) {
 type UseCompatibleIndexesResult = {
 	indexes: IndexMinimal[];
 	isPending: boolean;
+	isError: boolean;
 };
 
 export function useCompatibleIndexes(): UseCompatibleIndexesResult {
-	const { data, isPending } = useListIndexes({ ready: true, archived: false });
+	const { data, isPending, isError } = useListIndexes({
+		ready: true,
+		archived: false,
+	});
 
 	const indexes = Object.values(
 		groupBy(data ?? [], (item) => item.reference.id),
@@ -96,13 +100,14 @@ export function useCompatibleIndexes(): UseCompatibleIndexesResult {
 		.map((group) => maxBy(group, (item) => Number(item.version)))
 		.filter((index): index is IndexMinimal => index !== undefined);
 
-	return { indexes, isPending };
+	return { indexes, isPending, isError };
 }
 
 type UseSubtractionOptionsResult = {
 	defaultSubtractions: SubtractionOption[];
 	subtractions: SubtractionOption[];
 	isPending: boolean;
+	isError: boolean;
 };
 
 /**
@@ -122,11 +127,25 @@ export function useSubtractionOptions(
 	const {
 		data: subtractionShortlist,
 		isPending: isPendingSubtractionShortlist,
+		isError: isErrorSubtractionShortlist,
 	} = useFetchSubtractionsShortlist(true);
 
 	const sampleId = sampleIds[0] ?? "";
 
-	const { data: sample, isPending: isPendingSample } = useFetchSample(sampleId);
+	const {
+		data: sample,
+		isPending: isPendingSample,
+		isError: isErrorSample,
+	} = useFetchSample(sampleId);
+
+	if (isErrorSample || isErrorSubtractionShortlist) {
+		return {
+			defaultSubtractions: [],
+			subtractions: [],
+			isPending: false,
+			isError: true,
+		};
+	}
 
 	if (
 		isPendingSample ||
@@ -138,6 +157,7 @@ export function useSubtractionOptions(
 			defaultSubtractions: [],
 			subtractions: [],
 			isPending: true,
+			isError: false,
 		};
 	}
 
@@ -163,5 +183,6 @@ export function useSubtractionOptions(
 		defaultSubtractions,
 		subtractions,
 		isPending: false,
+		isError: false,
 	};
 }

--- a/apps/web/src/base/QueryError.tsx
+++ b/apps/web/src/base/QueryError.tsx
@@ -1,0 +1,14 @@
+import Alert from "./Alert";
+
+type QueryErrorProps = {
+	noun: string;
+};
+
+/**
+ * Inline error for a failed secondary (Tier 2) query. Contains the failure to
+ * one view — a list, sidebar widget, or banner — instead of escalating to the
+ * route-level `RouteError` takeover used for primary data.
+ */
+export default function QueryError({ noun }: QueryErrorProps) {
+	return <Alert color="red">Couldn't load {noun}.</Alert>;
+}

--- a/apps/web/src/groups/components/Groups.tsx
+++ b/apps/web/src/groups/components/Groups.tsx
@@ -1,6 +1,7 @@
 import Button from "@base/Button";
 import InputHeader from "@base/InputHeader";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import RemoveBanner from "@base/RemoveBanner";
 import { sortBy } from "es-toolkit/compat";
 import { Tabs } from "radix-ui";
@@ -26,7 +27,11 @@ export default function Groups() {
 		GroupMinimal[] | undefined | null
 	>(null);
 
-	const { data: groups, isPending: isPendingGroups } = useListGroups();
+	const {
+		data: groups,
+		isPending: isPendingGroups,
+		isError: isErrorGroups,
+	} = useListGroups();
 
 	if (groups !== prevGroups) {
 		setPrevGroups(groups);
@@ -37,7 +42,11 @@ export default function Groups() {
 
 	const { data: selectedGroup } = useFetchGroup(selectedGroupId ?? 0);
 
-	if (isPendingGroups || !groups || (groups.length && !selectedGroup)) {
+	if (isErrorGroups && !groups) {
+		return <QueryError noun="groups" />;
+	}
+
+	if (isPendingGroups || (groups.length && !selectedGroup)) {
 		return <LoadingPlaceholder className="mt-32" />;
 	}
 

--- a/apps/web/src/groups/components/Groups.tsx
+++ b/apps/web/src/groups/components/Groups.tsx
@@ -40,13 +40,25 @@ export default function Groups() {
 		}
 	}
 
-	const { data: selectedGroup } = useFetchGroup(selectedGroupId ?? 0);
+	const {
+		data: selectedGroup,
+		isPending: isPendingSelectedGroup,
+		isError: isErrorSelectedGroup,
+	} = useFetchGroup(selectedGroupId ?? 0);
 
 	if (isErrorGroups && !groups) {
 		return <QueryError noun="groups" />;
 	}
 
-	if (isPendingGroups || (groups.length && !selectedGroup)) {
+	if (isPendingGroups || !groups) {
+		return <LoadingPlaceholder className="mt-32" />;
+	}
+
+	if (isErrorSelectedGroup && groups.length && !selectedGroup) {
+		return <QueryError noun="selected group" />;
+	}
+
+	if (groups.length && isPendingSelectedGroup) {
 		return <LoadingPlaceholder className="mt-32" />;
 	}
 

--- a/apps/web/src/hmm/components/HmmInstall.tsx
+++ b/apps/web/src/hmm/components/HmmInstall.tsx
@@ -5,6 +5,7 @@ import Button from "@base/Button";
 import Icon from "@base/Icon";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import ProgressBarAffixed from "@base/ProgressBarAffixed";
+import QueryError from "@base/QueryError";
 import { useQueryClient } from "@tanstack/react-query";
 import { useFetchTask } from "@tasks/queries";
 import { Info } from "lucide-react";
@@ -15,7 +16,7 @@ import { hmmQueryKeys, useInstallHmm, useListHmms } from "../queries";
  * Displays the installation progress information or provides the option to install HMMs
  */
 export function HmmInstall() {
-	const { data, isPending } = useListHmms(1, 25);
+	const { data, isPending, isError } = useListHmms(1, 25);
 	const queryClient = useQueryClient();
 	const { hasPermission: canInstall } =
 		useCheckAdminRoleOrPermission("modify_hmm");
@@ -35,7 +36,11 @@ export function HmmInstall() {
 		}
 	}, [taskComplete, queryClient]);
 
-	if (isPending || !data) {
+	if (isError && !data) {
+		return <QueryError noun="HMMs" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/hmm/components/HmmList.tsx
+++ b/apps/web/src/hmm/components/HmmList.tsx
@@ -2,6 +2,7 @@ import BoxGroup from "@base/BoxGroup";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundBox from "@base/NoneFoundBox";
 import Pagination from "@base/Pagination";
+import QueryError from "@base/QueryError";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
@@ -20,9 +21,13 @@ type HmmListProps = {
  * A list of HMMs with filtering options
  */
 export default function HmmList({ find, page, setSearch }: HmmListProps) {
-	const { data, isPending } = useListHmms(page, 25, find);
+	const { data, isPending, isError } = useListHmms(page, 25, find);
 
-	if (isPending || !data) {
+	if (isError && !data) {
+		return <QueryError noun="HMMs" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/indexes/components/IndexDetail.tsx
+++ b/apps/web/src/indexes/components/IndexDetail.tsx
@@ -31,7 +31,7 @@ export default function IndexDetail() {
 		isError: isErrorReference,
 	} = useFetchReference(refId);
 
-	if ((isError || isErrorReference) && (!index || !reference)) {
+	if ((isError && !index) || (isErrorReference && !reference)) {
 		return <NotFound />;
 	}
 	if (isPendingIndex || isPendingReference) {

--- a/apps/web/src/indexes/components/IndexDetail.tsx
+++ b/apps/web/src/indexes/components/IndexDetail.tsx
@@ -25,13 +25,16 @@ export default function IndexDetail() {
 		isPending: isPendingIndex,
 		isError,
 	} = useFetchIndex(indexId);
-	const { data: reference, isPending: isPendingReference } =
-		useFetchReference(refId);
+	const {
+		data: reference,
+		isPending: isPendingReference,
+		isError: isErrorReference,
+	} = useFetchReference(refId);
 
-	if (isError) {
+	if ((isError || isErrorReference) && (!index || !reference)) {
 		return <NotFound />;
 	}
-	if (isPendingIndex || isPendingReference || !index || !reference) {
+	if (isPendingIndex || isPendingReference) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/indexes/components/Indexes.tsx
+++ b/apps/web/src/indexes/components/Indexes.tsx
@@ -2,6 +2,7 @@ import BoxGroup from "@base/BoxGroup";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundBox from "@base/NoneFoundBox";
 import Pagination from "@base/Pagination";
+import QueryError from "@base/QueryError";
 import { useReferenceIsArchived } from "@references/hooks";
 import { getRouteApi } from "@tanstack/react-router";
 import { useFindIndexes } from "../queries";
@@ -28,10 +29,14 @@ export default function Indexes({
 	setSearch,
 }: IndexesProps) {
 	const { refId } = routeApi.useParams();
-	const { data, isPending } = useFindIndexes(page, 25, refId);
+	const { data, isPending, isError } = useFindIndexes(page, 25, refId);
 	const archived = useReferenceIsArchived(refId);
 
-	if (isPending || !data) {
+	if (isError && !data) {
+		return <QueryError noun="indexes" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/indexes/components/RebuildAlert.tsx
+++ b/apps/web/src/indexes/components/RebuildAlert.tsx
@@ -16,11 +16,13 @@ type RebuildAlertProps = {
  * An alert that appears when the reference has unbuilt changes.
  */
 export default function RebuildAlert({ page, refId }: RebuildAlertProps) {
-	const { data, isPending } = useFindIndexes(page, 25, refId);
+	const { data, isPending, isError } = useFindIndexes(page, 25, refId);
 	const { hasPermission: hasRights } = useCheckReferenceRight(refId, "build");
 	const archived = useReferenceIsArchived(refId);
 
-	if (isPending || archived || !data) {
+	// Stay silent on error: this is a supplementary alert, and the index list
+	// that renders it already surfaces the failure.
+	if (isError || isPending || archived) {
 		return null;
 	}
 

--- a/apps/web/src/jobs/components/JobList.tsx
+++ b/apps/web/src/jobs/components/JobList.tsx
@@ -3,6 +3,7 @@ import BoxGroup from "@base/BoxGroup";
 import ContainerNarrow from "@base/ContainerNarrow";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Pagination from "@base/Pagination";
+import QueryError from "@base/QueryError";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import { useFindJobs } from "../queries";
@@ -23,9 +24,13 @@ export default function JobsList({
 	setSearch = () => {},
 	states = initialState,
 }: JobsListProps) {
-	const { data, isPending } = useFindJobs(page, 25, states);
+	const { data, isPending, isError } = useFindJobs(page, 25, states);
 
-	if (isPending || !data) {
+	if (isError && !data) {
+		return <QueryError noun="jobs" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/labels/components/Labels.tsx
+++ b/apps/web/src/labels/components/Labels.tsx
@@ -2,6 +2,7 @@ import BoxGroup from "@base/BoxGroup";
 import ContainerNarrow from "@base/ContainerNarrow";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundSection from "@base/NoneFoundSection";
+import QueryError from "@base/QueryError";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderSubtitle from "@base/ViewHeaderSubtitle";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
@@ -19,12 +20,16 @@ import { LabelItem } from "./LabelItem";
  * for the labels management page.
  */
 export function Labels() {
-	const { data, isPending } = useFetchLabels();
+	const { data, isPending, isError } = useFetchLabels();
 	const createMutation = useCreateLabel();
 	const updateMutation = useUpdateLabel();
 	const removeMutation = useRemoveLabel();
 
-	if (isPending || !data) {
+	if (isError && !data) {
+		return <QueryError noun="labels" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/otus/components/Detail/OtuSection.tsx
+++ b/apps/web/src/otus/components/Detail/OtuSection.tsx
@@ -1,4 +1,5 @@
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import { CurrentOtuContextProvider, useFetchOTU } from "@otus/queries";
 import { useFetchReference } from "@references/queries";
 import { getRouteApi } from "@tanstack/react-router";
@@ -13,10 +14,19 @@ const routeApi = getRouteApi("/_authenticated/refs/$refId/otus/$otuId");
 export default function OtuSection() {
 	const { otuId, refId } = routeApi.useParams();
 
-	const { isPending: isPendingReference } = useFetchReference(refId);
-	const { data: otu, isPending: isPendingOTU } = useFetchOTU(otuId);
+	const { isPending: isPendingReference, isError: isErrorReference } =
+		useFetchReference(refId);
+	const {
+		data: otu,
+		isPending: isPendingOTU,
+		isError: isErrorOTU,
+	} = useFetchOTU(otuId);
 
-	if (isPendingReference || isPendingOTU || !otu) {
+	if ((isErrorReference || isErrorOTU) && !otu) {
+		return <QueryError noun="OTU" />;
+	}
+
+	if (isPendingReference || isPendingOTU) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/otus/components/Detail/OtuSection.tsx
+++ b/apps/web/src/otus/components/Detail/OtuSection.tsx
@@ -14,15 +14,18 @@ const routeApi = getRouteApi("/_authenticated/refs/$refId/otus/$otuId");
 export default function OtuSection() {
 	const { otuId, refId } = routeApi.useParams();
 
-	const { isPending: isPendingReference, isError: isErrorReference } =
-		useFetchReference(refId);
+	const {
+		data: reference,
+		isPending: isPendingReference,
+		isError: isErrorReference,
+	} = useFetchReference(refId);
 	const {
 		data: otu,
 		isPending: isPendingOTU,
 		isError: isErrorOTU,
 	} = useFetchOTU(otuId);
 
-	if ((isErrorReference || isErrorOTU) && !otu) {
+	if ((isErrorReference && !reference) || (isErrorOTU && !otu)) {
 		return <QueryError noun="OTU" />;
 	}
 

--- a/apps/web/src/otus/components/Detail/Schema/Schema.tsx
+++ b/apps/web/src/otus/components/Detail/Schema/Schema.tsx
@@ -1,6 +1,7 @@
 import BoxGroup from "@base/BoxGroup";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundBox from "@base/NoneFoundBox";
+import QueryError from "@base/QueryError";
 import { useFetchOTU, useUpdateOTU } from "@otus/queries";
 import type { OtuSegment } from "@otus/types";
 import {
@@ -26,13 +27,17 @@ export default function Schema() {
 		useCheckReferenceRight(refId, "modify_otu");
 	const archived = useReferenceIsArchived(refId);
 
-	const { data, isPending } = useFetchOTU(otuId);
+	const { data, isPending, isError } = useFetchOTU(otuId);
 	const mutation = useUpdateOTU(otuId);
 	const [openAddSegment, setOpenAddSegment] = useState(false);
 	const [segmentToEdit, setSegmentToEdit] = useState<string | undefined>();
 	const [segmentToRemove, setSegmentToRemove] = useState<string | undefined>();
 
-	if (isPending || isPendingPermission || !data) {
+	if (isError && !data) {
+		return <QueryError noun="schema" />;
+	}
+
+	if (isPending || isPendingPermission) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/otus/components/OtuList.tsx
+++ b/apps/web/src/otus/components/OtuList.tsx
@@ -3,6 +3,7 @@ import ContainerNarrow from "@base/ContainerNarrow";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundBox from "@base/NoneFoundBox";
 import Pagination from "@base/Pagination";
+import QueryError from "@base/QueryError";
 import RebuildAlert from "@indexes/components/RebuildAlert";
 import { useListOTUs } from "@otus/queries";
 import { useFetchReference } from "@references/queries";
@@ -29,16 +30,22 @@ type OtuListProps = {
 export default function OtuList({ find, page, setSearch }: OtuListProps) {
 	const { refId } = routeApi.useParams();
 	const [openCreate, setOpenCreate] = useState(false);
-	const { data: reference, isPending: isPendingReference } =
-		useFetchReference(refId);
-	const { data: otus, isPending: isPendingOTUs } = useListOTUs(
-		refId,
-		page,
-		25,
-		find,
-	);
+	const {
+		data: reference,
+		isPending: isPendingReference,
+		isError: isErrorReference,
+	} = useFetchReference(refId);
+	const {
+		data: otus,
+		isPending: isPendingOTUs,
+		isError: isErrorOTUs,
+	} = useListOTUs(refId, page, 25, find);
 
-	if (isPendingOTUs || isPendingReference || !otus || !reference) {
+	if ((isErrorReference || isErrorOTUs) && (!reference || !otus)) {
+		return <QueryError noun="OTUs" />;
+	}
+
+	if (isPendingOTUs || isPendingReference) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/otus/queries.tsx
+++ b/apps/web/src/otus/queries.tsx
@@ -1,5 +1,6 @@
 import { apiClient } from "@app/api";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import {
 	keepPreviousData,
 	queryOptions,
@@ -446,11 +447,22 @@ export function CurrentOtuContextProvider({
 	otuId,
 	refId,
 }: CurrentOtuContextProviderProps) {
-	const { data: otu, isPending: isPendingOTU } = useFetchOTU(otuId);
-	const { data: reference, isPending: isPendingReference } =
-		useFetchReference(refId);
+	const {
+		data: otu,
+		isPending: isPendingOTU,
+		isError: isErrorOTU,
+	} = useFetchOTU(otuId);
+	const {
+		data: reference,
+		isPending: isPendingReference,
+		isError: isErrorReference,
+	} = useFetchReference(refId);
 
-	if (isPendingOTU || isPendingReference || !otu || !reference) {
+	if ((isErrorOTU || isErrorReference) && (!otu || !reference)) {
+		return <QueryError noun="OTU" />;
+	}
+
+	if (isPendingOTU || isPendingReference) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/references/components/Detail/AddReferenceGroup.tsx
+++ b/apps/web/src/references/components/Detail/AddReferenceGroup.tsx
@@ -4,6 +4,7 @@ import { Dialog, DialogContent, DialogTitle } from "@base/Dialog";
 import InitialIcon from "@base/InitialIcon";
 import InputSearch from "@base/InputSearch";
 import NoneFoundSection from "@base/NoneFoundSection";
+import QueryError from "@base/QueryError";
 import SelectBoxGroupSection from "@base/SelectBoxGroupSection";
 import Toolbar from "@base/Toolbar";
 import { useInfiniteFindGroups } from "@groups/queries";
@@ -31,10 +32,26 @@ export default function AddReferenceGroup({
 }: AddReferenceGroupProps) {
 	const mutation = useAddReferenceMember(refId, "group");
 	const [term, setTerm] = useState("");
-	const { data, isPending, isFetchingNextPage, fetchNextPage } =
+	const { data, isPending, isError, isFetchingNextPage, fetchNextPage } =
 		useInfiniteFindGroups(25, term);
 
-	if (isPending || !data) {
+	function onOpenChange() {
+		onHide();
+		setTerm("");
+	}
+
+	if (isError && !data) {
+		return (
+			<Dialog open={show} onOpenChange={onOpenChange}>
+				<DialogContent>
+					<DialogTitle>Add Group</DialogTitle>
+					<QueryError noun="groups" />
+				</DialogContent>
+			</Dialog>
+		);
+	}
+
+	if (isPending) {
 		return null;
 	}
 
@@ -53,11 +70,6 @@ export default function AddReferenceGroup({
 				{item.name}
 			</SelectBoxGroupSection>
 		);
-	}
-
-	function onOpenChange() {
-		onHide();
-		setTerm("");
 	}
 
 	return (

--- a/apps/web/src/references/components/Detail/AddReferenceUser.tsx
+++ b/apps/web/src/references/components/Detail/AddReferenceUser.tsx
@@ -4,6 +4,7 @@ import { Dialog, DialogContent, DialogTitle } from "@base/Dialog";
 import InitialIcon from "@base/InitialIcon";
 import InputSearch from "@base/InputSearch";
 import NoneFoundSection from "@base/NoneFoundSection";
+import QueryError from "@base/QueryError";
 import SelectBoxGroupSection from "@base/SelectBoxGroupSection";
 import Toolbar from "@base/Toolbar";
 import { useAddReferenceMember } from "@references/queries";
@@ -31,10 +32,26 @@ export default function AddReferenceUser({
 }: AddReferenceUserProps) {
 	const mutation = useAddReferenceMember(refId, "user");
 	const [term, setTerm] = useState("");
-	const { data, isPending, isFetchingNextPage, fetchNextPage } =
+	const { data, isPending, isError, isFetchingNextPage, fetchNextPage } =
 		useInfiniteFindUsers(25, term);
 
-	if (isPending || !data) {
+	function onOpenChange() {
+		onHide();
+		setTerm("");
+	}
+
+	if (isError && !data) {
+		return (
+			<Dialog open={show} onOpenChange={onOpenChange}>
+				<DialogContent>
+					<DialogTitle>Add User</DialogTitle>
+					<QueryError noun="users" />
+				</DialogContent>
+			</Dialog>
+		);
+	}
+
+	if (isPending) {
 		return null;
 	}
 
@@ -53,11 +70,6 @@ export default function AddReferenceUser({
 				{item.handle}
 			</SelectBoxGroupSection>
 		);
-	}
-
-	function onOpenChange() {
-		onHide();
-		setTerm("");
 	}
 
 	return (

--- a/apps/web/src/references/components/Detail/ReferenceManager.tsx
+++ b/apps/web/src/references/components/Detail/ReferenceManager.tsx
@@ -3,6 +3,7 @@ import BoxGroupHeader from "@base/BoxGroupHeader";
 import BoxGroupTable from "@base/BoxGroupTable";
 import ContainerNarrow from "@base/ContainerNarrow";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import Contributors from "@indexes/components/Contributors";
 import { useFetchReference } from "@references/queries";
 /**
@@ -17,9 +18,13 @@ const routeApi = getRouteApi("/_authenticated/refs/$refId");
 
 export default function ReferenceManager() {
 	const { refId } = routeApi.useParams();
-	const { data: reference, isPending } = useFetchReference(refId);
+	const { data: reference, isPending, isError } = useFetchReference(refId);
 
-	if (isPending || !reference) {
+	if (isError && !reference) {
+		return <QueryError noun="reference" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/references/components/ReferenceList.tsx
+++ b/apps/web/src/references/components/ReferenceList.tsx
@@ -3,6 +3,7 @@ import ContainerNarrow from "@base/ContainerNarrow";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundBox from "@base/NoneFoundBox";
 import Pagination from "@base/Pagination";
+import QueryError from "@base/QueryError";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
@@ -42,9 +43,18 @@ export default function ReferenceList({
 	page = 1,
 	setSearch = () => {},
 }: ReferenceListProps) {
-	const { data, isPending } = useFindReferences(page, 25, find, archived);
+	const { data, isPending, isError } = useFindReferences(
+		page,
+		25,
+		find,
+		archived,
+	);
 
-	if (isPending || !data) {
+	if (isError && !data) {
+		return <QueryError noun="references" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/routes/_authenticated/samples/$sampleId/general.tsx
+++ b/apps/web/src/routes/_authenticated/samples/$sampleId/general.tsx
@@ -1,4 +1,5 @@
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import { useFetchLabels } from "@labels/queries";
 import SampleDetailGeneral from "@samples/components/Detail/SampleDetailGeneral";
 import { createFileRoute } from "@tanstack/react-router";
@@ -10,9 +11,13 @@ export const Route = createFileRoute(
 });
 
 function SampleDetailGeneralRoute() {
-	const { data: labels, isPending } = useFetchLabels();
+	const { data: labels, isPending, isError } = useFetchLabels();
 
-	if (isPending || !labels) {
+	if (isError && !labels) {
+		return <QueryError noun="labels" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/routes/_authenticated/samples/create.tsx
+++ b/apps/web/src/routes/_authenticated/samples/create.tsx
@@ -1,4 +1,5 @@
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import { useFetchLabels } from "@labels/queries";
 import CreateSample from "@samples/components/Create/CreateSample";
 import { createFileRoute } from "@tanstack/react-router";
@@ -8,9 +9,13 @@ export const Route = createFileRoute("/_authenticated/samples/create")({
 });
 
 function CreateSampleRoute() {
-	const { data: labels, isPending } = useFetchLabels();
+	const { data: labels, isPending, isError } = useFetchLabels();
 
-	if (isPending || !labels) {
+	if (isError && !labels) {
+		return <QueryError noun="labels" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/routes/_authenticated/samples/index.tsx
+++ b/apps/web/src/routes/_authenticated/samples/index.tsx
@@ -1,4 +1,5 @@
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import { useFetchLabels } from "@labels/queries";
 import SamplesList from "@samples/components/SamplesList";
 import { createFileRoute } from "@tanstack/react-router";
@@ -19,9 +20,13 @@ export const Route = createFileRoute("/_authenticated/samples/")({
 function SamplesRoute() {
 	const search = Route.useSearch();
 	const navigate = Route.useNavigate();
-	const { data: labels, isPending } = useFetchLabels();
+	const { data: labels, isPending, isError } = useFetchLabels();
 
-	if (isPending || !labels) {
+	if (isError && !labels) {
+		return <QueryError noun="labels" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/samples/components/SamplesList.tsx
+++ b/apps/web/src/samples/components/SamplesList.tsx
@@ -2,6 +2,7 @@ import QuickAnalyze from "@analyses/components/Create/QuickAnalyze";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundBox from "@base/NoneFoundBox";
 import Pagination from "@base/Pagination";
+import QueryError from "@base/QueryError";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
@@ -41,19 +42,22 @@ export default function SamplesList({
 	term = "",
 	workflows: filterWorkflows = [],
 }: SamplesListProps) {
-	const { data: samples, isPending: isPendingSamples } = useListSamples(
-		urlPage,
-		25,
-		term,
-		filterLabels,
-		filterWorkflows,
-	);
-	const { isPending: isPendingIndexes } = useListIndexes({ ready: true });
+	const {
+		data: samples,
+		isPending: isPendingSamples,
+		isError: isErrorSamples,
+	} = useListSamples(urlPage, 25, term, filterLabels, filterWorkflows);
+	const { isPending: isPendingIndexes, isError: isErrorIndexes } =
+		useListIndexes({ ready: true });
 
 	const [selected, setSelected] = useState<string[]>([]);
 	const [openQuickAnalyze, setOpenQuickAnalyze] = useState(false);
 
-	if (isPendingSamples || isPendingIndexes || !samples) {
+	if ((isErrorSamples || isErrorIndexes) && !samples) {
+		return <QueryError noun="samples" />;
+	}
+
+	if (isPendingSamples || isPendingIndexes) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/samples/components/Sidebar/DefaultSubtractions.tsx
+++ b/apps/web/src/samples/components/Sidebar/DefaultSubtractions.tsx
@@ -1,5 +1,6 @@
 import Link from "@base/Link";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import SideBarSection from "@base/SideBarSection";
 import SidebarHeader from "@base/SidebarHeader";
 import { useFetchSubtractionsShortlist } from "@subtraction/queries";
@@ -26,10 +27,17 @@ export default function DefaultSubtractions({
 	defaultSubtractions,
 	onUpdate,
 }: DefaultSubtractionsProps) {
-	const { data: subtractionOptions, isPending } =
-		useFetchSubtractionsShortlist();
+	const {
+		data: subtractionOptions,
+		isPending,
+		isError,
+	} = useFetchSubtractionsShortlist();
 
-	if (isPending || !subtractionOptions) {
+	if (isError && !subtractionOptions) {
+		return <QueryError noun="subtractions" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/samples/hooks.ts
+++ b/apps/web/src/samples/hooks.ts
@@ -20,11 +20,11 @@ export function useCheckCanEditSample(sampleId: string) {
 		isError: isErrorSample,
 	} = useFetchSample(sampleId);
 
-	if (isErrorAccount || isErrorSample) {
+	if ((isErrorAccount && !account) || (isErrorSample && !sample)) {
 		return { hasPermission: false, isPending: false };
 	}
 
-	if (isPendingSample || isPendingAccount) {
+	if (isPendingSample || isPendingAccount || !account || !sample) {
 		return { hasPermission: false, isPending: true };
 	}
 

--- a/apps/web/src/samples/hooks.ts
+++ b/apps/web/src/samples/hooks.ts
@@ -9,10 +9,22 @@ import { useFetchSample } from "./queries";
  * @returns whether the current user has permission to edit the sample
  */
 export function useCheckCanEditSample(sampleId: string) {
-	const { data: account, isPending: isPendingAccount } = useFetchAccount();
-	const { data: sample, isPending: isPendingSample } = useFetchSample(sampleId);
+	const {
+		data: account,
+		isPending: isPendingAccount,
+		isError: isErrorAccount,
+	} = useFetchAccount();
+	const {
+		data: sample,
+		isPending: isPendingSample,
+		isError: isErrorSample,
+	} = useFetchSample(sampleId);
 
-	if (isPendingSample || isPendingAccount || !sample || !account) {
+	if (isErrorAccount || isErrorSample) {
+		return { hasPermission: false, isPending: false };
+	}
+
+	if (isPendingSample || isPendingAccount) {
 		return { hasPermission: false, isPending: true };
 	}
 

--- a/apps/web/src/subtraction/components/SubtractionCreate.tsx
+++ b/apps/web/src/subtraction/components/SubtractionCreate.tsx
@@ -12,6 +12,7 @@ import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import InputSimple from "@base/InputSimple";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import SaveButton from "@base/SaveButton";
 import { RestoredAlert } from "@forms/components/RestoredAlert";
 import { usePersistentForm } from "@forms/hooks";
@@ -49,6 +50,7 @@ export default function SubtractionCreate() {
 	const {
 		data: files,
 		isPending,
+		isError,
 		isFetchingNextPage,
 		fetchNextPage,
 	} = useInfiniteFindFiles("subtraction", 25);
@@ -82,7 +84,9 @@ export default function SubtractionCreate() {
 				<DialogDescription>
 					Create a new subtraction from a FASTA file.
 				</DialogDescription>
-				{isPending || !files ? (
+				{isError && !files ? (
+					<QueryError noun="files" />
+				) : isPending ? (
 					<LoadingPlaceholder className="mt-9" />
 				) : (
 					<form onSubmit={handleSubmit(onSubmit)}>

--- a/apps/web/src/subtraction/components/SubtractionList.tsx
+++ b/apps/web/src/subtraction/components/SubtractionList.tsx
@@ -2,6 +2,7 @@ import BoxGroup from "@base/BoxGroup";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundBox from "@base/NoneFoundBox";
 import Pagination from "@base/Pagination";
+import QueryError from "@base/QueryError";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
@@ -23,9 +24,13 @@ export default function SubtractionList({
 	page = 1,
 	setSearch = () => {},
 }: SubtractionListProps) {
-	const { data, isPending } = useFindSubtractions(page, 25, find);
+	const { data, isPending, isError } = useFindSubtractions(page, 25, find);
 
-	if (isPending || !data) {
+	if (isError && !data) {
+		return <QueryError noun="subtractions" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/uploads/components/FileManager.tsx
+++ b/apps/web/src/uploads/components/FileManager.tsx
@@ -5,6 +5,7 @@ import BoxGroup from "@base/BoxGroup";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundBox from "@base/NoneFoundBox";
 import Pagination from "@base/Pagination";
+import QueryError from "@base/QueryError";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
@@ -44,14 +45,22 @@ export function FileManager({
 	regex,
 	setPage = () => {},
 }: FileManagerProps) {
-	const { data: account, isPending: isPendingAccount } = useFetchAccount();
-	const { data: files, isPending: isPendingFiles } = useListFiles(
-		fileType,
-		page,
-		25,
-	);
+	const {
+		data: account,
+		isPending: isPendingAccount,
+		isError: isErrorAccount,
+	} = useFetchAccount();
+	const {
+		data: files,
+		isPending: isPendingFiles,
+		isError: isErrorFiles,
+	} = useListFiles(fileType, page, 25);
 
-	if (isPendingFiles || isPendingAccount || !account || !files) {
+	if ((isErrorAccount || isErrorFiles) && (!account || !files)) {
+		return <QueryError noun="files" />;
+	}
+
+	if (isPendingFiles || isPendingAccount) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/uploads/components/FileManager.tsx
+++ b/apps/web/src/uploads/components/FileManager.tsx
@@ -56,7 +56,11 @@ export function FileManager({
 		isError: isErrorFiles,
 	} = useListFiles(fileType, page, 25);
 
-	if ((isErrorAccount || isErrorFiles) && (!account || !files)) {
+	if (isErrorAccount && !account) {
+		return <QueryError noun="account" />;
+	}
+
+	if (isErrorFiles && !files) {
 		return <QueryError noun="files" />;
 	}
 

--- a/apps/web/src/users/components/UserGroups.tsx
+++ b/apps/web/src/users/components/UserGroups.tsx
@@ -3,6 +3,7 @@ import BoxGroup from "@base/BoxGroup";
 import InputLabel from "@base/InputLabel";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundSection from "@base/NoneFoundSection";
+import QueryError from "@base/QueryError";
 import { useListGroups } from "@groups/queries";
 import type { GroupMinimal } from "@groups/types";
 import { xor } from "es-toolkit/array";
@@ -21,11 +22,15 @@ type UserGroupsType = {
  * A list of user groups
  */
 export default function UserGroups({ memberGroups, userId }: UserGroupsType) {
-	const { data, isPending } = useListGroups();
+	const { data, isPending, isError } = useListGroups();
 	const mutation = useUpdateUser();
 	const labelId = useId();
 
-	if (isPending || !data) {
+	if (isError && !data) {
+		return <QueryError noun="groups" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/users/components/UsersList.tsx
+++ b/apps/web/src/users/components/UsersList.tsx
@@ -3,6 +3,7 @@ import BoxGroup from "@base/BoxGroup";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundBox from "@base/NoneFoundBox";
 import Pagination from "@base/Pagination";
+import QueryError from "@base/QueryError";
 import type { User } from "../types";
 import { UserItem } from "./UserItem";
 
@@ -23,7 +24,7 @@ export default function UsersList({
 	status,
 	term,
 }: UsersListProps) {
-	const { data, isPending } = useFindUsers(
+	const { data, isPending, isError } = useFindUsers(
 		urlPage,
 		25,
 		term,
@@ -31,7 +32,11 @@ export default function UsersList({
 		status === "active",
 	);
 
-	if (isPending || !data) {
+	if (isError && !data) {
+		return <QueryError noun="users" />;
+	}
+
+	if (isPending) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -151,22 +151,52 @@ boundary.
 
 For data that should fail without taking over the page — paginated lists using
 `keepPreviousData`, polling, sidebar widgets, anything optional — stay on
-`useQuery` and handle the states explicitly. Check `isError` **before**
-`isPending`, and render an inline error rather than a blocking one:
+`useQuery` and handle the states explicitly. Render the inline error with
+`@base/QueryError` (a red `Alert` taking a `noun`), and gate it on
+`isError && !data` — error **only when there's nothing to show** — then handle
+`isPending`:
 
 ```tsx
 const { data, isPending, isError } = useListSamples(page, perPage);
 
-if (isError) {
-  return <Alert color="red">Couldn't load samples.</Alert>;
+if (isError && !data) {
+  return <QueryError noun="samples" />;
 }
 if (isPending) {
   return <LoadingPlaceholder />;
 }
 ```
 
+The `&& !data` is load-bearing, not defensive. In React Query v5 `error` and
+`data` coexist: once a query has loaded successfully, `data` survives a later
+failed refetch (the retries-exhausted `refetchError` state). A bare
+`if (isError)` would blank an already-rendered list the moment a background
+refetch fails — the opposite of Tier 2's job. `isError && !data` shows the
+inline error only on an initial-load failure (the real "spins forever" case
+this replaces) and keeps stale data on screen through background errors. The
+guard still narrows `data` to defined for the success branch, because the only
+error state left past it carries `data`.
+
+`if (isPending || !data) return <LoadingPlaceholder />` remains the
+anti-pattern: it puts `!data` in the **loading** branch, so an initial-load
+failure (where `data` is `undefined`) spins forever instead of erroring.
+
+For a view backed by several `useQuery` calls, the same rule generalises —
+error only when something needed is still missing:
+
+```tsx
+if ((isErrorA || isErrorB) && (!dataA || !dataB)) {
+  return <QueryError noun="files" />;
+}
+if (isPendingA || isPendingB) {
+  return <LoadingPlaceholder />;
+}
+```
+
 The distinction is deliberate: Tier 1 escalates a failure to a full-route
-error state; Tier 2 contains it so the rest of the page keeps working.
+error state; Tier 2 contains it so the rest of the page keeps working. Make a
+view *eager* (error even with stale data on screen) only when staleness
+actively misleads — permissions, balances, live job status.
 
 ## Pagination keeps the previous page on screen
 


### PR DESCRIPTION
## Summary
- Replace the `if (isPending || !data)` anti-pattern in secondary (Tier 2) React Query consumers — lists, sidebar widgets, dialogs, banners, and the wrapper hooks that compose queries — so a failed request shows a contained inline error instead of spinning forever (VIR-2537).
- Add a shared `@base/QueryError` (a red `Alert` taking a `noun`, the Tier 2 counterpart to `RouteError`) and gate it on `isError && !data` — error only when there's nothing to show. In React Query v5 `error` and `data` coexist, so a bare `if (isError)` would blank an already-loaded view the moment a background refetch fails; `&& !data` fixes the initial-load spin while keeping stale data on screen through background errors.
- Fix a latent crash in `AnalysisDetail`, which never checked its analysis query's error and would fall through to `analysis.ready`.
- Update `docs/queries.md` and `AGENTS.md` to document the `QueryError` component and the `isError && !data` rule.