### PR TITLE
fix: soften the hover and focus halo on icon buttons

### DIFF
--- a/apps/web/src/base/IconButton.tsx
+++ b/apps/web/src/base/IconButton.tsx
@@ -39,21 +39,22 @@ export default function IconButton({
 				"p-2.5",
 				"rounded-full",
 				"text-inherit",
-				"hover:text-white",
-				"focus:text-white",
 
 				{
-					"text-blue-500 hover:bg-blue-500 focus:bg-blue-400": color === "blue",
-					"text-black hover:bg-black focus:bg-gray-800": color === "black",
-					"text-green-500 hover:bg-green-500 focus:bg-green-400":
+					"text-blue-500 hover:text-blue-600 hover:bg-blue-500/10 focus:bg-blue-500/20":
+						color === "blue",
+					"text-black hover:bg-black/10 focus:bg-black/20": color === "black",
+					"text-green-500 hover:text-green-600 hover:bg-green-500/10 focus:bg-green-500/20":
 						color === "green",
-					"text-gray-400 hover:bg-gray-400 focus:bg-gray-300": color === "gray",
-					"text-gray-500 hover:bg-gray-500 focus:bg-gray-400":
+					"text-gray-400 hover:text-gray-500 hover:bg-gray-400/10 focus:bg-gray-400/20":
+						color === "gray",
+					"text-gray-500 hover:text-gray-600 hover:bg-gray-500/10 focus:bg-gray-500/20":
 						color === "grayDark",
-					"text-red-500 hover:bg-red-500 focus:bg-red-400": color === "red",
-					"text-orange-500 hover:bg-orange-500 focus:bg-orange-400":
+					"text-red-500 hover:text-red-600 hover:bg-red-500/10 focus:bg-red-500/20":
+						color === "red",
+					"text-orange-500 hover:text-orange-600 hover:bg-orange-500/10 focus:bg-orange-500/20":
 						color === "orange",
-					"text-purple-500 hover:bg-purple-500 focus:bg-purple-400":
+					"text-purple-500 hover:text-purple-600 hover:bg-purple-500/10 focus:bg-purple-500/20":
 						color === "purple",
 				},
 				className,


### PR DESCRIPTION
## Summary
- Replace icon buttons' solid, high-contrast hover/focus backgrounds with a soft tinted (10–20% opacity) halo
- Swap the hover text color from white to a darker shade of the button's own color for better legibility and less visual harshness