### PR TITLE
test: pin auth middleware, session, and cookie behavior

### DIFF
--- a/apps/web/src/server/auth/cookies.test.ts
+++ b/apps/web/src/server/auth/cookies.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const deleteCookie = vi.fn();
+const getCookie = vi.fn();
+const setCookie = vi.fn();
+
+vi.mock("@tanstack/react-start/server", () => ({
+	deleteCookie,
+	getCookie,
+	setCookie,
+}));
+
+const { realCookies, SESSION_ID_COOKIE, SESSION_TOKEN_COOKIE } = await import(
+	"./cookies"
+);
+
+// Python sets this on both cookies. A mismatch would make a cookie written here
+// expire on a different schedule from one written by the Python backend.
+const MAX_AGE_SECONDS = 2_600_000;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe("realCookies", () => {
+	it("reads the session id", () => {
+		getCookie.mockReturnValue("session_abc");
+
+		expect(realCookies.getSessionId()).toBe("session_abc");
+		expect(getCookie).toHaveBeenCalledWith(SESSION_ID_COOKIE);
+	});
+
+	it("reads the session token", () => {
+		getCookie.mockReturnValue("token_abc");
+
+		expect(realCookies.getSessionToken()).toBe("token_abc");
+		expect(getCookie).toHaveBeenCalledWith(SESSION_TOKEN_COOKIE);
+	});
+
+	it("returns undefined when a cookie is absent", () => {
+		getCookie.mockReturnValue(undefined);
+
+		expect(realCookies.getSessionId()).toBeUndefined();
+		expect(realCookies.getSessionToken()).toBeUndefined();
+	});
+
+	it.each([
+		["setSessionId", SESSION_ID_COOKIE],
+		["setSessionToken", SESSION_TOKEN_COOKIE],
+	] as const)("%s writes an http-only lax cookie", (method, name) => {
+		realCookies[method]("value");
+
+		expect(setCookie).toHaveBeenCalledWith(name, "value", {
+			httpOnly: true,
+			maxAge: MAX_AGE_SECONDS,
+			path: "/",
+			sameSite: "lax",
+			secure: false,
+		});
+	});
+
+	it("does not mark cookies secure outside production", () => {
+		vi.stubEnv("NODE_ENV", "development");
+
+		realCookies.setSessionId("session_abc");
+
+		expect(setCookie).toHaveBeenCalledWith(
+			SESSION_ID_COOKIE,
+			"session_abc",
+			expect.objectContaining({ secure: false }),
+		);
+	});
+
+	it("marks cookies secure in production", () => {
+		vi.stubEnv("NODE_ENV", "production");
+
+		realCookies.setSessionId("session_abc");
+		realCookies.setSessionToken("token_abc");
+
+		expect(setCookie).toHaveBeenNthCalledWith(
+			1,
+			SESSION_ID_COOKIE,
+			"session_abc",
+			expect.objectContaining({ secure: true }),
+		);
+		expect(setCookie).toHaveBeenNthCalledWith(
+			2,
+			SESSION_TOKEN_COOKIE,
+			"token_abc",
+			expect.objectContaining({ secure: true }),
+		);
+	});
+
+	it("clears both cookies from the root path", () => {
+		realCookies.clear();
+
+		expect(deleteCookie).toHaveBeenCalledTimes(2);
+		expect(deleteCookie).toHaveBeenCalledWith(SESSION_ID_COOKIE, { path: "/" });
+		expect(deleteCookie).toHaveBeenCalledWith(SESSION_TOKEN_COOKIE, {
+			path: "/",
+		});
+	});
+});

--- a/apps/web/src/server/auth/exceptions.ts
+++ b/apps/web/src/server/auth/exceptions.ts
@@ -1,0 +1,22 @@
+import {
+	createFirstUserFn,
+	loginFn,
+	logoutFn,
+	resetPasswordFn,
+} from "./functions";
+
+/**
+ * Server functions exempt from global authentication.
+ *
+ * logoutFn must be exempt so stale or missing cookies can still be cleared.
+ * createFirstUserFn runs before any user or session exists.
+ */
+// Annotated rather than inferred: an inferred type would reference TanStack's
+// server-fn types transitively, breaking declaration emit for `@server/*`
+// importers.
+export const authenticationExceptions: ReadonlyArray<{ url: string }> = [
+	createFirstUserFn,
+	loginFn,
+	logoutFn,
+	resetPasswordFn,
+];

--- a/apps/web/src/server/auth/middleware.test.ts
+++ b/apps/web/src/server/auth/middleware.test.ts
@@ -1,0 +1,298 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+
+import type { Db } from "../db/pg";
+import { sessions } from "../db/schema/sessions";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+
+const getRequest = vi.fn();
+const setResponseStatus = vi.fn();
+const setUser = vi.fn();
+
+vi.mock("@tanstack/react-start/server", () => ({
+	deleteCookie: vi.fn(),
+	getCookie: vi.fn(),
+	getRequest,
+	setCookie: vi.fn(),
+	setResponseStatus,
+}));
+
+vi.mock("@sentry/tanstackstart-react", () => ({
+	captureException: vi.fn(),
+	setUser,
+}));
+
+// The middleware reads the `db` singleton at module scope. A getter defers the
+// read until a handler actually runs, by which point beforeAll has pointed it
+// at this file's isolated database.
+let db: Db;
+vi.mock("../db/pg", () => ({
+	client: {},
+	get db() {
+		return db;
+	},
+}));
+
+const { authenticationExceptions } = await import("./exceptions");
+const {
+	createAuthenticationMiddleware,
+	ForbiddenError,
+	requireAdminRole,
+	requireAuthenticatedRequest,
+	requireSession,
+	UnauthorizedError,
+} = await import("./middleware");
+const { createFirstUserFn, loginFn, logoutFn, resetPasswordFn } = await import(
+	"./functions"
+);
+const { SESSION_ID_COOKIE, SESSION_TOKEN_COOKIE } = await import("./cookies");
+const { seedSession, seedUser } = await import("./test/fixtures");
+
+let database: TestDatabase;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	await db.delete(sessions);
+	await db.delete(users);
+});
+
+/** The middleware's server handler, which `createMiddleware` stores verbatim. */
+type ServerHandler = (options: {
+	next: (options?: unknown) => Promise<unknown>;
+}) => Promise<unknown>;
+
+function serverHandler(exceptions: ReadonlyArray<{ url: string }>) {
+	const middleware = createAuthenticationMiddleware(exceptions);
+	return (middleware as unknown as { options: { server: ServerHandler } })
+		.options.server;
+}
+
+function cookieHeader(sessionId: string, token: string): string {
+	return `${SESSION_ID_COOKIE}=${sessionId}; ${SESSION_TOKEN_COOKIE}=${token}`;
+}
+
+function requestFor(url: string, cookie?: string) {
+	return new Request(new URL(url, "https://virtool.test"), {
+		headers: cookie ? { cookie } : undefined,
+	});
+}
+
+describe("authenticationExceptions", () => {
+	// The list is the whole security boundary: anything on it is publicly
+	// callable. A fn added here by mistake is a silent hole, so pin the contents
+	// rather than just the middleware's handling of them.
+	it("exempts exactly the four unauthenticated endpoints", () => {
+		expect(authenticationExceptions).toHaveLength(4);
+		expect(authenticationExceptions.map((fn) => fn.url).sort()).toEqual(
+			[createFirstUserFn, loginFn, logoutFn, resetPasswordFn]
+				.map((fn) => fn.url)
+				.sort(),
+		);
+	});
+});
+
+describe("createAuthenticationMiddleware", () => {
+	it.each([
+		["createFirstUserFn", () => createFirstUserFn],
+		["loginFn", () => loginFn],
+		["logoutFn", () => logoutFn],
+		["resetPasswordFn", () => resetPasswordFn],
+	])("lets an unauthenticated call reach %s", async (_label, get) => {
+		getRequest.mockReturnValue(requestFor(get().url));
+		const next = vi.fn().mockResolvedValue("result");
+
+		await serverHandler(authenticationExceptions)({ next });
+
+		expect(next).toHaveBeenCalledWith({ context: { session: null } });
+		expect(setUser).not.toHaveBeenCalled();
+	});
+
+	it("rejects an unauthenticated call to a fn that is not excepted", async () => {
+		getRequest.mockReturnValue(requestFor("/_serverFn/somethingElse"));
+		const next = vi.fn();
+
+		await expect(
+			serverHandler(authenticationExceptions)({ next }),
+		).rejects.toBeInstanceOf(UnauthorizedError);
+
+		expect(setResponseStatus).toHaveBeenCalledWith(401);
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it("attaches the resolved session to the handler context", async () => {
+		const userId = await seedUser(db);
+		const { sessionId, token } = await seedSession(db, userId);
+
+		getRequest.mockReturnValue(
+			requestFor("/_serverFn/somethingElse", cookieHeader(sessionId, token)),
+		);
+		const next = vi.fn().mockResolvedValue("result");
+
+		await serverHandler(authenticationExceptions)({ next });
+
+		expect(next).toHaveBeenCalledWith({ context: { session: { userId } } });
+	});
+
+	it("ties the acting user to the sentry scope", async () => {
+		const userId = await seedUser(db);
+		const { sessionId, token } = await seedSession(db, userId);
+
+		getRequest.mockReturnValue(
+			requestFor("/_serverFn/somethingElse", cookieHeader(sessionId, token)),
+		);
+
+		await serverHandler(authenticationExceptions)({
+			next: vi.fn().mockResolvedValue("result"),
+		});
+
+		expect(setUser).toHaveBeenCalledWith({ id: userId });
+	});
+
+	it("rejects a session whose user has been deactivated", async () => {
+		const userId = await seedUser(db, { active: false });
+		const { sessionId, token } = await seedSession(db, userId);
+
+		getRequest.mockReturnValue(
+			requestFor("/_serverFn/somethingElse", cookieHeader(sessionId, token)),
+		);
+
+		await expect(
+			serverHandler(authenticationExceptions)({ next: vi.fn() }),
+		).rejects.toBeInstanceOf(UnauthorizedError);
+	});
+
+	it("authenticates every call when there are no exceptions", async () => {
+		getRequest.mockReturnValue(requestFor(loginFn.url));
+
+		await expect(serverHandler([])({ next: vi.fn() })).rejects.toBeInstanceOf(
+			UnauthorizedError,
+		);
+	});
+
+	// The path is compared as a pathname, so a query string must not defeat the
+	// match and turn a public endpoint into a 401.
+	it("matches an exception carrying a query string", async () => {
+		getRequest.mockReturnValue(requestFor(`${loginFn.url}?createServerFn`));
+		const next = vi.fn().mockResolvedValue("result");
+
+		await serverHandler(authenticationExceptions)({ next });
+
+		expect(next).toHaveBeenCalledWith({ context: { session: null } });
+	});
+
+	it("does not treat a path that merely extends an exception as excepted", async () => {
+		getRequest.mockReturnValue(requestFor(`${loginFn.url}Extra`));
+
+		await expect(
+			serverHandler(authenticationExceptions)({ next: vi.fn() }),
+		).rejects.toBeInstanceOf(UnauthorizedError);
+	});
+});
+
+describe("requireSession", () => {
+	it("resolves the session carried by the request cookies", async () => {
+		const userId = await seedUser(db);
+		const { sessionId, token } = await seedSession(db, userId);
+
+		getRequest.mockReturnValue(
+			requestFor("/_serverFn/me", cookieHeader(sessionId, token)),
+		);
+
+		expect(await requireSession()).toEqual({ userId });
+	});
+
+	it("throws and sets a 401 when the request has no cookies", async () => {
+		getRequest.mockReturnValue(requestFor("/_serverFn/me"));
+
+		await expect(requireSession()).rejects.toBeInstanceOf(UnauthorizedError);
+		expect(setResponseStatus).toHaveBeenCalledWith(401);
+	});
+});
+
+describe("requireAuthenticatedRequest", () => {
+	it("resolves the session for a raw request", async () => {
+		const userId = await seedUser(db);
+		const { sessionId, token } = await seedSession(db, userId);
+
+		expect(
+			await requireAuthenticatedRequest(
+				requestFor("/events", cookieHeader(sessionId, token)),
+			),
+		).toEqual({ userId });
+	});
+
+	// Raw route handlers run outside the server-function context, so this returns
+	// a Response for the caller to return rather than throwing.
+	it("returns a 401 response rather than throwing", async () => {
+		const result = await requireAuthenticatedRequest(requestFor("/events"));
+
+		expect(result).toBeInstanceOf(Response);
+		expect((result as Response).status).toBe(401);
+	});
+});
+
+describe("requireAdminRole", () => {
+	it("rejects a user with no administrator role", async () => {
+		const userId = await seedUser(db);
+
+		await expect(requireAdminRole({ userId }, "base")).rejects.toBeInstanceOf(
+			ForbiddenError,
+		);
+		expect(setResponseStatus).toHaveBeenCalledWith(403);
+	});
+
+	it("rejects a session whose user no longer exists", async () => {
+		await expect(
+			requireAdminRole({ userId: 404 }, "base"),
+		).rejects.toBeInstanceOf(ForbiddenError);
+	});
+
+	it.each([
+		"full",
+		"settings",
+		"spaces",
+		"users",
+		"base",
+	] as const)("allows a full administrator to satisfy a %s requirement", async (requiredRole) => {
+		const userId = await seedUser(db, { administratorRole: "full" });
+
+		await expect(
+			requireAdminRole({ userId }, requiredRole),
+		).resolves.toBeUndefined();
+	});
+
+	// `full` is the strongest role and `base` the weakest, so a role satisfies a
+	// requirement it outranks. Easy to invert; pin both directions.
+	it("allows a stronger role to satisfy a weaker requirement", async () => {
+		const userId = await seedUser(db, { administratorRole: "settings" });
+
+		await expect(
+			requireAdminRole({ userId }, "users"),
+		).resolves.toBeUndefined();
+	});
+
+	it("rejects a weaker role against a stronger requirement", async () => {
+		const userId = await seedUser(db, { administratorRole: "base" });
+
+		await expect(
+			requireAdminRole({ userId }, "settings"),
+		).rejects.toBeInstanceOf(ForbiddenError);
+	});
+});

--- a/apps/web/src/server/auth/session.test.ts
+++ b/apps/web/src/server/auth/session.test.ts
@@ -1,0 +1,243 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import type { Db } from "../db/pg";
+import { sessions } from "../db/schema/sessions";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import {
+	createAuthenticatedSession,
+	createResetSession,
+	invalidateSession,
+	invalidateUserSessions,
+} from "./session";
+import { seedSession, seedUser } from "./test/fixtures";
+import { hashToken } from "./tokens";
+import { verifyAuthenticatedSession } from "./verify";
+
+// The Python lifetimes in `virtool/sessions/data.py`, which these rows must be
+// indistinguishable from.
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+const SIXTY_MINUTES_MS = 60 * 60 * 1000;
+const TEN_MINUTES_MS = 10 * 60 * 1000;
+
+let database: TestDatabase;
+let db: Db;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(sessions);
+	await db.delete(users);
+});
+
+// `createdAt` and `expiresAt` are both derived from a single `now`, so the gap
+// between them is the lifetime exactly — no clock stubbing required.
+function lifetimeOf(row: { createdAt: Date; expiresAt: Date }): number {
+	return row.expiresAt.getTime() - row.createdAt.getTime();
+}
+
+describe("createAuthenticatedSession", () => {
+	it("gives a remembered session a thirty day lifetime", async () => {
+		const userId = await seedUser(db);
+
+		const { row } = await createAuthenticatedSession(db, {
+			userId,
+			ip: "127.0.0.1",
+			remember: true,
+		});
+
+		expect(lifetimeOf(row)).toBe(THIRTY_DAYS_MS);
+	});
+
+	it("gives an unremembered session a sixty minute lifetime", async () => {
+		const userId = await seedUser(db);
+
+		const { row } = await createAuthenticatedSession(db, {
+			userId,
+			ip: "127.0.0.1",
+			remember: false,
+		});
+
+		expect(lifetimeOf(row)).toBe(SIXTY_MINUTES_MS);
+	});
+
+	it("writes an authenticated row for the user and ip", async () => {
+		const userId = await seedUser(db);
+
+		const { row } = await createAuthenticatedSession(db, {
+			userId,
+			ip: "10.0.0.4",
+			remember: false,
+		});
+
+		expect(row.sessionType).toBe("authenticated");
+		expect(row.userId).toBe(userId);
+		expect(row.ip).toBe("10.0.0.4");
+		expect(row.resetCode).toBeNull();
+	});
+
+	it("stores only the hash of the token, never the plaintext", async () => {
+		const userId = await seedUser(db);
+
+		const { token, row } = await createAuthenticatedSession(db, {
+			userId,
+			ip: "127.0.0.1",
+			remember: false,
+		});
+
+		expect(row.tokenHash).toBe(hashToken(token));
+		expect(row.tokenHash).not.toBe(token);
+	});
+
+	it("mints a session that verifies with the returned token", async () => {
+		const userId = await seedUser(db);
+
+		const { sessionId, token } = await createAuthenticatedSession(db, {
+			userId,
+			ip: "127.0.0.1",
+			remember: false,
+		});
+
+		expect(await verifyAuthenticatedSession(db, sessionId, token)).toEqual({
+			userId,
+		});
+	});
+
+	it("mints a distinct session id and token each time", async () => {
+		const userId = await seedUser(db);
+		const input = { userId, ip: "127.0.0.1", remember: false };
+
+		const first = await createAuthenticatedSession(db, input);
+		const second = await createAuthenticatedSession(db, input);
+
+		expect(first.sessionId).not.toBe(second.sessionId);
+		expect(first.token).not.toBe(second.token);
+	});
+});
+
+describe("createResetSession", () => {
+	it("gives a reset session a ten minute lifetime", async () => {
+		const userId = await seedUser(db);
+
+		const { row } = await createResetSession(db, {
+			userId,
+			ip: "127.0.0.1",
+			remember: false,
+		});
+
+		expect(lifetimeOf(row)).toBe(TEN_MINUTES_MS);
+	});
+
+	it("writes a reset row with a reset code and no token hash", async () => {
+		const userId = await seedUser(db);
+
+		const { resetCode, row } = await createResetSession(db, {
+			userId,
+			ip: "127.0.0.1",
+			remember: false,
+		});
+
+		expect(row.sessionType).toBe("reset");
+		expect(row.userId).toBe(userId);
+		expect(row.tokenHash).toBeNull();
+		expect(row.resetCode).toBe(resetCode);
+		expect(resetCode).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	// `resetPassword` reads `resetRemember` back to carry the flag into the
+	// authenticated session it mints. If it were not persisted, a user who ticked
+	// "remember me" would silently get a sixty minute session after a reset.
+	it.each([
+		true,
+		false,
+	])("persists remember=%s across the reset", async (remember) => {
+		const userId = await seedUser(db);
+
+		const { row } = await createResetSession(db, {
+			userId,
+			ip: "127.0.0.1",
+			remember,
+		});
+
+		expect(row.resetRemember).toBe(remember);
+	});
+
+	it("is not accepted as an authenticated session", async () => {
+		const userId = await seedUser(db);
+
+		const { sessionId, resetCode } = await createResetSession(db, {
+			userId,
+			ip: "127.0.0.1",
+			remember: false,
+		});
+
+		expect(
+			await verifyAuthenticatedSession(db, sessionId, resetCode),
+		).toBeNull();
+	});
+});
+
+describe("invalidateSession", () => {
+	it("deletes only the named session", async () => {
+		const userId = await seedUser(db);
+		const doomed = await seedSession(db, userId);
+		const kept = await seedSession(db, userId);
+
+		await invalidateSession(db, doomed.sessionId);
+
+		const remaining = await db
+			.select({ sessionId: sessions.sessionId })
+			.from(sessions);
+
+		expect(remaining).toEqual([{ sessionId: kept.sessionId }]);
+	});
+
+	it("is a no-op for an unknown session id", async () => {
+		const userId = await seedUser(db);
+		await seedSession(db, userId);
+
+		await invalidateSession(db, "session_unknown");
+
+		expect(await db.select().from(sessions)).toHaveLength(1);
+	});
+});
+
+describe("invalidateUserSessions", () => {
+	it("deletes every session of one user and leaves other users alone", async () => {
+		const alice = await seedUser(db);
+		const bob = await seedUser(db, { handle: "bob" });
+
+		await seedSession(db, alice);
+		await seedSession(db, alice);
+		const bobSession = await seedSession(db, bob);
+
+		await invalidateUserSessions(db, alice);
+
+		const remaining = await db
+			.select({ sessionId: sessions.sessionId, userId: sessions.userId })
+			.from(sessions);
+
+		expect(remaining).toEqual([
+			{ sessionId: bobSession.sessionId, userId: bob },
+		]);
+	});
+
+	it("leaves the user row itself in place", async () => {
+		const userId = await seedUser(db);
+		await seedSession(db, userId);
+
+		await invalidateUserSessions(db, userId);
+
+		expect(
+			await db.select({ id: users.id }).from(users).where(eq(users.id, userId)),
+		).toEqual([{ id: userId }]);
+	});
+});

--- a/apps/web/src/server/auth/test/fixtures.ts
+++ b/apps/web/src/server/auth/test/fixtures.ts
@@ -1,3 +1,5 @@
+import type { AdministratorRoleName } from "@administration/types";
+
 import type { Db } from "../../db/pg";
 import { sessions } from "../../db/schema/sessions";
 import { users } from "../../db/schema/users";
@@ -10,18 +12,30 @@ export type SeededSession = {
 	userId: number;
 };
 
-/** Insert a user, active unless told otherwise, and return its id. */
+/**
+ * Insert a user, active and with no administrator role unless told otherwise,
+ * and return its id.
+ *
+ * `handle` is unique (case-insensitively), so a test seeding a second user must
+ * pass a distinct one.
+ */
 export async function seedUser(
 	db: Db,
 	{
 		active = true,
+		administratorRole = null,
 		handle = "alice",
-	}: { active?: boolean; handle?: string } = {},
+	}: {
+		active?: boolean;
+		administratorRole?: AdministratorRoleName | null;
+		handle?: string;
+	} = {},
 ): Promise<number> {
 	const [user] = await db
 		.insert(users)
 		.values({
 			active,
+			administratorRole,
 			handle,
 			lastPasswordChange: new Date(),
 			password: Buffer.from("not-a-real-hash"),

--- a/apps/web/src/server/auth/verify.test.ts
+++ b/apps/web/src/server/auth/verify.test.ts
@@ -7,7 +7,11 @@ import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
 import { SESSION_ID_COOKIE, SESSION_TOKEN_COOKIE } from "./cookies";
 import { seedSession, seedUser } from "./test/fixtures";
 import { newSessionToken } from "./tokens";
-import { verifyAuthenticatedSession, verifyRequest } from "./verify";
+import {
+	parseCookieHeader,
+	verifyAuthenticatedSession,
+	verifyRequest,
+} from "./verify";
 
 let database: TestDatabase;
 let db: Db;
@@ -109,12 +113,66 @@ describe("verifyAuthenticatedSession", () => {
 	});
 });
 
+describe("parseCookieHeader", () => {
+	it("returns nothing for a request that sent no cookie header", () => {
+		expect(parseCookieHeader(null)).toEqual({});
+	});
+
+	it("parses a pair of cookies", () => {
+		expect(parseCookieHeader("session_id=abc; session_token=def")).toEqual({
+			session_id: "abc",
+			session_token: "def",
+		});
+	});
+
+	it("trims the whitespace around names and values", () => {
+		expect(parseCookieHeader("  session_id  =  abc  ")).toEqual({
+			session_id: "abc",
+		});
+	});
+
+	it("decodes a percent-encoded value", () => {
+		expect(parseCookieHeader("session_id=a%20b%3Bc")).toEqual({
+			session_id: "a b;c",
+		});
+	});
+
+	// Splitting on the last `=` would corrupt any base64-padded value.
+	it("splits on the first equals sign only", () => {
+		expect(parseCookieHeader("session_token=aGk=")).toEqual({
+			session_token: "aGk=",
+		});
+	});
+
+	it("skips segments with no equals sign", () => {
+		expect(parseCookieHeader("broken; session_id=abc")).toEqual({
+			session_id: "abc",
+		});
+	});
+
+	it("skips a segment with an empty name", () => {
+		expect(parseCookieHeader("=orphan; session_id=abc")).toEqual({
+			session_id: "abc",
+		});
+	});
+
+	it("keeps a cookie with an empty value", () => {
+		expect(parseCookieHeader("session_id=")).toEqual({ session_id: "" });
+	});
+});
+
 describe("verifyRequest", () => {
 	function request(cookie: string): Request {
 		return new Request("https://virtool.test/events", {
 			headers: { cookie },
 		});
 	}
+
+	it("rejects a request that sent no cookies at all", async () => {
+		expect(
+			await verifyRequest(db, new Request("https://virtool.test/events")),
+		).toBeNull();
+	});
 
 	it("resolves the session from the cookie header", async () => {
 		const userId = await seedUser(db);

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -2,12 +2,7 @@ import {
 	sentryGlobalFunctionMiddleware,
 	sentryGlobalRequestMiddleware,
 } from "@sentry/tanstackstart-react";
-import {
-	createFirstUserFn,
-	loginFn,
-	logoutFn,
-	resetPasswordFn,
-} from "@server/auth/functions";
+import { authenticationExceptions } from "@server/auth/exceptions";
 import { createAuthenticationMiddleware } from "@server/auth/middleware";
 import { errorLoggingMiddleware } from "@server/error-logging";
 import {
@@ -16,14 +11,9 @@ import {
 	createStart,
 } from "@tanstack/react-start";
 
-// logoutFn must be exempt so stale or missing cookies can still be cleared.
-// createFirstUserFn runs before any user or session exists.
-const authenticationMiddleware = createAuthenticationMiddleware([
-	createFirstUserFn,
-	loginFn,
-	logoutFn,
-	resetPasswordFn,
-]);
+const authenticationMiddleware = createAuthenticationMiddleware(
+	authenticationExceptions,
+);
 
 const cspDirectives = [
 	"default-src 'self'",

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -37,15 +37,24 @@ should look like labels.
 ## Authentication middleware
 
 Authentication is enforced globally at the server-function boundary,
-not per-handler. The wiring lives in `apps/web/src/start.ts`:
+not per-handler. The exempt endpoints live in
+`server/auth/exceptions.ts`:
 
 ```ts
-const authenticationMiddleware = createAuthenticationMiddleware([
+export const authenticationExceptions: ReadonlyArray<{ url: string }> = [
   createFirstUserFn,
   loginFn,
   logoutFn,
   resetPasswordFn,
-]);
+];
+```
+
+and are wired up in `apps/web/src/start.ts`:
+
+```ts
+const authenticationMiddleware = createAuthenticationMiddleware(
+  authenticationExceptions,
+);
 
 export const startInstance = createStart(() => ({
   defaultSsr: false,
@@ -59,6 +68,13 @@ being listed in the `exceptions` array — passed as **server-function
 references**, not URL strings. The middleware derives the path from
 each fn's bound `url`, so the exception list can't drift out of sync
 with a rename.
+
+The list is a standalone module rather than an inline array so it can
+be asserted on: `middleware.test.ts` pins its exact contents, and a fn
+added to it by mistake fails that test instead of silently becoming
+publicly callable. Its type is annotated rather than inferred — an
+inferred type would name TanStack's server-fn types transitively and
+break declaration emit for `@server/*` importers.
 
 The middleware lives in `server/auth/middleware.ts` and exposes three
 helpers:


### PR DESCRIPTION
## Summary
- Adds 79 tests covering the auth module's primitives — cookie attributes and parsing, session lifetimes, and the middleware's exception list — so a mistakenly exempted server function or a drifted session lifetime fails the suite instead of shipping silently.
- Extracts the authentication exceptions list out of a closure in `start.ts` into `server/auth/exceptions.ts`. It was an inline array literal nothing could read back; as a module, the security boundary (which endpoints skip global auth) is something a test can actually pin.
- Asserts session lifetimes exactly rather than within a tolerance — `createdAt` and `expiresAt` derive from a single `now`, so no clock stubbing is needed — and pins `resetRemember`, which `resetPassword` reads back to carry the remember flag through a forced reset.