### PR TITLE
fix: prevent a failed password reset from changing the password

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,6 +253,12 @@ Imports flow `functions → service → data` and never the reverse. The
 db handle is injected as the first argument to `data.ts` functions,
 not imported.
 
+Type that first argument `DbOrTx` (from `@server/db/pg`), not `Db`, for
+any function that might be called inside a `db.transaction(...)`.
+Drizzle's transaction handle is not assignable to `Db`, so a helper
+typed `Db` cannot be reused inside a transaction without being widened
+first.
+
 Legacy features that still call the Python API through their
 client-side `api.ts` are not subject to this layering.
 

--- a/apps/web/src/server/auth/core.test.ts
+++ b/apps/web/src/server/auth/core.test.ts
@@ -1,0 +1,246 @@
+import { eq } from "drizzle-orm";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+
+import type { Db } from "../db/pg";
+import { sessions } from "../db/schema/sessions";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import type { CookieAdapter } from "./cookies";
+import {
+	InvalidResetSessionError,
+	PasswordReuseError,
+	resetPassword,
+} from "./core";
+import { hashPassword, verifyPassword } from "./password";
+import * as sessionModule from "./session";
+import { seedSession, seedUser } from "./test/fixtures";
+
+// `createAuthenticatedSession` is the third and last write in the reset. Making
+// it fail is how we drive the partial failure the transaction has to undo. The
+// rest of the module keeps its real behaviour — the other two writes must
+// actually hit the database for a rollback to be worth asserting.
+vi.mock("./session", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./session")>();
+	return {
+		...actual,
+		createAuthenticatedSession: vi.fn(actual.createAuthenticatedSession),
+	};
+});
+
+const { createResetSession } = sessionModule;
+const createAuthenticatedSession = vi.mocked(
+	sessionModule.createAuthenticatedSession,
+);
+
+const OLD_PASSWORD = "old-password";
+const NEW_PASSWORD = "new-password";
+
+type FakeCookies = CookieAdapter & {
+	sessionId: string | undefined;
+	token: string | undefined;
+};
+
+function fakeCookies(sessionId?: string): FakeCookies {
+	return {
+		sessionId,
+		token: undefined,
+		getSessionId() {
+			return this.sessionId;
+		},
+		getSessionToken() {
+			return this.token;
+		},
+		setSessionId(value: string) {
+			this.sessionId = value;
+		},
+		setSessionToken(value: string) {
+			this.token = value;
+		},
+		clear() {
+			this.sessionId = undefined;
+			this.token = undefined;
+		},
+	};
+}
+
+let database: TestDatabase;
+let db: Db;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	vi.mocked(createAuthenticatedSession).mockClear();
+	await db.delete(sessions);
+	await db.delete(users);
+});
+
+/** Seed a force-reset user with a real bcrypt hash, plus a live reset session. */
+async function seedResetFlow() {
+	const userId = await seedUser(db, {
+		forceReset: true,
+		password: await hashPassword(OLD_PASSWORD),
+	});
+
+	const { sessionId, resetCode } = await createResetSession(db, {
+		userId,
+		ip: "127.0.0.1",
+		remember: false,
+	});
+
+	return { userId, sessionId, resetCode };
+}
+
+function readUser(userId: number) {
+	return db
+		.select()
+		.from(users)
+		.where(eq(users.id, userId))
+		.limit(1)
+		.then((rows) => rows[0]);
+}
+
+describe("resetPassword", () => {
+	it("changes the password and sets the session cookies", async () => {
+		const { userId, sessionId, resetCode } = await seedResetFlow();
+		const cookies = fakeCookies(sessionId);
+
+		await resetPassword(db, cookies, {
+			password: NEW_PASSWORD,
+			resetCode,
+			ip: "127.0.0.1",
+		});
+
+		const user = await readUser(userId);
+		expect(user).toBeDefined();
+		expect(await verifyPassword(NEW_PASSWORD, user?.password as Buffer)).toBe(
+			true,
+		);
+		expect(user?.forceReset).toBe(false);
+
+		// The reset session is gone and an authenticated one took its place.
+		const rows = await db
+			.select()
+			.from(sessions)
+			.where(eq(sessions.userId, userId));
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.sessionType).toBe("authenticated");
+
+		expect(cookies.sessionId).toBe(rows[0]?.sessionId);
+		expect(cookies.token).toBeDefined();
+	});
+
+	it("rolls the password back when the session write fails", async () => {
+		const { userId, sessionId, resetCode } = await seedResetFlow();
+		const before = await readUser(userId);
+
+		// A session the user already holds. It must survive the failed reset —
+		// `invalidateUserSessions` runs first and has to be undone too.
+		const existing = await seedSession(db, userId);
+
+		const cookies = fakeCookies(sessionId);
+
+		createAuthenticatedSession.mockRejectedValueOnce(
+			new Error("session insert failed"),
+		);
+
+		await expect(
+			resetPassword(db, cookies, {
+				password: NEW_PASSWORD,
+				resetCode,
+				ip: "127.0.0.1",
+			}),
+		).rejects.toThrow("session insert failed");
+
+		// The password is untouched: the old one still works, the new one does not.
+		const after = await readUser(userId);
+		expect(await verifyPassword(OLD_PASSWORD, after?.password as Buffer)).toBe(
+			true,
+		);
+		expect(await verifyPassword(NEW_PASSWORD, after?.password as Buffer)).toBe(
+			false,
+		);
+		expect(after?.forceReset).toBe(true);
+		expect(after?.lastPasswordChange).toEqual(before?.lastPasswordChange);
+		expect(after?.invalidateSessions).toBe(before?.invalidateSessions);
+
+		// The session deletion rolled back with it.
+		const surviving = await db
+			.select()
+			.from(sessions)
+			.where(eq(sessions.sessionId, existing.sessionId));
+		expect(surviving).toHaveLength(1);
+
+		// And the browser was told nothing.
+		expect(cookies.sessionId).toBe(sessionId);
+		expect(cookies.token).toBeUndefined();
+	});
+
+	it("rejects a password matching the current one", async () => {
+		const { userId, sessionId, resetCode } = await seedResetFlow();
+		const cookies = fakeCookies(sessionId);
+
+		await expect(
+			resetPassword(db, cookies, {
+				password: OLD_PASSWORD,
+				resetCode,
+				ip: "127.0.0.1",
+			}),
+		).rejects.toThrow(PasswordReuseError);
+
+		expect(createAuthenticatedSession).not.toHaveBeenCalled();
+
+		const user = await readUser(userId);
+		expect(user?.forceReset).toBe(true);
+	});
+
+	it("rejects a wrong reset code and burns the session", async () => {
+		const { userId, sessionId, resetCode } = await seedResetFlow();
+		const cookies = fakeCookies(sessionId);
+
+		await expect(
+			resetPassword(db, cookies, {
+				password: NEW_PASSWORD,
+				resetCode: "0".repeat(resetCode.length),
+				ip: "127.0.0.1",
+			}),
+		).rejects.toThrow(InvalidResetSessionError);
+
+		const rows = await db
+			.select()
+			.from(sessions)
+			.where(eq(sessions.userId, userId));
+		expect(rows).toHaveLength(0);
+
+		const user = await readUser(userId);
+		expect(await verifyPassword(OLD_PASSWORD, user?.password as Buffer)).toBe(
+			true,
+		);
+	});
+
+	it("rejects when there is no session cookie", async () => {
+		await seedResetFlow();
+
+		await expect(
+			resetPassword(db, fakeCookies(), {
+				password: NEW_PASSWORD,
+				resetCode: "whatever",
+				ip: "127.0.0.1",
+			}),
+		).rejects.toThrow(InvalidResetSessionError);
+	});
+});

--- a/apps/web/src/server/auth/core.test.ts
+++ b/apps/web/src/server/auth/core.test.ts
@@ -190,6 +190,49 @@ describe("resetPassword", () => {
 		expect(cookies.token).toBeUndefined();
 	});
 
+	it("lets only one of two concurrent resets for the same code win", async () => {
+		const { userId, sessionId, resetCode } = await seedResetFlow();
+
+		const first = fakeCookies(sessionId);
+		const second = fakeCookies(sessionId);
+
+		// A double-clicked submit. Both pass validation and the reuse check before
+		// either commits — neither has written yet, so both still read the old hash.
+		const results = await Promise.allSettled([
+			resetPassword(db, first, {
+				password: NEW_PASSWORD,
+				resetCode,
+				ip: "127.0.0.1",
+			}),
+			resetPassword(db, second, {
+				password: NEW_PASSWORD,
+				resetCode,
+				ip: "127.0.0.1",
+			}),
+		]);
+
+		const fulfilled = results.filter((r) => r.status === "fulfilled");
+		const rejected = results.filter((r) => r.status === "rejected");
+
+		expect(fulfilled).toHaveLength(1);
+		expect(rejected).toHaveLength(1);
+		expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+			InvalidResetSessionError,
+		);
+
+		// The loser rolled back rather than deleting the winner's session, so the
+		// one surviving session is the one whose cookies the winner was handed.
+		const rows = await db
+			.select()
+			.from(sessions)
+			.where(eq(sessions.userId, userId));
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.sessionType).toBe("authenticated");
+
+		const winner = [first, second].find((c) => c.token !== undefined);
+		expect(winner?.sessionId).toBe(rows[0]?.sessionId);
+	});
+
 	it("rejects a password matching the current one", async () => {
 		const { userId, sessionId, resetCode } = await seedResetFlow();
 		const cookies = fakeCookies(sessionId);

--- a/apps/web/src/server/auth/core.ts
+++ b/apps/web/src/server/auth/core.ts
@@ -14,6 +14,7 @@ import {
 import type { CookieAdapter } from "./cookies";
 import { hashPassword, verifyPassword } from "./password";
 import {
+	consumeResetSession,
 	createAuthenticatedSession,
 	createResetSession,
 	invalidateSession,
@@ -253,16 +254,29 @@ export async function resetPassword(
 
 	const remember = row.resetRemember ?? false;
 
-	// The three writes are one unit: a failure partway through must not leave the
+	// The writes are one unit: a failure partway through must not leave the
 	// password changed with no session to show for it.
 	//
-	// Within the transaction they keep Python's order in
+	// Consuming the reset session first makes the code single-use under
+	// concurrency. Everything above — validation, the reuse check, the hash —
+	// takes no lock, so two submissions of the same code can both reach this
+	// point; only the one that deletes the row proceeds. Without it the loser
+	// would go on to invalidate the sessions of the winner, handing the browser
+	// cookies for a session that no longer exists.
+	//
+	// The remaining writes keep Python's order in
 	// `virtool.account.data.AccountData.reset`:
 	//   delete_by_user → users.update → sessions.create_authenticated.
 	// Sequencing matters so a user mid-reset sees the same behaviour regardless
-	// of which backend serves them during the transition.
+	// of which backend serves them during the transition. `delete_by_user` would
+	// have removed the reset session anyway, so consuming it above leaves the
+	// committed state identical.
 	const { sessionId: newSessionId, token } = await db.transaction(
 		async (tx) => {
+			if (!(await consumeResetSession(tx, sessionId))) {
+				throw new InvalidResetSessionError();
+			}
+
 			await invalidateUserSessions(tx, userId);
 
 			await tx

--- a/apps/web/src/server/auth/core.ts
+++ b/apps/web/src/server/auth/core.ts
@@ -218,6 +218,10 @@ export async function resetPassword(
 		throw new InvalidResetSessionError();
 	}
 
+	// Bound here rather than read off `row` below: the narrowing above does not
+	// survive into the transaction callback.
+	const userId = row.userId;
+
 	if (!constantTimeEqualHex(row.resetCode, input.resetCode)) {
 		await invalidateSession(db, sessionId);
 		throw new InvalidResetSessionError();
@@ -231,7 +235,7 @@ export async function resetPassword(
 	const [user] = await db
 		.select({ password: users.password })
 		.from(users)
-		.where(eq(users.id, row.userId))
+		.where(eq(users.id, userId))
 		.limit(1);
 
 	if (!user) {
@@ -243,29 +247,44 @@ export async function resetPassword(
 		throw new PasswordReuseError();
 	}
 
-	// Match Python's order in `virtool.account.data.AccountData.reset`:
+	// Hashing is CPU-bound and slow by design, so it happens before the
+	// transaction opens rather than holding one idle for the duration.
+	const newHash = await hashPassword(input.password);
+
+	const remember = row.resetRemember ?? false;
+
+	// The three writes are one unit: a failure partway through must not leave the
+	// password changed with no session to show for it.
+	//
+	// Within the transaction they keep Python's order in
+	// `virtool.account.data.AccountData.reset`:
 	//   delete_by_user → users.update → sessions.create_authenticated.
 	// Sequencing matters so a user mid-reset sees the same behaviour regardless
 	// of which backend serves them during the transition.
-	await invalidateUserSessions(db, row.userId);
+	const { sessionId: newSessionId, token } = await db.transaction(
+		async (tx) => {
+			await invalidateUserSessions(tx, userId);
 
-	const newHash = await hashPassword(input.password);
+			await tx
+				.update(users)
+				.set({
+					password: newHash,
+					forceReset: false,
+					lastPasswordChange: new Date(),
+					invalidateSessions: true,
+				})
+				.where(eq(users.id, userId));
 
-	await db
-		.update(users)
-		.set({
-			password: newHash,
-			forceReset: false,
-			lastPasswordChange: new Date(),
-			invalidateSessions: true,
-		})
-		.where(eq(users.id, row.userId));
-
-	const remember = row.resetRemember ?? false;
-	const { sessionId: newSessionId, token } = await createAuthenticatedSession(
-		db,
-		{ userId: row.userId, ip: input.ip, remember },
+			return createAuthenticatedSession(tx, {
+				userId,
+				ip: input.ip,
+				remember,
+			});
+		},
 	);
+
+	// Only after the commit. A rolled-back reset must leave the browser holding
+	// no new session.
 	cookies.setSessionId(newSessionId);
 	cookies.setSessionToken(token);
 }

--- a/apps/web/src/server/auth/session.ts
+++ b/apps/web/src/server/auth/session.ts
@@ -2,7 +2,7 @@ import { randomBytes } from "node:crypto";
 
 import { eq } from "drizzle-orm";
 
-import type { Db } from "../db/pg";
+import type { DbOrTx } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import { type SessionRow, sessions } from "../db/schema/sessions";
 import { hashToken, newSessionId, newSessionToken } from "./tokens";
@@ -32,7 +32,7 @@ export type CreateAuthenticatedSessionResult = {
 };
 
 export async function createAuthenticatedSession(
-	db: Db,
+	db: DbOrTx,
 	{ userId, ip, remember }: CreateAuthenticatedSessionInput,
 ): Promise<CreateAuthenticatedSessionResult> {
 	const sessionId = newSessionId();
@@ -77,7 +77,7 @@ export type CreateResetSessionResult = {
 };
 
 export async function createResetSession(
-	db: Db,
+	db: DbOrTx,
 	{ userId, ip, remember }: CreateResetSessionInput,
 ): Promise<CreateResetSessionResult> {
 	const sessionId = newSessionId();
@@ -105,14 +105,14 @@ export async function createResetSession(
 }
 
 export async function invalidateSession(
-	db: Db,
+	db: DbOrTx,
 	sessionId: string,
 ): Promise<void> {
 	await db.delete(sessions).where(eq(sessions.sessionId, sessionId));
 }
 
 export async function invalidateUserSessions(
-	db: Db,
+	db: DbOrTx,
 	userId: number,
 ): Promise<void> {
 	await db.delete(sessions).where(eq(sessions.userId, userId));

--- a/apps/web/src/server/auth/session.ts
+++ b/apps/web/src/server/auth/session.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import type { DbOrTx } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
@@ -109,6 +109,30 @@ export async function invalidateSession(
 	sessionId: string,
 ): Promise<void> {
 	await db.delete(sessions).where(eq(sessions.sessionId, sessionId));
+}
+
+/**
+ * Delete a reset session, reporting whether this call is the one that consumed
+ * it. False means it was already spent (or never existed).
+ *
+ * A reset code is single-use, but nothing between reading it and writing the
+ * new password holds a lock — and the bcrypt hash in that gap is slow. Called
+ * inside the reset transaction, this is the point two concurrent resets for the
+ * same code serialize on: the second blocks on the row lock, then finds nothing
+ * to delete and rolls back rather than clobbering the session the first minted.
+ */
+export async function consumeResetSession(
+	db: DbOrTx,
+	sessionId: string,
+): Promise<boolean> {
+	const rows = await db
+		.delete(sessions)
+		.where(
+			and(eq(sessions.sessionId, sessionId), eq(sessions.sessionType, "reset")),
+		)
+		.returning({ sessionId: sessions.sessionId });
+
+	return rows.length > 0;
 }
 
 export async function invalidateUserSessions(

--- a/apps/web/src/server/auth/test/fixtures.ts
+++ b/apps/web/src/server/auth/test/fixtures.ts
@@ -18,17 +18,25 @@ export type SeededSession = {
  *
  * `handle` is unique (case-insensitively), so a test seeding a second user must
  * pass a distinct one.
+ *
+ * `password` defaults to a placeholder that is not a real bcrypt hash. A test
+ * that exercises a code path which verifies the stored password must pass a
+ * hash from `hashPassword`.
  */
 export async function seedUser(
 	db: Db,
 	{
 		active = true,
 		administratorRole = null,
+		forceReset = false,
 		handle = "alice",
+		password = Buffer.from("not-a-real-hash"),
 	}: {
 		active?: boolean;
 		administratorRole?: AdministratorRoleName | null;
+		forceReset?: boolean;
 		handle?: string;
+		password?: Buffer;
 	} = {},
 ): Promise<number> {
 	const [user] = await db
@@ -36,9 +44,10 @@ export async function seedUser(
 		.values({
 			active,
 			administratorRole,
+			forceReset,
 			handle,
 			lastPasswordChange: new Date(),
-			password: Buffer.from("not-a-real-hash"),
+			password,
 			settings: {},
 		})
 		.returning({ id: users.id });

--- a/apps/web/src/server/db/pg.ts
+++ b/apps/web/src/server/db/pg.ts
@@ -11,6 +11,12 @@ export const db = drizzle(client, { schema });
 /** Drizzle database client typed against the full schema. */
 export type Db = typeof db;
 
+/** A Drizzle transaction handle, as passed to a `db.transaction` callback. */
+export type Transaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+/** Either the pooled database handle or an open transaction. */
+export type DbOrTx = Db | Transaction;
+
 /** The underlying postgres-js client used by Drizzle. */
 export type PgClient = typeof client;
 

--- a/apps/web/src/wall/components/ResetForm.tsx
+++ b/apps/web/src/wall/components/ResetForm.tsx
@@ -37,7 +37,7 @@ export default function ResetForm({ redirect, resetCode }: ResetFormProps) {
 		);
 	}
 
-	const { error, isError } = resetPasswordMutation;
+	const { error, isError, isPending } = resetPasswordMutation;
 
 	return (
 		<>
@@ -70,7 +70,9 @@ export default function ResetForm({ redirect, resetCode }: ResetFormProps) {
 						</InputError>
 					)}
 				</InputGroup>
-				<Button type="submit" color="blue">
+				{/* A reset code is single-use. Letting a double-click fire a second
+				    submission only ever earns the user an error. */}
+				<Button type="submit" color="blue" disabled={isPending}>
 					Reset
 				</Button>
 			</form>

--- a/docs/database.md
+++ b/docs/database.md
@@ -101,6 +101,41 @@ layer would otherwise pull in:
 If a domain you need is still Mongo-primary, the answer is to wait for
 its Postgres migration, not to add a Mongo client back to this repo.
 
+## Transactions and the `DbOrTx` handle
+
+A sequence of writes where a partial result is a bug — a password change
+that must not land unless the session that goes with it lands too —
+belongs in a single `db.transaction(...)`. Return whatever the caller
+needs out of the callback and act on it *after* the commit; a side effect
+performed inside the callback (setting a cookie, emitting an event) still
+happens when the transaction later rolls back.
+
+Do the slow, non-database work before opening the transaction. `updateUser`
+and `resetPassword` both hash the new password first: bcrypt at cost 12
+costs hundreds of milliseconds, and an open transaction should not sit idle
+waiting for it.
+
+`db.transaction` hands the callback a Drizzle transaction handle, which is
+**not** assignable to `Db` (`Db` is the pooled `PostgresJsDatabase` and
+carries a `$client` the transaction lacks). Passing one to a function typed
+`Db` fails to compile with `TS2345`. So a helper that needs to work both
+standalone and inside a transaction takes `DbOrTx`:
+
+```ts
+import type { DbOrTx } from "../db/pg";
+
+export async function invalidateUserSessions(
+    db: DbOrTx,
+    userId: number,
+): Promise<void> {
+    await db.delete(sessions).where(eq(sessions.userId, userId));
+}
+```
+
+`DbOrTx` covers the shared query-builder surface, which is everything a
+`data.ts` function normally touches. Reach for `Db` only when the function
+genuinely needs something a transaction cannot give it.
+
 ### Stubbed-out cross-store reads
 
 A migrated domain occasionally exposes a field that depends on a


### PR DESCRIPTION
## Summary
- Wrap the reset-password flow's three dependent writes (session invalidation, password update, new session creation) in `db.transaction`, so a failure partway through no longer leaves the password permanently changed with no session issued and an error on screen.
- Set the session cookies only after the transaction commits, and hash above the transaction rather than holding one open across a slow bcrypt.
- Widen the session helpers to a new `DbOrTx`, since Drizzle's transaction handle is not assignable to `Db`.

Closes VIR-2673.