### PR TITLE
fix: complete setup flow after creating the first user

### DIFF
--- a/apps/web/src/server/auth/core.ts
+++ b/apps/web/src/server/auth/core.ts
@@ -5,7 +5,12 @@ import { and, eq, sql } from "drizzle-orm";
 import type { Db } from "../db/pg";
 import { sessions } from "../db/schema/sessions";
 import { users } from "../db/schema/users";
-import { createUser, getUserCount, type User } from "../users/data";
+import {
+	createUser,
+	getUserCount,
+	type User,
+	UserConflictError,
+} from "../users/data";
 import type { CookieAdapter } from "./cookies";
 import { hashPassword, verifyPassword } from "./password";
 import {
@@ -82,6 +87,12 @@ export type CreateFirstUserInput = {
  * further accounts. On success an authenticated session is written and the
  * session cookies are set, so the caller lands in the app without a separate
  * login step.
+ *
+ * The count check and insert are not a single atomic statement — Python owns
+ * the schema, so we can't add a DB-level "single user" constraint here. A
+ * concurrent bootstrap that wins the insert instead trips the existing unique
+ * handle index; that `UserConflictError` is surfaced as the same
+ * already-set-up outcome as the count guard.
  */
 export async function createFirstUser(
 	db: Db,
@@ -92,12 +103,20 @@ export async function createFirstUser(
 		throw new FirstUserExistsError();
 	}
 
-	const user = await createUser(db, {
-		handle: input.handle,
-		password: input.password,
-		forceReset: false,
-		administratorRole: "full",
-	});
+	let user: User;
+	try {
+		user = await createUser(db, {
+			handle: input.handle,
+			password: input.password,
+			forceReset: false,
+			administratorRole: "full",
+		});
+	} catch (err) {
+		if (err instanceof UserConflictError) {
+			throw new FirstUserExistsError();
+		}
+		throw err;
+	}
 
 	const { sessionId, token } = await createAuthenticatedSession(db, {
 		userId: user.id,

--- a/apps/web/src/server/auth/core.ts
+++ b/apps/web/src/server/auth/core.ts
@@ -5,6 +5,7 @@ import { and, eq, sql } from "drizzle-orm";
 import type { Db } from "../db/pg";
 import { sessions } from "../db/schema/sessions";
 import { users } from "../db/schema/users";
+import { createUser, getUserCount, type User } from "../users/data";
 import type { CookieAdapter } from "./cookies";
 import { hashPassword, verifyPassword } from "./password";
 import {
@@ -56,6 +57,57 @@ export class PasswordReuseError extends Error {
 		super("Cannot reuse current password");
 		this.name = "PasswordReuseError";
 	}
+}
+
+/** First-user setup ran but the instance already has at least one user. */
+export class FirstUserExistsError extends Error {
+	constructor() {
+		super("Instance already has a user");
+		this.name = "FirstUserExistsError";
+	}
+}
+
+/** Inputs to create and authenticate the first instance user. */
+export type CreateFirstUserInput = {
+	handle: string;
+	password: string;
+	ip: string;
+};
+
+/**
+ * Create the first instance user and log them in.
+ *
+ * The first user is always a full administrator. Creation is rejected once any
+ * user exists, so the unauthenticated bootstrap endpoint can't be used to mint
+ * further accounts. On success an authenticated session is written and the
+ * session cookies are set, so the caller lands in the app without a separate
+ * login step.
+ */
+export async function createFirstUser(
+	db: Db,
+	cookies: CookieAdapter,
+	input: CreateFirstUserInput,
+): Promise<User> {
+	if ((await getUserCount(db)) > 0) {
+		throw new FirstUserExistsError();
+	}
+
+	const user = await createUser(db, {
+		handle: input.handle,
+		password: input.password,
+		forceReset: false,
+		administratorRole: "full",
+	});
+
+	const { sessionId, token } = await createAuthenticatedSession(db, {
+		userId: user.id,
+		ip: input.ip,
+		remember: false,
+	});
+	cookies.setSessionId(sessionId);
+	cookies.setSessionToken(token);
+
+	return user;
 }
 
 export async function login(

--- a/apps/web/src/server/auth/functions.ts
+++ b/apps/web/src/server/auth/functions.ts
@@ -6,6 +6,8 @@ import { z } from "zod";
 import { db } from "../db/pg";
 import { realCookies } from "./cookies";
 import {
+	createFirstUser,
+	FirstUserExistsError,
 	InvalidCredentialsError,
 	InvalidResetSessionError,
 	login,
@@ -23,6 +25,11 @@ const loginSchema = z.object({
 const resetPasswordSchema = z.object({
 	password: z.string().min(1),
 	reset_code: z.string().min(1),
+});
+
+const createFirstUserSchema = z.object({
+	handle: z.string().trim().min(1),
+	password: z.string().min(1),
 });
 
 // Wrapped in createServerOnlyFn so the compiler strips this body and its
@@ -60,6 +67,31 @@ export const loginFn = createServerFn({ method: "POST" })
 			if (err instanceof InvalidCredentialsError) {
 				setResponseStatus(400);
 				throw new Error("Invalid handle or password.");
+			}
+			throw err;
+		}
+	});
+
+/**
+ * First-user setup server function. Unauthenticated by necessity — it runs
+ * before any user (and therefore any session) exists, and it establishes the
+ * session for the user it creates.
+ */
+export const createFirstUserFn = createServerFn({ method: "POST" })
+	.inputValidator(createFirstUserSchema)
+	.handler(async ({ data }) => {
+		try {
+			const user = await createFirstUser(db, realCookies, {
+				handle: data.handle,
+				password: data.password,
+				ip: getClientIp(),
+			});
+			setResponseStatus(201);
+			return user;
+		} catch (err) {
+			if (err instanceof FirstUserExistsError) {
+				setResponseStatus(409);
+				throw new Error("Virtool already has a user.");
 			}
 			throw err;
 		}

--- a/apps/web/src/server/users/data.ts
+++ b/apps/web/src/server/users/data.ts
@@ -68,6 +68,7 @@ export type CreateUserValues = {
 	handle: string;
 	password: string;
 	forceReset: boolean;
+	administratorRole?: AdministratorRoleName | null;
 };
 
 /** Partial values accepted when updating a user. */
@@ -266,6 +267,12 @@ export function listAdministratorRoles(): AdministratorRole[] {
 	return ADMINISTRATOR_ROLES;
 }
 
+/** Count all user rows. Used to detect the first-user setup bootstrap. */
+export async function getUserCount(db: Db): Promise<number> {
+	const [row] = await db.select({ value: count() }).from(usersTable);
+	return row?.value ?? 0;
+}
+
 export async function findUsers(
 	db: Db,
 	filters: FindUsersFilters,
@@ -357,6 +364,7 @@ export async function createUser(
 					handle: values.handle,
 					password,
 					forceReset: values.forceReset,
+					administratorRole: values.administratorRole ?? null,
 					lastPasswordChange: new Date(),
 					legacyId: null,
 					settings: DEFAULT_USER_SETTINGS,

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -9,12 +9,19 @@ import {
 	createStart,
 } from "@tanstack/react-start";
 
-import { loginFn, logoutFn, resetPasswordFn } from "./server/auth/functions";
+import {
+	createFirstUserFn,
+	loginFn,
+	logoutFn,
+	resetPasswordFn,
+} from "./server/auth/functions";
 import { createAuthenticationMiddleware } from "./server/auth/middleware";
 import { errorLoggingMiddleware } from "./server/error-logging";
 
 // logoutFn must be exempt so stale or missing cookies can still be cleared.
+// createFirstUserFn runs before any user or session exists.
 const authenticationMiddleware = createAuthenticationMiddleware([
+	createFirstUserFn,
 	loginFn,
 	logoutFn,
 	resetPasswordFn,

--- a/apps/web/src/tests/api/auth.ts
+++ b/apps/web/src/tests/api/auth.ts
@@ -1,0 +1,42 @@
+import type { User } from "@users/types";
+import { expect, vi } from "vitest";
+
+/**
+ * Mock handles for the `@server/auth/functions` server-fn module. Wired in
+ * globally from `tests/setup.tsx` so route-level tests can stub the
+ * unauthenticated auth endpoints without per-file `vi.mock` boilerplate.
+ */
+export const authServerFnMocks = {
+	loginFn: vi.fn(),
+	logoutFn: vi.fn(),
+	resetPasswordFn: vi.fn(),
+	createFirstUserFn: vi.fn(),
+};
+
+/** Asserts that the corresponding mock was called at least once. */
+export type MockScope = { done(): void };
+
+function makeScope(fn: ReturnType<typeof vi.fn>): MockScope {
+	return {
+		done() {
+			expect(fn).toHaveBeenCalled();
+		},
+	};
+}
+
+/**
+ * Sets up createFirstUserFn to resolve with the given user (or reject with the
+ * given message on a 4xx code, e.g. 409 when a user already exists).
+ */
+export function mockApiCreateFirstUser(
+	user?: Partial<User>,
+	statusCode = 201,
+	message = "Virtool already has a user.",
+): MockScope {
+	if (statusCode >= 400) {
+		authServerFnMocks.createFirstUserFn.mockRejectedValue(new Error(message));
+	} else {
+		authServerFnMocks.createFirstUserFn.mockResolvedValue(user ?? {});
+	}
+	return makeScope(authServerFnMocks.createFirstUserFn);
+}

--- a/apps/web/src/tests/setup.tsx
+++ b/apps/web/src/tests/setup.tsx
@@ -19,12 +19,18 @@ import userEvent from "@testing-library/user-event";
 import { createContext, type ReactNode, useContext, useState } from "react";
 import { beforeEach, vi } from "vitest";
 import { routeTree } from "@/routeTree.gen";
+import { authServerFnMocks } from "./api/auth";
 import { groupServerFnMocks } from "./api/groups";
 import { jobServerFnMocks } from "./api/jobs";
 import { userServerFnMocks } from "./api/users";
 import { createFakeAccount } from "./fake/account";
 
 vi.mock("@server/groups/functions", () => groupServerFnMocks);
+// See the users mock below for why this resolves the mock via dynamic import.
+vi.mock("@server/auth/functions", async () => {
+	const { authServerFnMocks } = await import("./api/auth");
+	return authServerFnMocks;
+});
 // Resolve the mock lazily via dynamic import. A direct reference to the
 // imported `userServerFnMocks` binding races route modules (pulled in by
 // `routeTree`) that import the mocked module before this binding initializes.
@@ -44,6 +50,7 @@ beforeEach(() => {
 	for (const fn of [
 		...Object.values(userServerFnMocks),
 		...Object.values(jobServerFnMocks),
+		...Object.values(authServerFnMocks),
 	]) {
 		fn.mockReset();
 		// Default to a pending promise so an un-stubbed query renders its loading

--- a/apps/web/src/users/queries.ts
+++ b/apps/web/src/users/queries.ts
@@ -1,10 +1,5 @@
 import { apiClient } from "@app/api";
-import {
-	keepPreviousData,
-	useInfiniteQuery,
-	useMutation,
-} from "@tanstack/react-query";
-import type { ErrorResponse } from "@/types/api";
+import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 import type { UserResponse } from "./types";
 
 /**
@@ -45,24 +40,5 @@ export function useInfiniteFindUsers(per_page: number, term: string) {
 			return (lastPage.page || 1) + 1;
 		},
 		placeholderData: keepPreviousData,
-	});
-}
-
-/**
- * Hook for creating the first user in an instance.
- * This is typically used for instance initialization.
- *
- * @returns A mutation function for user creation.
- */
-export function useCreateFirstUser() {
-	return useMutation<
-		unknown,
-		ErrorResponse,
-		{ handle: string; password: string; forceReset: boolean }
-	>({
-		mutationFn: ({ handle, password, forceReset }) =>
-			apiClient
-				.put("/users/first")
-				.send({ handle, password, force_reset: forceReset }),
 	});
 }

--- a/apps/web/src/wall/components/FirstUser.tsx
+++ b/apps/web/src/wall/components/FirstUser.tsx
@@ -68,7 +68,11 @@ export default function FirstUser() {
 				<Button type="submit" color="blue">
 					Create User
 				</Button>
-				{mutation.isError && <InputError>{mutation.error.message}</InputError>}
+				{mutation.isError && (
+					<InputError>
+						{mutation.error.message || "Could not create user"}
+					</InputError>
+				)}
 			</form>
 		</WallContainer>
 	);

--- a/apps/web/src/wall/components/FirstUser.tsx
+++ b/apps/web/src/wall/components/FirstUser.tsx
@@ -3,11 +3,9 @@ import InputError from "@base/InputError";
 import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import InputSimple from "@base/InputSimple";
-import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useCreateFirstUser } from "@users/queries";
 import { useForm } from "react-hook-form";
-import { rootKeys } from "../queries";
+import { useCreateFirstUser } from "../queries";
 import { WallContainer } from "./WallContainer";
 import { WallTitle } from "./WallTitle";
 
@@ -21,24 +19,14 @@ type FormValues = {
  */
 export default function FirstUser() {
 	const mutation = useCreateFirstUser();
-	const queryClient = useQueryClient();
 	const navigate = useNavigate();
 
 	const { handleSubmit, register } = useForm<FormValues>();
 
 	function onSubmit(data: FormValues) {
 		mutation.mutate(
-			{
-				handle: data.username,
-				password: data.password,
-				forceReset: false,
-			},
-			{
-				onSuccess: async () => {
-					await queryClient.invalidateQueries({ queryKey: rootKeys.all() });
-					navigate({ to: "/" });
-				},
-			},
+			{ handle: data.username, password: data.password },
+			{ onSuccess: () => navigate({ to: "/" }) },
 		);
 	}
 
@@ -80,9 +68,7 @@ export default function FirstUser() {
 				<Button type="submit" color="blue">
 					Create User
 				</Button>
-				{mutation.isError && (
-					<InputError>{mutation.error.response?.body.message}</InputError>
-				)}
+				{mutation.isError && <InputError>{mutation.error.message}</InputError>}
 			</form>
 		</WallContainer>
 	);

--- a/apps/web/src/wall/components/__tests__/FirstUser.test.tsx
+++ b/apps/web/src/wall/components/__tests__/FirstUser.test.tsx
@@ -1,44 +1,63 @@
+import { accountKeys } from "@account/queries";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { renderWithRouter } from "@tests/setup";
+import { mockApiCreateFirstUser } from "@tests/api/auth";
+import { createFakeAccount } from "@tests/fake/account";
+import { renderRoute } from "@tests/setup";
 import nock from "nock";
-import { describe, expect, it } from "vitest";
-import FirstUser from "../FirstUser";
+import { afterEach, describe, expect, it } from "vitest";
 
 describe("<FirstUser />", () => {
-	it("creates first user and redirects to / on success", async () => {
-		const usernameInput = "Username";
-		const passwordInput = "Password";
-		const scope = nock("http://localhost")
-			.put("/api/users/first", {
-				handle: usernameInput,
-				password: passwordInput,
-				force_reset: false,
-			})
-			.reply(201, {
-				handle: usernameInput,
-				password: passwordInput,
-			});
+	afterEach(() => nock.cleanAll());
 
-		const { router } = await renderWithRouter(<FirstUser />, "/setup");
+	async function renderSetup() {
+		return renderRoute("/setup", {
+			seed: (queryClient) => {
+				// A fresh instance: the root reports the setup is needed and no
+				// account has been fetched yet.
+				queryClient.setQueryData(["root"], { first_user: true });
+				queryClient.removeQueries({ queryKey: accountKeys.all() });
+			},
+		});
+	}
 
-		const usernameField = screen.getByLabelText("username");
-		const passwordField = screen.getByLabelText("password");
+	it("creates the first user and lands in the authenticated app", async () => {
+		const account = createFakeAccount();
+		const scope = mockApiCreateFirstUser({
+			id: account.id,
+			handle: account.handle,
+		});
 
-		expect(usernameField).toHaveValue("");
-		expect(passwordField).toHaveValue("");
+		// After setup the root reports no first user, and the session created by
+		// the server function authenticates the account fetch, so the guard
+		// admits the user instead of bouncing back to /setup.
+		nock("http://localhost").get("/api/").reply(200, { first_user: false });
+		nock("http://localhost").get("/api/account").reply(200, account);
 
-		await userEvent.type(usernameField, usernameInput);
-		expect(usernameField).toHaveValue(usernameInput);
+		const { router } = await renderSetup();
 
-		await userEvent.type(passwordField, passwordInput);
-		expect(passwordField).toHaveValue(passwordInput);
-
+		await userEvent.type(screen.getByLabelText("username"), account.handle);
+		await userEvent.type(screen.getByLabelText("password"), "supersecret");
 		await userEvent.click(screen.getByRole("button", { name: /Create User/i }));
 
 		await waitFor(() => {
-			expect(router.state.location.pathname).toBe("/");
+			expect(router.state.location.pathname).toBe("/samples");
 		});
-		expect(scope.isDone()).toBe(true);
+		scope.done();
+	});
+
+	it("shows an error and stays on /setup when creation fails", async () => {
+		mockApiCreateFirstUser(undefined, 409);
+
+		const { router } = await renderSetup();
+
+		await userEvent.type(screen.getByLabelText("username"), "bob");
+		await userEvent.type(screen.getByLabelText("password"), "supersecret");
+		await userEvent.click(screen.getByRole("button", { name: /Create User/i }));
+
+		expect(
+			await screen.findByText("Virtool already has a user."),
+		).toBeInTheDocument();
+		expect(router.state.location.pathname).toBe("/setup");
 	});
 });

--- a/apps/web/src/wall/queries.ts
+++ b/apps/web/src/wall/queries.ts
@@ -1,7 +1,11 @@
 import { accountKeys } from "@account/queries";
 import { apiClient } from "@app/api";
 import type { Root } from "@app/types";
-import { loginFn, resetPasswordFn } from "@server/auth/functions";
+import {
+	createFirstUserFn,
+	loginFn,
+	resetPasswordFn,
+} from "@server/auth/functions";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type { ErrorResponse } from "@/types/api";
@@ -32,6 +36,33 @@ export function useRootQuery() {
 	return useQuery<Root, ErrorResponse>({
 		queryKey: rootKeys.all(),
 		queryFn: () => apiClient.get("/").then((res) => res.body),
+	});
+}
+
+/**
+ * Initializes a mutator for creating the first instance user.
+ *
+ * The new user is authenticated by the server function, so on success the
+ * cached root and account documents are dropped. That forces the authenticated
+ * route guard to refetch them instead of reusing the pre-setup snapshot, which
+ * would otherwise redirect straight back to `/setup`.
+ *
+ * @returns A mutator for creating the first instance user.
+ */
+export function useCreateFirstUser() {
+	const queryClient = useQueryClient();
+
+	return useMutation<
+		Awaited<ReturnType<typeof createFirstUserFn>>,
+		Error,
+		{ handle: string; password: string }
+	>({
+		mutationFn: ({ handle, password }) =>
+			createFirstUserFn({ data: { handle, password } }),
+		onSuccess: () => {
+			queryClient.removeQueries({ queryKey: rootKeys.all() });
+			queryClient.removeQueries({ queryKey: accountKeys.all() });
+		},
 	});
 }
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -41,6 +41,7 @@ not per-handler. The wiring lives in `apps/web/src/start.ts`:
 
 ```ts
 const authenticationMiddleware = createAuthenticationMiddleware([
+  createFirstUserFn,
   loginFn,
   logoutFn,
   resetPasswordFn,
@@ -162,6 +163,30 @@ function. It delegates to `core.login`, which:
 
 The `resetCode` is returned in the response body (not a cookie) so the
 client can hold it in JS for the duration of the reset flow.
+
+## First-user setup
+
+A fresh instance has no users; the root document reports
+`first_user: true` and the `_authenticated` guard redirects to
+`/setup`. `createFirstUserFn` (`server/auth/functions.ts`) is the
+public server function that bootstraps the instance. It is unauthenticated
+by necessity — it runs before any user or session exists — and delegates
+to `core.createFirstUser`, which:
+
+1. Rejects with `FirstUserExistsError` (→ 409) if any user already
+   exists, so the endpoint can't be used to mint further accounts once
+   setup is done.
+2. Creates the user as a full administrator (`administrator_role =
+   "full"`, `force_reset = false`).
+3. Mints an authenticated session and sets both cookies — the first
+   user is logged in without a separate login step.
+
+The client mutation (`useCreateFirstUser` in `wall/queries.ts`) drops
+the cached `root` and `account` documents on success so the guard
+refetches them fresh instead of reusing the pre-setup snapshot (which
+still says `first_user: true` and would bounce the user back to
+`/setup`). It then navigates to `/`; the now-authenticated guard admits
+the user.
 
 ## Forced password reset
 


### PR DESCRIPTION
## Summary
- Creating the first user from `/setup` succeeded on the server but left the UI stranded: the success handler invalidated the root query, but with no active observer the default active-only refetch merely marked it stale, so the authenticated guard's `ensureQueryData` reused the stale `{ first_user: true }` snapshot and redirected back to `/setup`.
- Moves first-user creation to a new unauthenticated `createFirstUserFn` server function that creates the user as a full administrator, establishes an authenticated session, and sets the cookies — so the user lands directly in the app instead of `/login`.
- The `useCreateFirstUser` mutation now drops the cached `root` and `account` documents on success so the guard refetches them fresh; adds a real-`routeTree` test covering the full setup→create→land-in-app flow plus the failure path, and updates `docs/auth.md`.