### PR TITLE
fix: load job detail instead of failing on subtraction lookup

### DIFF
--- a/apps/web/src/server/db/schema/analyses.ts
+++ b/apps/web/src/server/db/schema/analyses.ts
@@ -1,0 +1,13 @@
+// Partial read-only mirror of the `analyses` table managed by the upstream
+// Python service via Alembic. Only the columns needed to reconstruct a job's
+// `args` are declared here — the analyses domain is not otherwise served from
+// this side yet. Keep in sync with
+// `../../../../../../virtool/virtool/analyses/sql.py`.
+
+import { bigint, integer, pgTable, text } from "drizzle-orm/pg-core";
+
+export const analyses = pgTable("analyses", {
+	id: bigint("id", { mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
+	legacy_id: text("legacy_id").unique(),
+	job_id: integer("job_id"),
+});

--- a/apps/web/src/server/db/schema/index.ts
+++ b/apps/web/src/server/db/schema/index.ts
@@ -3,10 +3,12 @@
 // (Alembic + SQLAlchemy migrations) — Drizzle does not push migrations from
 // here. Each feature owns a sibling file (e.g. `labels.ts`) and is added to
 // the `export *` list as it lands.
+export * from "./analyses";
 export * from "./groups";
 export * from "./jobs";
 export * from "./labels";
 export * from "./messages";
 export * from "./sessions";
+export * from "./subtractions";
 export * from "./tasks";
 export * from "./users";

--- a/apps/web/src/server/db/schema/jobs.ts
+++ b/apps/web/src/server/db/schema/jobs.ts
@@ -3,8 +3,11 @@
 // migrations from this side. Keep the columns in sync with
 // `../../../../../../virtool/virtool/jobs/pg.py`.
 //
-// The legacy Mongo `args` field is not a column; workflow resource ids live in
-// the `job_*` junction tables and are recombined into `args` when a job is read.
+// The legacy Mongo `args` field is not a column. A job's sample and index
+// resources live in the `job_samples` / `job_indexes` junction tables, while
+// its subtraction and analysis resources are found on the owning rows
+// (`subtractions.job_id`, `analyses.job_id`). All are recombined into `args`
+// when a job is read.
 
 import {
 	boolean,
@@ -60,14 +63,4 @@ export const jobSamples = pgTable("job_samples", {
 export const jobIndexes = pgTable("job_indexes", {
 	job_id: integer("job_id").primaryKey(),
 	index_id: text("index_id").notNull(),
-});
-
-export const jobSubtractions = pgTable("job_subtractions", {
-	job_id: integer("job_id").primaryKey(),
-	subtraction_id: text("subtraction_id").notNull(),
-});
-
-export const jobAnalyses = pgTable("job_analyses", {
-	job_id: integer("job_id").primaryKey(),
-	analysis_id: text("analysis_id").notNull(),
 });

--- a/apps/web/src/server/db/schema/subtractions.ts
+++ b/apps/web/src/server/db/schema/subtractions.ts
@@ -1,0 +1,12 @@
+// Partial read-only mirror of the `subtractions` table managed by the upstream
+// Python service via Alembic. Only the columns needed to reconstruct a job's
+// `args` are declared here — the subtractions domain is not otherwise served
+// from this side yet. Keep in sync with
+// `../../../../../../virtool/virtool/subtractions/pg.py`.
+
+import { bigint, integer, pgTable } from "drizzle-orm/pg-core";
+
+export const subtractions = pgTable("subtractions", {
+	id: bigint("id", { mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
+	job_id: integer("job_id").unique(),
+});

--- a/apps/web/src/server/jobs/data.ts
+++ b/apps/web/src/server/jobs/data.ts
@@ -1,15 +1,15 @@
 import { count, desc, eq, inArray } from "drizzle-orm";
 import type { Db } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
+import { analyses } from "../db/schema/analyses";
 import {
 	type JobClaim,
 	type JobStep,
-	jobAnalyses,
 	jobIndexes,
 	jobSamples,
-	jobSubtractions,
 	jobs,
 } from "../db/schema/jobs";
+import { subtractions } from "../db/schema/subtractions";
 import { users } from "../db/schema/users";
 import { AppError } from "../errors";
 
@@ -187,23 +187,25 @@ export async function getJob(db: Db, jobId: number): Promise<Job> {
 			handle: users.handle,
 			sample_id: jobSamples.sample_id,
 			index_id: jobIndexes.index_id,
-			subtraction_id: jobSubtractions.subtraction_id,
-			analysis_id: jobAnalyses.analysis_id,
+			subtraction_id: subtractions.id,
+			analysis_id: analyses.legacy_id,
 		})
 		.from(jobs)
 		.innerJoin(users, eq(jobs.user_id, users.id))
 		.leftJoin(jobSamples, eq(jobs.id, jobSamples.job_id))
 		.leftJoin(jobIndexes, eq(jobs.id, jobIndexes.job_id))
-		.leftJoin(jobSubtractions, eq(jobs.id, jobSubtractions.job_id))
-		.leftJoin(jobAnalyses, eq(jobs.id, jobAnalyses.job_id))
+		.leftJoin(subtractions, eq(jobs.id, subtractions.job_id))
+		.leftJoin(analyses, eq(jobs.id, analyses.job_id))
 		.where(eq(jobs.id, jobId));
 
 	if (!row) {
 		throw new JobNotFoundError();
 	}
 
-	// `args` is reconstructed from the resource junction tables — the legacy
-	// Mongo `args` field is not stored as a column.
+	// `args` is reconstructed from the related resources — the legacy Mongo
+	// `args` field is not stored as a column. Samples and indexes come from the
+	// `job_*` junction tables; the subtraction and analysis are found on the
+	// owning rows.
 	const args: Record<string, string> = {};
 	if (row.sample_id != null) {
 		args.sample_id = row.sample_id;
@@ -212,7 +214,7 @@ export async function getJob(db: Db, jobId: number): Promise<Job> {
 		args.index_id = row.index_id;
 	}
 	if (row.subtraction_id != null) {
-		args.subtraction_id = row.subtraction_id;
+		args.subtraction_id = String(row.subtraction_id);
 	}
 	if (row.analysis_id != null) {
 		args.analysis_id = row.analysis_id;


### PR DESCRIPTION
## Summary
- Fix job detail crashing with `relation "job_subtractions" does not exist`: the query joined a junction table that Python (the schema owner) never created, and read its analysis id from the deprecated, no-longer-written `job_analyses` junction.
- Mirror Python's `get` query instead — derive `subtraction_id` from `subtractions.id` and `analysis_id` from `analyses.legacy_id`, each joined on the owning row's `job_id`.
- Add partial read-only Drizzle mirrors for the `subtractions` and `analyses` tables; drop the bogus `job_subtractions` / `job_analyses` definitions.