### PR TITLE
feat: convert NuVs export scope selector to a tabs widget

### DIFF
--- a/apps/web/src/administration/components/AdministrationTabs.tsx
+++ b/apps/web/src/administration/components/AdministrationTabs.tsx
@@ -22,5 +22,5 @@ export default function AdministrationTabs({
 		tabs.push(<NavTab to="/administration/groups">Groups</NavTab>);
 	}
 
-	return <NavTabs>{...tabs}</NavTabs>;
+	return <NavTabs>{tabs}</NavTabs>;
 }

--- a/apps/web/src/administration/components/AdministrationTabs.tsx
+++ b/apps/web/src/administration/components/AdministrationTabs.tsx
@@ -1,5 +1,5 @@
-import Tabs from "@base/Tabs";
-import TabsLink from "@base/TabsLink";
+import NavTab from "@base/NavTab";
+import NavTabs from "@base/NavTabs";
 import type { ReactNode } from "react";
 import type { AdministratorRoleName } from "../types";
 import { hasSufficientAdminRole } from "../utils";
@@ -14,15 +14,13 @@ export default function AdministrationTabs({
 	const tabs: ReactNode[] = [];
 
 	if (hasSufficientAdminRole("settings", administratorRole)) {
-		tabs.push(<TabsLink to="/administration/settings">Settings</TabsLink>);
+		tabs.push(<NavTab to="/administration/settings">Settings</NavTab>);
 	}
 
 	if (hasSufficientAdminRole("users", administratorRole)) {
-		tabs.push(
-			<TabsLink to="/administration/users?status=active">Users</TabsLink>,
-		);
-		tabs.push(<TabsLink to="/administration/groups">Groups</TabsLink>);
+		tabs.push(<NavTab to="/administration/users?status=active">Users</NavTab>);
+		tabs.push(<NavTab to="/administration/groups">Groups</NavTab>);
 	}
 
-	return <Tabs>{...tabs}</Tabs>;
+	return <NavTabs>{...tabs}</NavTabs>;
 }

--- a/apps/web/src/analyses/components/Create/CreateAnalysis.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysis.tsx
@@ -1,7 +1,6 @@
-import { cn } from "@app/utils";
 import { Dialog, DialogTitle } from "@base/Dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@base/Tabs";
 import type { HmmSearchResults } from "@hmm/types";
-import { Tabs } from "radix-ui";
 import HMMAlert from "../HMMAlert";
 import CreateAnalysisDialogContent from "./CreateAnalysisDialogContent";
 import CreateNuvs from "./CreateNuvs";
@@ -19,17 +18,6 @@ type CreateAnalysisProps = {
 	/** The id of the sample being used */
 	sampleId: string;
 };
-
-function Content({ children, value }) {
-	return (
-		<Tabs.Content
-			className="mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-			value={value}
-		>
-			{children}
-		</Tabs.Content>
-	);
-}
 
 /**
  * Dialog for creating an analysis
@@ -49,58 +37,21 @@ export default function CreateAnalysis({
 			<CreateAnalysisDialogContent>
 				<DialogTitle>Analyze</DialogTitle>
 				<HMMAlert installed={Boolean(hmms.status.task?.complete)} />
-				<Tabs.Root defaultValue="pathoscope">
-					<Tabs.List
-						className={cn(
-							"bg-gray-100",
-							"flex",
-							"h-12",
-							"items-center",
-							"justify-center",
-							"p-1",
-							"rounded-lg",
-							"inset-1",
-							"text-lg",
-							"text-muted-foreground",
-						)}
-					>
+				<Tabs defaultValue="pathoscope">
+					<TabsList>
 						{compatibleWorkflows.map((workflow) => (
-							<Tabs.Trigger
-								className={cn(
-									"font-medium",
-									"inline-flex",
-									"items-center",
-									"justify-center",
-									"px-3",
-									"py-1",
-									"rounded-md",
-									"ring-offset-background",
-									"transition-all",
-									"focus-visible:outline-none",
-									"focus-visible:ring-2",
-									"focus-visible:ring-ring",
-									"focus-visible:ring-offset-2",
-									"disabled:pointer-events-none",
-									"disabled:opacity-50",
-									"data-[state=active]:bg-white",
-									"data-[state=active]:text-foreground",
-									"data-[state=active]:shadow",
-									"whitespace-nowrap",
-								)}
-								key={workflow.id}
-								value={workflow.id}
-							>
+							<TabsTrigger key={workflow.id} value={workflow.id}>
 								{workflow.name}
-							</Tabs.Trigger>
+							</TabsTrigger>
 						))}
-					</Tabs.List>
-					<Content value="nuvs">
+					</TabsList>
+					<TabsContent value="nuvs">
 						<CreateNuvs sampleCount={1} sampleIds={sampleIds} />
-					</Content>
-					<Content value="pathoscope">
+					</TabsContent>
+					<TabsContent value="pathoscope">
 						<CreatePathoscope sampleCount={1} sampleIds={sampleIds} />
-					</Content>
-				</Tabs.Root>
+					</TabsContent>
+				</Tabs>
 			</CreateAnalysisDialogContent>
 		</Dialog>
 	);

--- a/apps/web/src/analyses/components/Create/QuickAnalyze.tsx
+++ b/apps/web/src/analyses/components/Create/QuickAnalyze.tsx
@@ -3,9 +3,9 @@ import Badge from "@base/Badge";
 import BoxGroupSection from "@base/BoxGroupSection";
 import { Dialog, DialogTitle } from "@base/Dialog";
 import QueryError from "@base/QueryError";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@base/Tabs";
 import { useListHmms } from "@hmm/queries";
 import type { SampleMinimal } from "@samples/types";
-import { Tabs } from "radix-ui";
 import { useEffect } from "react";
 import HMMAlert from "../HMMAlert";
 import CreateAnalysisDialogContent from "./CreateAnalysisDialogContent";
@@ -13,17 +13,6 @@ import CreateAnalysisFieldTitle from "./CreateAnalysisFieldTitle";
 import CreateNuvs from "./CreateNuvs";
 import CreatePathoscope from "./CreatePathoscope";
 import { getCompatibleWorkflows } from "./workflows";
-
-function Content({ children, value }) {
-	return (
-		<Tabs.Content
-			className="mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-			value={value}
-		>
-			{children}
-		</Tabs.Content>
-	);
-}
 
 type QuickAnalyzeProps = {
 	open: boolean;
@@ -77,52 +66,14 @@ export default function QuickAnalyze({
 				<DialogTitle>Quick Analyze</DialogTitle>
 				<HMMAlert installed={Boolean(hmms.status.task?.complete)} />
 
-				<Tabs.Root defaultValue="pathoscope">
-					<Tabs.List
-						className={cn(
-							"bg-gray-100",
-							"flex",
-							"h-12",
-							"items-center",
-							"justify-center",
-							"mb-4",
-							"p-1",
-							"rounded-lg",
-							"inset-1",
-							"text-lg",
-							"text-muted-foreground",
-						)}
-					>
+				<Tabs defaultValue="pathoscope">
+					<TabsList className="mb-4">
 						{compatibleWorkflows.map((workflow) => (
-							<Tabs.Trigger
-								className={cn(
-									"font-medium",
-									"inline-flex",
-									"items-center",
-									"justify-center",
-									"px-3",
-									"py-1",
-									"rounded-md",
-									"ring-offset-background",
-									"transition-all",
-									"focus-visible:outline-none",
-									"focus-visible:ring-2",
-									"focus-visible:ring-ring",
-									"focus-visible:ring-offset-2",
-									"disabled:pointer-events-none",
-									"disabled:opacity-50",
-									"data-[state=active]:bg-white",
-									"data-[state=active]:text-foreground",
-									"data-[state=active]:shadow",
-									"whitespace-nowrap",
-								)}
-								key={workflow.id}
-								value={workflow.id}
-							>
+							<TabsTrigger key={workflow.id} value={workflow.id}>
 								{workflow.name}
-							</Tabs.Trigger>
+							</TabsTrigger>
 						))}
-					</Tabs.List>
+					</TabsList>
 					<CreateAnalysisFieldTitle>
 						Compatible Samples <Badge>{samples.length}</Badge>
 					</CreateAnalysisFieldTitle>
@@ -142,16 +93,16 @@ export default function QuickAnalyze({
 							</BoxGroupSection>
 						))}
 					</div>
-					<Content value="nuvs">
+					<TabsContent value="nuvs">
 						<CreateNuvs sampleCount={sampleIds.length} sampleIds={sampleIds} />
-					</Content>
-					<Content value="pathoscope">
+					</TabsContent>
+					<TabsContent value="pathoscope">
 						<CreatePathoscope
 							sampleCount={sampleIds.length}
 							sampleIds={sampleIds}
 						/>
-					</Content>
-				</Tabs.Root>
+					</TabsContent>
+				</Tabs>
 			</CreateAnalysisDialogContent>
 		</Dialog>
 	);

--- a/apps/web/src/analyses/components/Nuvs/NuvsExport.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsExport.tsx
@@ -9,11 +9,9 @@ import {
 	DialogTrigger,
 } from "@base/Dialog";
 import Icon from "@base/Icon";
-import InputLabel from "@base/InputLabel";
-import ToggleGroup from "@base/ToggleGroup";
-import ToggleGroupItem from "@base/ToggleGroupItem";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@base/Tabs";
 import { Download } from "lucide-react";
-import { useId, useState } from "react";
+import { useState } from "react";
 import NuvsExportPreview from "./NuvsExportPreview";
 
 function getBestHit(items) {
@@ -96,7 +94,6 @@ export default function NuvsExport({
 }: NuvsExportProps) {
 	const [mode, setMode] = useState("contigs");
 	const [open, setOpen] = useState(false);
-	const scopeLabelId = useId();
 
 	function onSubmit(e) {
 		e.preventDefault();
@@ -106,7 +103,7 @@ export default function NuvsExport({
 				analysisId,
 				exportContigData(results.hits, sampleName),
 				sampleName,
-				"configs",
+				"contigs",
 			);
 		} else {
 			downloadData(
@@ -126,18 +123,18 @@ export default function NuvsExport({
 			<DialogContent>
 				<DialogTitle>Export Analysis</DialogTitle>
 				<form onSubmit={onSubmit}>
-					<InputLabel id={scopeLabelId}>Scope</InputLabel>
-					<ToggleGroup
-						aria-labelledby={scopeLabelId}
-						className="flex mb-3"
-						value={mode}
-						onValueChange={setMode}
-					>
-						<ToggleGroupItem value="contigs">Contigs</ToggleGroupItem>
-						<ToggleGroupItem value="orfs">ORFs</ToggleGroupItem>
-					</ToggleGroup>
-
-					<NuvsExportPreview mode={mode} />
+					<Tabs value={mode} onValueChange={setMode}>
+						<TabsList aria-label="Scope" className="mb-3">
+							<TabsTrigger value="contigs">Contigs</TabsTrigger>
+							<TabsTrigger value="orfs">ORFs</TabsTrigger>
+						</TabsList>
+						<TabsContent value="contigs">
+							<NuvsExportPreview mode="contigs" />
+						</TabsContent>
+						<TabsContent value="orfs">
+							<NuvsExportPreview mode="orfs" />
+						</TabsContent>
+					</Tabs>
 
 					<DialogFooter>
 						<Button type="submit" className="inline-flex gap-1.5">

--- a/apps/web/src/analyses/components/Nuvs/__tests__/NuvsExport.test.tsx
+++ b/apps/web/src/analyses/components/Nuvs/__tests__/NuvsExport.test.tsx
@@ -1,0 +1,81 @@
+import NuvsExport from "@analyses/components/Nuvs/NuvsExport";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createFakeFormattedNuVsAnalysis } from "@tests/fake/analyses";
+import { renderWithProviders } from "@tests/setup";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("<NuvsExport />", () => {
+	let props: React.ComponentProps<typeof NuvsExport>;
+	let clickSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		const analysis = createFakeFormattedNuVsAnalysis();
+
+		props = {
+			analysisId: "test_analysis",
+			results: analysis.results,
+			sampleName: "Test Sample",
+		};
+
+		clickSpy = vi
+			.spyOn(HTMLAnchorElement.prototype, "click")
+			.mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		clickSpy.mockRestore();
+	});
+
+	async function openDialog() {
+		renderWithProviders(<NuvsExport {...props} />);
+		await userEvent.click(screen.getByRole("button", { name: "Export" }));
+	}
+
+	it("shows the contigs tab and preview by default", async () => {
+		await openDialog();
+
+		const tabs = screen.getByRole("tablist", { name: "Scope" });
+		expect(tabs).toBeInTheDocument();
+		expect(screen.getByRole("tab", { name: "Contigs" })).toHaveAttribute(
+			"aria-selected",
+			"true",
+		);
+		expect(screen.getByText("sequence index")).toBeInTheDocument();
+	});
+
+	it("switches the preview when the ORFs tab is selected", async () => {
+		await openDialog();
+
+		await userEvent.click(screen.getByRole("tab", { name: "ORFs" }));
+
+		expect(screen.getByRole("tab", { name: "ORFs" })).toHaveAttribute(
+			"aria-selected",
+			"true",
+		);
+		expect(screen.getByText("sequence index + orf index")).toBeInTheDocument();
+	});
+
+	it("downloads contig data with a contigs filename by default", async () => {
+		await openDialog();
+
+		await userEvent.click(screen.getByRole("button", { name: "Download" }));
+
+		await waitFor(() => expect(clickSpy).toHaveBeenCalledTimes(1));
+		const anchor = clickSpy.mock.instances[0] as HTMLAnchorElement;
+		expect(anchor.download).toBe("nuvs.Test_Sample.test_analysis.contigs.fa");
+		expect(decodeURIComponent(anchor.href)).toContain(">sequence_");
+	});
+
+	it("downloads orf data with an orfs filename when ORFs is selected", async () => {
+		await openDialog();
+
+		await userEvent.click(screen.getByRole("tab", { name: "ORFs" }));
+		await userEvent.click(screen.getByRole("button", { name: "Download" }));
+
+		await waitFor(() => expect(clickSpy).toHaveBeenCalledTimes(1));
+		const anchor = clickSpy.mock.instances[0] as HTMLAnchorElement;
+		expect(anchor.download).toBe("nuvs.Test_Sample.test_analysis.orfs.fa");
+		expect(decodeURIComponent(anchor.href)).toContain(">orf_");
+	});
+});

--- a/apps/web/src/base/NavTab.tsx
+++ b/apps/web/src/base/NavTab.tsx
@@ -3,7 +3,7 @@ import { cn } from "@app/utils";
 import Link from "@base/Link";
 import type { ReactNode } from "react";
 
-type TabsLinkProps = {
+type NavTabProps = {
 	children: ReactNode;
 	className?: string;
 	isActive?: boolean;
@@ -14,13 +14,13 @@ type TabsLinkProps = {
 /**
  * A navigation link with active state styling
  */
-export default function TabsLink({
+export default function NavTab({
 	children,
 	className,
 	isActive,
 	search,
 	to,
-}: TabsLinkProps) {
+}: NavTabProps) {
 	isActive = useMatchPartialPath(to) || isActive;
 
 	const classname = cn(

--- a/apps/web/src/base/NavTabs.tsx
+++ b/apps/web/src/base/NavTabs.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@app/utils";
+import type { ReactNode } from "react";
+
+type NavTabsProps = {
+	children: ReactNode;
+	className?: string;
+};
+
+/**
+ * A styled tabs component used for navigating
+ */
+export default function NavTabs({ children, className }: NavTabsProps) {
+	return (
+		<nav
+			className={cn(
+				"border-b",
+				"border-gray-300",
+				"flex",
+				"mb-4",
+				"w-full",
+				className,
+			)}
+		>
+			{children}
+		</nav>
+	);
+}

--- a/apps/web/src/base/Tabs.tsx
+++ b/apps/web/src/base/Tabs.tsx
@@ -1,27 +1,123 @@
 import { cn } from "@app/utils";
-import type { ReactNode } from "react";
+import { cva } from "class-variance-authority";
+import { Tabs as TabsPrimitive } from "radix-ui";
+import { type ComponentProps, createContext, useContext } from "react";
 
-type TabsProps = {
-	children: ReactNode;
-	className?: string;
+type TabsVariant = "segmented" | "vertical";
+
+const TabsVariantContext = createContext<TabsVariant>("segmented");
+
+const rootVariants = cva("", {
+	variants: {
+		variant: {
+			segmented: "",
+			vertical: "gap-x-4 grid grid-cols-4",
+		},
+	},
+	defaultVariants: { variant: "segmented" },
+});
+
+const listVariants = cva("flex", {
+	variants: {
+		variant: {
+			segmented:
+				"bg-gray-100 h-12 items-center justify-center p-1 rounded-lg text-lg text-muted-foreground",
+			vertical:
+				"bg-white border border-gray-300 col-span-1 flex-col overflow-hidden rounded-sm self-start",
+		},
+	},
+	defaultVariants: { variant: "segmented" },
+});
+
+const triggerVariants = cva("cursor-pointer", {
+	variants: {
+		variant: {
+			segmented:
+				"data-[state=active]:bg-white data-[state=active]:shadow data-[state=active]:text-foreground disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring font-medium inline-flex items-center justify-center px-3 py-1 ring-offset-background rounded-md transition-all whitespace-nowrap",
+			vertical:
+				"data-[state=active]:font-medium data-[state=active]:shadow-[inset_3px_0_0_var(--color-virtool)] data-[state=active]:text-gray-900 focus-visible:ring-2 focus-visible:ring-blue-600/50 focus-visible:ring-inset focus:outline-none hover:bg-gray-50 hover:text-gray-700 px-6 py-3 text-gray-500 text-left transition-colors",
+		},
+	},
+	defaultVariants: { variant: "segmented" },
+});
+
+const contentVariants = cva("", {
+	variants: {
+		variant: {
+			segmented:
+				"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring mt-2 ring-offset-background",
+			vertical: "col-span-3 focus:outline-none",
+		},
+	},
+	defaultVariants: { variant: "segmented" },
+});
+
+type TabsProps = ComponentProps<typeof TabsPrimitive.Root> & {
+	variant?: TabsVariant;
 };
 
 /**
- * A styled tabs component used for navigating
+ * An accessible tabs widget wrapping Radix Tabs, where each tab reveals its own
+ * panel. Use `variant="vertical"` for a master-detail layout. For route
+ * navigation use NavTabs instead.
  */
-export default function Tabs({ children, className }: TabsProps) {
+export function Tabs({
+	variant = "segmented",
+	className,
+	orientation,
+	...props
+}: TabsProps) {
 	return (
-		<nav
-			className={cn(
-				"border-b",
-				"border-gray-300",
-				"flex",
-				"mb-4",
-				"w-full",
-				className,
-			)}
-		>
-			{children}
-		</nav>
+		<TabsVariantContext.Provider value={variant}>
+			<TabsPrimitive.Root
+				className={cn(rootVariants({ variant }), className)}
+				orientation={
+					orientation ?? (variant === "vertical" ? "vertical" : "horizontal")
+				}
+				{...props}
+			/>
+		</TabsVariantContext.Provider>
+	);
+}
+
+export function TabsList({
+	className,
+	...props
+}: ComponentProps<typeof TabsPrimitive.List>) {
+	const variant = useContext(TabsVariantContext);
+
+	return (
+		<TabsPrimitive.List
+			className={cn(listVariants({ variant }), className)}
+			{...props}
+		/>
+	);
+}
+
+export function TabsTrigger({
+	className,
+	...props
+}: ComponentProps<typeof TabsPrimitive.Trigger>) {
+	const variant = useContext(TabsVariantContext);
+
+	return (
+		<TabsPrimitive.Trigger
+			className={cn(triggerVariants({ variant }), className)}
+			{...props}
+		/>
+	);
+}
+
+export function TabsContent({
+	className,
+	...props
+}: ComponentProps<typeof TabsPrimitive.Content>) {
+	const variant = useContext(TabsVariantContext);
+
+	return (
+		<TabsPrimitive.Content
+			className={cn(contentVariants({ variant }), className)}
+			{...props}
+		/>
 	);
 }

--- a/apps/web/src/groups/components/Groups.tsx
+++ b/apps/web/src/groups/components/Groups.tsx
@@ -3,8 +3,8 @@ import InputHeader from "@base/InputHeader";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
 import RemoveBanner from "@base/RemoveBanner";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@base/Tabs";
 import { sortBy } from "es-toolkit/compat";
-import { Tabs } from "radix-ui";
 import { useState } from "react";
 import {
 	useFetchGroup,
@@ -75,31 +75,20 @@ export default function Groups() {
 			</header>
 
 			{groups.length && selectedGroup ? (
-				<Tabs.Root
+				<Tabs
+					variant="vertical"
 					value={activeValue}
 					onValueChange={(value) => setSelectedGroupId(Number(value))}
-					orientation="vertical"
-					className="gap-x-4 grid grid-cols-4"
 				>
-					<Tabs.List
-						aria-label="Groups"
-						className="col-span-1 flex flex-col self-start bg-white border border-gray-300 rounded-sm overflow-hidden"
-					>
+					<TabsList aria-label="Groups">
 						{sortedGroups.map((group) => (
-							<Tabs.Trigger
-								key={group.id}
-								value={String(group.id)}
-								className="px-6 py-3 text-left text-gray-500 cursor-pointer transition-colors hover:bg-gray-50 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-600/50 data-[state=active]:shadow-[inset_3px_0_0_var(--color-virtool)] data-[state=active]:text-gray-900 data-[state=active]:font-medium"
-							>
+							<TabsTrigger key={group.id} value={String(group.id)}>
 								{group.name}
-							</Tabs.Trigger>
+							</TabsTrigger>
 						))}
-					</Tabs.List>
+					</TabsList>
 
-					<Tabs.Content
-						value={activeValue}
-						className="col-span-3 focus:outline-none"
-					>
+					<TabsContent value={activeValue}>
 						<InputHeader
 							id="name"
 							value={selectedGroup.name}
@@ -118,8 +107,8 @@ export default function Groups() {
 							buttonText="Delete"
 							onClick={() => removeMutation.mutate({ id: selectedGroup.id })}
 						/>
-					</Tabs.Content>
-				</Tabs.Root>
+					</TabsContent>
+				</Tabs>
 			) : (
 				<div className="bg-gray-200 flex items-center h-48 justify-center rounded-md text-gray-600">
 					No Groups Exist

--- a/apps/web/src/references/components/CreateReference.tsx
+++ b/apps/web/src/references/components/CreateReference.tsx
@@ -1,6 +1,6 @@
 import { Dialog, DialogContent, DialogTitle } from "@base/Dialog";
-import Tabs from "@base/Tabs";
-import TabsLink from "@base/TabsLink";
+import NavTab from "@base/NavTab";
+import NavTabs from "@base/NavTabs";
 import EmptyReference from "./EmptyReference";
 import ImportReference from "./ImportReference";
 
@@ -25,22 +25,22 @@ export function CreateReference({
 		>
 			<DialogContent size="lg">
 				<DialogTitle>Create Reference</DialogTitle>
-				<Tabs>
-					<TabsLink
+				<NavTabs>
+					<NavTab
 						to="."
 						search={{ createReferenceType: "empty" }}
 						isActive={createReferenceType === "empty"}
 					>
 						Empty
-					</TabsLink>
-					<TabsLink
+					</NavTab>
+					<NavTab
 						to="."
 						search={{ createReferenceType: "import" }}
 						isActive={createReferenceType === "import"}
 					>
 						Import
-					</TabsLink>
-				</Tabs>
+					</NavTab>
+				</NavTabs>
 
 				{createReferenceType === "import" ? (
 					<ImportReference />

--- a/apps/web/src/references/components/Detail/ReferenceDetailTabs.tsx
+++ b/apps/web/src/references/components/Detail/ReferenceDetailTabs.tsx
@@ -1,6 +1,6 @@
 import Badge from "@base/Badge";
-import Tabs from "@base/Tabs";
-import TabsLink from "@base/TabsLink";
+import NavTab from "@base/NavTab";
+import NavTabs from "@base/NavTabs";
 
 type ReferenceDetailTabsProps = {
 	id: string;
@@ -15,13 +15,13 @@ export default function ReferenceDetailTabs({
 	otuCount,
 }: ReferenceDetailTabsProps) {
 	return (
-		<Tabs>
-			<TabsLink to={`/refs/${id}/manage`}>Manage</TabsLink>
-			<TabsLink to={`/refs/${id}/otus`}>
+		<NavTabs>
+			<NavTab to={`/refs/${id}/manage`}>Manage</NavTab>
+			<NavTab to={`/refs/${id}/otus`}>
 				OTUs <Badge>{otuCount}</Badge>
-			</TabsLink>
-			<TabsLink to={`/refs/${id}/indexes`}>Indexes</TabsLink>
-			<TabsLink to={`/refs/${id}/settings`}>Settings</TabsLink>
-		</Tabs>
+			</NavTab>
+			<NavTab to={`/refs/${id}/indexes`}>Indexes</NavTab>
+			<NavTab to={`/refs/${id}/settings`}>Settings</NavTab>
+		</NavTabs>
 	);
 }

--- a/apps/web/src/routes/_authenticated/account.tsx
+++ b/apps/web/src/routes/_authenticated/account.tsx
@@ -1,7 +1,7 @@
 import ContainerNarrow from "@base/ContainerNarrow";
 import ContainerWide from "@base/ContainerWide";
-import Tabs from "@base/Tabs";
-import TabsLink from "@base/TabsLink";
+import NavTab from "@base/NavTab";
+import NavTabs from "@base/NavTabs";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
@@ -17,10 +17,10 @@ function AccountLayout() {
 				<ViewHeaderTitle>Account</ViewHeaderTitle>
 			</ViewHeader>
 
-			<Tabs>
-				<TabsLink to="/account/profile">Profile</TabsLink>
-				<TabsLink to="/account/api">API</TabsLink>
-			</Tabs>
+			<NavTabs>
+				<NavTab to="/account/profile">Profile</NavTab>
+				<NavTab to="/account/api">API</NavTab>
+			</NavTabs>
 
 			<ContainerNarrow>
 				<Outlet />

--- a/apps/web/src/routes/_authenticated/refs/$refId/otus/$otuId/route.tsx
+++ b/apps/web/src/routes/_authenticated/refs/$refId/otus/$otuId/route.tsx
@@ -1,7 +1,7 @@
 import Badge from "@base/Badge";
 import Link from "@base/Link";
-import Tabs from "@base/Tabs";
-import TabsLink from "@base/TabsLink";
+import NavTab from "@base/NavTab";
+import NavTabs from "@base/NavTabs";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderIcons from "@base/ViewHeaderIcons";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
@@ -86,11 +86,11 @@ function OtuDetailLayout() {
 				</p>
 			</ViewHeader>
 
-			<Tabs>
-				<TabsLink to={`/refs/${refId}/otus/${otuId}/otu`}>OTU</TabsLink>
-				<TabsLink to={`/refs/${refId}/otus/${otuId}/schema`}>Schema</TabsLink>
-				<TabsLink to={`/refs/${refId}/otus/${otuId}/history`}>History</TabsLink>
-			</Tabs>
+			<NavTabs>
+				<NavTab to={`/refs/${refId}/otus/${otuId}/otu`}>OTU</NavTab>
+				<NavTab to={`/refs/${refId}/otus/${otuId}/schema`}>Schema</NavTab>
+				<NavTab to={`/refs/${refId}/otus/${otuId}/history`}>History</NavTab>
+			</NavTabs>
 
 			<Outlet />
 		</>

--- a/apps/web/src/routes/_authenticated/samples/$sampleId.tsx
+++ b/apps/web/src/routes/_authenticated/samples/$sampleId.tsx
@@ -1,7 +1,7 @@
 import Icon from "@base/Icon";
 import IconButton from "@base/IconButton";
-import Tabs from "@base/Tabs";
-import TabsLink from "@base/TabsLink";
+import NavTab from "@base/NavTab";
+import NavTabs from "@base/NavTabs";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderAttribution from "@base/ViewHeaderAttribution";
 import ViewHeaderIcons from "@base/ViewHeaderIcons";
@@ -76,21 +76,21 @@ function SampleDetailLayout() {
 				<ViewHeaderAttribution time={created_at} user={user.handle} />
 			</ViewHeader>
 
-			<Tabs>
-				<TabsLink to={`/samples/${sampleId}/general`}>General</TabsLink>
+			<NavTabs>
+				<NavTab to={`/samples/${sampleId}/general`}>General</NavTab>
 				{data.ready && (
 					<>
-						<TabsLink to={`/samples/${sampleId}/files`}>Files</TabsLink>
-						<TabsLink to={`/samples/${sampleId}/quality`}>Quality</TabsLink>
-						<TabsLink to={`/samples/${sampleId}/analyses`}>Analyses</TabsLink>
+						<NavTab to={`/samples/${sampleId}/files`}>Files</NavTab>
+						<NavTab to={`/samples/${sampleId}/quality`}>Quality</NavTab>
+						<NavTab to={`/samples/${sampleId}/analyses`}>Analyses</NavTab>
 						{canModify && (
-							<TabsLink to={`/samples/${sampleId}/rights`}>
+							<NavTab to={`/samples/${sampleId}/rights`}>
 								<Icon icon={Key} />
-							</TabsLink>
+							</NavTab>
 						)}
 					</>
 				)}
-			</Tabs>
+			</NavTabs>
 
 			<Outlet />
 


### PR DESCRIPTION
## Summary
- Convert the Contigs/ORFs scope selector in the NuVs export dialog from a toggle group to an accessible tabs widget (WAI-ARIA tabs pattern), with each option's preview shown in its tab panel.
- Add a Radix-backed `Tabs` primitive to `src/base` (`Tabs`/`TabsList`/`TabsTrigger`/`TabsContent`) with `segmented` and `vertical` variants, and adopt it in `NuvsExport`, `CreateAnalysis`, `QuickAnalyze`, and `Groups` — removing the previously duplicated inline Radix styling. The existing route-navigation `Tabs`/`TabsLink` are renamed to `NavTabs`/`NavTab` to free the `Tabs` name.
- Correct the contig export filename suffix (was `configs`) and add tests covering tab switching and both export download paths.