### PR TITLE
feat: select a range of samples with shift-click

### DIFF
--- a/apps/web/src/base/Checkbox.tsx
+++ b/apps/web/src/base/Checkbox.tsx
@@ -11,7 +11,7 @@ type CheckboxProps = {
 	labelComponent?: ReactNode;
 	disabled?: boolean;
 	id: string;
-	onClick?: (event: MouseEvent) => void;
+	onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 };
 
 function Checkbox({

--- a/apps/web/src/base/Checkbox.tsx
+++ b/apps/web/src/base/Checkbox.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@app/utils";
 import { Check, Minus } from "lucide-react";
 import { Checkbox as CheckboxPrimitive } from "radix-ui";
-import type { ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import Icon from "./Icon";
 
 type CheckboxProps = {
@@ -11,7 +11,7 @@ type CheckboxProps = {
 	labelComponent?: ReactNode;
 	disabled?: boolean;
 	id: string;
-	onClick?: () => void;
+	onClick?: (event: MouseEvent) => void;
 };
 
 function Checkbox({

--- a/apps/web/src/base/__tests__/useListSelection.test.ts
+++ b/apps/web/src/base/__tests__/useListSelection.test.ts
@@ -1,0 +1,332 @@
+import { act, renderHook } from "@testing-library/react";
+import { at } from "@tests/setup";
+import { describe, expect, it } from "vitest";
+import { useListSelection } from "../useListSelection";
+
+type Item = { id: number; name: string };
+
+function makeItems(count: number): Item[] {
+	return Array.from({ length: count }, (_unused, index) => ({
+		id: index + 1,
+		name: `Item ${index + 1}`,
+	}));
+}
+
+function setup(resetKey?: unknown) {
+	return renderHook(
+		(props: { resetKey?: unknown }) =>
+			useListSelection<Item>({
+				getKey: (item) => item.id,
+				resetKey: props.resetKey,
+			}),
+		{ initialProps: { resetKey } },
+	);
+}
+
+function selectedIds(selectedKeys: Set<string | number>): number[] {
+	return [...selectedKeys].map(Number).sort((a, b) => a - b);
+}
+
+describe("useListSelection()", () => {
+	it("starts with an empty selection", () => {
+		const { result } = setup();
+
+		expect(result.current.selected).toEqual([]);
+		expect(result.current.selectedKeys.size).toBe(0);
+	});
+
+	it("toggles a single item on and off", () => {
+		const items = makeItems(3);
+		const { result } = setup();
+
+		act(() => {
+			result.current.select(at(items, 0), {
+				shiftKey: false,
+				visibleItems: items,
+			});
+		});
+		expect(result.current.isSelected(at(items, 0))).toBe(true);
+		expect(result.current.selected).toHaveLength(1);
+
+		act(() => {
+			result.current.select(at(items, 0), {
+				shiftKey: false,
+				visibleItems: items,
+			});
+		});
+		expect(result.current.isSelected(at(items, 0))).toBe(false);
+		expect(result.current.selected).toHaveLength(0);
+	});
+
+	it("treats a shift-click with no anchor as a plain toggle", () => {
+		const items = makeItems(3);
+		const { result } = setup();
+
+		act(() => {
+			result.current.select(at(items, 1), {
+				shiftKey: true,
+				visibleItems: items,
+			});
+		});
+
+		expect(result.current.isSelected(at(items, 1))).toBe(true);
+		expect(result.current.selected).toHaveLength(1);
+	});
+
+	it("selects a contiguous range on a forward shift-click", () => {
+		const items = makeItems(4);
+		const { result } = setup();
+
+		act(() => {
+			result.current.select(at(items, 0), {
+				shiftKey: false,
+				visibleItems: items,
+			});
+		});
+		act(() => {
+			result.current.select(at(items, 2), {
+				shiftKey: true,
+				visibleItems: items,
+			});
+		});
+
+		expect(selectedIds(result.current.selectedKeys)).toEqual([1, 2, 3]);
+	});
+
+	it("selects the same range on a backward shift-click", () => {
+		const items = makeItems(4);
+		const { result } = setup();
+
+		act(() => {
+			result.current.select(at(items, 2), {
+				shiftKey: false,
+				visibleItems: items,
+			});
+		});
+		act(() => {
+			result.current.select(at(items, 0), {
+				shiftKey: true,
+				visibleItems: items,
+			});
+		});
+
+		expect(selectedIds(result.current.selectedKeys)).toEqual([1, 2, 3]);
+	});
+
+	it("deselects a range when the shift-clicked row is already selected", () => {
+		const items = makeItems(3);
+		const { result } = setup();
+
+		act(() => {
+			result.current.select(at(items, 0), {
+				shiftKey: false,
+				visibleItems: items,
+			});
+		});
+		act(() => {
+			result.current.select(at(items, 2), {
+				shiftKey: true,
+				visibleItems: items,
+			});
+		});
+		act(() => {
+			result.current.select(at(items, 0), {
+				shiftKey: true,
+				visibleItems: items,
+			});
+		});
+
+		expect(result.current.selected).toHaveLength(0);
+	});
+
+	it("re-anchors on the most recently shift-clicked row", () => {
+		const items = makeItems(5);
+		const { result } = setup();
+
+		// Select every row, moving the anchor to the last row.
+		act(() => {
+			result.current.select(at(items, 0), {
+				shiftKey: false,
+				visibleItems: items,
+			});
+		});
+		act(() => {
+			result.current.select(at(items, 4), {
+				shiftKey: true,
+				visibleItems: items,
+			});
+		});
+
+		// Shift-clicking a selected middle row deselects the range up to the anchor
+		// (the last row), not back to the original first-row anchor.
+		act(() => {
+			result.current.select(at(items, 2), {
+				shiftKey: true,
+				visibleItems: items,
+			});
+		});
+
+		expect(selectedIds(result.current.selectedKeys)).toEqual([1, 2]);
+	});
+
+	it("falls back to a plain toggle when the anchor is not visible", () => {
+		const page = makeItems(5);
+		const offPage = [
+			{ id: 6, name: "Item 6" },
+			{ id: 7, name: "Item 7" },
+		];
+		const { result } = setup();
+
+		act(() => {
+			result.current.select(at(page, 0), {
+				shiftKey: false,
+				visibleItems: page,
+			});
+		});
+		act(() => {
+			result.current.select(at(offPage, 1), {
+				shiftKey: true,
+				visibleItems: offPage,
+			});
+		});
+
+		expect(selectedIds(result.current.selectedKeys)).toEqual([1, 7]);
+	});
+
+	it("selects and clears all visible items, leaving off-page selections", () => {
+		const items = makeItems(3);
+		const offPage: Item = { id: 99, name: "Item 99" };
+		const { result } = setup();
+
+		act(() => {
+			result.current.setSelected([offPage]);
+		});
+		act(() => {
+			result.current.toggleVisible(items);
+		});
+		expect(selectedIds(result.current.selectedKeys)).toEqual([1, 2, 3, 99]);
+
+		act(() => {
+			result.current.toggleVisible(items);
+		});
+		expect(result.current.selected).toEqual([offPage]);
+	});
+
+	it("completes the selection when only some visible items are selected", () => {
+		const items = makeItems(3);
+		const { result } = setup();
+
+		act(() => {
+			result.current.select(at(items, 0), {
+				shiftKey: false,
+				visibleItems: items,
+			});
+		});
+		act(() => {
+			result.current.toggleVisible(items);
+		});
+
+		expect(result.current.selected).toHaveLength(3);
+	});
+
+	it("reports the tri-state of the visible items", () => {
+		const items = makeItems(3);
+		const { result } = setup();
+
+		expect(result.current.getVisibleState(items)).toBe(false);
+
+		act(() => {
+			result.current.select(at(items, 0), {
+				shiftKey: false,
+				visibleItems: items,
+			});
+		});
+		expect(result.current.getVisibleState(items)).toBe("indeterminate");
+
+		act(() => {
+			result.current.toggleVisible(items);
+		});
+		expect(result.current.getVisibleState(items)).toBe(true);
+	});
+
+	it("resets the selection and anchor when the reset key changes", () => {
+		const items = makeItems(3);
+		const { result, rerender } = setup("a");
+
+		act(() => {
+			result.current.select(at(items, 0), {
+				shiftKey: false,
+				visibleItems: items,
+			});
+		});
+		act(() => {
+			result.current.select(at(items, 2), {
+				shiftKey: true,
+				visibleItems: items,
+			});
+		});
+		expect(result.current.selected).toHaveLength(3);
+
+		rerender({ resetKey: "b" });
+		expect(result.current.selected).toEqual([]);
+
+		// A shift-click now has no anchor, so it behaves as a plain toggle.
+		act(() => {
+			result.current.select(at(items, 2), {
+				shiftKey: true,
+				visibleItems: items,
+			});
+		});
+		expect(result.current.selected).toHaveLength(1);
+	});
+
+	it("clears the selection and anchor", () => {
+		const items = makeItems(3);
+		const { result } = setup();
+
+		act(() => {
+			result.current.select(at(items, 0), {
+				shiftKey: false,
+				visibleItems: items,
+			});
+		});
+		act(() => {
+			result.current.clear();
+		});
+		expect(result.current.selected).toEqual([]);
+
+		act(() => {
+			result.current.select(at(items, 2), {
+				shiftKey: true,
+				visibleItems: items,
+			});
+		});
+		expect(result.current.selected).toHaveLength(1);
+	});
+
+	it("keeps key-based dedupe after patching items via setSelected", () => {
+		const items = makeItems(2);
+		const { result } = setup();
+
+		act(() => {
+			result.current.select(at(items, 0), {
+				shiftKey: false,
+				visibleItems: items,
+			});
+		});
+		act(() => {
+			result.current.setSelected((previous) =>
+				previous.map((item) => ({ ...item, name: "Patched" })),
+			);
+		});
+		expect(at(result.current.selected, 0).name).toBe("Patched");
+
+		act(() => {
+			result.current.select(at(items, 0), {
+				shiftKey: false,
+				visibleItems: items,
+			});
+		});
+		expect(result.current.isSelected(at(items, 0))).toBe(false);
+	});
+});

--- a/apps/web/src/base/useListSelection.ts
+++ b/apps/web/src/base/useListSelection.ts
@@ -104,35 +104,39 @@ export function useListSelection<T>({
 		const end = Math.max(anchorIndex, clickedIndex);
 		const range = visibleItems.slice(start, end + 1);
 		const rangeKeys = new Set(range.map(getKey));
-		const shouldSelect = !selectedKeys.has(clickedKey);
 
 		setSelected((previous) => {
-			if (shouldSelect) {
-				const existingKeys = new Set(previous.map(getKey));
-				return [
-					...previous,
-					...range.filter((candidate) => !existingKeys.has(getKey(candidate))),
-				];
+			const previousKeys = new Set(previous.map(getKey));
+
+			if (previousKeys.has(clickedKey)) {
+				return previous.filter(
+					(candidate) => !rangeKeys.has(getKey(candidate)),
+				);
 			}
 
-			return previous.filter((candidate) => !rangeKeys.has(getKey(candidate)));
+			return [
+				...previous,
+				...range.filter((candidate) => !previousKeys.has(getKey(candidate))),
+			];
 		});
 	}
 
 	function toggleVisible(visibleItems: T[]) {
 		const visibleKeys = new Set(visibleItems.map(getKey));
-		const allSelected = visibleItems.every((item) =>
-			selectedKeys.has(getKey(item)),
-		);
 
-		setSelected((previous) =>
-			allSelected
+		setSelected((previous) => {
+			const previousKeys = new Set(previous.map(getKey));
+			const allSelected = visibleItems.every((item) =>
+				previousKeys.has(getKey(item)),
+			);
+
+			return allSelected
 				? previous.filter((item) => !visibleKeys.has(getKey(item)))
 				: [
 						...previous,
-						...visibleItems.filter((item) => !selectedKeys.has(getKey(item))),
-					],
-		);
+						...visibleItems.filter((item) => !previousKeys.has(getKey(item))),
+					];
+		});
 	}
 
 	function getVisibleState(visibleItems: T[]): boolean | "indeterminate" {

--- a/apps/web/src/base/useListSelection.ts
+++ b/apps/web/src/base/useListSelection.ts
@@ -1,0 +1,165 @@
+import { type Dispatch, type SetStateAction, useState } from "react";
+
+/** A stable key identifying a selectable item — a string or numeric id. */
+type SelectionKey = string | number;
+
+/** Options for {@link useListSelection}. */
+type UseListSelectionOptions<T> = {
+	/** Derives the stable key used to identify and dedupe an item. */
+	getKey: (item: T) => SelectionKey;
+
+	/** When this value changes, the selection and the range anchor are reset. */
+	resetKey?: unknown;
+};
+
+/** Options passed when selecting an item. */
+type SelectOptions<T> = {
+	/** Whether the shift modifier was held, requesting a range extension. */
+	shiftKey: boolean;
+
+	/** The items currently rendered, in display order; the range operates over these. */
+	visibleItems: T[];
+};
+
+/** A headless multi-select for a list, with shift-click range selection. */
+type ListSelection<T> = {
+	/** The selected items, surviving changes to the visible items. */
+	selected: T[];
+
+	/** The keys of the selected items. */
+	selectedKeys: Set<SelectionKey>;
+
+	/** Whether an item is currently selected. */
+	isSelected: (item: T) => boolean;
+
+	/** Toggle an item, or extend the range from the anchor when shift is held. */
+	select: (item: T, options: SelectOptions<T>) => void;
+
+	/** Toggle every visible item as a group, leaving off-page selections alone. */
+	toggleVisible: (visibleItems: T[]) => void;
+
+	/** The tri-state of a select-all control over the visible items. */
+	getVisibleState: (visibleItems: T[]) => boolean | "indeterminate";
+
+	/** Replace the selection, e.g. to patch items after a mutation. */
+	setSelected: Dispatch<SetStateAction<T[]>>;
+
+	/** Clear the selection and the range anchor. */
+	clear: () => void;
+};
+
+/**
+ * Manages multi-selection for a list of items, including shift-click range
+ * selection anchored on the last clicked row.
+ *
+ * Selection follows the additive checkbox-list convention (Gmail, GitHub): a
+ * shift-click applies the clicked row's resulting checked state to every item
+ * between the anchor and the clicked row, and never disturbs selections outside
+ * that range — so selections made on other pages survive.
+ */
+export function useListSelection<T>({
+	getKey,
+	resetKey,
+}: UseListSelectionOptions<T>): ListSelection<T> {
+	const [selected, setSelected] = useState<T[]>([]);
+	const [anchorKey, setAnchorKey] = useState<SelectionKey | null>(null);
+	const [previousResetKey, setPreviousResetKey] = useState(resetKey);
+
+	if (previousResetKey !== resetKey) {
+		setPreviousResetKey(resetKey);
+		setSelected([]);
+		setAnchorKey(null);
+	}
+
+	const selectedKeys = new Set(selected.map(getKey));
+
+	function isSelected(item: T): boolean {
+		return selectedKeys.has(getKey(item));
+	}
+
+	function select(item: T, { shiftKey, visibleItems }: SelectOptions<T>) {
+		const clickedKey = getKey(item);
+		const anchorIndex =
+			anchorKey === null
+				? -1
+				: visibleItems.findIndex(
+						(candidate) => getKey(candidate) === anchorKey,
+					);
+		const clickedIndex = visibleItems.findIndex(
+			(candidate) => getKey(candidate) === clickedKey,
+		);
+
+		setAnchorKey(clickedKey);
+
+		if (!shiftKey || anchorIndex === -1 || clickedIndex === -1) {
+			setSelected((previous) =>
+				previous.some((candidate) => getKey(candidate) === clickedKey)
+					? previous.filter((candidate) => getKey(candidate) !== clickedKey)
+					: [...previous, item],
+			);
+			return;
+		}
+
+		const start = Math.min(anchorIndex, clickedIndex);
+		const end = Math.max(anchorIndex, clickedIndex);
+		const range = visibleItems.slice(start, end + 1);
+		const rangeKeys = new Set(range.map(getKey));
+		const shouldSelect = !selectedKeys.has(clickedKey);
+
+		setSelected((previous) => {
+			if (shouldSelect) {
+				const existingKeys = new Set(previous.map(getKey));
+				return [
+					...previous,
+					...range.filter((candidate) => !existingKeys.has(getKey(candidate))),
+				];
+			}
+
+			return previous.filter((candidate) => !rangeKeys.has(getKey(candidate)));
+		});
+	}
+
+	function toggleVisible(visibleItems: T[]) {
+		const visibleKeys = new Set(visibleItems.map(getKey));
+		const allSelected = visibleItems.every((item) =>
+			selectedKeys.has(getKey(item)),
+		);
+
+		setSelected((previous) =>
+			allSelected
+				? previous.filter((item) => !visibleKeys.has(getKey(item)))
+				: [
+						...previous,
+						...visibleItems.filter((item) => !selectedKeys.has(getKey(item))),
+					],
+		);
+	}
+
+	function getVisibleState(visibleItems: T[]): boolean | "indeterminate" {
+		const selectedCount = visibleItems.filter((item) =>
+			selectedKeys.has(getKey(item)),
+		).length;
+
+		if (selectedCount === 0) {
+			return false;
+		}
+
+		return selectedCount === visibleItems.length ? true : "indeterminate";
+	}
+
+	function clear() {
+		setSelected([]);
+		setAnchorKey(null);
+	}
+
+	return {
+		selected,
+		selectedKeys,
+		isSelected,
+		select,
+		toggleVisible,
+		getVisibleState,
+		setSelected,
+		clear,
+	};
+}

--- a/apps/web/src/samples/components/Item/SampleItem.tsx
+++ b/apps/web/src/samples/components/Item/SampleItem.tsx
@@ -4,6 +4,7 @@ import Checkbox from "@base/Checkbox";
 import Link from "@base/Link";
 import { useFetchJob } from "@jobs/queries";
 import type { SampleMinimal } from "@samples/types";
+import type { MouseEvent } from "react";
 import SampleLabel from "../Label/SampleLabel";
 import SampleLibraryTypeLabel from "../Label/SampleLibraryTypeLabel";
 import WorkflowTags from "../Tag/WorkflowTags";
@@ -16,8 +17,8 @@ type SampleItemProps = {
 	/** Whether the sample is selected */
 	checked: boolean;
 
-	/** Callback to handle sample selection */
-	handleSelect: () => void;
+	/** Callback to handle sample selection, receiving the checkbox click event */
+	handleSelect: (event: MouseEvent) => void;
 
 	/** Callback to open a quick analysis scoped to this sample */
 	onQuickAnalyze: () => void;

--- a/apps/web/src/samples/components/Item/SampleItem.tsx
+++ b/apps/web/src/samples/components/Item/SampleItem.tsx
@@ -18,7 +18,7 @@ type SampleItemProps = {
 	checked: boolean;
 
 	/** Callback to handle sample selection, receiving the checkbox click event */
-	handleSelect: (event: MouseEvent) => void;
+	handleSelect: (event: MouseEvent<HTMLButtonElement>) => void;
 
 	/** Callback to open a quick analysis scoped to this sample */
 	onQuickAnalyze: () => void;

--- a/apps/web/src/samples/components/SamplesList.tsx
+++ b/apps/web/src/samples/components/SamplesList.tsx
@@ -11,6 +11,7 @@ import {
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Pagination from "@base/Pagination";
 import QueryError from "@base/QueryError";
+import { useListSelection } from "@base/useListSelection";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import { useListIndexes } from "@indexes/queries";
@@ -19,7 +20,7 @@ import { useListSamples } from "@samples/queries";
 import type { Sample, SampleMinimal } from "@samples/types";
 import { xor } from "es-toolkit/array";
 import { FlaskConical, SearchX } from "lucide-react";
-import { useState } from "react";
+import { type MouseEvent, useState } from "react";
 import FilterBar from "./Filter/FilterBar";
 import SampleItem from "./Item/SampleItem";
 import SampleListHeader from "./SampleListHeader";
@@ -94,27 +95,23 @@ export default function SamplesList({
 		useListIndexes({ ready: true });
 
 	// The samples themselves are held, not just their ids: the selection outlives
-	// the page they were checked on, and the bulk actions need their labels.
-	const [selected, setSelected] = useState<SampleMinimal[]>([]);
-	const [openQuickAnalyze, setOpenQuickAnalyze] = useState(false);
-	const [quickAnalyzeTarget, setQuickAnalyzeTarget] =
-		useState<QuickAnalyzeTarget>({ fromSelection: false, samples: [] });
-
-	// Selection survives pagination, but not a change to the filters: the ids
-	// would otherwise linger unseen and re-check themselves if the user paged
-	// back to them.
+	// the page they were checked on, and the bulk actions need their labels. It
+	// survives pagination but resets when the filters change (via ``resetKey``),
+	// otherwise samples would linger unseen and re-check themselves if the user
+	// paged back to them.
 	const filterKey = getFilterKey(
 		term,
 		filterLabels,
 		filterWorkflows,
 		filterUsers,
 	);
-	const [previousFilterKey, setPreviousFilterKey] = useState(filterKey);
-
-	if (previousFilterKey !== filterKey) {
-		setPreviousFilterKey(filterKey);
-		setSelected([]);
-	}
+	const selection = useListSelection<SampleMinimal>({
+		getKey: (sample) => sample.id,
+		resetKey: filterKey,
+	});
+	const [openQuickAnalyze, setOpenQuickAnalyze] = useState(false);
+	const [quickAnalyzeTarget, setQuickAnalyzeTarget] =
+		useState<QuickAnalyzeTarget>({ fromSelection: false, samples: [] });
 
 	// Held separately from ``selected`` so a row's quick analyze can ignore the
 	// checkbox selection, and so the samples outlive the dialog's exit animation.
@@ -152,36 +149,13 @@ export default function SamplesList({
 	}
 
 	const itemsById = new Map(items.map((item) => [item.id, item]));
-	const selectedIds = new Set(selected.map((sample) => sample.id));
 
 	// The bulk actions apply to the whole selection, including samples checked on
 	// pages that are no longer fetched. Those still on this page are re-read from
 	// the fetched page so a refetch doesn't leave the actions holding a stale copy.
-	const selectedSamples = selected.map(
+	const selectedSamples = selection.selected.map(
 		(sample) => itemsById.get(sample.id) ?? sample,
 	);
-
-	// Select-all reflects and acts on the current page only. The selection itself
-	// survives pagination, so samples from other pages are left alone.
-	const pageSelectedCount = items.filter((item) =>
-		selectedIds.has(item.id),
-	).length;
-
-	function getSelectAllState(): boolean | "indeterminate" {
-		if (pageSelectedCount === 0) {
-			return false;
-		}
-
-		return pageSelectedCount === items.length ? true : "indeterminate";
-	}
-
-	function handleSelectAll() {
-		setSelected(
-			pageSelectedCount === items.length
-				? selected.filter((sample) => !itemsById.has(sample.id))
-				: [...selected, ...items.filter((item) => !selectedIds.has(item.id))],
-		);
-	}
 
 	// A selected sample from an unfetched page won't be refreshed by invalidating
 	// the list, so its labels are taken from the update response instead.
@@ -190,7 +164,7 @@ export default function SamplesList({
 			updated.map((sample) => [sample.id, sample.labels]),
 		);
 
-		setSelected((previous) =>
+		selection.setSelected((previous) =>
 			previous.map((sample) => {
 				const labels = labelsById.get(sample.id);
 				return labels ? { ...sample, labels } : sample;
@@ -199,19 +173,18 @@ export default function SamplesList({
 	}
 
 	function renderRow(item: SampleMinimal) {
-		function handleSelect() {
-			setSelected(
-				selectedIds.has(item.id)
-					? selected.filter((sample) => sample.id !== item.id)
-					: [...selected, item],
-			);
+		function handleSelect(event: MouseEvent) {
+			selection.select(item, {
+				shiftKey: event.shiftKey,
+				visibleItems: items,
+			});
 		}
 
 		return (
 			<SampleItem
 				key={item.id}
 				sample={item}
-				checked={selectedIds.has(item.id)}
+				checked={selection.isSelected(item)}
 				handleSelect={handleSelect}
 				onQuickAnalyze={() =>
 					openQuickAnalyzeFor({ fromSelection: false, samples: [item] })
@@ -298,11 +271,11 @@ export default function SamplesList({
 							currentPage={urlPage}
 							header={
 								<SampleListHeader
-									checked={getSelectAllState()}
+									checked={selection.getVisibleState(items)}
 									found={found_count}
 									labels={labels}
 									onLabelsUpdated={handleLabelsUpdated}
-									onSelectAll={handleSelectAll}
+									onSelectAll={() => selection.toggleVisible(items)}
 									onQuickAnalyze={() =>
 										openQuickAnalyzeFor({
 											fromSelection: true,

--- a/apps/web/src/samples/components/SamplesList.tsx
+++ b/apps/web/src/samples/components/SamplesList.tsx
@@ -173,7 +173,7 @@ export default function SamplesList({
 	}
 
 	function renderRow(item: SampleMinimal) {
-		function handleSelect(event: MouseEvent) {
+		function handleSelect(event: MouseEvent<HTMLButtonElement>) {
 			selection.select(item, {
 				shiftKey: event.shiftKey,
 				visibleItems: items,

--- a/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
+++ b/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
@@ -96,6 +96,25 @@ function mockApiGetSamplePages() {
 	return documents;
 }
 
+/**
+ * Serves a single page of named samples, so a contiguous range can be
+ * shift-selected within one page.
+ *
+ * @returns The sample documents, in page order
+ */
+function mockApiGetSampleRange(names: string[]) {
+	nock.cleanAll();
+
+	const documents = names.map((name) => createFakeSampleMinimal({ name }));
+
+	mockApiGetHmms(createFakeHmmSearchResults());
+	mockApiListIndexes([createFakeIndexMinimal()]);
+	mockApiGetShortlistSubtractions([createFakeShortlistSubtraction()], true);
+	mockApiGetSamples(documents);
+
+	return documents;
+}
+
 describe("<SamplesList />", () => {
 	let samples: ReturnType<typeof createFakeSampleMinimal>[];
 	let labels: ReturnType<typeof createFakeLabel>[];
@@ -559,6 +578,116 @@ describe("<SamplesList />", () => {
 
 			expect(await screen.findByText("2 samples")).toBeInTheDocument();
 			expect(screen.queryByText("1 selected")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("shift-click range select", () => {
+		function checkboxFor(name: string) {
+			return screen.getByRole("checkbox", { name: `Select ${name}` });
+		}
+
+		// A single user-event session is used per test so a held shift modifier
+		// carries across to the click; the default per-call helpers reset it.
+		function withShift(user: ReturnType<typeof userEvent.setup>) {
+			return async function shiftSelect(name: string) {
+				await user.keyboard("{Shift>}");
+				await user.click(checkboxFor(name));
+				await user.keyboard("{/Shift}");
+			};
+		}
+
+		async function renderRange(names: string[]) {
+			const documents = mockApiGetSampleRange(names);
+			await renderWithRouter(<SamplesList labels={labels} />, path);
+			expect(await screen.findByText("Samples")).toBeInTheDocument();
+			return documents;
+		}
+
+		const fourNames = [
+			"Range Sample 1",
+			"Range Sample 2",
+			"Range Sample 3",
+			"Range Sample 4",
+		];
+
+		it("should select a contiguous range when a row is shift-clicked", async () => {
+			const user = userEvent.setup();
+			const shiftSelect = withShift(user);
+			const range = await renderRange(fourNames);
+
+			await user.click(checkboxFor(at(range, 0).name));
+			await shiftSelect(at(range, 2).name);
+
+			expect(checkboxFor(at(range, 0).name)).toBeChecked();
+			expect(checkboxFor(at(range, 1).name)).toBeChecked();
+			expect(checkboxFor(at(range, 2).name)).toBeChecked();
+			expect(checkboxFor(at(range, 3).name)).not.toBeChecked();
+			expect(screen.getByText("3 selected")).toBeInTheDocument();
+		});
+
+		it("should select the same range regardless of click direction", async () => {
+			const user = userEvent.setup();
+			const shiftSelect = withShift(user);
+			const range = await renderRange(fourNames);
+
+			await user.click(checkboxFor(at(range, 2).name));
+			await shiftSelect(at(range, 0).name);
+
+			expect(checkboxFor(at(range, 0).name)).toBeChecked();
+			expect(checkboxFor(at(range, 1).name)).toBeChecked();
+			expect(checkboxFor(at(range, 2).name)).toBeChecked();
+			expect(checkboxFor(at(range, 3).name)).not.toBeChecked();
+		});
+
+		it("should deselect the range when the shift-clicked row was selected", async () => {
+			const user = userEvent.setup();
+			const shiftSelect = withShift(user);
+			const range = await renderRange(fourNames);
+
+			await user.click(checkboxFor(at(range, 0).name));
+			await shiftSelect(at(range, 3).name);
+			expect(screen.getByText("4 selected")).toBeInTheDocument();
+
+			await shiftSelect(at(range, 0).name);
+
+			for (const sample of range) {
+				expect(checkboxFor(sample.name)).not.toBeChecked();
+			}
+			expect(screen.getByText("4 samples")).toBeInTheDocument();
+		});
+
+		it("should anchor the range on the most recent shift-click", async () => {
+			const user = userEvent.setup();
+			const shiftSelect = withShift(user);
+			const range = await renderRange([...fourNames, "Range Sample 5"]);
+
+			await user.click(checkboxFor(at(range, 0).name));
+			await shiftSelect(at(range, 4).name);
+			await shiftSelect(at(range, 2).name);
+
+			expect(checkboxFor(at(range, 0).name)).toBeChecked();
+			expect(checkboxFor(at(range, 1).name)).toBeChecked();
+			expect(checkboxFor(at(range, 2).name)).not.toBeChecked();
+			expect(checkboxFor(at(range, 3).name)).not.toBeChecked();
+			expect(checkboxFor(at(range, 4).name)).not.toBeChecked();
+			expect(screen.getByText("2 selected")).toBeInTheDocument();
+		});
+
+		it("should fall back to a single toggle when the anchor is on another page", async () => {
+			const user = userEvent.setup();
+			const shiftSelect = withShift(user);
+			const [first, second] = mockApiGetSamplePages();
+
+			await renderWithRouter(<SamplesListHarness labels={labels} />, path);
+			expect(await screen.findByText("Samples")).toBeInTheDocument();
+
+			await user.click(checkboxFor(first.name));
+			await user.click(screen.getByRole("button", { name: "2" }));
+			expect(await screen.findByText(second.name)).toBeInTheDocument();
+
+			await shiftSelect(second.name);
+
+			expect(screen.getByText("2 selected")).toBeInTheDocument();
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Shift-clicking a sample checkbox now selects every row between the last clicked row and the clicked row, following the additive checkbox-list convention so selections on other pages are preserved.
- Extracted the selection logic into a reusable `useListSelection` hook in `base/` so future lists can adopt shift-click range selection, page select-all, and filter-reset behaviour without reimplementing it.