### PR TITLE
fix: scope quick analyze to the clicked sample

### DIFF
--- a/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
@@ -134,11 +134,11 @@ export default function CreateAnalysisForm({
 				rules={{ required: true }}
 			/>
 
-			<InputError className="-mt-6 mb-1">
+			<InputError className="mb-0">
 				{errors.indexId && "A reference must be selected"}
 			</InputError>
 
-			<DialogFooter className="items-center justify-between mt-2.5 [&_button]:ml-auto">
+			<DialogFooter className="items-center justify-between">
 				<CreateAnalysisSummary
 					sampleCount={sampleCount}
 					indexCount={watch("indexId") ? 1 : 0}

--- a/apps/web/src/analyses/components/Create/IndexSelector.tsx
+++ b/apps/web/src/analyses/components/Create/IndexSelector.tsx
@@ -77,7 +77,7 @@ export default function IndexSelector({
 	));
 
 	return (
-		<div className="mb-8">
+		<div>
 			<CreateAnalysisFieldTitle>Reference</CreateAnalysisFieldTitle>
 			{indexes.length ? (
 				<Select value={selected} onValueChange={onChange}>
@@ -90,7 +90,7 @@ export default function IndexSelector({
 					<SelectContent>{indexItems}</SelectContent>
 				</Select>
 			) : (
-				<Box>
+				<Box className="mb-0">
 					<Empty className="py-12">
 						<EmptyMedia className="text-gray-400">
 							<Library size={40} strokeWidth={1.5} />

--- a/apps/web/src/analyses/components/Create/QuickAnalyze.tsx
+++ b/apps/web/src/analyses/components/Create/QuickAnalyze.tsx
@@ -2,7 +2,6 @@ import { Dialog, DialogTitle } from "@base/Dialog";
 import QueryError from "@base/QueryError";
 import { useListHmms } from "@hmm/queries";
 import type { SampleMinimal } from "@samples/types";
-import { useEffect } from "react";
 import HMMAlert from "../HMMAlert";
 import CreateAnalysisDialogContent from "./CreateAnalysisDialogContent";
 import CreateAnalysisForm from "./CreateAnalysisForm";
@@ -11,16 +10,14 @@ import { getCompatibleWorkflows } from "./workflows";
 
 type QuickAnalyzeProps = {
 	open: boolean;
-	/** A callback function to clear selected samples */
-	onClear: () => void;
 	setOpen: (open: boolean) => void;
 
-	/** The selected samples */
+	/** The samples to analyze */
 	samples: SampleMinimal[];
 };
 
 /**
- * A form for triggering quick analyses on selected samples
+ * A form for triggering quick analyses on the passed samples
  */
 export default function QuickAnalyze({
 	open,
@@ -28,13 +25,6 @@ export default function QuickAnalyze({
 	setOpen,
 }: QuickAnalyzeProps) {
 	const { data: hmms, isPending, isError } = useListHmms(1, 1, "");
-
-	// The dialog should close when all selected samples have been analyzed and deselected.
-	useEffect(() => {
-		if (open && samples.length === 0) {
-			setOpen(false);
-		}
-	}, [open, samples, setOpen]);
 
 	if (isError && !hmms) {
 		return (

--- a/apps/web/src/analyses/components/Create/QuickAnalyze.tsx
+++ b/apps/web/src/analyses/components/Create/QuickAnalyze.tsx
@@ -9,6 +9,9 @@ import { SelectedSamples } from "./SelectedSamples";
 import { getCompatibleWorkflows } from "./workflows";
 
 type QuickAnalyzeProps = {
+	/** Whether the samples came from the list selection rather than a single sample */
+	fromSelection: boolean;
+
 	open: boolean;
 	setOpen: (open: boolean) => void;
 
@@ -20,6 +23,7 @@ type QuickAnalyzeProps = {
  * A form for triggering quick analyses on the passed samples
  */
 export default function QuickAnalyze({
+	fromSelection,
 	open,
 	samples,
 	setOpen,
@@ -51,7 +55,7 @@ export default function QuickAnalyze({
 				<DialogTitle>Quick Analyze</DialogTitle>
 				<HMMAlert installed={Boolean(hmms.status.task?.complete)} />
 
-				<SelectedSamples samples={samples} />
+				<SelectedSamples fromSelection={fromSelection} samples={samples} />
 
 				<CreateAnalysisForm
 					compatibleWorkflows={compatibleWorkflows}

--- a/apps/web/src/analyses/components/Create/SelectedSamples.tsx
+++ b/apps/web/src/analyses/components/Create/SelectedSamples.tsx
@@ -25,7 +25,7 @@ export function SelectedSamples({
 	samples,
 }: SelectedSamplesProps) {
 	return (
-		<>
+		<div className="mb-6">
 			<CreateAnalysisFieldTitle>
 				{fromSelection ? (
 					<>
@@ -36,7 +36,7 @@ export function SelectedSamples({
 				)}
 			</CreateAnalysisFieldTitle>
 			<div
-				className={cn("border", "border-gray-300", "mb-2", "rounded-sm", {
+				className={cn("border", "border-gray-300", "rounded-sm", {
 					"max-h-32 overflow-y-scroll": fromSelection,
 				})}
 			>
@@ -46,6 +46,6 @@ export function SelectedSamples({
 					</BoxGroupSection>
 				))}
 			</div>
-		</>
+		</div>
 	);
 }

--- a/apps/web/src/analyses/components/Create/SelectedSamples.tsx
+++ b/apps/web/src/analyses/components/Create/SelectedSamples.tsx
@@ -10,8 +10,8 @@ type SelectedSamplesProps = {
 
 	/**
 	 * Whether the samples came from the list selection rather than a single
-	 * sample. A selection is titled in the plural and counted, even when only one
-	 * sample is in it.
+	 * sample. A selection is titled in the plural, counted even when only one
+	 * sample is in it, and scrolls once it outgrows the dialog.
 	 */
 	fromSelection: boolean;
 };
@@ -36,14 +36,9 @@ export function SelectedSamples({
 				)}
 			</CreateAnalysisFieldTitle>
 			<div
-				className={cn(
-					"border",
-					"border-gray-300",
-					"mb-2",
-					"max-h-32",
-					"overflow-y-scroll",
-					"rounded-sm",
-				)}
+				className={cn("border", "border-gray-300", "mb-2", "rounded-sm", {
+					"max-h-32 overflow-y-scroll": fromSelection,
+				})}
 			>
 				{samples.map(({ id, name }) => (
 					<BoxGroupSection key={id} disabled>

--- a/apps/web/src/analyses/components/Create/SelectedSamples.tsx
+++ b/apps/web/src/analyses/components/Create/SelectedSamples.tsx
@@ -7,17 +7,33 @@ import CreateAnalysisFieldTitle from "./CreateAnalysisFieldTitle";
 type SelectedSamplesProps = {
 	/** The samples selected for the open quick analysis dialog. */
 	samples: SampleMinimal[];
+
+	/**
+	 * Whether the samples came from the list selection rather than a single
+	 * sample. A selection is titled in the plural and counted, even when only one
+	 * sample is in it.
+	 */
+	fromSelection: boolean;
 };
 
 /**
  * Displays the sample selected for the analyses that will be started by the open
  * quick analysis dialog.
  */
-export function SelectedSamples({ samples }: SelectedSamplesProps) {
+export function SelectedSamples({
+	fromSelection,
+	samples,
+}: SelectedSamplesProps) {
 	return (
 		<>
 			<CreateAnalysisFieldTitle>
-				Selected Samples <Badge>{samples.length}</Badge>
+				{fromSelection ? (
+					<>
+						Selected Samples <Badge>{samples.length}</Badge>
+					</>
+				) : (
+					"Selected Sample"
+				)}
 			</CreateAnalysisFieldTitle>
 			<div
 				className={cn(

--- a/apps/web/src/analyses/components/Create/SubtractionSelector.tsx
+++ b/apps/web/src/analyses/components/Create/SubtractionSelector.tsx
@@ -30,7 +30,7 @@ export default function SubtractionSelector({
 	}
 
 	return (
-		<div className="mb-8">
+		<div className="mb-6">
 			<MultiSelectComboBox<SubtractionOption>
 				label="Subtractions"
 				items={results}

--- a/apps/web/src/analyses/components/Create/WorkflowSelector.tsx
+++ b/apps/web/src/analyses/components/Create/WorkflowSelector.tsx
@@ -24,14 +24,14 @@ export default function WorkflowSelector({
 	onChange,
 }: WorkflowSelectorProps) {
 	return (
-		<div>
+		<div className="mb-6">
 			<CreateAnalysisFieldTitle>Workflow</CreateAnalysisFieldTitle>
 			<RadioGroup
 				aria-label="Workflow"
 				value={selected}
 				onValueChange={onChange}
 			>
-				<BoxGroup>
+				<BoxGroup className="mb-0">
 					{workflows.map((workflow) => (
 						<BoxGroupSection
 							key={workflow.id}

--- a/apps/web/src/analyses/components/Create/WorkflowSelector.tsx
+++ b/apps/web/src/analyses/components/Create/WorkflowSelector.tsx
@@ -1,7 +1,4 @@
-import BoxGroup from "@base/BoxGroup";
-import BoxGroupSection from "@base/BoxGroupSection";
-import { RadioGroup, RadioGroupItem } from "@base/RadioGroup";
-import CreateAnalysisFieldTitle from "./CreateAnalysisFieldTitle";
+import { SelectBox, SelectBoxItem } from "@base/SelectBox";
 import type { workflow } from "./workflows";
 
 type WorkflowSelectorProps = {
@@ -16,7 +13,7 @@ type WorkflowSelectorProps = {
 };
 
 /**
- * A radio group for choosing which analysis workflow to run.
+ * A boxed picker for choosing which analysis workflow to run.
  */
 export default function WorkflowSelector({
 	workflows,
@@ -25,32 +22,19 @@ export default function WorkflowSelector({
 }: WorkflowSelectorProps) {
 	return (
 		<div className="mb-6">
-			<CreateAnalysisFieldTitle>Workflow</CreateAnalysisFieldTitle>
-			<RadioGroup
-				aria-label="Workflow"
-				value={selected}
+			<SelectBox
+				className="grid-cols-2"
+				label="Workflow"
 				onValueChange={onChange}
+				value={selected}
 			>
-				<BoxGroup className="mb-0">
-					{workflows.map((workflow) => (
-						<BoxGroupSection
-							key={workflow.id}
-							className="flex items-center gap-3"
-						>
-							<RadioGroupItem
-								id={`workflow-${workflow.id}`}
-								value={workflow.id}
-							/>
-							<label
-								htmlFor={`workflow-${workflow.id}`}
-								className="grow cursor-pointer"
-							>
-								{workflow.name}
-							</label>
-						</BoxGroupSection>
-					))}
-				</BoxGroup>
-			</RadioGroup>
+				{workflows.map(({ description, id, name }) => (
+					<SelectBoxItem key={id} value={id}>
+						<div>{name}</div>
+						<span>{description}</span>
+					</SelectBoxItem>
+				))}
+			</SelectBox>
 		</div>
 	);
 }

--- a/apps/web/src/analyses/components/Create/__tests__/WorkflowSelector.test.tsx
+++ b/apps/web/src/analyses/components/Create/__tests__/WorkflowSelector.test.tsx
@@ -6,6 +6,9 @@ import { describe, expect, it } from "vitest";
 import WorkflowSelector from "../WorkflowSelector";
 import { nuvsWorkflow, pathoscopeWorkflow } from "../workflows";
 
+const pathoscopeName = `${pathoscopeWorkflow.name} ${pathoscopeWorkflow.description}`;
+const nuvsName = `${nuvsWorkflow.name} ${nuvsWorkflow.description}`;
+
 function Harness() {
 	const [selected, setSelected] = useState(pathoscopeWorkflow.id);
 
@@ -23,24 +26,33 @@ describe("<WorkflowSelector>", () => {
 		renderWithProviders(<Harness />);
 
 		expect(screen.getByRole("radiogroup", { name: "Workflow" })).toBeVisible();
-		expect(screen.getByRole("radio", { name: "Pathoscope" })).toBeChecked();
-		expect(screen.getByRole("radio", { name: "NuVs" })).not.toBeChecked();
+		expect(screen.getByRole("radio", { name: pathoscopeName })).toBeChecked();
+		expect(screen.getByRole("radio", { name: nuvsName })).not.toBeChecked();
+	});
+
+	it("describes what each workflow finds", () => {
+		renderWithProviders(<Harness />);
+
+		expect(screen.getByText("Find known viruses.")).toBeVisible();
+		expect(screen.getByText("Find novel viruses.")).toBeVisible();
 	});
 
 	it("selects a workflow when its option is chosen", async () => {
 		renderWithProviders(<Harness />);
 
-		await userEvent.click(screen.getByRole("radio", { name: "NuVs" }));
+		await userEvent.click(screen.getByRole("radio", { name: nuvsName }));
 
-		expect(screen.getByRole("radio", { name: "NuVs" })).toBeChecked();
-		expect(screen.getByRole("radio", { name: "Pathoscope" })).not.toBeChecked();
+		expect(screen.getByRole("radio", { name: nuvsName })).toBeChecked();
+		expect(
+			screen.getByRole("radio", { name: pathoscopeName }),
+		).not.toBeChecked();
 	});
 
-	it("selects a workflow when its label is clicked", async () => {
+	it("selects a workflow when its name is clicked", async () => {
 		renderWithProviders(<Harness />);
 
-		await userEvent.click(screen.getByText("NuVs"));
+		await userEvent.click(screen.getByText(nuvsWorkflow.name));
 
-		expect(screen.getByRole("radio", { name: "NuVs" })).toBeChecked();
+		expect(screen.getByRole("radio", { name: nuvsName })).toBeChecked();
 	});
 });

--- a/apps/web/src/analyses/components/Create/workflows.ts
+++ b/apps/web/src/analyses/components/Create/workflows.ts
@@ -1,14 +1,17 @@
 export type workflow = {
+	description: string;
 	id: string;
 	name: string;
 };
 
 export const pathoscopeWorkflow = {
+	description: "Find known viruses.",
 	id: "pathoscope",
 	name: "Pathoscope",
 };
 
 export const nuvsWorkflow = {
+	description: "Find novel viruses.",
 	id: "nuvs",
 	name: "NuVs",
 };

--- a/apps/web/src/base/IconButton.tsx
+++ b/apps/web/src/base/IconButton.tsx
@@ -4,6 +4,8 @@ import Tooltip from "./Tooltip";
 import type { IconColor } from "./types";
 
 export type IconButtonProps = {
+	/** Accessible name for the button. Defaults to ``tip``. */
+	ariaLabel?: string;
 	className?: string;
 	color?: IconColor;
 	IconComponent: LucideIcon;
@@ -17,6 +19,7 @@ export type IconButtonProps = {
  * A styled clickable icon with tooltip describing its action
  */
 export default function IconButton({
+	ariaLabel,
 	className,
 	color = "black",
 	IconComponent,
@@ -55,7 +58,7 @@ export default function IconButton({
 				},
 				className,
 			)}
-			aria-label={tip}
+			aria-label={ariaLabel ?? tip}
 			type="button"
 			onClick={onClick}
 		>

--- a/apps/web/src/base/SelectBox.tsx
+++ b/apps/web/src/base/SelectBox.tsx
@@ -21,7 +21,7 @@ export function SelectBox({
 	const labelId = useId();
 
 	return (
-		<div className="mb-4">
+		<div>
 			<InputLabel id={labelId}>{label}</InputLabel>
 			<ToggleGroup.Root
 				aria-labelledby={labelId}

--- a/apps/web/src/references/components/CreateReference.tsx
+++ b/apps/web/src/references/components/CreateReference.tsx
@@ -30,24 +30,26 @@ export function CreateReference({ open, onOpenChange }: CreateReferenceProps) {
 		<Dialog open={open} onOpenChange={handleOpenChange}>
 			<DialogContent size="lg">
 				<DialogTitle>Create Reference</DialogTitle>
-				<SelectBox
-					className="grid-cols-2"
-					label="Method"
-					onValueChange={(value) => setMode(value as "empty" | "import")}
-					value={mode}
-				>
-					<SelectBoxItem value="empty">
-						<div>Empty</div>
-						<span>Start from a blank reference.</span>
-					</SelectBoxItem>
-					<SelectBoxItem value="import">
-						<div>Import</div>
-						<span>
-							Create a reference from a file previously exported from another
-							Virtool reference.
-						</span>
-					</SelectBoxItem>
-				</SelectBox>
+				<div className="mb-4">
+					<SelectBox
+						className="grid-cols-2"
+						label="Method"
+						onValueChange={(value) => setMode(value as "empty" | "import")}
+						value={mode}
+					>
+						<SelectBoxItem value="empty">
+							<div>Empty</div>
+							<span>Start from a blank reference.</span>
+						</SelectBoxItem>
+						<SelectBoxItem value="import">
+							<div>Import</div>
+							<span>
+								Create a reference from a file previously exported from another
+								Virtool reference.
+							</span>
+						</SelectBoxItem>
+					</SelectBox>
+				</div>
 				<CreateReferenceForm mode={mode} onSuccess={handleSuccess} />
 			</DialogContent>
 		</Dialog>

--- a/apps/web/src/samples/components/Item/EndIcon.tsx
+++ b/apps/web/src/samples/components/Item/EndIcon.tsx
@@ -5,6 +5,9 @@ import { ChartArea } from "lucide-react";
 import { cn } from "@/app/utils";
 
 type SampleItemEndIconProps = {
+	/** Accessible name for the quick analyze button */
+	ariaLabel: string;
+
 	/** Progress of the job responsible for creating the sample */
 	progress: number;
 
@@ -25,6 +28,7 @@ type SampleItemEndIconProps = {
  * Icon indicating the status of sample
  */
 export default function SampleItemEndIcon({
+	ariaLabel,
 	onClick,
 	ready,
 	progress,
@@ -40,6 +44,7 @@ export default function SampleItemEndIcon({
 		return (
 			<div className={containerClasses}>
 				<IconButton
+					ariaLabel={ariaLabel}
 					className="text-lg"
 					color="green"
 					IconComponent={ChartArea}

--- a/apps/web/src/samples/components/Item/SampleItem.tsx
+++ b/apps/web/src/samples/components/Item/SampleItem.tsx
@@ -19,9 +19,8 @@ type SampleItemProps = {
 	/** Callback to handle sample selection */
 	handleSelect: () => void;
 
-	/** Callback to handle sample selection on end icon quick analysis */
-	selectOnQuickAnalyze: () => void;
-	setOpenQuickAnalyze: (open: boolean) => void;
+	/** Callback to open a quick analysis scoped to this sample */
+	onQuickAnalyze: () => void;
 };
 
 /**
@@ -31,20 +30,15 @@ export default function SampleItem({
 	sample,
 	checked,
 	handleSelect,
-	selectOnQuickAnalyze,
-	setOpenQuickAnalyze,
+	onQuickAnalyze,
 }: SampleItemProps) {
-	function onQuickAnalyze() {
-		selectOnQuickAnalyze();
-		setOpenQuickAnalyze(true);
-	}
-
 	const { data: job } = useFetchJob(sample.job?.id ?? Number.NaN, sample.job);
 
 	return (
 		<Box className="flex items-stretch basis-0 gap-4">
 			<div className="flex">
 				<Checkbox
+					ariaLabel={`Select ${sample.name}`}
 					checked={checked}
 					id={`SampleCheckbox${sample.id}`}
 					onClick={handleSelect}
@@ -66,6 +60,7 @@ export default function SampleItem({
 							<WorkflowTags id={sample.id} workflows={sample.workflows} />
 						)}
 						<EndIcon
+							ariaLabel={`Quick analyze ${sample.name}`}
 							progress={job?.progress ?? 0}
 							state={job?.state}
 							onClick={onQuickAnalyze}

--- a/apps/web/src/samples/components/SampleSelectionToolbar.tsx
+++ b/apps/web/src/samples/components/SampleSelectionToolbar.tsx
@@ -5,9 +5,12 @@ import { AreaChart } from "lucide-react";
 type SampleSelectionToolbarProps = {
 	/** A callback function to clear selected samples */
 	onClear: () => void;
+
+	/** A callback to open a quick analysis scoped to the selected samples */
+	onQuickAnalyze: () => void;
+
 	/** A list of selected samples */
 	selected: string[];
-	setOpenQuickAnalyze: (open: boolean) => void;
 };
 
 /**
@@ -15,15 +18,15 @@ type SampleSelectionToolbarProps = {
  */
 export default function SampleSelectionToolbar({
 	onClear,
+	onQuickAnalyze,
 	selected,
-	setOpenQuickAnalyze,
 }: SampleSelectionToolbarProps) {
 	return (
 		<div className="flex items-center mb-4 [&_button]:h-10 [&_button:first-child]:flex [&_button:first-child]:flex-1 [&_button:first-child]:items-center [&_button:first-child]:justify-start [&_button:first-child]:mr-0.5">
 			<Button onClick={onClear}>
 				Clear selection of {selected.length} samples
 			</Button>
-			<Button color="green" onClick={() => setOpenQuickAnalyze(true)}>
+			<Button color="green" onClick={onQuickAnalyze}>
 				<Icon icon={AreaChart} /> Quick Analyze
 			</Button>
 		</div>

--- a/apps/web/src/samples/components/SamplesList.tsx
+++ b/apps/web/src/samples/components/SamplesList.tsx
@@ -19,6 +19,13 @@ import SampleItem from "./Item/SampleItem";
 import SampleToolbar from "./SamplesToolbar";
 import SampleLabels from "./Sidebar/ManageLabels";
 
+type QuickAnalyzeTarget = {
+	/** Whether the samples came from the list selection rather than a single sample */
+	fromSelection: boolean;
+
+	samples: SampleMinimal[];
+};
+
 type SamplesListProps = {
 	labels: Label[];
 	filterLabels?: number[];
@@ -54,14 +61,13 @@ export default function SamplesList({
 
 	const [selected, setSelected] = useState<string[]>([]);
 	const [openQuickAnalyze, setOpenQuickAnalyze] = useState(false);
-	const [quickAnalyzeSamples, setQuickAnalyzeSamples] = useState<
-		SampleMinimal[]
-	>([]);
+	const [quickAnalyzeTarget, setQuickAnalyzeTarget] =
+		useState<QuickAnalyzeTarget>({ fromSelection: false, samples: [] });
 
 	// Held separately from ``selected`` so a row's quick analyze can ignore the
 	// checkbox selection, and so the samples outlive the dialog's exit animation.
-	function openQuickAnalyzeFor(samples: SampleMinimal[]) {
-		setQuickAnalyzeSamples(samples);
+	function openQuickAnalyzeFor(target: QuickAnalyzeTarget) {
+		setQuickAnalyzeTarget(target);
 		setOpenQuickAnalyze(true);
 	}
 
@@ -92,7 +98,9 @@ export default function SamplesList({
 				sample={item}
 				checked={selected.includes(item.id)}
 				handleSelect={handleSelect}
-				onQuickAnalyze={() => openQuickAnalyzeFor([item])}
+				onQuickAnalyze={() =>
+					openQuickAnalyzeFor({ fromSelection: false, samples: [item] })
+				}
 			/>
 		);
 	}
@@ -100,9 +108,10 @@ export default function SamplesList({
 	return (
 		<>
 			<QuickAnalyze
+				fromSelection={quickAnalyzeTarget.fromSelection}
 				open={openQuickAnalyze}
 				setOpen={setOpenQuickAnalyze}
-				samples={quickAnalyzeSamples}
+				samples={quickAnalyzeTarget.samples}
 			/>
 			<div
 				className="grid gap-4"
@@ -119,7 +128,12 @@ export default function SamplesList({
 					<SampleToolbar
 						selected={selected}
 						onClear={() => setSelected([])}
-						onQuickAnalyze={() => openQuickAnalyzeFor(selectedSamples)}
+						onQuickAnalyze={() =>
+							openQuickAnalyzeFor({
+								fromSelection: true,
+								samples: selectedSamples,
+							})
+						}
 						term={term}
 						onChange={(e) => setSearch({ term: e.target.value })}
 					/>

--- a/apps/web/src/samples/components/SamplesList.tsx
+++ b/apps/web/src/samples/components/SamplesList.tsx
@@ -11,7 +11,7 @@ import { useListIndexes } from "@indexes/queries";
 import type { Label } from "@labels/types";
 import { useListSamples } from "@samples/queries";
 import type { SampleMinimal } from "@samples/types";
-import { intersectionWith, union, xor } from "es-toolkit/array";
+import { intersectionWith, xor } from "es-toolkit/array";
 import { FlaskConical, SearchX } from "lucide-react";
 import { useState } from "react";
 import SampleFilters from "./Filter/SampleFilters";
@@ -54,6 +54,16 @@ export default function SamplesList({
 
 	const [selected, setSelected] = useState<string[]>([]);
 	const [openQuickAnalyze, setOpenQuickAnalyze] = useState(false);
+	const [quickAnalyzeSamples, setQuickAnalyzeSamples] = useState<
+		SampleMinimal[]
+	>([]);
+
+	// Held separately from ``selected`` so a row's quick analyze can ignore the
+	// checkbox selection, and so the samples outlive the dialog's exit animation.
+	function openQuickAnalyzeFor(samples: SampleMinimal[]) {
+		setQuickAnalyzeSamples(samples);
+		setOpenQuickAnalyze(true);
+	}
 
 	if ((isErrorSamples || isErrorIndexes) && !samples) {
 		return <QueryError noun="samples" />;
@@ -65,15 +75,15 @@ export default function SamplesList({
 
 	const { items, page, page_count, total_count } = samples;
 
+	const selectedSamples = intersectionWith(
+		items,
+		selected,
+		(item, id) => item.id === id,
+	);
+
 	function renderRow(item: SampleMinimal) {
 		function handleSelect() {
 			setSelected(xor(selected, [item.id]));
-		}
-
-		function selectOnQuickAnalyze() {
-			if (!selected.includes(item.id)) {
-				setSelected(union(selected, [item.id]));
-			}
 		}
 
 		return (
@@ -82,8 +92,7 @@ export default function SamplesList({
 				sample={item}
 				checked={selected.includes(item.id)}
 				handleSelect={handleSelect}
-				selectOnQuickAnalyze={selectOnQuickAnalyze}
-				setOpenQuickAnalyze={setOpenQuickAnalyze}
+				onQuickAnalyze={() => openQuickAnalyzeFor([item])}
 			/>
 		);
 	}
@@ -92,13 +101,8 @@ export default function SamplesList({
 		<>
 			<QuickAnalyze
 				open={openQuickAnalyze}
-				onClear={() => setSelected([])}
 				setOpen={setOpenQuickAnalyze}
-				samples={intersectionWith(
-					items,
-					selected,
-					(item, id) => item.id === id,
-				)}
+				samples={quickAnalyzeSamples}
 			/>
 			<div
 				className="grid gap-4"
@@ -115,7 +119,7 @@ export default function SamplesList({
 					<SampleToolbar
 						selected={selected}
 						onClear={() => setSelected([])}
-						setOpenQuickAnalyze={setOpenQuickAnalyze}
+						onQuickAnalyze={() => openQuickAnalyzeFor(selectedSamples)}
 						term={term}
 						onChange={(e) => setSearch({ term: e.target.value })}
 					/>
@@ -151,14 +155,7 @@ export default function SamplesList({
 					)}
 				</div>
 				{selected.length ? (
-					<SampleLabels
-						labels={labels}
-						selectedSamples={intersectionWith(
-							items,
-							selected,
-							(item, id) => item.id === id,
-						)}
-					/>
+					<SampleLabels labels={labels} selectedSamples={selectedSamples} />
 				) : (
 					<SampleFilters
 						labels={labels}

--- a/apps/web/src/samples/components/SamplesToolbar.tsx
+++ b/apps/web/src/samples/components/SamplesToolbar.tsx
@@ -2,9 +2,15 @@ import { useCheckAdminRoleOrPermission } from "@administration/hooks";
 import InputSearch from "@base/InputSearch";
 import LinkButton from "@base/LinkButton";
 import Toolbar from "@base/Toolbar";
+import type { ChangeEvent } from "react";
 import SampleSelectionToolbar from "./SampleSelectionToolbar";
 
-function SampleSearchToolbar({ onChange, term }) {
+type SampleSearchToolbarProps = {
+	onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+	term: string;
+};
+
+function SampleSearchToolbar({ onChange, term }: SampleSearchToolbarProps) {
 	const { hasPermission: canCreate } =
 		useCheckAdminRoleOrPermission("create_sample");
 
@@ -26,6 +32,17 @@ function SampleSearchToolbar({ onChange, term }) {
 	);
 }
 
+type SampleToolbarProps = SampleSearchToolbarProps & {
+	/** A callback function to clear selected samples */
+	onClear: () => void;
+
+	/** A callback to open a quick analysis scoped to the selected samples */
+	onQuickAnalyze: () => void;
+
+	/** A list of selected samples */
+	selected: string[];
+};
+
 /**
  * A toolbar allowing samples to be filtered by name and to create an analysis for selected samples
  */
@@ -33,14 +50,14 @@ export default function SampleToolbar({
 	selected,
 	onClear,
 	onChange,
-	setOpenQuickAnalyze,
+	onQuickAnalyze,
 	term,
-}) {
+}: SampleToolbarProps) {
 	return selected.length ? (
 		<SampleSelectionToolbar
 			selected={selected}
 			onClear={onClear}
-			setOpenQuickAnalyze={setOpenQuickAnalyze}
+			onQuickAnalyze={onQuickAnalyze}
 		/>
 	) : (
 		<SampleSearchToolbar onChange={onChange} term={term} />

--- a/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
+++ b/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
@@ -126,6 +126,41 @@ describe("<SamplesList />", () => {
 			).not.toBeInTheDocument();
 		});
 
+		it("should title a single clicked sample without a count", async () => {
+			await renderWithRouter(<SamplesList labels={labels} />, path);
+			expect(await screen.findByText("Samples")).toBeInTheDocument();
+
+			await userEvent.click(
+				screen.getByRole("button", {
+					name: `Quick analyze ${at(samples, 0).name}`,
+				}),
+			);
+
+			const dialog = await screen.findByRole("dialog");
+
+			expect(within(dialog).getByText("Selected Sample")).toBeInTheDocument();
+			expect(
+				within(dialog).queryByText("Selected Samples"),
+			).not.toBeInTheDocument();
+		});
+
+		it("should count a single-sample selection from the toolbar", async () => {
+			await renderWithRouter(<SamplesList labels={labels} />, path);
+			expect(await screen.findByText("Samples")).toBeInTheDocument();
+
+			await userEvent.click(
+				screen.getByRole("checkbox", { name: `Select ${at(samples, 0).name}` }),
+			);
+			await userEvent.click(
+				screen.getByRole("button", { name: "Quick Analyze" }),
+			);
+
+			const dialog = await screen.findByRole("dialog");
+
+			const title = within(dialog).getByText("Selected Samples");
+			expect(within(title).getByText("1")).toBeInTheDocument();
+		});
+
 		it("should leave the existing selection intact after a row is analyzed", async () => {
 			await renderWithRouter(<SamplesList labels={labels} />, path);
 			expect(await screen.findByText("Samples")).toBeInTheDocument();
@@ -170,6 +205,9 @@ describe("<SamplesList />", () => {
 			);
 
 			const dialog = await screen.findByRole("dialog");
+
+			const title = within(dialog).getByText("Selected Samples");
+			expect(within(title).getByText("2")).toBeInTheDocument();
 
 			for (const sample of samples) {
 				expect(within(dialog).getByText(sample.name)).toBeInTheDocument();

--- a/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
+++ b/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeAccount, mockApiGetAccount } from "@tests/fake/account";
 import { createFakeHmmSearchResults, mockApiGetHmms } from "@tests/fake/hmm";
@@ -99,5 +99,81 @@ describe("<SamplesList />", () => {
 		expect(
 			screen.queryByRole("link", { name: "Create" }),
 		).not.toBeInTheDocument();
+	});
+
+	describe("quick analyze", () => {
+		it("should scope to the clicked sample, ignoring the selection", async () => {
+			await renderWithRouter(<SamplesList labels={labels} />, path);
+			expect(await screen.findByText("Samples")).toBeInTheDocument();
+
+			const selectedSample = at(samples, 0);
+			const clickedSample = at(samples, 1);
+
+			await userEvent.click(
+				screen.getByRole("checkbox", { name: `Select ${selectedSample.name}` }),
+			);
+			await userEvent.click(
+				screen.getByRole("button", {
+					name: `Quick analyze ${clickedSample.name}`,
+				}),
+			);
+
+			const dialog = await screen.findByRole("dialog");
+
+			expect(within(dialog).getByText(clickedSample.name)).toBeInTheDocument();
+			expect(
+				within(dialog).queryByText(selectedSample.name),
+			).not.toBeInTheDocument();
+		});
+
+		it("should leave the existing selection intact after a row is analyzed", async () => {
+			await renderWithRouter(<SamplesList labels={labels} />, path);
+			expect(await screen.findByText("Samples")).toBeInTheDocument();
+
+			const selectedSample = at(samples, 0);
+			const clickedSample = at(samples, 1);
+
+			await userEvent.click(
+				screen.getByRole("checkbox", { name: `Select ${selectedSample.name}` }),
+			);
+			await userEvent.click(
+				screen.getByRole("button", {
+					name: `Quick analyze ${clickedSample.name}`,
+				}),
+			);
+
+			expect(await screen.findByRole("dialog")).toBeInTheDocument();
+
+			await userEvent.keyboard("{Escape}");
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+			expect(
+				screen.getByRole("checkbox", { name: `Select ${selectedSample.name}` }),
+			).toBeChecked();
+			expect(
+				screen.getByRole("checkbox", { name: `Select ${clickedSample.name}` }),
+			).not.toBeChecked();
+		});
+
+		it("should include every selected sample when triggered from the toolbar", async () => {
+			await renderWithRouter(<SamplesList labels={labels} />, path);
+			expect(await screen.findByText("Samples")).toBeInTheDocument();
+
+			for (const sample of samples) {
+				await userEvent.click(
+					screen.getByRole("checkbox", { name: `Select ${sample.name}` }),
+				);
+			}
+
+			await userEvent.click(
+				screen.getByRole("button", { name: "Quick Analyze" }),
+			);
+
+			const dialog = await screen.findByRole("dialog");
+
+			for (const sample of samples) {
+				expect(within(dialog).getByText(sample.name)).toBeInTheDocument();
+			}
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- Quick analyzing a single sample row no longer merges it into the checkbox selection. The dialog is scoped to just that sample, and titles it "Selected Sample" with no count or scrollbar, while the selection toolbar keeps the plural title and count badge.
- Replaces the workflow radio list with the boxed `SelectBox` picker and describes what each workflow finds. Evens out the dialog's field spacing, which ran from 0 to 2rem and leaned on a negative margin.
- Row checkboxes and quick analyze buttons get sample-scoped accessible names, replacing the duplicate generic labels every row shared.