### PR TITLE
feat: use icon buttons for edit and remove in reference members

### DIFF
--- a/apps/web/src/references/components/Detail/MemberItem.tsx
+++ b/apps/web/src/references/components/Detail/MemberItem.tsx
@@ -1,6 +1,7 @@
 import BoxGroupSection from "@base/BoxGroupSection";
-import Button from "@base/Button";
+import IconButton from "@base/IconButton";
 import InitialIcon from "@base/InitialIcon";
+import { Pencil, Trash } from "lucide-react";
 
 function MemberItemIcon({ handle }) {
 	return (
@@ -43,12 +44,18 @@ export default function MemberItem({
 			{handleOrName}
 			{canModify && (
 				<span className="flex items-center gap-1 ml-auto">
-					<Button onClick={() => onEdit(id)} size="small">
-						Edit
-					</Button>
-					<Button onClick={() => onRemove(id)} size="small" color="red">
-						Remove
-					</Button>
+					<IconButton
+						IconComponent={Pencil}
+						color="grayDark"
+						tip="edit member"
+						onClick={() => onEdit(id)}
+					/>
+					<IconButton
+						IconComponent={Trash}
+						color="red"
+						tip="remove member"
+						onClick={() => onRemove(id)}
+					/>
 				</span>
 			)}
 		</BoxGroupSection>

--- a/apps/web/src/references/components/Detail/__tests__/MemberItem.test.tsx
+++ b/apps/web/src/references/components/Detail/__tests__/MemberItem.test.tsx
@@ -21,25 +21,29 @@ describe("<MemberItem />", () => {
 		renderWithProviders(<MemberItem {...props} />);
 		expect(screen.getByText("bob")).toBeInTheDocument();
 		expect(
-			screen.queryByRole("button", { name: "Edit" }),
+			screen.queryByRole("button", { name: "edit member" }),
 		).not.toBeInTheDocument();
 		expect(
-			screen.queryByRole("button", { name: "Remove" }),
+			screen.queryByRole("button", { name: "remove member" }),
 		).not.toBeInTheDocument();
 	});
 
 	it("should show modification button when [canModify=true]", () => {
 		props.canModify = true;
 		renderWithProviders(<MemberItem {...props} />);
-		expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "edit member" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "remove member" }),
+		).toBeInTheDocument();
 	});
 
 	it("should call onEdit when edit icon is clicked", async () => {
 		props.canModify = true;
 		renderWithProviders(<MemberItem {...props} />);
 
-		await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+		await userEvent.click(screen.getByRole("button", { name: "edit member" }));
 		expect(props.onEdit).toHaveBeenCalledWith(props.id);
 	});
 
@@ -47,7 +51,9 @@ describe("<MemberItem />", () => {
 		props.canModify = true;
 		renderWithProviders(<MemberItem {...props} />);
 
-		await userEvent.click(screen.getByRole("button", { name: "Remove" }));
+		await userEvent.click(
+			screen.getByRole("button", { name: "remove member" }),
+		);
 		expect(props.onRemove).toHaveBeenCalledWith(props.id);
 	});
 });


### PR DESCRIPTION
## Summary
- Replace the text Edit/Remove buttons in the reference users and groups lists with Pencil and Trash icon buttons, matching the labels list
- Update `MemberItem` tests to target the new accessible names ("edit member"/"remove member") instead of button text