### PR TITLE
feat: use icon buttons for edit and delete in the labels list

### DIFF
--- a/apps/web/src/labels/components/DeleteLabel.tsx
+++ b/apps/web/src/labels/components/DeleteLabel.tsx
@@ -5,9 +5,11 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@base/Dialog";
+import IconButton from "@base/IconButton";
+import { Trash } from "lucide-react";
 import { useState } from "react";
 
-type RemoveLabelProps = {
+type DeleteLabelProps = {
 	name: string;
 	/** Resolves on success so the dialog can close. */
 	onConfirm: () => Promise<unknown>;
@@ -17,7 +19,7 @@ type RemoveLabelProps = {
  * Dialog confirming label removal. Pure presentation — deletion is delegated
  * to `onConfirm`.
  */
-export function RemoveLabel({ name, onConfirm }: RemoveLabelProps) {
+export function DeleteLabel({ name, onConfirm }: DeleteLabelProps) {
 	const [open, setOpen] = useState(false);
 
 	async function handleConfirm() {
@@ -32,9 +34,9 @@ export function RemoveLabel({ name, onConfirm }: RemoveLabelProps) {
 
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
-			<Button as={DialogTrigger} color="red" size="small">
-				Delete
-			</Button>
+			<DialogTrigger asChild>
+				<IconButton IconComponent={Trash} color="red" tip="delete label" />
+			</DialogTrigger>
 			<DialogContent>
 				<DialogTitle>Delete Label</DialogTitle>
 				<p className="text-base">

--- a/apps/web/src/labels/components/EditLabel.tsx
+++ b/apps/web/src/labels/components/EditLabel.tsx
@@ -1,12 +1,11 @@
-import Button from "@base/Button";
 import {
 	Dialog,
 	DialogContent,
 	DialogTitle,
 	DialogTrigger,
 } from "@base/Dialog";
-import Icon from "@base/Icon";
-import { Pen } from "lucide-react";
+import IconButton from "@base/IconButton";
+import { Pencil } from "lucide-react";
 import { useState } from "react";
 import { LabelForm } from "./LabelForm";
 
@@ -57,10 +56,9 @@ export function EditLabel({
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
-			<Button as={DialogTrigger} size="small">
-				<Icon icon={Pen} />
-				<span>Edit</span>
-			</Button>
+			<DialogTrigger asChild>
+				<IconButton IconComponent={Pencil} color="grayDark" tip="edit label" />
+			</DialogTrigger>
 			<DialogContent>
 				<DialogTitle>Edit a label</DialogTitle>
 				<LabelForm

--- a/apps/web/src/labels/components/LabelItem.tsx
+++ b/apps/web/src/labels/components/LabelItem.tsx
@@ -1,7 +1,7 @@
 import BoxGroupSection from "@base/BoxGroupSection";
 import SampleLabel from "@samples/components/Label/SampleLabel";
+import { DeleteLabel } from "./DeleteLabel";
 import { EditLabel, type UpdatedLabel } from "./EditLabel";
-import { RemoveLabel } from "./RemoveLabel";
 
 type LabelItemProps = {
 	color: string;
@@ -36,7 +36,7 @@ export function LabelItem({
 					name={name}
 					onSubmit={(values) => onEdit(id, values)}
 				/>
-				<RemoveLabel name={name} onConfirm={() => onRemove(id)} />
+				<DeleteLabel name={name} onConfirm={() => onRemove(id)} />
 			</div>
 		</BoxGroupSection>
 	);

--- a/apps/web/src/labels/components/__tests__/DeleteLabel.test.tsx
+++ b/apps/web/src/labels/components/__tests__/DeleteLabel.test.tsx
@@ -22,4 +22,17 @@ describe("<DeleteLabel>", () => {
 			expect(screen.queryByText(/are you sure/i)).not.toBeInTheDocument(),
 		);
 	});
+
+	it("keeps the dialog open when deletion fails", async () => {
+		const onConfirm = vi.fn().mockRejectedValue(new Error("oops"));
+		renderWithProviders(<DeleteLabel name="Foo" onConfirm={onConfirm} />);
+
+		await userEvent.click(screen.getByRole("button", { name: "delete label" }));
+		await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+		await waitFor(() => expect(onConfirm).toHaveBeenCalledOnce());
+		expect(
+			screen.getByText(/are you sure you want to delete the label/i),
+		).toBeInTheDocument();
+	});
 });

--- a/apps/web/src/labels/components/__tests__/DeleteLabel.test.tsx
+++ b/apps/web/src/labels/components/__tests__/DeleteLabel.test.tsx
@@ -1,0 +1,25 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@tests/setup";
+import { describe, expect, it, vi } from "vitest";
+import { DeleteLabel } from "../DeleteLabel";
+
+describe("<DeleteLabel>", () => {
+	it("confirms deletion and closes the dialog on success", async () => {
+		const onConfirm = vi.fn().mockResolvedValue(undefined);
+		renderWithProviders(<DeleteLabel name="Foo" onConfirm={onConfirm} />);
+
+		await userEvent.click(screen.getByRole("button", { name: "delete label" }));
+
+		expect(
+			screen.getByText(/are you sure you want to delete the label/i),
+		).toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+		await waitFor(() => expect(onConfirm).toHaveBeenCalledOnce());
+		await waitFor(() =>
+			expect(screen.queryByText(/are you sure/i)).not.toBeInTheDocument(),
+		);
+	});
+});

--- a/apps/web/src/labels/components/__tests__/EditLabel.test.tsx
+++ b/apps/web/src/labels/components/__tests__/EditLabel.test.tsx
@@ -15,7 +15,7 @@ describe("<EditLabel>", () => {
 		const onSubmit = vi.fn().mockResolvedValue(undefined);
 		renderWithProviders(<EditLabel {...baseProps} onSubmit={onSubmit} />);
 
-		await userEvent.click(screen.getByText("Edit"));
+		await userEvent.click(screen.getByRole("button", { name: "edit label" }));
 
 		const descriptionInput = screen.getByLabelText("Description");
 		const nameInput = screen.getByLabelText("Name");


### PR DESCRIPTION
## Summary
- Replace the text "Edit"/"Delete" buttons in the labels list with icon-only buttons (pencil and trash) to give the list a more compact, consistent action layout
- Add accessible tooltips ("edit label", "delete label") so the icon-only controls stay discoverable
- Rename `RemoveLabel` to `DeleteLabel` to match the action's wording, with tests updated accordingly