### PR TITLE
refactor: replace Settings class with the existing type

### DIFF
--- a/apps/web/src/administration/types.ts
+++ b/apps/web/src/administration/types.ts
@@ -21,6 +21,9 @@ export type AdministratorRoleName =
 	| "users"
 	| "base";
 
+/**
+ * Instance-wide settings
+ */
 export type Settings = {
 	default_source_types: string[];
 	enable_api: boolean;

--- a/apps/web/src/tests/fake/administrator.ts
+++ b/apps/web/src/tests/fake/administrator.ts
@@ -1,7 +1,6 @@
-import type { AdministratorRole } from "@administration/types";
+import type { AdministratorRole, Settings } from "@administration/types";
 import { faker } from "@faker-js/faker";
 import nock from "nock";
-import type { Settings } from "@/types/api";
 
 export const administratorRoles: AdministratorRole[] = [
 	{

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -26,20 +26,6 @@ export type SearchResult = {
 	total_count: number;
 };
 
-export class Settings {
-	default_source_types: string[];
-	enable_api: boolean;
-	enable_sentry: boolean;
-	hmm_slug: string;
-	minimum_password_length: number;
-	sample_all_read: boolean;
-	sample_all_write: boolean;
-	sample_group: string;
-	sample_group_read: boolean;
-	sample_group_write: boolean;
-	sample_unique_names: boolean;
-}
-
 export type Task = {
 	complete: boolean;
 	created_at: Date;


### PR DESCRIPTION
## Summary
- `types/api.ts` declared an unused `Settings` class — 11 bare fields, no constructor or methods, never `new`'d or checked with `instanceof` — that duplicated a field-for-field identical type already living in `administration/types.ts`.
- Removed the class and repointed its one remaining consumer, `tests/fake/administrator.ts`, at the existing definition. Every other consumer already imported that one, so converting the class in place would only have enshrined the duplicate.
- Clears all 11 `TS2564` errors, which were the entirety of the server project's `strictPropertyInitialization` failures. That flag now passes clean, unblocking the strict rollout (VIR-2685).