### PR TITLE
fix: keep reference list item height consistent across states

### DIFF
--- a/apps/web/src/references/components/ReferenceItem.tsx
+++ b/apps/web/src/references/components/ReferenceItem.tsx
@@ -63,7 +63,7 @@ export function ReferenceItem({ onClone, reference }: ReferenceItemProps) {
 				{name}
 			</Link>
 			<Attribution time={created_at} user={user.handle} />
-			<div className="flex justify-end">{end}</div>
+			<div className="flex h-10 items-center justify-end">{end}</div>
 		</BoxGroupSection>
 	);
 }


### PR DESCRIPTION
## Summary
- Fixed reference list items visually jumping in height when toggling between active and archived states
- Gave the trailing action area a fixed height so it no longer shrinks when its content is empty