### PR TITLE
feat: remove ability to revert OTU changes

### DIFF
--- a/apps/web/src/otus/components/Detail/History/Change.tsx
+++ b/apps/web/src/otus/components/Detail/History/Change.tsx
@@ -1,9 +1,7 @@
 import Attribution from "@base/Attribution";
 import BoxGroupSection from "@base/BoxGroupSection";
 import Icon from "@base/Icon";
-import IconButton from "@base/IconButton";
 import Label from "@base/Label";
-import { useRevertOtu } from "@otus/queries";
 import type { OtuNested } from "@otus/types";
 import type { UserNested } from "@users/types";
 import {
@@ -13,7 +11,6 @@ import {
 	Dna,
 	FileUp,
 	FlaskConical,
-	History,
 	Link,
 	Pencil,
 	PlusSquare,
@@ -90,13 +87,10 @@ function getMethodIcon(methodName: string) {
 }
 
 type ChangeProps = {
-	id: string;
-	archived?: boolean;
 	createdAt: string;
 	description: string;
 	methodName: string;
 	otu: OtuNested;
-	unbuilt: boolean;
 	user: UserNested;
 };
 
@@ -104,26 +98,14 @@ type ChangeProps = {
  * A condensed change item for use in a list of changes
  */
 export default function Change({
-	id,
-	archived = false,
 	createdAt,
 	description,
 	methodName,
 	otu,
-	unbuilt,
 	user,
 }: ChangeProps) {
-	const mutation = useRevertOtu(otu.id);
-
-	const showRevert = unbuilt && !archived;
-
 	return (
-		<BoxGroupSection
-			className="grid items-center"
-			style={{
-				gridTemplateColumns: showRevert ? "42px 2fr 1fr 15px" : "42px 2fr 1fr",
-			}}
-		>
+		<BoxGroupSection className="grid grid-cols-[42px_2fr_1fr] items-center">
 			<div>
 				<Label>{otu.version}</Label>
 			</div>
@@ -134,14 +116,6 @@ export default function Change({
 			</div>
 
 			<Attribution time={createdAt} user={user.handle} verb="" />
-
-			{showRevert && (
-				<IconButton
-					IconComponent={History}
-					tip="revert"
-					onClick={() => mutation.mutate({ changeId: id })}
-				/>
-			)}
 		</BoxGroupSection>
 	);
 }

--- a/apps/web/src/otus/components/Detail/History/HistoryList.tsx
+++ b/apps/web/src/otus/components/Detail/History/HistoryList.tsx
@@ -6,8 +6,6 @@ import { sortBy } from "es-toolkit";
 import Change from "./Change";
 
 type HistoryListProps = {
-	/** Whether revert is disabled because the parent reference is archived */
-	archived?: boolean;
 	/** The history of built or unbuilt changes */
 	history: OtuHistory[];
 	/** Whether the changes are unbuilt */
@@ -15,10 +13,9 @@ type HistoryListProps = {
 };
 
 /**
- * Displays a history list of changes with options to revert the OTU
+ * Displays a history list of changes made to the OTU
  */
 export default function HistoryList({
-	archived,
 	history,
 	unbuilt = false,
 }: HistoryListProps) {
@@ -27,14 +24,11 @@ export default function HistoryList({
 	const changeComponents = changes.map((change) => (
 		<Change
 			key={change.id}
-			id={change.id}
-			archived={archived}
 			methodName={change.method_name}
 			otu={change.otu}
 			user={change.user}
 			description={change.description}
 			createdAt={change.created_at}
-			unbuilt={unbuilt}
 		/>
 	));
 

--- a/apps/web/src/otus/components/Detail/History/OtuHistory.tsx
+++ b/apps/web/src/otus/components/Detail/History/OtuHistory.tsx
@@ -1,5 +1,4 @@
 import { useSuspenseOtuHistory } from "@otus/queries";
-import { useReferenceIsArchived } from "@references/hooks";
 import { getRouteApi } from "@tanstack/react-router";
 import { groupBy } from "es-toolkit";
 import HistoryList from "./HistoryList";
@@ -7,12 +6,11 @@ import HistoryList from "./HistoryList";
 const routeApi = getRouteApi("/_authenticated/refs/$refId/otus/$otuId");
 
 /**
- * Display and manage the history for the OTU
+ * Display the history for the OTU
  */
 export default function OtuHistory() {
-	const { otuId, refId } = routeApi.useParams();
+	const { otuId } = routeApi.useParams();
 	const { data } = useSuspenseOtuHistory(otuId);
-	const archived = useReferenceIsArchived(refId);
 
 	const changes = groupBy(data, (change) =>
 		change.index.version === "unbuilt" ? "unbuilt" : "built",
@@ -20,15 +18,8 @@ export default function OtuHistory() {
 
 	return (
 		<div>
-			{archived && (
-				<p className="mb-3 text-sm text-gray-500">Read only - archived</p>
-			)}
-			{changes.unbuilt && (
-				<HistoryList archived={archived} history={changes.unbuilt} unbuilt />
-			)}
-			{changes.built && (
-				<HistoryList archived={archived} history={changes.built} />
-			)}
+			{changes.unbuilt && <HistoryList history={changes.unbuilt} unbuilt />}
+			{changes.built && <HistoryList history={changes.built} />}
 		</div>
 	);
 }

--- a/apps/web/src/otus/queries.tsx
+++ b/apps/web/src/otus/queries.tsx
@@ -227,25 +227,6 @@ export function useRemoveOtu() {
 }
 
 /**
- * Initializes a mutator for reverting an otu to how it was before a given change
- *
- * @returns A mutator for reverting an otu to how it was before a given change
- */
-export function useRevertOtu(otuId: string) {
-	const queryClient = useQueryClient();
-
-	return useMutation<null, ErrorResponse, { changeId: string }>({
-		mutationFn: ({ changeId }) =>
-			apiClient.delete(`/history/${changeId}`).then((res) => res.body),
-		onSuccess: () => {
-			queryClient.invalidateQueries({
-				queryKey: OtuQueryKeys.detail(otuId),
-			});
-		},
-	});
-}
-
-/**
  * Initializes a mutator for creating an OTU isolate
  *
  * @returns A mutator for creating an OTU isolate


### PR DESCRIPTION
## Summary
- Drop the revert action from the OTU history tab: removes the button in `Change`, the `useRevertOtu` mutation, and its `DELETE /history/{change_id}` call — the only caller of that endpoint in the repo.
- Remove the archived-reference plumbing that existed only to disable revert, along with the "Read only - archived" banner, since no mutating actions remain on the tab.
- Must ship before the backend endpoint is removed (VIR-2662), so the deployed frontend never calls a dead endpoint.