### PR TITLE
fix: show errors instead of spinning on sample rights and analyses

### DIFF
--- a/apps/web/src/analyses/components/AnalysisList.tsx
+++ b/apps/web/src/analyses/components/AnalysisList.tsx
@@ -46,14 +46,17 @@ export default function AnalysesList({
 		isPending: isPendingHmms,
 		isError: isErrorHmms,
 	} = useListHmms(1, 25);
-	const { isPending: isPendingSample, isError: isErrorSample } =
-		useFetchSample(sampleId);
+	const {
+		data: sample,
+		isPending: isPendingSample,
+		isError: isErrorSample,
+	} = useFetchSample(sampleId);
 	const { hasPermission: canCreate } = useCheckCanEditSample(sampleId);
 
 	if (
 		(isErrorAnalyses && !analyses) ||
 		(isErrorHmms && !hmms) ||
-		isErrorSample
+		(isErrorSample && !sample)
 	) {
 		return <QueryError noun="analyses" />;
 	}

--- a/apps/web/src/analyses/components/AnalysisList.tsx
+++ b/apps/web/src/analyses/components/AnalysisList.tsx
@@ -3,6 +3,7 @@ import ContainerNarrow from "@base/ContainerNarrow";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NoneFoundBox from "@base/NoneFoundBox";
 import Pagination from "@base/Pagination";
+import QueryError from "@base/QueryError";
 import { useListHmms } from "@hmm/queries";
 import { useCheckCanEditSample } from "@samples/hooks";
 import { useFetchSample } from "@samples/queries";
@@ -35,14 +36,27 @@ export default function AnalysesList({
 	sampleId,
 }: AnalysesListProps) {
 	const [openCreateAnalysis, setOpenCreateAnalysis] = useState(false);
-	const { data: analyses, isPending: isPendingAnalyses } = useListAnalyses(
-		sampleId,
-		page,
-		25,
-	);
-	const { data: hmms, isPending: isPendingHmms } = useListHmms(1, 25);
-	const { isPending: isPendingSample } = useFetchSample(sampleId);
+	const {
+		data: analyses,
+		isPending: isPendingAnalyses,
+		isError: isErrorAnalyses,
+	} = useListAnalyses(sampleId, page, 25);
+	const {
+		data: hmms,
+		isPending: isPendingHmms,
+		isError: isErrorHmms,
+	} = useListHmms(1, 25);
+	const { isPending: isPendingSample, isError: isErrorSample } =
+		useFetchSample(sampleId);
 	const { hasPermission: canCreate } = useCheckCanEditSample(sampleId);
+
+	if (
+		(isErrorAnalyses && !analyses) ||
+		(isErrorHmms && !hmms) ||
+		isErrorSample
+	) {
+		return <QueryError noun="analyses" />;
+	}
 
 	if (
 		isPendingAnalyses ||

--- a/apps/web/src/samples/components/Detail/SampleRights.tsx
+++ b/apps/web/src/samples/components/Detail/SampleRights.tsx
@@ -9,6 +9,7 @@ import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import InputSelect from "@base/InputSelect";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import { useListGroups } from "@groups/queries";
 import {
 	samplesQueryKeys,
@@ -26,12 +27,32 @@ type SampleRightsProps = {
  */
 export default function SampleRights({ sampleId }: SampleRightsProps) {
 	const { hasPermission } = useCheckAdminRole("full");
-	const { data: sample, isPending: isPendingSample } = useFetchSample(sampleId);
-	const { data: account, isPending: isPendingAccount } = useFetchAccount();
-	const { data: groups, isPending: isPendingGroups } = useListGroups();
+	const {
+		data: sample,
+		isPending: isPendingSample,
+		isError: isErrorSample,
+	} = useFetchSample(sampleId);
+	const {
+		data: account,
+		isPending: isPendingAccount,
+		isError: isErrorAccount,
+	} = useFetchAccount();
+	const {
+		data: groups,
+		isPending: isPendingGroups,
+		isError: isErrorGroups,
+	} = useListGroups();
 
 	const queryClient = useQueryClient();
 	const mutation = useUpdateSampleRights(sampleId);
+
+	if (
+		(isErrorSample && !sample) ||
+		(isErrorAccount && !account) ||
+		(isErrorGroups && !groups)
+	) {
+		return <QueryError noun="sample rights" />;
+	}
 
 	if (
 		isPendingSample ||


### PR DESCRIPTION
## Summary

- `SampleRights` and `AnalysisList` each fan out to several React Query hooks but guarded only on `isPending`, so a failed request spun forever with no way out.
- Added an `isError`-any → inline `@base/QueryError` guard **before** the loading guard in both, per the two-tier convention in `docs/queries.md`. Each query's error is paired with its own missing data (`isError && !data`) so stale data survives a failed background refetch.
- Closes VIR-2481 (the last two Pattern A multi-query sites missed by the June 11 two-tier sweep).