### PR TITLE
chore: replace deprecated inputValidator with validator

### DIFF
--- a/apps/web/src/server/auth/functions.ts
+++ b/apps/web/src/server/auth/functions.ts
@@ -46,7 +46,7 @@ const getClientIp = createServerOnlyFn((): string => {
 
 /** Login server function. Unauthenticated by necessity — this *creates* the session. */
 export const loginFn = createServerFn({ method: "POST" })
-	.inputValidator(loginSchema)
+	.validator(loginSchema)
 	.handler(async ({ data }) => {
 		try {
 			const result = await login(db, realCookies, {
@@ -78,7 +78,7 @@ export const loginFn = createServerFn({ method: "POST" })
  * session for the user it creates.
  */
 export const createFirstUserFn = createServerFn({ method: "POST" })
-	.inputValidator(createFirstUserSchema)
+	.validator(createFirstUserSchema)
 	.handler(async ({ data }) => {
 		try {
 			const user = await createFirstUser(db, realCookies, {
@@ -110,7 +110,7 @@ export const logoutFn = createServerFn({ method: "POST" }).handler(async () => {
  * carried by the `reset_code` returned from `loginFn`.
  */
 export const resetPasswordFn = createServerFn({ method: "POST" })
-	.inputValidator(resetPasswordSchema)
+	.validator(resetPasswordSchema)
 	.handler(async ({ data }) => {
 		try {
 			await resetPassword(db, realCookies, {

--- a/apps/web/src/server/groups/functions.ts
+++ b/apps/web/src/server/groups/functions.ts
@@ -68,13 +68,13 @@ export const listGroups = createServerFn({ method: "GET" }).handler(async () =>
 );
 
 export const findGroups = createServerFn({ method: "GET" })
-	.inputValidator(findGroupsSchema)
+	.validator(findGroupsSchema)
 	.handler(async ({ data }) =>
 		findGroupsImpl(data?.term ?? "", data?.page ?? 1, data?.per_page ?? 25),
 	);
 
 export const getGroup = createServerFn({ method: "GET" })
-	.inputValidator(groupIdSchema)
+	.validator(groupIdSchema)
 	.handler(async ({ data }) => {
 		try {
 			return await getGroupImpl(data.groupId);
@@ -84,7 +84,7 @@ export const getGroup = createServerFn({ method: "GET" })
 	});
 
 export const createGroup = createServerFn({ method: "POST" })
-	.inputValidator(createGroupSchema)
+	.validator(createGroupSchema)
 	.handler(async ({ data }) => {
 		try {
 			const group = await createGroupImpl(data.name);
@@ -96,7 +96,7 @@ export const createGroup = createServerFn({ method: "POST" })
 	});
 
 export const updateGroup = createServerFn({ method: "POST" })
-	.inputValidator(updateGroupSchema)
+	.validator(updateGroupSchema)
 	.handler(async ({ data }) => {
 		const { groupId, ...values } = data;
 		try {
@@ -107,7 +107,7 @@ export const updateGroup = createServerFn({ method: "POST" })
 	});
 
 export const deleteGroup = createServerFn({ method: "POST" })
-	.inputValidator(groupIdSchema)
+	.validator(groupIdSchema)
 	.handler(async ({ data }) => {
 		try {
 			await deleteGroupImpl(data.groupId);

--- a/apps/web/src/server/jobs/functions.ts
+++ b/apps/web/src/server/jobs/functions.ts
@@ -34,11 +34,11 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 });
 
 export const findJobs = createServerFn({ method: "GET" })
-	.inputValidator(findJobsSchema)
+	.validator(findJobsSchema)
 	.handler(async ({ data }) => findJobsImpl(db, data));
 
 export const getJob = createServerFn({ method: "GET" })
-	.inputValidator(jobIdSchema)
+	.validator(jobIdSchema)
 	.handler(async ({ data }) => {
 		try {
 			return await getJobImpl(db, data.jobId);

--- a/apps/web/src/server/labels/functions.ts
+++ b/apps/web/src/server/labels/functions.ts
@@ -56,11 +56,11 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 });
 
 export const findLabels = createServerFn({ method: "GET" })
-	.inputValidator(findLabelsSchema)
+	.validator(findLabelsSchema)
 	.handler(async ({ data }) => findLabelsImpl(db, data?.term ?? ""));
 
 export const getLabel = createServerFn({ method: "GET" })
-	.inputValidator(labelIdSchema)
+	.validator(labelIdSchema)
 	.handler(async ({ data }) => {
 		try {
 			return await getLabelImpl(db, data.labelId);
@@ -70,7 +70,7 @@ export const getLabel = createServerFn({ method: "GET" })
 	});
 
 export const createLabel = createServerFn({ method: "POST" })
-	.inputValidator(labelValuesSchema)
+	.validator(labelValuesSchema)
 	.handler(async ({ data }) => {
 		try {
 			const label = await createLabelImpl(db, normalizeValues(data));
@@ -82,7 +82,7 @@ export const createLabel = createServerFn({ method: "POST" })
 	});
 
 export const updateLabel = createServerFn({ method: "POST" })
-	.inputValidator(labelIdSchema.extend(labelValuesSchema.partial().shape))
+	.validator(labelIdSchema.extend(labelValuesSchema.partial().shape))
 	.handler(async ({ data }) => {
 		const { labelId, ...values } = data;
 		try {
@@ -93,7 +93,7 @@ export const updateLabel = createServerFn({ method: "POST" })
 	});
 
 export const deleteLabel = createServerFn({ method: "POST" })
-	.inputValidator(labelIdSchema)
+	.validator(labelIdSchema)
 	.handler(async ({ data }) => {
 		try {
 			await deleteLabelImpl(db, data.labelId);

--- a/apps/web/src/server/messages/functions.ts
+++ b/apps/web/src/server/messages/functions.ts
@@ -56,7 +56,7 @@ export const findMessages = createServerFn({ method: "GET" }).handler(
 );
 
 export const createMessage = createServerFn({ method: "POST" })
-	.inputValidator(createMessageSchema)
+	.validator(createMessageSchema)
 	.handler(async ({ data }) => {
 		const session = await requireSession();
 		await requireAdminRole(session, "settings");
@@ -70,7 +70,7 @@ export const createMessage = createServerFn({ method: "POST" })
 	});
 
 export const updateMessage = createServerFn({ method: "POST" })
-	.inputValidator(updateMessageSchema)
+	.validator(updateMessageSchema)
 	.handler(async ({ data }) => {
 		const session = await requireSession();
 		await requireAdminRole(session, "settings");
@@ -86,7 +86,7 @@ export const updateMessage = createServerFn({ method: "POST" })
 	});
 
 export const deleteMessage = createServerFn({ method: "POST" })
-	.inputValidator(idSchema)
+	.validator(idSchema)
 	.handler(async ({ data }) => {
 		const session = await requireSession();
 		await requireAdminRole(session, "settings");
@@ -100,7 +100,7 @@ export const deleteMessage = createServerFn({ method: "POST" })
 	});
 
 export const setActiveMessage = createServerFn({ method: "POST" })
-	.inputValidator(idSchema)
+	.validator(idSchema)
 	.handler(async ({ data }) => {
 		const session = await requireSession();
 		await requireAdminRole(session, "settings");

--- a/apps/web/src/server/tasks/functions.ts
+++ b/apps/web/src/server/tasks/functions.ts
@@ -20,7 +20,7 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 });
 
 export const getTask = createServerFn({ method: "GET" })
-	.inputValidator(taskIdSchema)
+	.validator(taskIdSchema)
 	.handler(async ({ data }) => {
 		try {
 			return await getTaskImpl(data.taskId);

--- a/apps/web/src/server/users/functions.ts
+++ b/apps/web/src/server/users/functions.ts
@@ -102,7 +102,7 @@ export const listAdministratorRoles = createServerFn({ method: "GET" }).handler(
 );
 
 export const findUsers = createServerFn({ method: "GET" })
-	.inputValidator(findUsersSchema)
+	.validator(findUsersSchema)
 	.handler(async ({ data }) => {
 		await requireAdminRole(await requireSession(), "users");
 		return findUsersImpl(db, {
@@ -115,7 +115,7 @@ export const findUsers = createServerFn({ method: "GET" })
 	});
 
 export const getUser = createServerFn({ method: "GET" })
-	.inputValidator(userIdSchema)
+	.validator(userIdSchema)
 	.handler(async ({ data }) => {
 		await requireAdminRole(await requireSession(), "users");
 		try {
@@ -128,7 +128,7 @@ export const getUser = createServerFn({ method: "GET" })
 	});
 
 export const createUser = createServerFn({ method: "POST" })
-	.inputValidator(createUserSchema)
+	.validator(createUserSchema)
 	.handler(async ({ data }) => {
 		await requireAdminRole(await requireSession(), "users");
 
@@ -148,7 +148,7 @@ export const createUser = createServerFn({ method: "POST" })
 	});
 
 export const updateUser = createServerFn({ method: "POST" })
-	.inputValidator(updateUserSchema)
+	.validator(updateUserSchema)
 	.handler(async ({ data }) => {
 		const session = await requireSession();
 		await requireAdminRole(session, "users");
@@ -172,7 +172,7 @@ export const updateUser = createServerFn({ method: "POST" })
 	});
 
 export const updateAccountHandle = createServerFn({ method: "POST" })
-	.inputValidator(accountHandleSchema)
+	.validator(accountHandleSchema)
 	.handler(async ({ data }) => {
 		const session = await requireSession();
 
@@ -188,7 +188,7 @@ export const updateAccountHandle = createServerFn({ method: "POST" })
 	});
 
 export const setAdministratorRole = createServerFn({ method: "POST" })
-	.inputValidator(setAdministratorRoleSchema)
+	.validator(setAdministratorRoleSchema)
 	.handler(async ({ data }) => {
 		const session = await requireSession();
 		await requireAdminRole(session, "full");


### PR DESCRIPTION
## Summary
- TanStack Start deprecated `createServerFn().inputValidator()` in favor of `.validator()`; this updates all remaining call sites so we're not building against a removed API.
- Renames `inputValidator` to `validator` across `auth`, `groups`, `jobs`, `labels`, `messages`, `tasks`, and `users` server functions.
- No behavior change — schemas and handlers are untouched.