### PR TITLE
fix: polish quick analyze dialog and shared select menus

### DIFF
--- a/apps/web/src/administration/components/AdministratorRoleSelect.tsx
+++ b/apps/web/src/administration/components/AdministratorRoleSelect.tsx
@@ -31,7 +31,7 @@ export default function AdministratorRoleSelect({
 				id={id}
 				placeholder="Select administrator role"
 			/>
-			<SelectContent position="popper" align="start">
+			<SelectContent>
 				{roles.map((role) => (
 					<SelectItem
 						value={role.id}

--- a/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
@@ -128,6 +128,7 @@ export default function CreateAnalysisForm({
 						indexes={indexes}
 						selected={value}
 						onChange={onChange}
+						invalid={Boolean(errors.indexId)}
 					/>
 				)}
 				rules={{ required: true }}

--- a/apps/web/src/analyses/components/Create/IndexSelector.tsx
+++ b/apps/web/src/analyses/components/Create/IndexSelector.tsx
@@ -5,6 +5,8 @@ import Label from "@base/Label";
 import Select from "@base/Select";
 import SelectButton from "@base/SelectButton";
 import SelectContent from "@base/SelectContent";
+import { SelectItemIndicator } from "@base/SelectItem";
+import { selectItemStateClasses } from "@base/styles";
 import type { IndexMinimal } from "@indexes/types";
 import { sortBy } from "es-toolkit";
 import { ChevronDown, Library } from "lucide-react";
@@ -25,14 +27,17 @@ function IndexSelectorItem({ id, name, version }: IndexSelectorItemProps) {
 				"flex",
 				"items-center",
 				"justify-between",
+				"gap-2",
 				"py-1.5",
 				"px-6",
 				"text-base",
-				"hover:bg-gray-100",
+				selectItemStateClasses,
 			)}
+			data-slot="select-item"
 			key={id}
 			value={id}
 		>
+			<SelectItemIndicator />
 			<SelectPrimitive.ItemText className="whitespace-nowrap">
 				{name}
 			</SelectPrimitive.ItemText>
@@ -47,6 +52,8 @@ type IndexSelectorProps = {
 	indexes: IndexMinimal[];
 	selected: string;
 	onChange: (value: string) => void;
+	/** Whether the field is in an invalid state (e.g. required but empty) */
+	invalid?: boolean;
 };
 
 /**
@@ -56,6 +63,7 @@ export default function IndexSelector({
 	indexes,
 	selected,
 	onChange,
+	invalid,
 }: IndexSelectorProps) {
 	const sortedIndexes = sortBy(indexes, [(index) => index.reference.name]);
 
@@ -74,13 +82,12 @@ export default function IndexSelector({
 			{indexes.length ? (
 				<Select value={selected} onValueChange={onChange}>
 					<SelectButton
+						aria-invalid={invalid}
 						className={cn("flex", "w-full")}
 						placeholder="Select a reference"
 						icon={ChevronDown}
 					/>
-					<SelectContent position="popper" align="start">
-						{indexItems}
-					</SelectContent>
+					<SelectContent>{indexItems}</SelectContent>
 				</Select>
 			) : (
 				<Box>

--- a/apps/web/src/analyses/components/Create/SelectedSamples.tsx
+++ b/apps/web/src/analyses/components/Create/SelectedSamples.tsx
@@ -17,7 +17,7 @@ export function SelectedSamples({ samples }: SelectedSamplesProps) {
 	return (
 		<>
 			<CreateAnalysisFieldTitle>
-				Compatible Samples <Badge>{samples.length}</Badge>
+				Selected Samples <Badge>{samples.length}</Badge>
 			</CreateAnalysisFieldTitle>
 			<div
 				className={cn(

--- a/apps/web/src/base/ComboBox.tsx
+++ b/apps/web/src/base/ComboBox.tsx
@@ -5,6 +5,7 @@ import type { ReactElement } from "react";
 import WrapRow from "./ComboBoxItem";
 import Icon from "./Icon";
 import InputSearch from "./InputSearch";
+import { inputHeightClass } from "./styles";
 
 function ComboboxTriggerButton({
 	TriggerButtonProps,
@@ -15,7 +16,10 @@ function ComboboxTriggerButton({
 }) {
 	return (
 		<button
-			className="flex justify-between items-center px-2.5 py-2 bg-white border border-gray-300 rounded font-medium capitalize w-full [&_svg]:ml-1"
+			className={cn(
+				"flex justify-between items-center px-2.5 bg-white border border-gray-300 rounded font-medium capitalize w-full [&_svg]:ml-1",
+				inputHeightClass,
+			)}
 			{...TriggerButtonProps}
 			id={id}
 			type="button"

--- a/apps/web/src/base/Dialog.tsx
+++ b/apps/web/src/base/Dialog.tsx
@@ -1,6 +1,13 @@
 import { cn } from "@app/utils";
 import { Dialog as DialogPrimitive } from "radix-ui";
-import type { ReactElement, ReactNode } from "react";
+import { type ReactElement, type ReactNode, useRef } from "react";
+
+/**
+ * Whether a viewport point falls within a rectangle, inclusive of its edges.
+ */
+function isPointWithinRect(x: number, y: number, rect: DOMRect): boolean {
+	return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+}
 
 export const Dialog = DialogPrimitive.Root;
 export const DialogClose = DialogPrimitive.Close;
@@ -39,10 +46,28 @@ export function DialogContent({
 	className,
 	size,
 }: DialogContentProps) {
+	const contentRef = useRef<HTMLDivElement>(null);
+
 	return (
 		<DialogPrimitive.Portal>
 			<DialogOverlay />
 			<DialogPrimitive.Content
+				ref={contentRef}
+				onPointerDownOutside={(event) => {
+					// An open popover-style child (e.g. a Radix Select) sets
+					// pointer-events:none on this content while it is open, so a
+					// press on the dialog's own body falls through to the
+					// full-screen overlay and reads as an outside press that would
+					// close the dialog. A genuine outside press lands beyond the
+					// content box, so ignore any press whose coordinates are inside
+					// it — the child popover closes, the dialog stays open.
+					const { clientX, clientY } = event.detail.originalEvent;
+					const rect = contentRef.current?.getBoundingClientRect();
+
+					if (rect && isPointWithinRect(clientX, clientY, rect)) {
+						event.preventDefault();
+					}
+				}}
 				className={cn(
 					"data-[state=open]:animate-contentShow",
 					"data-[state=closed]:animate-contentHide",

--- a/apps/web/src/base/Input.tsx
+++ b/apps/web/src/base/Input.tsx
@@ -6,6 +6,7 @@ import {
 	inputBaseClasses,
 	inputErrorClasses,
 	inputFocusClasses,
+	inputHeightClass,
 } from "./styles";
 
 export interface InputProps {
@@ -64,6 +65,7 @@ export default function Input({
 			autoFocus={autoFocus}
 			className={cn(
 				inputBaseClasses,
+				Component !== "textarea" && inputHeightClass,
 				error ? inputErrorClasses : inputFocusClasses,
 				{
 					"read-only:bg-gray-100": Component !== "select",

--- a/apps/web/src/base/InputSimple.tsx
+++ b/apps/web/src/base/InputSimple.tsx
@@ -1,6 +1,10 @@
 import { cn } from "@app/utils";
 import React from "react";
-import { inputBaseClasses, inputFocusClasses } from "./styles";
+import {
+	inputBaseClasses,
+	inputFocusClasses,
+	inputHeightClass,
+} from "./styles";
 
 export interface InputSimpleProps
 	extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -15,6 +19,7 @@ const InputSimple = React.forwardRef<HTMLInputElement, InputSimpleProps>(
 				ref={ref}
 				className={cn(
 					inputBaseClasses,
+					inputHeightClass,
 					inputFocusClasses,
 					"read-only:bg-gray-100",
 					className,

--- a/apps/web/src/base/MultiSelectComboBox.tsx
+++ b/apps/web/src/base/MultiSelectComboBox.tsx
@@ -141,6 +141,7 @@ export default function MultiSelectComboBox<Item>({
 						"flex-wrap",
 						"items-center",
 						"gap-1.5",
+						"min-h-10",
 						"bg-white",
 						"border",
 						"border-gray-300",

--- a/apps/web/src/base/MultiSelectComboBox.tsx
+++ b/apps/web/src/base/MultiSelectComboBox.tsx
@@ -146,7 +146,7 @@ export default function MultiSelectComboBox<Item>({
 						"border-gray-300",
 						"rounded",
 						"px-2",
-						"py-1.5",
+						"py-2",
 						"focus-within:border-blue-500",
 						"focus-within:ring",
 						"focus-within:ring-blue-500/30",

--- a/apps/web/src/base/SelectButton.tsx
+++ b/apps/web/src/base/SelectButton.tsx
@@ -22,7 +22,7 @@ export default function SelectButton({
 		<SelectPrimitive.Trigger
 			aria-label={ariaLabel}
 			className={cn(
-				"flex justify-between items-center px-2.5 py-1.5 bg-white border border-gray-300 rounded font-medium capitalize [&_svg]:ml-1",
+				"flex justify-between items-center px-2.5 py-2 bg-white border border-gray-300 rounded font-medium capitalize [&_svg]:ml-1",
 				className,
 			)}
 			id={id}

--- a/apps/web/src/base/SelectButton.tsx
+++ b/apps/web/src/base/SelectButton.tsx
@@ -2,6 +2,8 @@ import { cn } from "@app/utils";
 import Icon from "@base/Icon";
 import type { LucideIcon } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
+import type { AriaAttributes } from "react";
+import { inputFocusClasses, inputHeightClass } from "./styles";
 
 type SelectButtonProps = {
 	placeholder?: string;
@@ -9,6 +11,8 @@ type SelectButtonProps = {
 	icon: LucideIcon;
 	id?: string;
 	"aria-label"?: string;
+	/** Marks the trigger invalid, turning its border and focus ring red */
+	"aria-invalid"?: AriaAttributes["aria-invalid"];
 };
 
 export default function SelectButton({
@@ -17,14 +21,21 @@ export default function SelectButton({
 	className,
 	id,
 	"aria-label": ariaLabel,
+	"aria-invalid": ariaInvalid,
 }: SelectButtonProps) {
 	return (
 		<SelectPrimitive.Trigger
+			aria-invalid={ariaInvalid}
 			aria-label={ariaLabel}
 			className={cn(
-				"flex justify-between items-center px-2.5 py-2 bg-white border border-gray-300 rounded font-medium capitalize [&_svg]:ml-1",
+				"flex justify-between items-center px-2.5 bg-white border rounded font-medium capitalize [&_svg]:ml-1",
+				inputHeightClass,
+				inputFocusClasses,
+				"data-[placeholder]:text-gray-400",
+				"aria-invalid:border-red-500 aria-invalid:focus-visible:border-red-500 aria-invalid:focus-visible:ring-2 aria-invalid:focus-visible:ring-red-500/50",
 				className,
 			)}
+			data-slot="select-trigger"
 			id={id}
 		>
 			<SelectPrimitive.Value placeholder={placeholder} />

--- a/apps/web/src/base/SelectContent.tsx
+++ b/apps/web/src/base/SelectContent.tsx
@@ -1,16 +1,18 @@
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
+import type { ReactNode } from "react";
 import Icon from "./Icon";
 
-export default function SelectContent({ children, position, align }) {
+type SelectContentProps = {
+	children: ReactNode;
+};
+
+export default function SelectContent({ children }: SelectContentProps) {
 	return (
 		<SelectPrimitive.Portal>
 			<SelectPrimitive.Content
-				className="origin-top animate-contentOpen bg-white rounded-md shadow-md overflow-hidden z-50 max-h-[var(--radix-select-content-available-height)] min-w-[var(--radix-select-trigger-width)] first:mt-2.5"
-				position={position}
-				align={align}
-				side="bottom"
-				avoidCollisions={false}
+				className="origin-top bg-white rounded-md border border-gray-300 shadow-md overflow-hidden z-50 max-h-96 min-w-32 data-[state=open]:animate-contentShow data-[state=closed]:animate-contentHide"
+				data-slot="select-content"
 			>
 				<SelectPrimitive.ScrollUpButton className="my-1 flex justify-center hover:bg-gray-50">
 					<Icon icon={ChevronUp} />

--- a/apps/web/src/base/SelectContent.tsx
+++ b/apps/web/src/base/SelectContent.tsx
@@ -11,7 +11,7 @@ export default function SelectContent({ children }: SelectContentProps) {
 	return (
 		<SelectPrimitive.Portal>
 			<SelectPrimitive.Content
-				className="origin-top bg-white rounded-md border border-gray-300 shadow-md overflow-hidden z-50 max-h-96 min-w-32 data-[state=open]:animate-contentShow data-[state=closed]:animate-contentHide"
+				className="origin-top bg-white rounded-md border border-gray-300 shadow-md overflow-hidden z-50 max-h-96 min-w-32 data-[state=open]:animate-contentShow"
 				data-slot="select-content"
 			>
 				<SelectPrimitive.ScrollUpButton className="my-1 flex justify-center hover:bg-gray-50">

--- a/apps/web/src/base/SelectContent.tsx
+++ b/apps/web/src/base/SelectContent.tsx
@@ -17,7 +17,9 @@ export default function SelectContent({ children }: SelectContentProps) {
 				<SelectPrimitive.ScrollUpButton className="my-1 flex justify-center hover:bg-gray-50">
 					<Icon icon={ChevronUp} />
 				</SelectPrimitive.ScrollUpButton>
-				<SelectPrimitive.Viewport>{children}</SelectPrimitive.Viewport>
+				<SelectPrimitive.Viewport className="p-1">
+					{children}
+				</SelectPrimitive.Viewport>
 				<SelectPrimitive.ScrollDownButton className="my-1 flex justify-center hover:bg-gray-50">
 					<Icon icon={ChevronDown} />
 				</SelectPrimitive.ScrollDownButton>

--- a/apps/web/src/base/SelectItem.tsx
+++ b/apps/web/src/base/SelectItem.tsx
@@ -51,7 +51,7 @@ export default function SelectItem({
 	return (
 		<SelectPrimitive.Item
 			className={cn(
-				"font-medium flex flex-col items-start py-1.5 pr-9 pl-6 mb-1 capitalize",
+				"font-medium flex flex-col items-start py-1.5 pr-9 pl-6 capitalize",
 				selectItemStateClasses,
 			)}
 			data-slot="select-item"

--- a/apps/web/src/base/SelectItem.tsx
+++ b/apps/web/src/base/SelectItem.tsx
@@ -4,13 +4,30 @@ import { Select as SelectPrimitive } from "radix-ui";
 import type { ReactNode } from "react";
 import { selectItemStateClasses } from "./styles";
 
+/** Props for the Select item check mark. */
+type SelectItemIndicatorProps = {
+	/**
+	 * Vertical placement classes. Defaults to centering on the item, which is
+	 * correct for single-line items. Items that render more than one line pass
+	 * an offset and height matching their first line instead.
+	 */
+	className?: string;
+};
+
 /**
  * The check mark shown on the currently-selected Select item. Positioned in the
  * left gutter that every Select item reserves with `pl-6`.
  */
-export function SelectItemIndicator() {
+export function SelectItemIndicator({
+	className = "top-1/2 -translate-y-1/2",
+}: SelectItemIndicatorProps) {
 	return (
-		<SelectPrimitive.ItemIndicator className="absolute left-1.5 top-1/2 -translate-y-1/2 inline-flex items-center text-blue-500">
+		<SelectPrimitive.ItemIndicator
+			className={cn(
+				"absolute left-1.5 inline-flex items-center text-blue-500",
+				className,
+			)}
+		>
 			<Check size={14} />
 		</SelectPrimitive.ItemIndicator>
 	);
@@ -34,14 +51,14 @@ export default function SelectItem({
 	return (
 		<SelectPrimitive.Item
 			className={cn(
-				"text-sm font-medium flex flex-col items-start py-1.5 pr-9 pl-6 mb-1 capitalize",
+				"font-medium flex flex-col items-start py-1.5 pr-9 pl-6 mb-1 capitalize",
 				selectItemStateClasses,
 			)}
 			data-slot="select-item"
 			value={value}
 			key={value}
 		>
-			<SelectItemIndicator />
+			<SelectItemIndicator className="top-1.5 h-6" />
 			<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
 			{description && (
 				<div className="text-xs font-normal text-gray-600 mt-1 whitespace-pre-wrap">

--- a/apps/web/src/base/SelectItem.tsx
+++ b/apps/web/src/base/SelectItem.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@app/utils";
 import { Check } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
+import type { ReactNode } from "react";
 import { selectItemStateClasses } from "./styles";
 
 /**
@@ -15,7 +16,21 @@ export function SelectItemIndicator() {
 	);
 }
 
-export default function SelectItem({ value, children, description }) {
+/** Props for the shared Select item. */
+type SelectItemProps = {
+	/** The item's label, rendered as the selected value on the trigger. */
+	children: ReactNode;
+	/** An optional description rendered on a second line beneath the label. */
+	description?: string;
+	/** The value committed to the Select when the item is chosen. */
+	value: string;
+};
+
+export default function SelectItem({
+	value,
+	children,
+	description,
+}: SelectItemProps) {
 	return (
 		<SelectPrimitive.Item
 			className={cn(

--- a/apps/web/src/base/SelectItem.tsx
+++ b/apps/web/src/base/SelectItem.tsx
@@ -1,12 +1,32 @@
+import { cn } from "@app/utils";
+import { Check } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
+import { selectItemStateClasses } from "./styles";
+
+/**
+ * The check mark shown on the currently-selected Select item. Positioned in the
+ * left gutter that every Select item reserves with `pl-6`.
+ */
+export function SelectItemIndicator() {
+	return (
+		<SelectPrimitive.ItemIndicator className="absolute left-1.5 top-1/2 -translate-y-1/2 inline-flex items-center text-blue-500">
+			<Check size={14} />
+		</SelectPrimitive.ItemIndicator>
+	);
+}
 
 export default function SelectItem({ value, children, description }) {
 	return (
 		<SelectPrimitive.Item
-			className="text-sm font-medium flex flex-col items-start py-1.5 pr-9 pl-6 relative select-none mb-1 capitalize hover:bg-gray-50 hover:border-0"
+			className={cn(
+				"text-sm font-medium flex flex-col items-start py-1.5 pr-9 pl-6 mb-1 capitalize",
+				selectItemStateClasses,
+			)}
+			data-slot="select-item"
 			value={value}
 			key={value}
 		>
+			<SelectItemIndicator />
 			<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
 			{description && (
 				<div className="text-xs font-normal text-gray-600 mt-1 whitespace-pre-wrap">

--- a/apps/web/src/base/styles.ts
+++ b/apps/web/src/base/styles.ts
@@ -1,6 +1,13 @@
 /** Base classes shared by Input and InputSimple */
 export const inputBaseClasses =
-	"bg-white border rounded min-w-0 block h-auto outline-none py-2 px-2.5 relative transition-[color,box-shadow] w-full placeholder:text-gray-400 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50";
+	"bg-white border rounded min-w-0 block outline-none py-2 px-2.5 relative transition-[color,box-shadow] w-full placeholder:text-gray-400 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50";
+
+/**
+ * Explicit height shared by single-line form controls (text inputs, the Select
+ * and ComboBox triggers) so they line up. Multi-line controls (textarea) and
+ * chip containers use `min-h-10` instead so they can grow.
+ */
+export const inputHeightClass = "h-10";
 
 /** Focus ring for inputs in normal (non-error) state */
 export const inputFocusClasses =
@@ -9,6 +16,15 @@ export const inputFocusClasses =
 /** Focus ring + border for inputs in error state */
 export const inputErrorClasses =
 	"border-red-500 focus-visible:border-red-500 focus-visible:ring-2 focus-visible:ring-red-500/50";
+
+/**
+ * Interaction and state classes shared by every Select item so hover,
+ * keyboard-highlight, and disabled treatments stay consistent across the shared
+ * item and the inline item renderings. Layout (padding, flex direction) is left
+ * to each item.
+ */
+export const selectItemStateClasses =
+	"relative select-none outline-none cursor-default hover:bg-gray-100 data-[highlighted]:bg-gray-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50";
 
 import type { IconColor } from "./types";
 

--- a/apps/web/src/samples/components/Create/SampleUserGroup.tsx
+++ b/apps/web/src/samples/components/Create/SampleUserGroup.tsx
@@ -1,13 +1,17 @@
 import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
-import InputSelect from "@base/InputSelect";
+import Select from "@base/Select";
+import SelectButton from "@base/SelectButton";
+import SelectContent from "@base/SelectContent";
+import SelectItem from "@base/SelectItem";
 import type { GroupMinimal } from "@groups/types";
+import { ChevronDown } from "lucide-react";
 
 type SampleUserGroupProps = {
 	selected: string;
 	groups: GroupMinimal[];
 	/** A callback function to handle the user group change */
-	onChange: () => void;
+	onChange: (value: string) => void;
 };
 
 /**
@@ -18,21 +22,22 @@ export default function SampleUserGroup({
 	groups,
 	onChange,
 }: SampleUserGroupProps) {
-	const groupComponents = groups.map((group) => (
-		<option className="capitalize" key={group.id} value={group.id}>
-			{group.name}
-		</option>
-	));
-
 	return (
 		<InputGroup>
 			<InputLabel htmlFor="userGroups">User Group</InputLabel>
-			<InputSelect id="userGroups" value={selected} onChange={onChange}>
-				<option key="none" value="none">
-					None
-				</option>
-				{groupComponents}
-			</InputSelect>
+			<Select value={selected || "none"} onValueChange={onChange}>
+				<SelectButton className="w-full" icon={ChevronDown} id="userGroups" />
+				<SelectContent>
+					<SelectItem key="none" value="none">
+						None
+					</SelectItem>
+					{groups.map((group) => (
+						<SelectItem key={group.id} value={String(group.id)}>
+							{group.name}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
 		</InputGroup>
 	);
 }

--- a/apps/web/src/samples/components/Create/SampleUserGroup.tsx
+++ b/apps/web/src/samples/components/Create/SampleUserGroup.tsx
@@ -7,6 +7,12 @@ import SelectItem from "@base/SelectItem";
 import type { GroupMinimal } from "@groups/types";
 import { ChevronDown } from "lucide-react";
 
+/**
+ * Stands in for an unset group. Radix reserves the empty string, so the absence
+ * of a group can't be modelled by the item's value directly.
+ */
+const noGroup = "none";
+
 type SampleUserGroupProps = {
 	selected: string;
 	groups: GroupMinimal[];
@@ -25,10 +31,13 @@ export default function SampleUserGroup({
 	return (
 		<InputGroup>
 			<InputLabel htmlFor="userGroups">User Group</InputLabel>
-			<Select value={selected || "none"} onValueChange={onChange}>
+			<Select
+				value={selected || noGroup}
+				onValueChange={(value) => onChange(value === noGroup ? "" : value)}
+			>
 				<SelectButton className="w-full" icon={ChevronDown} id="userGroups" />
 				<SelectContent>
-					<SelectItem key="none" value="none">
+					<SelectItem key={noGroup} value={noGroup}>
 						None
 					</SelectItem>
 					{groups.map((group) => (

--- a/apps/web/src/samples/components/Create/__tests__/SampleUserGroup.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/SampleUserGroup.test.tsx
@@ -1,3 +1,4 @@
+import type { GroupMinimal } from "@groups/types";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeGroupMinimal } from "@tests/fake/groups";
@@ -7,10 +8,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import SampleUserGroup from "../SampleUserGroup";
 
 describe("SampleUserGroup", () => {
+	let group: GroupMinimal;
 	let props: ComponentProps<typeof SampleUserGroup>;
+
 	beforeEach(() => {
+		group = createFakeGroupMinimal({ name: "bar" });
 		props = {
-			groups: [createFakeGroupMinimal({ name: "bar" })],
+			groups: [group],
 			onChange: vi.fn(),
 			selected: "",
 		};
@@ -20,14 +24,24 @@ describe("SampleUserGroup", () => {
 		renderWithProviders(<SampleUserGroup {...props} />);
 
 		expect(screen.getByLabelText("User Group")).toBeInTheDocument();
-		expect(screen.getByText("None")).toBeInTheDocument();
-		expect(screen.getByText("bar")).toBeInTheDocument();
+		expect(screen.getByRole("combobox")).toHaveTextContent("None");
 	});
-	it("should call onChange input is changed", async () => {
+
+	it("should show the group options when opened", async () => {
 		renderWithProviders(<SampleUserGroup {...props} />);
 
-		await userEvent.selectOptions(screen.getByLabelText("User Group"), "bar");
+		await userEvent.click(screen.getByLabelText("User Group"));
 
-		expect(props.onChange).toHaveBeenCalled();
+		expect(screen.getByRole("option", { name: "None" })).toBeInTheDocument();
+		expect(screen.getByRole("option", { name: "bar" })).toBeInTheDocument();
+	});
+
+	it("should call onChange when a group is selected", async () => {
+		renderWithProviders(<SampleUserGroup {...props} />);
+
+		await userEvent.click(screen.getByLabelText("User Group"));
+		await userEvent.click(screen.getByRole("option", { name: "bar" }));
+
+		expect(props.onChange).toHaveBeenCalledWith(String(group.id));
 	});
 });

--- a/apps/web/src/samples/components/Create/__tests__/SampleUserGroup.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/SampleUserGroup.test.tsx
@@ -44,4 +44,15 @@ describe("SampleUserGroup", () => {
 
 		expect(props.onChange).toHaveBeenCalledWith(String(group.id));
 	});
+
+	it("should call onChange with an empty value when None is selected", async () => {
+		renderWithProviders(
+			<SampleUserGroup {...props} selected={String(group.id)} />,
+		);
+
+		await userEvent.click(screen.getByLabelText("User Group"));
+		await userEvent.click(screen.getByRole("option", { name: "None" }));
+
+		expect(props.onChange).toHaveBeenCalledWith("");
+	});
 });

--- a/apps/web/src/sequences/components/SequenceSegmentField.tsx
+++ b/apps/web/src/sequences/components/SequenceSegmentField.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@app/utils";
 import Box from "@base/Box";
 import Icon from "@base/Icon";
 import InputGroup from "@base/InputGroup";
@@ -6,7 +7,8 @@ import Link from "@base/Link";
 import Select from "@base/Select";
 import SelectButton from "@base/SelectButton";
 import SelectContent from "@base/SelectContent";
-import SelectItem from "@base/SelectItem";
+import SelectItem, { SelectItemIndicator } from "@base/SelectItem";
+import { selectItemStateClasses } from "@base/styles";
 import type { OtuSegment } from "@otus/types";
 import { ChevronDown, CircleAlert } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
@@ -34,10 +36,15 @@ type SequenceSegmentProps = {
 function SequenceSegment({ name, required }: SequenceSegmentProps) {
 	return (
 		<SelectPrimitive.Item
-			className="text-sm font-medium py-1 pl-6 pr-9 relative select-none mb-1 capitalize hover:bg-gray-50 hover:border-0"
+			className={cn(
+				"text-sm font-medium py-1 pl-6 pr-9 mb-1 capitalize",
+				selectItemStateClasses,
+			)}
+			data-slot="select-item"
 			value={name}
 			key={name}
 		>
+			<SelectItemIndicator />
 			<SelectPrimitive.ItemText>
 				<div className="flex items-center font-medium w-full">
 					<span>{name}</span>
@@ -97,7 +104,7 @@ export default function SequenceSegmentField({
 									}
 								>
 									<SelectButton icon={ChevronDown} />
-									<SelectContent position="popper" align="start">
+									<SelectContent>
 										<SelectItem key="None" value="None" description="">
 											None
 										</SelectItem>

--- a/apps/web/src/sequences/components/SequenceSegmentField.tsx
+++ b/apps/web/src/sequences/components/SequenceSegmentField.tsx
@@ -37,7 +37,7 @@ function SequenceSegment({ name, required }: SequenceSegmentProps) {
 	return (
 		<SelectPrimitive.Item
 			className={cn(
-				"text-sm font-medium py-1 pl-6 pr-9 mb-1 capitalize",
+				"font-medium py-1.5 pl-6 pr-9 mb-1 capitalize",
 				selectItemStateClasses,
 			)}
 			data-slot="select-item"
@@ -105,7 +105,7 @@ export default function SequenceSegmentField({
 								>
 									<SelectButton icon={ChevronDown} />
 									<SelectContent>
-										<SelectItem key="None" value="None" description="">
+										<SelectItem key="None" value="None">
 											None
 										</SelectItem>
 										{segmentOptions}

--- a/apps/web/src/sequences/components/SequenceSegmentField.tsx
+++ b/apps/web/src/sequences/components/SequenceSegmentField.tsx
@@ -37,7 +37,7 @@ function SequenceSegment({ name, required }: SequenceSegmentProps) {
 	return (
 		<SelectPrimitive.Item
 			className={cn(
-				"font-medium py-1.5 pl-6 pr-9 mb-1 capitalize",
+				"font-medium py-1.5 pl-6 pr-9 capitalize",
 				selectItemStateClasses,
 			)}
 			data-slot="select-item"


### PR DESCRIPTION
## Summary
- Align select/combobox triggers with text inputs (shared height, focus ring, invalid state, muted placeholder) and fix inconsistent option sizing, spacing, and checkmark alignment across every shared Select menu
- Stop an open select inside a dialog from causing the dialog itself to close, and drop the select menu's broken close animation
- Fix saving a sample with no group: choosing "None" was submitting the literal string "none" instead of clearing the group