### PR TITLE
test: stop booting a postgres container for component tests

### DIFF
--- a/apps/web/src/server/storage/test/globalSetup.ts
+++ b/apps/web/src/server/storage/test/globalSetup.ts
@@ -200,6 +200,5 @@ export async function setup() {
 	await Promise.all([startGarage(), startAzurite()]);
 }
 
-// Left empty on purpose, matching the postgres setup: stop() would remove the
-// container and defeat withReuse() on the next run.
-export async function teardown() {}
+// There is deliberately no teardown, matching the postgres setup: stop() would
+// remove the containers and defeat withReuse() on the next run.

--- a/apps/web/src/tests/globalSetup.ts
+++ b/apps/web/src/tests/globalSetup.ts
@@ -18,7 +18,7 @@ export async function setup() {
 	process.env.VT_STORAGE_S3_BUCKET = "virtool-test";
 }
 
-// Left empty on purpose. stop() removes the container, so withReuse() finds
-// nothing to match on the next run and starts a fresh one. Clean up with
-// `docker rm -f` when the container is no longer wanted.
-export async function teardown() {}
+// There is deliberately no teardown. stop() would remove the container, so
+// withReuse() would find nothing to match on the next run and pay a fresh boot
+// every time. Clean up with `docker rm -f` when the container is no longer
+// wanted.

--- a/apps/web/src/tests/postgresGuard.ts
+++ b/apps/web/src/tests/postgresGuard.ts
@@ -1,0 +1,12 @@
+// Reaching this module means a client-reachable file imported a server module
+// that opens Postgres. The `web` Vitest project aliases `@server/config` and
+// `@server/db/pg` here, so such an import fails loudly instead of silently
+// dragging a database — and a Docker daemon — back into the component tests.
+//
+// Server functions are fine to import from client code: the client transform
+// strips the `createServerFn` handler and the server-only imports behind it, so
+// nothing here resolves. An import that survives the transform is the bug.
+throw new Error(
+	"a server module that reaches Postgres was imported into the browser test program. " +
+		"Keep Postgres behind a createServerFn handler so the client transform can strip it.",
+);

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -7,7 +7,7 @@ import { nitro } from "nitro/vite";
 import { defineConfig } from "vite";
 import pkg from "./package.json" with { type: "json" };
 
-export default defineConfig(({ command }) => ({
+export default defineConfig(({ command, mode }) => ({
 	build: {
 		sourcemap: true,
 		rolldownOptions: {
@@ -83,14 +83,17 @@ export default defineConfig(({ command }) => ({
 				autoCodeSplitting: true,
 			},
 		}),
-		nitro({
-			// `@sentry/profiling-node` ships native `.node` addons the bundler can't
-			// inline. Tracing it (and its native helper) keeps the packages external
-			// and copies them into the server output, so the build doesn't choke on
-			// the binaries and the runtime import resolves. The dist image ships only
-			// `.output`, so the trace is what makes the package available at runtime.
-			traceDeps: ["@sentry/profiling-node*", "@sentry/node-cpu-profiler*"],
-		}),
+		// Tests never ask Nitro to serve anything, and it holds file handles open
+		// that stall Vitest's shutdown for ten seconds after the last test passes.
+		mode !== "test" &&
+			nitro({
+				// `@sentry/profiling-node` ships native `.node` addons the bundler can't
+				// inline. Tracing it (and its native helper) keeps the packages external
+				// and copies them into the server output, so the build doesn't choke on
+				// the binaries and the runtime import resolves. The dist image ships only
+				// `.output`, so the trace is what makes the package available at runtime.
+				traceDeps: ["@sentry/profiling-node*", "@sentry/node-cpu-profiler*"],
+			}),
 		react({
 			include: "**/*.tsx",
 			babel: {

--- a/apps/web/vitest.config.js
+++ b/apps/web/vitest.config.js
@@ -6,9 +6,14 @@ const viteConfig = viteConfigFn({ command: "serve", mode: "test" });
 
 export default defineConfig({
 	...viteConfig,
-	plugins: viteConfig.plugins
-		.flat(Infinity)
-		.filter((plugin) => !String(plugin?.name ?? "").startsWith("sentry")),
+	// Nitro is the server bundler; tests never ask it to serve anything, and it
+	// holds file handles open that stall Vitest's shutdown for ten seconds. Sentry
+	// is dropped for the same reason it is kept out of dev: it should never load
+	// here.
+	plugins: viteConfig.plugins.flat(Infinity).filter((plugin) => {
+		const name = String(plugin?.name ?? "");
+		return !name.startsWith("sentry") && !name.startsWith("nitro");
+	}),
 	test: {
 		globals: true,
 		silent: false,
@@ -17,10 +22,12 @@ export default defineConfig({
 			{
 				extends: true,
 				test: {
+					// No globalSetup: the client transform strips server function bodies
+					// and the server-only imports behind them, so nothing here reaches
+					// Postgres. Component tests must not need Docker.
 					name: "web",
 					environment: "jsdom",
 					setupFiles: ["./src/tests/setup.tsx"],
-					globalSetup: ["./src/tests/globalSetup.ts"],
 					include: ["src/**/*.test.{ts,tsx}"],
 					exclude: ["src/server/**"],
 				},

--- a/apps/web/vitest.config.js
+++ b/apps/web/vitest.config.js
@@ -1,19 +1,14 @@
 import os from "node:os";
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 import viteConfigFn from "./vite.config";
 
+// `mode: "test"` drops Nitro and `command: "serve"` drops Sentry, so neither is
+// ever constructed here and the plugin list needs no further filtering.
 const viteConfig = viteConfigFn({ command: "serve", mode: "test" });
 
 export default defineConfig({
 	...viteConfig,
-	// Nitro is the server bundler; tests never ask it to serve anything, and it
-	// holds file handles open that stall Vitest's shutdown for ten seconds. Sentry
-	// is dropped for the same reason it is kept out of dev: it should never load
-	// here.
-	plugins: viteConfig.plugins.flat(Infinity).filter((plugin) => {
-		const name = String(plugin?.name ?? "");
-		return !name.startsWith("sentry") && !name.startsWith("nitro");
-	}),
 	test: {
 		globals: true,
 		silent: false,
@@ -30,6 +25,17 @@ export default defineConfig({
 					setupFiles: ["./src/tests/setup.tsx"],
 					include: ["src/**/*.test.{ts,tsx}"],
 					exclude: ["src/server/**"],
+					// Pin the assumption above. These are the two modules that open
+					// Postgres at import; if one ever survives the client transform into
+					// the browser program, the guard throws instead of quietly making
+					// Docker a prerequisite again. Listed before the `@server` prefix
+					// alias so they win.
+					alias: [
+						{
+							find: /^@server\/(config|db\/pg)$/,
+							replacement: path.resolve("src/tests/postgresGuard.ts"),
+						},
+					],
 				},
 			},
 			{

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,8 +22,12 @@ semantics against a real Postgres, since mocks hide bugs that real DBs
 catch. A session check that forgets to filter on `users.active` passes
 against a stubbed query builder and fails against Postgres.
 
-`src/tests/globalSetup.ts` starts one Postgres container for the whole
-run and exports `VT_POSTGRES_URL`. Call `createTestDatabase()` from
+`src/tests/globalSetup.ts` starts one Postgres container for the
+`server` project and exports `VT_POSTGRES_URL`. It is wired only into
+that project: the `web` project's jsdom tests never reach Postgres,
+because the client transform strips server function bodies along with
+the server-only imports behind them. Component tests therefore run
+without Docker. Call `createTestDatabase()` from
 `@server/db/test/fixtures` in `beforeAll` to get an isolated database
 with the schema already applied, and `drop()` it in `afterAll`:
 


### PR DESCRIPTION
## Summary
- The web project's jsdom component tests never import `src/server` — the client transform strips server function bodies along with the server-only imports behind them, so `config.ts` and `db/pg.ts` are never reached. Booting Postgres for them was pure overhead, so `globalSetup` is dropped from that project. Component tests now run with no Docker at all.
- Filter the `nitro:*` plugins out of the Vitest plugin list. Nitro is the server bundler, which tests never ask to serve anything, and it holds file handles open that stalled shutdown by ~10s on every run. This was previously blamed on the empty `teardown()`, but a test importing nothing with no `globalSetup` at all still hung, while keeping `globalSetup` and dropping nitro did not. It also silences the `ReferenceError` spam from `@opentelemetry/instrumentation`.
- Remove the no-op `teardown()` exports rather than having them `stop()` the containers, which would defeat `withReuse()` and make every local run pay a fresh boot for no benefit — CI discards the runner anyway.