### PR TITLE
refactor: build every query key factory from createQueryKeys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,11 +195,19 @@ Use the superagent-based client in `apps/web/src/app/api.ts`. API errors have
 the shape `error.response?.body.message`.
 
 Each feature owns a `queries.ts` module that folds its request logic directly
-into React Query hooks and `queryOptions`/`*QueryKeys` factories — there is no
-separate per-feature `api.ts` layer. Inline each `apiClient` call into the
-hook's `queryFn`/`mutationFn`; keep a module-private helper only when a request
-is shared across hooks or branches. Route loaders prefetch via the same
+into React Query hooks and `queryOptions` factories — there is no separate
+per-feature `api.ts` layer. Inline each `apiClient` call into the hook's
+`queryFn`/`mutationFn`; keep a module-private helper only when a request is
+shared across hooks or branches. Route loaders prefetch via the same
 `queryOptions` factories where appropriate.
+
+Query keys are **not** hand-written. A feature's `*QueryKeys` comes from
+`createQueryKeys(domain)` in `@app/queryKeys`, which returns `all`, `lists`,
+`list`, `infiniteLists`, `infiniteList`, `details`, and `detail` — every list
+variant extending `lists()` and every detail extending `details()` by
+construction. A feature that caches something outside those seven shapes
+spreads the result and derives the extra member from a base key, so it stays
+inside the hierarchy.
 
 Loading and error states come in two tiers: primary route data uses
 `useSuspenseQuery` (loading via the route's `<Suspense>`, errors via the

--- a/apps/web/src/account/queries.ts
+++ b/apps/web/src/account/queries.ts
@@ -1,5 +1,6 @@
 import type { Account, APIKeyMinimal } from "@account/types";
 import { apiClient } from "@app/api";
+import { createQueryKeys } from "@app/queryKeys";
 import { resetClient } from "@app/utils";
 import type { Permissions } from "@groups/types";
 import * as Sentry from "@sentry/tanstackstart-react";
@@ -19,12 +20,18 @@ export type AccountUpdate = {
 	email?: string;
 };
 
+const accountKeys = createQueryKeys("account");
+
 /**
- * Factory object for generating account query keys
+ * Query keys for the logged-in user's account.
+ *
+ * The account is a singleton, so it is cached at `all()` itself. `apiKeys()`
+ * is the sub-collection of the account's API keys, nested under `all()` so
+ * that any account mutation refreshes it too.
  */
-export const accountKeys = {
-	all: () => ["account"],
-	details: () => ["account", "details"] as const,
+export const accountQueryKeys = {
+	...accountKeys,
+	apiKeys: () => [...accountKeys.all(), "keys"] as const,
 };
 
 /**
@@ -35,7 +42,7 @@ export const accountKeys = {
  */
 export function accountQueryOptions() {
 	return queryOptions<Account, ErrorResponse>({
-		queryKey: accountKeys.all(),
+		queryKey: accountQueryKeys.all(),
 		queryFn: () => apiClient.get("/account").then((response) => response.body),
 	});
 }
@@ -64,7 +71,7 @@ export function useUpdateAccount() {
 				.send({ update })
 				.then((res) => res.body),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: accountKeys.all() });
+			queryClient.invalidateQueries({ queryKey: accountQueryKeys.all() });
 		},
 	});
 }
@@ -84,7 +91,7 @@ export function useUpdateHandle() {
 	>({
 		mutationFn: ({ handle }) => updateAccountHandle({ data: { handle } }),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: accountKeys.all() });
+			queryClient.invalidateQueries({ queryKey: accountQueryKeys.all() });
 		},
 	});
 }
@@ -108,7 +115,7 @@ export function useChangePassword() {
 				.send({ old_password, password })
 				.then((res) => res.body),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: accountKeys.all() });
+			queryClient.invalidateQueries({ queryKey: accountQueryKeys.all() });
 		},
 	});
 }
@@ -120,7 +127,7 @@ export function useChangePassword() {
  */
 export function useFetchAPIKeys() {
 	return useQuery<APIKeyMinimal[]>({
-		queryKey: accountKeys.details(),
+		queryKey: accountQueryKeys.apiKeys(),
 		queryFn: () => apiClient.get("/account/keys").then((res) => res.body),
 	});
 }
@@ -144,7 +151,7 @@ export function useCreateAPIKey() {
 				.send({ name, permissions })
 				.then((res) => res.body),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: accountKeys.all() });
+			queryClient.invalidateQueries({ queryKey: accountQueryKeys.all() });
 		},
 	});
 }
@@ -168,7 +175,7 @@ export function useUpdateApiKey() {
 				.send({ permissions })
 				.then((res) => res.body),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: accountKeys.all() });
+			queryClient.invalidateQueries({ queryKey: accountQueryKeys.all() });
 		},
 	});
 }
@@ -185,7 +192,7 @@ export function useRemoveAPIKey() {
 		mutationFn: ({ keyId }) =>
 			apiClient.delete(`/account/keys/${keyId}`).then((res) => res.body),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: accountKeys.all() });
+			queryClient.invalidateQueries({ queryKey: accountQueryKeys.all() });
 		},
 	});
 }

--- a/apps/web/src/administration/components/__tests__/Settings.test.tsx
+++ b/apps/web/src/administration/components/__tests__/Settings.test.tsx
@@ -1,3 +1,4 @@
+import { bannerQueryKeys } from "@banner/queries";
 import { screen } from "@testing-library/react";
 import { createFakeAccount } from "@tests/fake/account";
 import {
@@ -22,7 +23,7 @@ describe("<Settings />", () => {
 		await renderRoute(path, {
 			account,
 			seed: (queryClient) => {
-				queryClient.setQueryData(["banner", "list"], []);
+				queryClient.setQueryData(bannerQueryKeys.lists(), []);
 			},
 		});
 

--- a/apps/web/src/administration/queries.ts
+++ b/apps/web/src/administration/queries.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@app/api";
+import { createQueryKeys } from "@app/queryKeys";
 import { listAdministratorRoles } from "@server/users/functions";
 import {
 	queryOptions,
@@ -25,12 +26,8 @@ export type SettingsUpdate = {
 	sample_unique_names?: boolean;
 };
 
-/**
- * Factory object for generating settings query keys
- */
-export const settingsQueryKeys = {
-	all: () => ["settings"] as const,
-};
+/** Query keys for the server settings. */
+export const settingsQueryKeys = createQueryKeys("settings");
 
 /**
  * Query options for the API settings.
@@ -84,9 +81,8 @@ export function useUpdateSettings() {
 	});
 }
 
-export const roleQueryKeys = {
-	all: () => ["roles"] as const,
-};
+/** Query keys for administrator roles. */
+export const roleQueryKeys = createQueryKeys("roles");
 
 /**
  * Query options for fetching the list of valid administrator roles.

--- a/apps/web/src/analyses/queries.ts
+++ b/apps/web/src/analyses/queries.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@app/api";
+import { createQueryKeys } from "@app/queryKeys";
 import { samplesQueryKeys } from "@samples/queries";
 import {
 	keepPreviousData,
@@ -11,17 +12,8 @@ import type { ErrorResponse } from "@/types/api";
 import type { Analysis, AnalysisSearchResult, GenericAnalysis } from "./types";
 import { formatData } from "./utils";
 
-/**
- * Factory object for generating analyses query keys
- */
-export const analysesQueryKeys = {
-	all: () => ["analyses"] as const,
-	lists: () => ["analyses", "list"] as const,
-	list: (filters: Array<string | number | boolean | string[] | undefined>) =>
-		["analyses", "list", ...filters] as const,
-	details: () => ["analyses", "details"] as const,
-	detail: (analysesId: string) => ["analyses", "details", analysesId] as const,
-};
+/** Query keys for analyses. */
+export const analysesQueryKeys = createQueryKeys("analyses");
 
 /**
  * Fetch a page of analyses search results from the API

--- a/apps/web/src/app/__tests__/queryKeys.test.ts
+++ b/apps/web/src/app/__tests__/queryKeys.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { createQueryKeys } from "../queryKeys";
+
+function startsWith(key: readonly unknown[], prefix: readonly unknown[]) {
+	return prefix.every((segment, index) => key[index] === segment);
+}
+
+describe("createQueryKeys", () => {
+	const keys = createQueryKeys("samples");
+
+	it("roots every key at the domain", () => {
+		expect(keys.all()).toEqual(["samples"]);
+		for (const key of [
+			keys.lists(),
+			keys.list([1, 25]),
+			keys.infiniteLists(),
+			keys.infiniteList([25]),
+			keys.details(),
+			keys.detail("abc"),
+		]) {
+			expect(startsWith(key, keys.all())).toBe(true);
+		}
+	});
+
+	it("nests every list variant under lists(), so one invalidation covers them all", () => {
+		for (const key of [
+			keys.list([1, 25, ""]),
+			keys.infiniteLists(),
+			keys.infiniteList([25, ""]),
+		]) {
+			expect(startsWith(key, keys.lists())).toBe(true);
+		}
+	});
+
+	it("nests details under details()", () => {
+		expect(startsWith(keys.detail("abc"), keys.details())).toBe(true);
+		expect(startsWith(keys.detail(7), keys.details())).toBe(true);
+	});
+
+	it("keeps lists and details in separate namespaces", () => {
+		expect(startsWith(keys.details(), keys.lists())).toBe(false);
+		expect(startsWith(keys.lists(), keys.details())).toBe(false);
+	});
+
+	it("distinguishes filter sets", () => {
+		expect(keys.list([1, 25, ""])).not.toEqual(keys.list([2, 25, ""]));
+		expect(keys.infiniteList([25, "a"])).not.toEqual(
+			keys.infiniteList([25, "b"]),
+		);
+	});
+
+	it("keeps paginated and infinite lists apart", () => {
+		expect(keys.list([25, ""])).not.toEqual(keys.infiniteList([25, ""]));
+	});
+
+	it("keeps domains apart", () => {
+		expect(createQueryKeys("users").all()).not.toEqual(keys.all());
+	});
+});

--- a/apps/web/src/app/queryKeys.ts
+++ b/apps/web/src/app/queryKeys.ts
@@ -1,0 +1,53 @@
+/** A value that can be used as a filter segment in a query key. */
+export type QueryKeyFilter =
+	| string
+	| number
+	| boolean
+	| undefined
+	| readonly (string | number)[];
+
+/** An identifier for a single cached record. */
+export type QueryKeyId = string | number;
+
+/** The complete set of query keys for one data domain. */
+export type QueryKeys = {
+	all: () => readonly [string];
+	lists: () => readonly [string, "list"];
+	list: (
+		filters: readonly QueryKeyFilter[],
+	) => readonly [string, "list", ...QueryKeyFilter[]];
+	infiniteLists: () => readonly [string, "list", "infinite"];
+	infiniteList: (
+		filters: readonly QueryKeyFilter[],
+	) => readonly [string, "list", "infinite", ...QueryKeyFilter[]];
+	details: () => readonly [string, "details"];
+	detail: (id: QueryKeyId) => readonly [string, "details", QueryKeyId];
+};
+
+/**
+ * Build the query keys for a data domain.
+ *
+ * Every list variant extends `lists()` and every detail extends `details()`, so
+ * invalidating the shorter key always invalidates the longer ones beneath it.
+ * Features that cache something outside these seven shapes spread the result
+ * and derive the extra member from a base key, keeping it inside the hierarchy.
+ *
+ * @param domain - The namespace the keys are rooted at, usually the plural resource name
+ * @returns The query keys for the domain
+ */
+export function createQueryKeys(domain: string): QueryKeys {
+	const all = () => [domain] as const;
+	const lists = () => [domain, "list"] as const;
+	const infiniteLists = () => [domain, "list", "infinite"] as const;
+	const details = () => [domain, "details"] as const;
+
+	return {
+		all,
+		lists,
+		list: (filters) => [...lists(), ...filters] as const,
+		infiniteLists,
+		infiniteList: (filters) => [...infiniteLists(), ...filters] as const,
+		details,
+		detail: (id) => [...details(), id] as const,
+	};
+}

--- a/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
+++ b/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
@@ -1,8 +1,15 @@
+import { accountQueryKeys } from "@account/queries";
 import { roleQueryKeys } from "@administration/queries";
+import { bannerQueryKeys } from "@banner/queries";
+import { groupQueryKeys } from "@groups/queries";
+import { indexQueryKeys } from "@indexes/queries";
 import { jobQueryKeys } from "@jobs/queries";
 import { labelQueryKeys } from "@labels/queries";
+import { referenceQueryKeys } from "@references/queries";
 import { samplesQueryKeys } from "@samples/queries";
 import { QueryClient } from "@tanstack/react-query";
+import { taskQueryKeys } from "@tasks/queries";
+import { fileQueryKeys } from "@uploads/queries";
 import { userQueryKeys } from "@users/queries";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { reactQueryHandler } from "../reactQueryHandler";
@@ -17,44 +24,170 @@ describe("reactQueryHandler", () => {
 		invalidate = vi.spyOn(queryClient, "invalidateQueries");
 	});
 
-	it("invalidates the matching detail key on update for a domain with a detail factory", () => {
-		const handle = reactQueryHandler(queryClient);
-		handle({ domain: "samples", operation: "update", id: "abc" });
-		expect(invalidate).toHaveBeenCalledExactlyOnceWith({
-			queryKey: samplesQueryKeys.detail("abc"),
-		});
+	describe("selects the narrowest key the domain actually caches under", () => {
+		const cases: Array<{
+			message: SseMessage;
+			queryKey: readonly unknown[];
+		}> = [
+			// Domains caching both details and lists narrow to one or the other.
+			{
+				message: { domain: "groups", operation: "update", id: 3 },
+				queryKey: groupQueryKeys.detail(3),
+			},
+			{
+				message: { domain: "groups", operation: "insert", id: 3 },
+				queryKey: groupQueryKeys.lists(),
+			},
+			{
+				message: { domain: "indexes", operation: "update", id: "idx" },
+				queryKey: indexQueryKeys.detail("idx"),
+			},
+			{
+				message: { domain: "indexes", operation: "delete", id: "idx" },
+				queryKey: indexQueryKeys.lists(),
+			},
+			{
+				message: { domain: "jobs", operation: "update", id: 42 },
+				queryKey: jobQueryKeys.detail(42),
+			},
+			{
+				message: { domain: "jobs", operation: "insert", id: 42 },
+				queryKey: jobQueryKeys.lists(),
+			},
+			{
+				message: { domain: "references", operation: "update", id: "ref" },
+				queryKey: referenceQueryKeys.detail("ref"),
+			},
+			{
+				message: { domain: "references", operation: "delete", id: "ref" },
+				queryKey: referenceQueryKeys.lists(),
+			},
+			{
+				message: { domain: "samples", operation: "update", id: "abc" },
+				queryKey: samplesQueryKeys.detail("abc"),
+			},
+			{
+				message: { domain: "samples", operation: "insert", id: "abc" },
+				queryKey: samplesQueryKeys.lists(),
+			},
+			{
+				message: { domain: "users", operation: "update", id: 7 },
+				queryKey: userQueryKeys.detail(7),
+			},
+			{
+				message: { domain: "users", operation: "delete", id: 7 },
+				queryKey: userQueryKeys.lists(),
+			},
+
+			// Labels, banners, and uploads cache lists but no details, so an
+			// update falls back to the whole domain.
+			{
+				message: { domain: "labels", operation: "update", id: 7 },
+				queryKey: labelQueryKeys.all(),
+			},
+			{
+				message: { domain: "labels", operation: "insert", id: 7 },
+				queryKey: labelQueryKeys.lists(),
+			},
+			{
+				message: { domain: "messages", operation: "update", id: 1 },
+				queryKey: bannerQueryKeys.all(),
+			},
+			{
+				message: { domain: "messages", operation: "delete", id: 1 },
+				queryKey: bannerQueryKeys.lists(),
+			},
+			{
+				message: { domain: "uploads", operation: "update", id: 5 },
+				queryKey: fileQueryKeys.all(),
+			},
+			{
+				message: { domain: "uploads", operation: "insert", id: 5 },
+				queryKey: fileQueryKeys.lists(),
+			},
+
+			// Tasks cache details but no list, so an insert falls back.
+			{
+				message: { domain: "tasks", operation: "update", id: 9 },
+				queryKey: taskQueryKeys.detail(9),
+			},
+			{
+				message: { domain: "tasks", operation: "insert", id: 9 },
+				queryKey: taskQueryKeys.all(),
+			},
+
+			// The account and the role list are cached at all() itself, so every
+			// operation falls back to it.
+			{
+				message: { domain: "account", operation: "update", id: 1 },
+				queryKey: accountQueryKeys.all(),
+			},
+			{
+				message: { domain: "account", operation: "insert", id: 1 },
+				queryKey: accountQueryKeys.all(),
+			},
+			{
+				message: { domain: "roles", operation: "update", id: "full" },
+				queryKey: roleQueryKeys.all(),
+			},
+			{
+				message: { domain: "roles", operation: "insert", id: "full" },
+				queryKey: roleQueryKeys.all(),
+			},
+		];
+
+		for (const { message, queryKey } of cases) {
+			it(`${message.domain} on ${message.operation}`, () => {
+				reactQueryHandler(queryClient)(message);
+				expect(invalidate).toHaveBeenCalledExactlyOnceWith({ queryKey });
+			});
+		}
 	});
 
-	it("invalidates lists on insert for a domain with a lists factory", () => {
-		const handle = reactQueryHandler(queryClient);
-		handle({ domain: "jobs", operation: "insert", id: 42 });
-		expect(invalidate).toHaveBeenCalledExactlyOnceWith({
-			queryKey: jobQueryKeys.lists(),
-		});
-	});
+	describe("marks what each domain actually caches stale", () => {
+		// A key nothing is cached under invalidates nothing, so asserting on the
+		// key alone would not catch a domain narrowing to a key it never uses.
+		const cases: Array<{ message: SseMessage; queryKey: readonly unknown[] }> =
+			[
+				{
+					message: { domain: "account", operation: "update", id: 1 },
+					queryKey: accountQueryKeys.all(),
+				},
+				{
+					message: { domain: "account", operation: "update", id: 1 },
+					queryKey: accountQueryKeys.apiKeys(),
+				},
+				{
+					message: { domain: "roles", operation: "update", id: "full" },
+					queryKey: roleQueryKeys.all(),
+				},
+				{
+					message: { domain: "labels", operation: "update", id: 7 },
+					queryKey: labelQueryKeys.lists(),
+				},
+				{
+					message: { domain: "messages", operation: "update", id: 1 },
+					queryKey: bannerQueryKeys.active(),
+				},
+				{
+					message: { domain: "uploads", operation: "update", id: 5 },
+					queryKey: fileQueryKeys.list(["reads", 1, 25]),
+				},
+				{
+					message: { domain: "tasks", operation: "insert", id: 9 },
+					queryKey: taskQueryKeys.detail(9),
+				},
+			];
 
-	it("invalidates lists on delete for a domain with a lists factory", () => {
-		const handle = reactQueryHandler(queryClient);
-		handle({ domain: "jobs", operation: "delete", id: 42 });
-		expect(invalidate).toHaveBeenCalledExactlyOnceWith({
-			queryKey: jobQueryKeys.lists(),
-		});
-	});
+		for (const { message, queryKey } of cases) {
+			it(`${message.domain} on ${message.operation} refreshes ${JSON.stringify(queryKey)}`, () => {
+				queryClient.setQueryData(queryKey, {});
 
-	it("falls back to all when the factory has lists but no detail on update", () => {
-		const handle = reactQueryHandler(queryClient);
-		handle({ domain: "labels", operation: "update", id: 7 });
-		expect(invalidate).toHaveBeenCalledExactlyOnceWith({
-			queryKey: labelQueryKeys.all(),
-		});
-	});
+				reactQueryHandler(queryClient)(message);
 
-	it("falls back to all when the factory has neither lists nor detail", () => {
-		const handle = reactQueryHandler(queryClient);
-		handle({ domain: "roles", operation: "insert", id: "full" });
-		expect(invalidate).toHaveBeenCalledExactlyOnceWith({
-			queryKey: roleQueryKeys.all(),
-		});
+				expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+			});
+		}
 	});
 
 	it("marks every user list variant stale on insert", () => {

--- a/apps/web/src/app/sse/reactQueryHandler.ts
+++ b/apps/web/src/app/sse/reactQueryHandler.ts
@@ -1,5 +1,6 @@
-import { accountKeys } from "@account/queries";
+import { accountQueryKeys } from "@account/queries";
 import { roleQueryKeys } from "@administration/queries";
+import type { QueryKeys } from "@app/queryKeys";
 import { bannerQueryKeys } from "@banner/queries";
 import { groupQueryKeys } from "@groups/queries";
 import { indexQueryKeys } from "@indexes/queries";
@@ -13,49 +14,63 @@ import { fileQueryKeys } from "@uploads/queries";
 import { userQueryKeys } from "@users/queries";
 import type { SseDomain, SseMessage } from "./schema";
 
-type KeyFactory = {
-	all(): readonly unknown[];
-	lists?(): readonly unknown[];
-	detail?(id: number | string): readonly unknown[];
+/**
+ * What a domain caches, and therefore how narrowly its frames can be
+ * invalidated.
+ *
+ * Every domain has the full set of keys, but not every domain caches a record
+ * at `detail(id)` or a collection under `lists()`. Invalidating a key nothing
+ * is cached under is a silent no-op, so a domain that caches neither has to
+ * fall back to `all()`. This must be declared rather than inferred from the
+ * keys: they are always present, so their absence can no longer signal it.
+ */
+type CachedShapes = {
+	keys: QueryKeys;
+
+	/** Whether single records are cached under `detail(id)`. */
+	details: boolean;
+
+	/** Whether collections are cached under `lists()`. */
+	lists: boolean;
 };
 
-const keyFactories: Record<SseDomain, KeyFactory> = {
-	account: accountKeys,
-	groups: groupQueryKeys,
-	indexes: indexQueryKeys,
-	jobs: jobQueryKeys,
-	labels: labelQueryKeys,
-	messages: bannerQueryKeys,
-	references: referenceQueryKeys,
-	roles: roleQueryKeys,
-	tasks: taskQueryKeys,
-	uploads: fileQueryKeys,
-	users: userQueryKeys,
-	samples: samplesQueryKeys,
+const domains: Record<SseDomain, CachedShapes> = {
+	account: { keys: accountQueryKeys, details: false, lists: false },
+	groups: { keys: groupQueryKeys, details: true, lists: true },
+	indexes: { keys: indexQueryKeys, details: true, lists: true },
+	jobs: { keys: jobQueryKeys, details: true, lists: true },
+	labels: { keys: labelQueryKeys, details: false, lists: true },
+	messages: { keys: bannerQueryKeys, details: false, lists: true },
+	references: { keys: referenceQueryKeys, details: true, lists: true },
+	roles: { keys: roleQueryKeys, details: false, lists: false },
+	samples: { keys: samplesQueryKeys, details: true, lists: true },
+	tasks: { keys: taskQueryKeys, details: true, lists: false },
+	uploads: { keys: fileQueryKeys, details: false, lists: true },
+	users: { keys: userQueryKeys, details: true, lists: true },
 };
 
 function selectQueryKey(
-	factory: KeyFactory,
+	domain: CachedShapes,
 	operation: SseMessage["operation"],
 	id: SseMessage["id"],
 ): readonly unknown[] {
-	if (operation === "update" && factory.detail) {
-		return factory.detail(id);
+	if (operation === "update" && domain.details) {
+		return domain.keys.detail(id);
 	}
-	if ((operation === "insert" || operation === "delete") && factory.lists) {
-		return factory.lists();
+	if ((operation === "insert" || operation === "delete") && domain.lists) {
+		return domain.keys.lists();
 	}
-	return factory.all();
+	return domain.keys.all();
 }
 
 export function reactQueryHandler(queryClient: QueryClient) {
 	return (message: SseMessage) => {
-		const factory = keyFactories[message.domain];
-		if (!factory) {
+		const domain = domains[message.domain];
+		if (!domain) {
 			return;
 		}
 		queryClient.invalidateQueries({
-			queryKey: selectQueryKey(factory, message.operation, message.id),
+			queryKey: selectQueryKey(domain, message.operation, message.id),
 		});
 	};
 }

--- a/apps/web/src/banner/queries.ts
+++ b/apps/web/src/banner/queries.ts
@@ -1,3 +1,4 @@
+import { createQueryKeys } from "@app/queryKeys";
 import {
 	clearActiveMessage,
 	createMessage,
@@ -10,13 +11,17 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Banner, BannerColor } from "./types";
 
+const bannerKeys = createQueryKeys("banner");
+
 /**
- * Factory for generating react-query keys for banner related queries.
+ * Query keys for banners.
+ *
+ * `active()` is the single banner shown to every user, which is a distinct
+ * resource from the admin list rather than a member of it.
  */
 export const bannerQueryKeys = {
-	all: () => ["banner"] as const,
-	lists: () => ["banner", "list"] as const,
-	active: () => ["banner", "active"] as const,
+	...bannerKeys,
+	active: () => [...bannerKeys.all(), "active"] as const,
 };
 
 /**

--- a/apps/web/src/groups/queries.ts
+++ b/apps/web/src/groups/queries.ts
@@ -1,3 +1,4 @@
+import { createQueryKeys } from "@app/queryKeys";
 import {
 	createGroup,
 	deleteGroup,
@@ -21,19 +22,8 @@ import type {
 	PermissionsUpdate,
 } from "./types";
 
-/**
- * Factory for generating react-query keys for group-related queries.
- */
-export const groupQueryKeys = {
-	all: () => ["groups"] as const,
-	lists: () => ["groups", "list"] as const,
-	list: (filters) => ["groups", "list", ...filters] as const,
-	infiniteLists: () => ["groups", "list", "infinite"] as const,
-	infiniteList: (filters: Array<string | number | boolean>) =>
-		["groups", "list", "infinite", ...filters] as const,
-	details: () => ["groups", "details"] as const,
-	detail: (id) => ["groups", "detail", id] as const,
-};
+/** Query keys for groups. */
+export const groupQueryKeys = createQueryKeys("groups");
 
 /**
  * Setup query for fetching group search results for infinite scrolling view

--- a/apps/web/src/hmm/queries.ts
+++ b/apps/web/src/hmm/queries.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@app/api";
+import { createQueryKeys } from "@app/queryKeys";
 import {
 	keepPreviousData,
 	useMutation,
@@ -8,17 +9,8 @@ import {
 import type { ErrorResponse } from "@/types/api";
 import type { HMMInstalled, Hmm, HmmSearchResults } from "./types";
 
-/**
- * Factory object for generating hmm query keys
- */
-export const hmmQueryKeys = {
-	all: () => ["hmm"] as const,
-	lists: () => ["hmm", "list"] as const,
-	list: (filters: Array<string | number | boolean | string[] | undefined>) =>
-		["hmm", "list", ...filters] as const,
-	details: () => ["hmm", "details"] as const,
-	detail: (hmmId: string) => ["hmm", "details", hmmId] as const,
-};
+/** Query keys for HMMs. */
+export const hmmQueryKeys = createQueryKeys("hmms");
 
 /**
  * Fetch a page of hmm search results from the API

--- a/apps/web/src/indexes/queries.ts
+++ b/apps/web/src/indexes/queries.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@app/api";
+import { createQueryKeys } from "@app/queryKeys";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ErrorResponse } from "@/types/api";
 import type {
@@ -11,16 +12,18 @@ import type {
 /**
  * Factory for generating react-query keys for index related queries.
  */
+const indexKeys = createQueryKeys("indexes");
+
+/**
+ * Query keys for indexes.
+ *
+ * `unbuilt()` is the list of a reference's changes that no index covers yet. It
+ * is keyed by reference rather than by index, so it gets its own namespace
+ * instead of sharing the index details one.
+ */
 export const indexQueryKeys = {
-	all: () => ["indexes"] as const,
-	lists: () => ["indexes", "list"] as const,
-	list: (filters: Array<string | number | boolean>) =>
-		["indexes", "list", ...filters] as const,
-	infiniteLists: () => ["indexes", "list", "infinite"] as const,
-	infiniteList: (filters: Array<string | number | boolean | undefined>) =>
-		["indexes", "list", "infinite", ...filters] as const,
-	details: () => ["indexes", "details"] as const,
-	detail: (id: string) => ["indexes", "detail", id] as const,
+	...indexKeys,
+	unbuilt: (refId: string) => [...indexKeys.all(), "unbuilt", refId] as const,
 };
 
 /**
@@ -39,7 +42,7 @@ export function useFindIndexes(
 	term?: string,
 ) {
 	return useQuery<IndexSearchResult>({
-		queryKey: indexQueryKeys.infiniteList([page, per_page, refId, term]),
+		queryKey: indexQueryKeys.list([page, per_page, refId, term]),
 		queryFn: () =>
 			apiClient
 				.get(`/refs/${refId}/indexes`)
@@ -106,7 +109,7 @@ export function useFetchUnbuiltChanges(refId: string) {
 				const { documents, ...rest } = res.body;
 				return { ...rest, items: documents };
 			}),
-		queryKey: indexQueryKeys.detail(refId),
+		queryKey: indexQueryKeys.unbuilt(refId),
 	});
 }
 
@@ -122,7 +125,7 @@ export function useCreateIndex() {
 			apiClient.post(`/refs/${refId}/indexes`).then((res) => res.body),
 		onSuccess: () => {
 			queryClient.invalidateQueries({
-				queryKey: indexQueryKeys.infiniteLists(),
+				queryKey: indexQueryKeys.all(),
 			});
 		},
 	});

--- a/apps/web/src/jobs/queries.ts
+++ b/apps/web/src/jobs/queries.ts
@@ -1,3 +1,4 @@
+import { createQueryKeys } from "@app/queryKeys";
 import { findJobs, getJob } from "@server/jobs/functions";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import {
@@ -8,17 +9,8 @@ import {
 	type ServerJobNested,
 } from "./types";
 
-/**
- * Factory object for generating job query keys
- */
-export const jobQueryKeys = {
-	all: () => ["job"] as const,
-	lists: () => ["job", "list"] as const,
-	list: (filters: Array<string | number | boolean>) =>
-		["job", "list", ...filters] as const,
-	details: () => ["job", "details"] as const,
-	detail: (jobId: number) => ["job", "details", jobId] as const,
-};
+/** Query keys for jobs. */
+export const jobQueryKeys = createQueryKeys("jobs");
 
 /**
  * Fetch a page of job search results from the API

--- a/apps/web/src/labels/queries.ts
+++ b/apps/web/src/labels/queries.ts
@@ -1,3 +1,4 @@
+import { createQueryKeys } from "@app/queryKeys";
 import {
 	createLabel,
 	deleteLabel,
@@ -7,12 +8,8 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Label } from "./types";
 
-export const labelQueryKeys = {
-	all: () => ["label"] as const,
-	lists: () => ["label", "list"] as const,
-	list: (filters: Array<string | number | boolean>) =>
-		["label", "list", "single", ...filters] as const,
-};
+/** Query keys for labels. */
+export const labelQueryKeys = createQueryKeys("labels");
 
 /**
  * Fetch a list of labels from the API
@@ -21,7 +18,7 @@ export const labelQueryKeys = {
  */
 export function useFetchLabels() {
 	return useQuery<Label[]>({
-		queryKey: labelQueryKeys.list([]),
+		queryKey: labelQueryKeys.lists(),
 		queryFn: () => findLabels(),
 	});
 }

--- a/apps/web/src/otus/queries.tsx
+++ b/apps/web/src/otus/queries.tsx
@@ -1,4 +1,5 @@
 import { apiClient } from "@app/api";
+import { createQueryKeys } from "@app/queryKeys";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
 import {
@@ -32,21 +33,17 @@ export function getGenbank(accession: string) {
 	return apiClient.get(`/genbank/${accession}`).then((res) => res.body);
 }
 
+const otuKeys = createQueryKeys("otus");
+
 /**
- * Factory for generating react-query keys for otu related queries.
+ * Query keys for OTUs.
+ *
+ * `history()` nests under the OTU's own detail key, so the mutations that
+ * invalidate a detail also refresh the change history they just added to.
  */
-export const OtuQueryKeys = {
-	all: () => ["OTU"] as const,
-	lists: () => ["OTU", "list"] as const,
-	list: (filters: Array<string | number | boolean>) =>
-		["OTU", "list", ...filters] as const,
-	infiniteLists: () => ["OTU", "list", "infinite"] as const,
-	infiniteList: (filters: Array<string | number | boolean>) =>
-		["OTU", "list", "infinite", ...filters] as const,
-	details: () => ["OTU", "detail"] as const,
-	detail: (id: string) => ["OTU", "detail", id] as const,
-	histories: () => ["OTU", "detail", "history"] as const,
-	history: (id: string) => ["OTU", "detail", "history", id] as const,
+export const otuQueryKeys = {
+	...otuKeys,
+	history: (id: string) => [...otuKeys.detail(id), "history"] as const,
 };
 
 /**
@@ -65,7 +62,7 @@ export function useListOtus(
 	term: string,
 ) {
 	return useQuery<OtuSearchResult>({
-		queryKey: OtuQueryKeys.list([page, per_page, term]),
+		queryKey: otuQueryKeys.list([page, per_page, term]),
 		queryFn: () =>
 			apiClient
 				.get(`/refs/${refId}/otus`)
@@ -80,7 +77,7 @@ export function useListOtus(
 
 export function otuQueryOptions(otuId: string) {
 	return queryOptions<Otu, ErrorResponse>({
-		queryKey: OtuQueryKeys.detail(otuId),
+		queryKey: otuQueryKeys.detail(otuId),
 		queryFn: () => apiClient.get(`/otus/${otuId}`).then((res) => res.body),
 	});
 }
@@ -105,7 +102,7 @@ export function useFetchOtu(otuId: string) {
 
 export function otuHistoryQueryOptions(otuId: string) {
 	return queryOptions<OtuHistory[], ErrorResponse>({
-		queryKey: OtuQueryKeys.history(otuId),
+		queryKey: otuQueryKeys.history(otuId),
 		queryFn: () =>
 			apiClient.get(`/otus/${otuId}/history`).then((res) => res.body),
 	});
@@ -150,7 +147,7 @@ export function useCreateOtu(refId: string) {
 				.send({ name, abbreviation })
 				.then((res) => res.body),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: OtuQueryKeys.lists() });
+			queryClient.invalidateQueries({ queryKey: otuQueryKeys.lists() });
 		},
 	});
 }
@@ -179,15 +176,15 @@ export function useUpdateOtu(otuId: string) {
 					.then((res) => res.body),
 			onMutate: async ({ name, abbreviation, schema }) => {
 				await queryClient.cancelQueries({
-					queryKey: OtuQueryKeys.detail(otuId),
+					queryKey: otuQueryKeys.detail(otuId),
 				});
 
 				const previousOtu = queryClient.getQueryData<Otu>(
-					OtuQueryKeys.detail(otuId),
+					otuQueryKeys.detail(otuId),
 				);
 
 				if (previousOtu) {
-					queryClient.setQueryData<Otu>(OtuQueryKeys.detail(otuId), {
+					queryClient.setQueryData<Otu>(otuQueryKeys.detail(otuId), {
 						...previousOtu,
 						...(name !== undefined && { name }),
 						...(abbreviation !== undefined && { abbreviation }),
@@ -200,14 +197,14 @@ export function useUpdateOtu(otuId: string) {
 			onError: (_error, _variables, context) => {
 				if (context?.previousOtu) {
 					queryClient.setQueryData(
-						OtuQueryKeys.detail(otuId),
+						otuQueryKeys.detail(otuId),
 						context.previousOtu,
 					);
 				}
 			},
 			onSettled: () => {
 				queryClient.invalidateQueries({
-					queryKey: OtuQueryKeys.detail(otuId),
+					queryKey: otuQueryKeys.detail(otuId),
 				});
 			},
 		},
@@ -246,7 +243,7 @@ export function useCreateIsolate(otuId: string) {
 				.then((res) => res.body),
 		onSuccess: () => {
 			queryClient.invalidateQueries({
-				queryKey: OtuQueryKeys.detail(otuId),
+				queryKey: otuQueryKeys.detail(otuId),
 			});
 		},
 	});
@@ -271,7 +268,7 @@ export function useSetIsolateAsDefault() {
 				.then((res) => res.body),
 		onSuccess: (_, { otuId }) => {
 			queryClient.invalidateQueries({
-				queryKey: OtuQueryKeys.detail(otuId),
+				queryKey: otuQueryKeys.detail(otuId),
 			});
 		},
 	});
@@ -302,7 +299,7 @@ export function useUpdateIsolate() {
 				.then((res) => res.body),
 		onSuccess: (_, { otuId }) => {
 			queryClient.invalidateQueries({
-				queryKey: OtuQueryKeys.detail(otuId),
+				queryKey: otuQueryKeys.detail(otuId),
 			});
 		},
 	});
@@ -324,7 +321,7 @@ export function useRemoveIsolate() {
 					.then((res) => res.body),
 			onSuccess: (_, { otuId }) => {
 				queryClient.invalidateQueries({
-					queryKey: OtuQueryKeys.detail(otuId),
+					queryKey: otuQueryKeys.detail(otuId),
 				});
 			},
 		},
@@ -366,7 +363,7 @@ export function useCreateSequence(otuId: string) {
 
 		onSuccess: () => {
 			queryClient.invalidateQueries({
-				queryKey: OtuQueryKeys.detail(otuId),
+				queryKey: otuQueryKeys.detail(otuId),
 			});
 		},
 	});
@@ -408,7 +405,7 @@ export function useEditSequence(otuId: string) {
 				.then((res) => res.body),
 		onSuccess: () => {
 			queryClient.invalidateQueries({
-				queryKey: OtuQueryKeys.detail(otuId),
+				queryKey: otuQueryKeys.detail(otuId),
 			});
 		},
 	});
@@ -433,7 +430,7 @@ export function useRemoveSequence(otuId: string) {
 				.then((res) => res.body),
 		onSuccess: () => {
 			queryClient.invalidateQueries({
-				queryKey: OtuQueryKeys.detail(otuId),
+				queryKey: otuQueryKeys.detail(otuId),
 			});
 		},
 	});

--- a/apps/web/src/references/hooks.ts
+++ b/apps/web/src/references/hooks.ts
@@ -1,7 +1,11 @@
 import { useFetchAccount } from "@account/queries";
 import { type ApiResponse, apiClient } from "@app/api";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+	type QueryKey,
+	useMutation,
+	useQueryClient,
+} from "@tanstack/react-query";
 import { difference, union } from "es-toolkit/array";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
@@ -41,7 +45,7 @@ export function useSourceTypesForm(sourceTypes: string[]) {
 export function useUpdateSourceTypes(
 	key: "default_source_types" | "source_types",
 	path: string,
-	queryKey: readonly string[],
+	queryKey: QueryKey,
 	sourceTypes: string[],
 ) {
 	const queryClient = useQueryClient();

--- a/apps/web/src/references/queries.ts
+++ b/apps/web/src/references/queries.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@app/api";
+import { createQueryKeys } from "@app/queryKeys";
 import {
 	keepPreviousData,
 	queryOptions,
@@ -17,17 +18,8 @@ import type {
 	ReferenceUser,
 } from "./types";
 
-/**
- * Factory for generating react-query keys for reference related queries.
- */
-export const referenceQueryKeys = {
-	all: () => ["reference"] as const,
-	lists: () => ["reference", "list"] as const,
-	list: (filters: Array<string | number | boolean | undefined>) =>
-		["reference", "list", "single", ...filters] as const,
-	details: () => ["reference", "detail"] as const,
-	detail: (refId: string) => ["reference", "detail", refId] as const,
-};
+/** Query keys for references. */
+export const referenceQueryKeys = createQueryKeys("references");
 
 /**
  * Adds a member (user or group) to a reference.

--- a/apps/web/src/routes/__tests__/-_authenticated.test.tsx
+++ b/apps/web/src/routes/__tests__/-_authenticated.test.tsx
@@ -1,4 +1,4 @@
-import { accountKeys } from "@account/queries";
+import { accountQueryKeys } from "@account/queries";
 import { waitFor } from "@testing-library/react";
 import { renderRoute } from "@tests/setup";
 import nock from "nock";
@@ -12,7 +12,7 @@ describe("<AuthenticatedLayout />", () => {
 
 		const { router } = await renderRoute("/samples", {
 			seed: (queryClient) => {
-				queryClient.removeQueries({ queryKey: accountKeys.all() });
+				queryClient.removeQueries({ queryKey: accountQueryKeys.all() });
 			},
 		});
 

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -18,7 +18,7 @@ import {
 	redirect,
 	useLocation,
 } from "@tanstack/react-router";
-import { rootKeys } from "@wall/queries";
+import { rootQueryKeys } from "@wall/queries";
 import { lazy, Suspense, useEffect } from "react";
 
 const UploadOverlay = lazy(() => import("@uploads/components/UploadOverlay"));
@@ -36,7 +36,7 @@ export const Route = createFileRoute("/_authenticated")({
 		const { queryClient } = context;
 
 		const rootData = await queryClient.ensureQueryData<Root>({
-			queryKey: rootKeys.all(),
+			queryKey: rootQueryKeys.all(),
 			queryFn: () => apiClient.get("/").then((res) => res.body),
 		});
 

--- a/apps/web/src/samples/queries.ts
+++ b/apps/web/src/samples/queries.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@app/api";
+import { createQueryKeys } from "@app/queryKeys";
 import type { LabelNested } from "@labels/types";
 import {
 	keepPreviousData,
@@ -26,18 +27,8 @@ export type SampleLabel = LabelNested & {
 	allLabeled: boolean;
 };
 
-/**
- * Factory for generating react-query keys for samples related queries.
- */
-export const samplesQueryKeys = {
-	all: () => ["samples"] as const,
-	lists: () => ["samples", "list"] as const,
-	list: (
-		filters: Array<string | number | boolean | string[] | number[] | undefined>,
-	) => ["samples", "list", ...filters] as const,
-	details: () => ["samples", "details"] as const,
-	detail: (sampleId: string) => ["samples", "details", sampleId] as const,
-};
+/** Query keys for samples. */
+export const samplesQueryKeys = createQueryKeys("samples");
 
 /**
  * Updates the data for a sample.

--- a/apps/web/src/subtraction/queries.ts
+++ b/apps/web/src/subtraction/queries.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@app/api";
+import { createQueryKeys } from "@app/queryKeys";
 import {
 	keepPreviousData,
 	useMutation,
@@ -12,18 +13,18 @@ import type {
 	SubtractionSearchResult,
 } from "./types";
 
+const subtractionKeys = createQueryKeys("subtractions");
+
 /**
- * Factory object for generating subtraction query keys
+ * Query keys for subtractions.
+ *
+ * `shortlist()` is the reduced list used to populate selectors. It nests under
+ * `lists()` so that a list invalidation refreshes it too.
  */
 export const subtractionQueryKeys = {
-	all: () => ["subtraction"] as const,
-	lists: () => ["subtraction", "list"] as const,
-	list: (filters: Array<string | number | boolean>) =>
-		["subtraction", "list", ...filters] as const,
-	details: () => ["subtraction", "details"] as const,
-	detail: (subtractionId: string) =>
-		["subtraction", "details", subtractionId] as const,
-	shortlist: () => ["subtraction", "list", "short"] as const,
+	...subtractionKeys,
+	shortlist: (ready?: boolean) =>
+		[...subtractionKeys.lists(), "short", ready] as const,
 };
 
 /**
@@ -139,7 +140,7 @@ export function useRemoveSubtraction() {
  */
 export function useFetchSubtractionsShortlist(ready?: boolean) {
 	return useQuery<SubtractionOption[]>({
-		queryKey: [...subtractionQueryKeys.shortlist(), ready],
+		queryKey: subtractionQueryKeys.shortlist(ready),
 		queryFn: () =>
 			apiClient
 				.get("/subtractions")

--- a/apps/web/src/tasks/queries.ts
+++ b/apps/web/src/tasks/queries.ts
@@ -1,15 +1,10 @@
+import { createQueryKeys } from "@app/queryKeys";
 import { getTask } from "@server/tasks/functions";
 import { useQuery } from "@tanstack/react-query";
 import { type ServerTask, TaskSchema } from "./types";
 
-/**
- * Factory object for generating task query keys
- */
-export const taskQueryKeys = {
-	all: () => ["tasks"] as const,
-	details: () => ["tasks", "details"] as const,
-	detail: (taskId: number) => ["tasks", "details", taskId] as const,
-};
+/** Query keys for tasks. */
+export const taskQueryKeys = createQueryKeys("tasks");
 
 /**
  * Fetch a task by its id

--- a/apps/web/src/tests/setup.tsx
+++ b/apps/web/src/tests/setup.tsx
@@ -1,3 +1,4 @@
+import { accountQueryKeys } from "@account/queries";
 import type { Account } from "@account/types";
 import { faker } from "@faker-js/faker";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -9,6 +10,7 @@ import {
 	Outlet,
 	RouterProvider,
 } from "@tanstack/react-router";
+import { rootQueryKeys } from "@wall/queries";
 import "@testing-library/jest-dom/vitest";
 import {
 	fireEvent,
@@ -197,9 +199,11 @@ export async function renderRoute(path: string, opts?: RenderRouteOptions) {
 		defaultOptions: { queries: { retry: false } },
 	});
 
-	queryClient.setQueryData(["root"], { first_user: false });
-	queryClient.setQueryData(["account"], opts?.account ?? createFakeAccount());
-	queryClient.setQueryData(["message"], { message: "" });
+	queryClient.setQueryData(rootQueryKeys.all(), { first_user: false });
+	queryClient.setQueryData(
+		accountQueryKeys.all(),
+		opts?.account ?? createFakeAccount(),
+	);
 
 	if (opts?.seed) {
 		opts.seed(queryClient);

--- a/apps/web/src/uploads/queries.ts
+++ b/apps/web/src/uploads/queries.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@app/api";
+import { createQueryKeys } from "@app/queryKeys";
 import {
 	keepPreviousData,
 	useInfiniteQuery,
@@ -8,14 +9,13 @@ import {
 import type { ErrorResponse } from "@/types/api";
 import type { FileResponse, UploadType } from "./types";
 
-export const fileQueryKeys = {
-	all: () => ["files"] as const,
-	lists: () => ["files", "list"] as const,
-	list: (type: string, filters: Array<string | number | boolean>) =>
-		["files", "list", type, ...filters] as const,
-	infiniteList: (type: string, filters: Array<string | number | boolean>) =>
-		["files", "list", "infinite", type, ...filters] as const,
-};
+/**
+ * Query keys for uploaded files.
+ *
+ * The upload type leads the filters, so every list of a given type sits under
+ * a common prefix.
+ */
+export const fileQueryKeys = createQueryKeys("uploads");
 
 function findFiles(
 	type: UploadType,
@@ -38,7 +38,7 @@ function findFiles(
 
 export function useListFiles(type: UploadType, page, per_page: number) {
 	return useQuery<FileResponse, ErrorResponse>({
-		queryKey: fileQueryKeys.list(type, [page, per_page]),
+		queryKey: fileQueryKeys.list([type, page, per_page]),
 		queryFn: () => findFiles(type, page, per_page),
 		placeholderData: keepPreviousData,
 	});
@@ -50,7 +50,7 @@ export function useInfiniteFindFiles(
 	term?: string,
 ) {
 	return useInfiniteQuery<FileResponse>({
-		queryKey: fileQueryKeys.infiniteList(type, [per_page]),
+		queryKey: fileQueryKeys.infiniteList([type, per_page]),
 		queryFn: ({ pageParam }) =>
 			findFiles(type, pageParam as number, per_page, term),
 		initialPageParam: 1,

--- a/apps/web/src/users/__tests__/queries.test.ts
+++ b/apps/web/src/users/__tests__/queries.test.ts
@@ -6,35 +6,13 @@ function startsWith(key: readonly unknown[], prefix: readonly unknown[]) {
 }
 
 describe("userQueryKeys", () => {
-	it("nests every list variant under lists(), so one invalidation covers them all", () => {
-		for (const key of [
-			userQueryKeys.list([1, 25, "", undefined, undefined]),
-			userQueryKeys.nested(),
-			userQueryKeys.infiniteLists(),
-			userQueryKeys.infiniteList([25, ""]),
-		]) {
-			expect(startsWith(key, userQueryKeys.lists())).toBe(true);
-		}
-	});
-
-	it("nests details under details()", () => {
-		expect(startsWith(userQueryKeys.detail(7), userQueryKeys.details())).toBe(
+	it("nests the nested list under lists(), so one invalidation covers it too", () => {
+		expect(startsWith(userQueryKeys.nested(), userQueryKeys.lists())).toBe(
 			true,
 		);
 	});
 
-	it("nests lists and details under all()", () => {
-		expect(startsWith(userQueryKeys.lists(), userQueryKeys.all())).toBe(true);
-		expect(startsWith(userQueryKeys.details(), userQueryKeys.all())).toBe(true);
-	});
-
 	it("gives the nested list its own key rather than colliding with lists()", () => {
 		expect(userQueryKeys.nested()).not.toEqual(userQueryKeys.lists());
-	});
-
-	it("distinguishes filter sets", () => {
-		expect(userQueryKeys.list([1, 25, ""])).not.toEqual(
-			userQueryKeys.list([2, 25, ""]),
-		);
 	});
 });

--- a/apps/web/src/users/queries.ts
+++ b/apps/web/src/users/queries.ts
@@ -1,5 +1,6 @@
 import type { AdministratorRoleName } from "@administration/types";
 import { apiClient } from "@app/api";
+import { createQueryKeys } from "@app/queryKeys";
 import {
 	createUser,
 	findUsers,
@@ -19,23 +20,17 @@ import {
 } from "@tanstack/react-query";
 import type { UserNested, UserResponse } from "./types";
 
+const userKeys = createQueryKeys("users");
+
 /**
- * Factory object for generating user query keys
+ * Query keys for users.
  *
- * Every list variant — paginated, nested, and infinite — nests under `lists()`,
- * so a single `lists()` invalidation refreshes all of them.
+ * `nested()` is the flat list used to populate selectors. It nests under
+ * `lists()`, so a single `lists()` invalidation refreshes every list variant.
  */
 export const userQueryKeys = {
-	all: () => ["users"] as const,
-	lists: () => ["users", "list"] as const,
-	list: (filters: Array<string | number | boolean | undefined>) =>
-		["users", "list", ...filters] as const,
-	nested: () => ["users", "list", "nested"] as const,
-	infiniteLists: () => ["users", "list", "infinite"] as const,
-	infiniteList: (filters: Array<string | number | boolean | undefined>) =>
-		["users", "list", "infinite", ...filters] as const,
-	details: () => ["users", "details"] as const,
-	detail: (userId: number) => ["users", "details", userId] as const,
+	...userKeys,
+	nested: () => [...userKeys.lists(), "nested"] as const,
 };
 
 /**

--- a/apps/web/src/wall/components/__tests__/FirstUser.test.tsx
+++ b/apps/web/src/wall/components/__tests__/FirstUser.test.tsx
@@ -1,4 +1,4 @@
-import { accountKeys } from "@account/queries";
+import { accountQueryKeys } from "@account/queries";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mockApiCreateFirstUser } from "@tests/api/auth";
@@ -16,7 +16,7 @@ describe("<FirstUser />", () => {
 				// A fresh instance: the root reports the setup is needed and no
 				// account has been fetched yet.
 				queryClient.setQueryData(["root"], { first_user: true });
-				queryClient.removeQueries({ queryKey: accountKeys.all() });
+				queryClient.removeQueries({ queryKey: accountQueryKeys.all() });
 			},
 		});
 	}

--- a/apps/web/src/wall/queries.ts
+++ b/apps/web/src/wall/queries.ts
@@ -1,5 +1,6 @@
-import { accountKeys } from "@account/queries";
+import { accountQueryKeys } from "@account/queries";
 import { apiClient } from "@app/api";
+import { createQueryKeys } from "@app/queryKeys";
 import type { Root } from "@app/types";
 import {
 	createFirstUserFn,
@@ -22,10 +23,8 @@ export type ResetPasswordResult = {
 	reset: false;
 };
 
-/** Key factory function for the root document */
-export const rootKeys = {
-	all: () => ["root"],
-};
+/** Query keys for the root document. */
+export const rootQueryKeys = createQueryKeys("root");
 
 /**
  * Initializes a query for fetching the root document.
@@ -34,7 +33,7 @@ export const rootKeys = {
  */
 export function useRootQuery() {
 	return useQuery<Root, ErrorResponse>({
-		queryKey: rootKeys.all(),
+		queryKey: rootQueryKeys.all(),
 		queryFn: () => apiClient.get("/").then((res) => res.body),
 	});
 }
@@ -60,8 +59,8 @@ export function useCreateFirstUser() {
 		mutationFn: ({ handle, password }) =>
 			createFirstUserFn({ data: { handle, password } }),
 		onSuccess: () => {
-			queryClient.removeQueries({ queryKey: rootKeys.all() });
-			queryClient.removeQueries({ queryKey: accountKeys.all() });
+			queryClient.removeQueries({ queryKey: rootQueryKeys.all() });
+			queryClient.removeQueries({ queryKey: accountQueryKeys.all() });
 		},
 	});
 }
@@ -83,7 +82,7 @@ export function useLoginMutation() {
 			loginFn({ data: { handle, password, remember } }),
 		onSuccess: (data) => {
 			if (!data.reset) {
-				queryClient.invalidateQueries({ queryKey: accountKeys.all() });
+				queryClient.invalidateQueries({ queryKey: accountQueryKeys.all() });
 			}
 		},
 	});
@@ -105,7 +104,7 @@ export function useResetPasswordMutation() {
 		mutationFn: ({ password, resetCode }) =>
 			resetPasswordFn({ data: { password, reset_code: resetCode } }),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: accountKeys.all() });
+			queryClient.invalidateQueries({ queryKey: accountQueryKeys.all() });
 		},
 	});
 }

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -19,69 +19,98 @@ logic lives directly inside the hook's `queryFn`/`mutationFn` (or a
 module-private helper only when the same request is shared by more than one
 hook or selected between branches.
 
-## Query keys come from a per-feature factory
+## Query keys come from `createQueryKeys`
 
 A query key is a tuple of primitives that uniquely identifies a cached
-request. Every feature that caches data exports a single `*QueryKeys`
-factory:
-
-```ts
-export const samplesQueryKeys = {
-  all: () => ["samples"] as const,
-  lists: () => ["samples", "list"] as const,
-  list: (filters: Array<string | number | boolean | string[] | number[]>) =>
-    ["samples", "list", ...filters] as const,
-  details: () => ["samples", "details"] as const,
-  detail: (sampleId: string) => ["samples", "details", sampleId] as const,
-};
-```
-
-Keys must be:
+request. Keys must be:
 
 - **Distinct** — every request with different parameters gets a different
   key. `list([5, 25])` and `list([6, 25])` are different keys.
 - **Deterministic** — the same parameters always produce the same key. Pick
-  an argument order in the factory and stick to it across call sites.
+  an argument order and stick to it across call sites.
 - **Hierarchical** — invalidating a shorter key invalidates every longer
   key beneath it. `invalidateQueries({ queryKey: samplesQueryKeys.lists() })`
-  marks every paginated list stale; `samplesQueryKeys.all()` marks every
-  sample query stale, lists and details alike.
+  marks every cached list of samples stale; `samplesQueryKeys.all()` marks
+  every sample query stale, lists and details alike.
 
-One factory per feature keeps the hierarchy visible in a single place and
-prevents accidental collisions between modules.
-
-### Every list variant nests under `lists()`
-
-A feature often caches the same collection more than one way — paginated,
-infinite-scrolling, or as a flat list for a selector. All of them nest
-beneath `lists()`, distinguished by a segment that follows it:
+Nothing hand-writes a key. Every feature that caches data exports a
+`*QueryKeys` built by `createQueryKeys(domain)` from `@app/queryKeys`:
 
 ```ts
-export const userQueryKeys = {
-  all: () => ["users"] as const,
-  lists: () => ["users", "list"] as const,
-  list: (filters: Array<string | number | boolean | undefined>) =>
-    ["users", "list", ...filters] as const,
-  nested: () => ["users", "list", "nested"] as const,
-  infiniteLists: () => ["users", "list", "infinite"] as const,
-  infiniteList: (filters: Array<string | number | boolean | undefined>) =>
-    ["users", "list", "infinite", ...filters] as const,
-  details: () => ["users", "details"] as const,
-  detail: (userId: number) => ["users", "details", userId] as const,
-};
+export const samplesQueryKeys = createQueryKeys("samples");
 ```
+
+That yields seven members — `all`, `lists`, `list`, `infiniteLists`,
+`infiniteList`, `details`, and `detail`:
+
+```ts
+samplesQueryKeys.all();               // ["samples"]
+samplesQueryKeys.lists();             // ["samples", "list"]
+samplesQueryKeys.list([5, 25]);       // ["samples", "list", 5, 25]
+samplesQueryKeys.infiniteList([25]);  // ["samples", "list", "infinite", 25]
+samplesQueryKeys.details();           // ["samples", "details"]
+samplesQueryKeys.detail("abc");       // ["samples", "details", "abc"]
+```
+
+The hierarchy holds *by construction*: every list variant extends `lists()`
+and every detail extends `details()`, because the factory builds the longer
+keys by spreading the shorter ones. A feature cannot end up with a
+`details()` that fails to invalidate its own `detail(id)`, and a domain that
+caches nothing under a member simply never calls it — an unused member costs
+nothing, so there is no reason to trim the set.
 
 This is what makes a single `invalidateQueries({ queryKey: lists() })` in a
 mutation's `onSuccess` — or in the SSE handler — refresh *every* cached view
-of the collection. Hoisting a variant to a sibling of `lists()` (say,
-`["users", "infiniteList"]`) silently removes it from that invalidation:
-nothing fails to compile and no test breaks, the list just stops updating.
+of the collection.
+
+### Extra members derive from a base key
+
+A feature sometimes caches something that is none of the seven shapes: a
+flat list for a selector, an OTU's change history, the one active banner.
+Spread the factory and derive the extra member **from a base key**, so it
+lands inside the hierarchy rather than beside it:
+
+```ts
+const userKeys = createQueryKeys("users");
+
+export const userQueryKeys = {
+  ...userKeys,
+  nested: () => [...userKeys.lists(), "nested"] as const,
+};
+```
+
+Because `nested()` extends `lists()`, one `lists()` invalidation still
+refreshes it. Hoisting it to a sibling instead (say, `["users", "nested"]`)
+silently removes it from that invalidation: nothing fails to compile and no
+test breaks, the selector just stops updating.
+
+Derive from the key whose invalidation *should* reach the new member. An
+OTU's history nests under that OTU's `detail(id)`, so the mutations that
+invalidate the OTU also refresh the history they just appended to. A
+reference's unbuilt changes are keyed by reference, not by index, so they
+get their own segment under `all()` rather than squatting in the index
+details namespace.
 
 Give each variant its own segment rather than letting it land on a prefix
 that is already a key. `list([])` collapses to `["users", "list"]` — exactly
 `lists()` — which parks a real cache entry on the invalidation prefix, where
-any `setQueryData(lists(), …)` would clobber it. That is what `nested()` is
-for.
+any `setQueryData(lists(), …)` would clobber it. A collection with no filters
+should key off `lists()` deliberately, not arrive there by passing an empty
+filter array.
+
+### The SSE handler declares what each domain caches
+
+`app/sse/reactQueryHandler.ts` maps a pushed frame to the narrowest key it
+can invalidate: `detail(id)` for an update, `lists()` for an insert or
+delete. Not every domain caches both — the account is a singleton cached at
+`all()`, tasks cache no list, labels cache no detail — and invalidating a key
+nothing is cached under is a **silent no-op**, not an error.
+
+So the handler's registry states, per domain, whether it caches details and
+whether it caches lists, and falls back to `all()` when it doesn't. Do not
+try to infer that from the keys: every domain has every member now, so their
+presence says nothing about what is cached. When a feature starts caching a
+shape it didn't before, flip its flag in that registry.
 
 ## Share query config with `queryOptions()`
 


### PR DESCRIPTION
## Summary

- Replace the 18 hand-written `*QueryKeys` factories with one shared `createQueryKeys(domain)` in `@app/queryKeys`. It builds the longer keys by spreading the shorter ones, so every list variant extends `lists()` and every detail extends `details()` by construction — fixing `indexQueryKeys` and `groupQueryKeys`, where the two had drifted apart and could no longer invalidate each other.
- Give the SSE handler an explicit per-domain registry of whether it caches details and whether it caches lists. It previously chose its key by probing for an *absent* member, a fallback a uniform factory would have silently broken for six domains. Its tests now cover all twelve domains across every operation and assert that seeded cache entries actually go stale, since key equality alone can't catch a domain narrowing onto a key nothing is cached under.
- Resolve two collisions the conversion surfaced: a reference's unbuilt changes get their own `unbuilt(refId)` key instead of squatting in `indexQueryKeys.detail(refId)`, and the paginated index list moves from `infiniteList` to `list`, so index creation now invalidates it (and clears the unbuilt list, which nothing was refreshing before).