### PR TITLE
chore: read instance settings from postgres

### DIFF
--- a/apps/web/src/administration/queries.ts
+++ b/apps/web/src/administration/queries.ts
@@ -16,14 +16,12 @@ export type SettingsUpdate = {
 	default_source_types?: string[];
 	enable_api?: boolean;
 	enable_sentry?: boolean;
-	hmm_slug?: string;
 	minimum_password_length?: number;
 	sample_all_read?: boolean;
 	sample_all_write?: boolean;
 	sample_group?: string;
 	sample_group_read?: boolean;
 	sample_group_write?: boolean;
-	sample_unique_names?: boolean;
 };
 
 /** Query keys for the server settings. */

--- a/apps/web/src/administration/types.ts
+++ b/apps/web/src/administration/types.ts
@@ -28,12 +28,10 @@ export type Settings = {
 	default_source_types: string[];
 	enable_api: boolean;
 	enable_sentry: boolean;
-	hmm_slug: string;
 	minimum_password_length: number;
 	sample_all_read: boolean;
 	sample_all_write: boolean;
 	sample_group: string;
 	sample_group_read: boolean;
 	sample_group_write: boolean;
-	sample_unique_names: boolean;
 };

--- a/apps/web/src/references/components/__tests__/ReferenceSettings.test.tsx
+++ b/apps/web/src/references/components/__tests__/ReferenceSettings.test.tsx
@@ -9,7 +9,6 @@ const settings = {
 	default_source_types: ["Clone", "Genotype"],
 	enable_api: true,
 	enable_sentry: true,
-	hmm_slug: "virtool/virtool-hmm",
 	minimum_password_length: 9,
 	sample_all_read: true,
 	sample_all_write: true,

--- a/apps/web/src/samples/components/__tests__/SampleSettings.test.tsx
+++ b/apps/web/src/samples/components/__tests__/SampleSettings.test.tsx
@@ -12,7 +12,17 @@ import SampleSettings from "../SampleSettings";
 
 describe("<SampleSettings />", () => {
 	beforeEach(() => {
-		mockApiGetSettings(createFakeSettings());
+		// The rights start denied so that selecting "Read & write" is always a
+		// change. Left to the fake's random booleans, they can start as read &
+		// write, making the click a no-op and the expected PATCH never fire.
+		mockApiGetSettings(
+			createFakeSettings({
+				sample_all_read: false,
+				sample_all_write: false,
+				sample_group_read: false,
+				sample_group_write: false,
+			}),
+		);
 	});
 
 	afterEach(() => nock.cleanAll());

--- a/apps/web/src/server/auth/password.ts
+++ b/apps/web/src/server/auth/password.ts
@@ -6,9 +6,10 @@ import { z } from "zod";
 // generated with this cost, and any new hashes we write must keep it.
 const COST = 12;
 
-// Hardcoded because the `minimum_password_length` instance setting still lives
-// in Mongo, which this server cannot read. VIR-2743 replaces this with the
-// configured value once VIR-2742 lands the settings model in Postgres.
+// Still hardcoded, but no longer because it has to be: the
+// `minimum_password_length` instance setting is readable from Postgres via
+// `getSettings`. VIR-2743 replaces this constant with the configured value,
+// which means threading a database read into password validation.
 export const MINIMUM_PASSWORD_LENGTH = 8;
 
 /**

--- a/apps/web/src/server/db/schema/index.ts
+++ b/apps/web/src/server/db/schema/index.ts
@@ -9,6 +9,7 @@ export * from "./jobs";
 export * from "./labels";
 export * from "./messages";
 export * from "./sessions";
+export * from "./settings";
 export * from "./subtractions";
 export * from "./tasks";
 export * from "./users";

--- a/apps/web/src/server/db/schema/settings.ts
+++ b/apps/web/src/server/db/schema/settings.ts
@@ -1,0 +1,51 @@
+// Mirror of the `settings` table managed by the upstream Python service via
+// Alembic. Do not generate or push migrations from this side. Keep the columns
+// in sync with `../../../../../../virtool/virtool/settings/sql.py`.
+//
+// The table is a singleton: exactly one row, pinned to `id = 1`. Python seeds
+// it in the `d16de6e24788` migration and re-seeds it at startup via
+// `SettingsData.ensure()`. No column has a server default — the defaults live
+// in Python's `Settings` model and are written into the row on insert, which is
+// why `DEFAULT_SETTINGS` in `../../settings/data.ts` mirrors them rather than
+// this file.
+
+import { sql } from "drizzle-orm";
+import {
+	boolean,
+	check,
+	integer,
+	jsonb,
+	pgTable,
+	text,
+} from "drizzle-orm/pg-core";
+
+/** The group-access policy applied to a newly created sample. */
+export type SampleGroup = "none" | "force_choice" | "users_primary_group";
+
+export const settings = pgTable(
+	"settings",
+	{
+		id: integer("id").primaryKey(),
+		defaultSourceTypes: jsonb("default_source_types")
+			.$type<string[]>()
+			.notNull(),
+		enableApi: boolean("enable_api").notNull(),
+		enableSentry: boolean("enable_sentry").notNull(),
+		minimumPasswordLength: integer("minimum_password_length").notNull(),
+		sampleAllRead: boolean("sample_all_read").notNull(),
+		sampleAllWrite: boolean("sample_all_write").notNull(),
+		sampleGroup: text("sample_group").$type<SampleGroup>().notNull(),
+		sampleGroupRead: boolean("sample_group_read").notNull(),
+		sampleGroupWrite: boolean("sample_group_write").notNull(),
+	},
+	(table) => [
+		check("ck_settings_singleton", sql`${table.id} = 1`),
+		check(
+			"ck_settings_sample_group",
+			sql`${table.sampleGroup} in ('none', 'force_choice', 'users_primary_group')`,
+		),
+	],
+);
+
+/** A row from the `settings` table. */
+export type SettingsRow = typeof settings.$inferSelect;

--- a/apps/web/src/server/settings/data.test.ts
+++ b/apps/web/src/server/settings/data.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import type { Db } from "../db/pg";
+import { settings } from "../db/schema/settings";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { DEFAULT_SETTINGS, getSettings } from "./data";
+import { seedSettings } from "./test/fixtures";
+
+let database: TestDatabase;
+let db: Db;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(settings);
+});
+
+function countRows(): Promise<{ id: number }[]> {
+	return db.select({ id: settings.id }).from(settings);
+}
+
+describe("getSettings", () => {
+	it("returns the stored settings", async () => {
+		await seedSettings(db, {
+			defaultSourceTypes: ["genotype", "serotype"],
+			enableApi: true,
+			minimumPasswordLength: 12,
+			sampleGroup: "force_choice",
+		});
+
+		await expect(getSettings(db)).resolves.toEqual({
+			...DEFAULT_SETTINGS,
+			defaultSourceTypes: ["genotype", "serotype"],
+			enableApi: true,
+			minimumPasswordLength: 12,
+			sampleGroup: "force_choice",
+		});
+	});
+
+	it("seeds the defaults when the row is absent", async () => {
+		await expect(getSettings(db)).resolves.toEqual(DEFAULT_SETTINGS);
+	});
+
+	it("persists the defaults it seeds", async () => {
+		await getSettings(db);
+
+		const [row] = await db.select().from(settings);
+
+		expect(row).toMatchObject({ id: 1, ...DEFAULT_SETTINGS });
+	});
+
+	it("leaves a single row when called repeatedly", async () => {
+		await getSettings(db);
+		await getSettings(db);
+
+		await expect(countRows()).resolves.toHaveLength(1);
+	});
+
+	it("does not duplicate the row when called concurrently", async () => {
+		const [first, second] = await Promise.all([
+			getSettings(db),
+			getSettings(db),
+		]);
+
+		expect(first).toEqual(DEFAULT_SETTINGS);
+		expect(second).toEqual(DEFAULT_SETTINGS);
+		await expect(countRows()).resolves.toHaveLength(1);
+	});
+
+	it("does not overwrite settings that are already stored", async () => {
+		await seedSettings(db, { minimumPasswordLength: 20 });
+
+		await getSettings(db);
+
+		await expect(getSettings(db)).resolves.toMatchObject({
+			minimumPasswordLength: 20,
+		});
+	});
+});
+
+describe("DEFAULT_SETTINGS", () => {
+	// These are the values Python's `Settings` model declares and its
+	// `d16de6e24788` migration seeds. A drift on either side means a virgin
+	// deployment gets different settings depending on which service starts first.
+	it("matches the defaults Python seeds", () => {
+		expect(DEFAULT_SETTINGS).toEqual({
+			defaultSourceTypes: ["isolate", "strain"],
+			enableApi: false,
+			enableSentry: true,
+			minimumPasswordLength: 8,
+			sampleAllRead: true,
+			sampleAllWrite: false,
+			sampleGroup: "none",
+			sampleGroupRead: true,
+			sampleGroupWrite: false,
+		});
+	});
+});

--- a/apps/web/src/server/settings/data.ts
+++ b/apps/web/src/server/settings/data.ts
@@ -1,0 +1,97 @@
+import { eq } from "drizzle-orm";
+
+import type { Db } from "../db/pg";
+import { takeFirst, takeFirstOrThrow } from "../db/rows";
+import {
+	type SampleGroup,
+	type SettingsRow,
+	settings as settingsTable,
+} from "../db/schema/settings";
+
+/** The `settings` table holds a single row, pinned to this id by a check constraint. */
+const SETTINGS_ID = 1;
+
+/** Instance-wide settings. */
+export type Settings = {
+	defaultSourceTypes: string[];
+	enableApi: boolean;
+	enableSentry: boolean;
+	minimumPasswordLength: number;
+	sampleAllRead: boolean;
+	sampleAllWrite: boolean;
+	sampleGroup: SampleGroup;
+	sampleGroupRead: boolean;
+	sampleGroupWrite: boolean;
+};
+
+/**
+ * The values written when the settings row is missing.
+ *
+ * Mirrors the defaults on Python's `Settings` model, which are the same values
+ * its `d16de6e24788` migration seeds the row with. The columns themselves have
+ * no server default, so every one must be supplied on insert.
+ */
+export const DEFAULT_SETTINGS: Settings = {
+	defaultSourceTypes: ["isolate", "strain"],
+	enableApi: false,
+	enableSentry: true,
+	minimumPasswordLength: 8,
+	sampleAllRead: true,
+	sampleAllWrite: false,
+	sampleGroup: "none",
+	sampleGroupRead: true,
+	sampleGroupWrite: false,
+};
+
+function toSettings(row: SettingsRow): Settings {
+	return {
+		defaultSourceTypes: row.defaultSourceTypes,
+		enableApi: row.enableApi,
+		enableSentry: row.enableSentry,
+		minimumPasswordLength: row.minimumPasswordLength,
+		sampleAllRead: row.sampleAllRead,
+		sampleAllWrite: row.sampleAllWrite,
+		sampleGroup: row.sampleGroup,
+		sampleGroupRead: row.sampleGroupRead,
+		sampleGroupWrite: row.sampleGroupWrite,
+	};
+}
+
+function selectSettings(db: Db): Promise<SettingsRow[]> {
+	return db
+		.select()
+		.from(settingsTable)
+		.where(eq(settingsTable.id, SETTINGS_ID));
+}
+
+/**
+ * Get the instance settings, seeding the defaults when the row is absent.
+ *
+ * Python guarantees the row in practice — its migration inserts it and
+ * `SettingsData.ensure()` re-seeds it at startup — but a database that has yet
+ * to see a Python boot has none. Writing the defaults here mirrors `ensure()`
+ * and keeps the read total, rather than failing a caller that only wanted the
+ * minimum password length.
+ */
+export async function getSettings(db: Db): Promise<Settings> {
+	const existing = takeFirst(await selectSettings(db));
+
+	if (existing) {
+		return toSettings(existing);
+	}
+
+	const seeded = takeFirst(
+		await db
+			.insert(settingsTable)
+			.values({ id: SETTINGS_ID, ...DEFAULT_SETTINGS })
+			.onConflictDoNothing()
+			.returning(),
+	);
+
+	if (seeded) {
+		return toSettings(seeded);
+	}
+
+	// The insert was a no-op, so a concurrent caller seeded the row first.
+	return toSettings(takeFirstOrThrow(await selectSettings(db)));
+}

--- a/apps/web/src/server/settings/test/fixtures.ts
+++ b/apps/web/src/server/settings/test/fixtures.ts
@@ -1,0 +1,24 @@
+import type { Db } from "../../db/pg";
+import { settings } from "../../db/schema/settings";
+import { DEFAULT_SETTINGS, type Settings } from "../data";
+
+/**
+ * Insert the singleton settings row, overriding any of the defaults.
+ *
+ * A test database is built from the Drizzle schema alone, so it starts with an
+ * empty `settings` table — unlike production, where Python seeds the row. A
+ * test that wants settings to already exist must call this.
+ */
+export async function seedSettings(
+	db: Db,
+	overrides: Partial<Settings> = {},
+): Promise<Settings> {
+	const values = { ...DEFAULT_SETTINGS, ...overrides };
+
+	await db
+		.insert(settings)
+		.values({ id: 1, ...values })
+		.onConflictDoNothing();
+
+	return values;
+}

--- a/apps/web/src/tests/fake/administrator.ts
+++ b/apps/web/src/tests/fake/administrator.ts
@@ -41,14 +41,12 @@ export function createFakeSettings(overrides?: Partial<Settings>): Settings {
 		default_source_types: [faker.word.noun({ strategy: "any-length" })],
 		enable_api: faker.datatype.boolean(),
 		enable_sentry: faker.datatype.boolean(),
-		hmm_slug: "virtool/virtool-hmm",
 		minimum_password_length: 8,
 		sample_all_read: faker.datatype.boolean(),
 		sample_all_write: faker.datatype.boolean(),
 		sample_group: "none",
 		sample_group_read: faker.datatype.boolean(),
 		sample_group_write: faker.datatype.boolean(),
-		sample_unique_names: faker.datatype.boolean(),
 	};
 
 	return { ...defaultSettings, ...overrides };

--- a/docs/database.md
+++ b/docs/database.md
@@ -74,7 +74,7 @@ Mongo-primary rows are reachable only from Python.
 | HMMs          | **Primary**      | —                 | Mongo-only; not available to TS           |
 | History       | **Primary**      | diffs             | Mixed; not yet available to TS            |
 | Jobs          | —                | **Primary**       | Fully migrated                            |
-| Settings      | **Primary**      | —                 | Mongo-only; not available to TS           |
+| Settings      | —                | **Primary**       | Postgres-only; singleton row              |
 | API keys      | **Primary**      | —                 | Mongo-only; not available to TS           |
 
 Use this to gauge migration readiness per feature: a Postgres-primary


### PR DESCRIPTION
## Summary

- Mirror Python's `settings` table in Drizzle and add `getSettings`, which seeds the default row when it is absent — the same thing `SettingsData.ensure()` does at startup, and necessary because a database built from the Drizzle schema alone starts with an empty settings table.
- Drop `hmm_slug` and `sample_unique_names` from the client `Settings` type. Neither exists in Python's model or the settings table, so nothing was ever returned for them.
- Pin the initial rights in the `SampleSettings` tests. They relied on the fake's random booleans differing from the value being selected, which made the interaction a no-op — and the expected PATCH never fire — whenever the seeded faker sequence shifted.