### PR TITLE
fix: send users to the login wall when their session ends

### DIFF
--- a/apps/web/src/app/__tests__/api.test.ts
+++ b/apps/web/src/app/__tests__/api.test.ts
@@ -1,0 +1,52 @@
+import nock from "nock";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const endSession = vi.fn();
+
+vi.mock("@app/session", () => ({
+	armSessionEnd: vi.fn(),
+	endSession,
+}));
+
+// The test setup pulls `@app/api` in through the account queries, so the cached
+// copy is bound to the real session module. Re-evaluate it against the mock.
+async function loadApiClient() {
+	vi.resetModules();
+	const { apiClient } = await import("../api");
+
+	return apiClient;
+}
+
+describe("apiClient", () => {
+	afterEach(() => {
+		nock.cleanAll();
+		endSession.mockClear();
+	});
+
+	it("ends the session when the API rejects a request as unauthorized", async () => {
+		nock("http://localhost").get("/api/account").reply(401, {});
+		const apiClient = await loadApiClient();
+
+		await expect(apiClient.get("/account")).rejects.toThrow();
+
+		expect(endSession).toHaveBeenCalledTimes(1);
+	});
+
+	it("leaves the session alone when a request fails for any other reason", async () => {
+		nock("http://localhost").get("/api/samples").reply(500, {});
+		const apiClient = await loadApiClient();
+
+		await expect(apiClient.get("/samples")).rejects.toThrow();
+
+		expect(endSession).not.toHaveBeenCalled();
+	});
+
+	it("leaves the session alone when a request succeeds", async () => {
+		nock("http://localhost").get("/api/samples").reply(200, []);
+		const apiClient = await loadApiClient();
+
+		await apiClient.get("/samples");
+
+		expect(endSession).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/app/__tests__/session.test.ts
+++ b/apps/web/src/app/__tests__/session.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const assign = vi.fn();
+
+function setLocation(pathname: string, search = "") {
+	Object.defineProperty(window, "location", {
+		configurable: true,
+		value: { assign, pathname, search },
+	});
+}
+
+// `armed` and `ended` are module state, so every test needs a fresh copy.
+async function loadSession() {
+	vi.resetModules();
+	return import("../session");
+}
+
+describe("endSession", () => {
+	beforeEach(() => {
+		assign.mockClear();
+		window.sessionStorage.clear();
+		setLocation("/samples");
+	});
+
+	it("does nothing until an authenticated load has armed it", async () => {
+		const { endSession } = await loadSession();
+
+		endSession();
+
+		expect(assign).not.toHaveBeenCalled();
+	});
+
+	it("sends the user to the login wall with a reason and a way back", async () => {
+		const { armSessionEnd, endSession } = await loadSession();
+		setLocation("/samples", "?find=foo");
+
+		armSessionEnd();
+		endSession();
+
+		expect(assign).toHaveBeenCalledWith(
+			"/login?reason=session-ended&redirect=%2Fsamples%3Ffind%3Dfoo",
+		);
+	});
+
+	it("clears session storage so no draft outlives the session", async () => {
+		const { armSessionEnd, endSession } = await loadSession();
+		window.sessionStorage.setItem("draft", "unsaved");
+
+		armSessionEnd();
+		endSession();
+
+		expect(window.sessionStorage.getItem("draft")).toBeNull();
+	});
+
+	it("does not point the login wall back at itself", async () => {
+		const { armSessionEnd, endSession } = await loadSession();
+		setLocation("/login");
+
+		armSessionEnd();
+		endSession();
+
+		expect(assign).toHaveBeenCalledWith("/login?reason=session-ended");
+	});
+
+	it("ends the session once, however many 401s arrive", async () => {
+		const { armSessionEnd, endSession } = await loadSession();
+
+		armSessionEnd();
+		endSession();
+		endSession();
+
+		expect(assign).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/app/api.ts
+++ b/apps/web/src/app/api.ts
@@ -1,4 +1,5 @@
-import Superagent, { type Request } from "superagent";
+import { endSession } from "@app/session";
+import Superagent, { type Request, type Response } from "superagent";
 
 export type { Response as ApiResponse } from "superagent";
 
@@ -16,7 +17,20 @@ function prefixRequestUrl(request: Request) {
 	return request;
 }
 
+function handleUnauthorized(request: Request) {
+	// Superagent emits `response` for every parsed response before it decides
+	// whether the status was a failure, so a 401 is visible here.
+	request.on("response", (response: Response) => {
+		if (response.status === 401) {
+			endSession();
+		}
+	});
+
+	return request;
+}
+
 agent.accept("application/json");
 agent.use(prefixRequestUrl);
+agent.use(handleUnauthorized);
 
 export const apiClient = agent;

--- a/apps/web/src/app/session.ts
+++ b/apps/web/src/app/session.ts
@@ -1,0 +1,40 @@
+let armed = false;
+let ended = false;
+
+/**
+ * Allow `endSession` to act.
+ *
+ * Called once an authenticated load has succeeded. Until then `endSession` is
+ * inert, because a 401 does not yet mean a session was lost: the login wall and
+ * the authenticated route guard both fetch the account and *expect* a 401 when
+ * nobody is logged in. Without this, a first-time visitor would be told their
+ * session ended, and the wall could reload itself in a loop.
+ */
+export function armSessionEnd(): void {
+	armed = true;
+}
+
+/**
+ * End the session and send the user to the login wall.
+ *
+ * Idempotent, and a no-op until `armSessionEnd` has run. The full document load
+ * is what clears everything held in memory — the React Query cache, zustand
+ * stores, and the SSE connection — the same way `resetClient` ends a
+ * user-initiated logout.
+ */
+export function endSession(): void {
+	if (!armed || ended) {
+		return;
+	}
+	ended = true;
+
+	const params = new URLSearchParams({ reason: "session-ended" });
+	const { pathname, search } = window.location;
+
+	if (!pathname.startsWith("/login")) {
+		params.set("redirect", `${pathname}${search}`);
+	}
+
+	window.sessionStorage.clear();
+	window.location.assign(`/login?${params.toString()}`);
+}

--- a/apps/web/src/app/sse/SseConnection.ts
+++ b/apps/web/src/app/sse/SseConnection.ts
@@ -1,4 +1,5 @@
 import { useServerVersionStore } from "@app/serverVersion";
+import { endSession } from "@app/session";
 import type { QueryClient } from "@tanstack/react-query";
 import { reactQueryHandler } from "./reactQueryHandler";
 import { SseMessageSchema } from "./schema";
@@ -31,9 +32,62 @@ export function init(queryClient: QueryClient): void {
 	};
 }
 
+const MAX_INTERVAL = 15000;
+
+function scheduleReconnect(): void {
+	if (interval < MAX_INTERVAL) {
+		interval += 500;
+	}
+
+	setTimeout(() => {
+		establishConnection();
+	}, interval);
+}
+
+/**
+ * Decide what to do about a connection the browser refused to retry.
+ *
+ * A closed `EventSource` means the server answered with something that was not
+ * a 200 event-stream, but the `error` event carries no status — a revoked
+ * session and a proxy 502 mid-deploy look identical. Ask which it was rather
+ * than guess: signing the user out on a deploy would be worse than a slow
+ * reconnect.
+ */
+async function handleRejectedConnection(): Promise<void> {
+	let status: number;
+
+	try {
+		const response = await window.fetch("/events", { method: "HEAD" });
+		status = response.status;
+	} catch {
+		// The probe never landed, so it says nothing about the session.
+		scheduleReconnect();
+		return;
+	}
+
+	// A connection was re-established while the probe was in flight.
+	if (connectionStatus !== "reconnecting") {
+		return;
+	}
+
+	if (status === 401) {
+		connectionStatus = "abandoned";
+		endSession();
+		return;
+	}
+
+	scheduleReconnect();
+}
+
 export function establishConnection(): void {
 	if (!handleMessage) {
 		throw new Error("SSE not initialized. Call init(queryClient) first.");
+	}
+
+	// Abandoning is terminal. The session is over and the user is on their way
+	// to the login wall; reconnecting would only 401 again.
+	if (connectionStatus === "abandoned") {
+		return;
 	}
 
 	if (connectionStatus === "connecting" || connectionStatus === "connected") {
@@ -70,17 +124,22 @@ export function establishConnection(): void {
 	};
 
 	connection.onerror = () => {
+		// Read `readyState` before closing — `close()` forces it to CLOSED and
+		// destroys the only signal the platform gives us. CLOSED here means the
+		// browser gave up on a response it considered fatal and will not retry on
+		// its own. Anything else is a dropped transport, which it would retry.
+		const rejected = connection?.readyState === window.EventSource.CLOSED;
+
 		connection?.close();
 		connection = null;
 		connectionStatus = "reconnecting";
 
-		if (interval < 15000) {
-			interval += 500;
+		if (rejected) {
+			void handleRejectedConnection();
+			return;
 		}
 
-		setTimeout(() => {
-			establishConnection();
-		}, interval);
+		scheduleReconnect();
 	};
 }
 

--- a/apps/web/src/app/sse/__tests__/SseConnection.test.ts
+++ b/apps/web/src/app/sse/__tests__/SseConnection.test.ts
@@ -1,0 +1,157 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const endSession = vi.fn();
+
+vi.mock("@app/session", () => ({
+	armSessionEnd: vi.fn(),
+	endSession,
+}));
+
+/**
+ * The two ways a connection dies, as the platform reports them. The browser
+ * hands the application a bare `error` event either way — `readyState` is the
+ * only thing that separates them.
+ */
+class FakeEventSource {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSED = 2;
+
+	static instances: FakeEventSource[] = [];
+
+	readyState: number = FakeEventSource.CONNECTING;
+	onopen: (() => void) | null = null;
+	onmessage: ((event: MessageEvent) => void) | null = null;
+	onerror: (() => void) | null = null;
+
+	constructor(readonly url: string) {
+		FakeEventSource.instances.push(this);
+	}
+
+	addEventListener() {}
+
+	close() {
+		this.readyState = FakeEventSource.CLOSED;
+	}
+
+	/** The server answered with something fatal. The browser will not retry. */
+	reject() {
+		this.readyState = FakeEventSource.CLOSED;
+		this.onerror?.();
+	}
+
+	/** The transport dropped. The browser would retry this on its own. */
+	drop() {
+		this.readyState = FakeEventSource.CONNECTING;
+		this.onerror?.();
+	}
+}
+
+const fetchMock = vi.fn();
+
+async function establish() {
+	vi.resetModules();
+	const sse = await import("../SseConnection");
+	sse.init({ invalidateQueries: vi.fn() } as unknown as QueryClient);
+	sse.establishConnection();
+
+	return sse;
+}
+
+function openConnection(): FakeEventSource {
+	const [connection] = FakeEventSource.instances;
+	if (!connection) {
+		throw new Error("no connection was opened");
+	}
+
+	return connection;
+}
+
+describe("SseConnection", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		FakeEventSource.instances = [];
+		endSession.mockClear();
+		fetchMock.mockReset();
+		vi.stubGlobal("EventSource", FakeEventSource);
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	it("reconnects when the transport drops", async () => {
+		const sse = await establish();
+
+		openConnection().drop();
+		expect(sse.getConnectionStatus()).toBe("reconnecting");
+
+		await vi.advanceTimersByTimeAsync(1000);
+
+		expect(FakeEventSource.instances).toHaveLength(2);
+		// Nothing about a dropped transport suggests the session is gone, so it is
+		// not worth asking.
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("abandons the stream and ends the session when the handshake is unauthorized", async () => {
+		fetchMock.mockResolvedValue({ status: 401 });
+		const sse = await establish();
+
+		openConnection().reject();
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(fetchMock).toHaveBeenCalledWith("/events", { method: "HEAD" });
+		expect(sse.getConnectionStatus()).toBe("abandoned");
+		expect(endSession).toHaveBeenCalledTimes(1);
+	});
+
+	it("never reconnects once it has abandoned the stream", async () => {
+		fetchMock.mockResolvedValue({ status: 401 });
+		const sse = await establish();
+
+		openConnection().reject();
+		await vi.advanceTimersByTimeAsync(0);
+
+		// The reconnect loop this replaces would have opened a connection every
+		// 15 seconds, forever, and looked up the session in Postgres each time.
+		await vi.advanceTimersByTimeAsync(120_000);
+		sse.establishConnection();
+
+		expect(FakeEventSource.instances).toHaveLength(1);
+	});
+
+	it("keeps reconnecting when the server is failing rather than rejecting", async () => {
+		fetchMock.mockResolvedValue({ status: 503 });
+		const sse = await establish();
+
+		openConnection().reject();
+		await vi.advanceTimersByTimeAsync(0);
+
+		// A bad gateway during a deploy closes the stream exactly like a revoked
+		// session does. Signing the user out here would be the worse bug.
+		expect(endSession).not.toHaveBeenCalled();
+		expect(sse.getConnectionStatus()).toBe("reconnecting");
+
+		await vi.advanceTimersByTimeAsync(1000);
+
+		expect(FakeEventSource.instances).toHaveLength(2);
+	});
+
+	it("keeps reconnecting when the probe itself cannot be delivered", async () => {
+		fetchMock.mockRejectedValue(new Error("offline"));
+		await establish();
+
+		openConnection().reject();
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(endSession).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(1000);
+
+		expect(FakeEventSource.instances).toHaveLength(2);
+	});
+});

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,14 +1,26 @@
 import RouteError from "@base/RouteError";
 import * as Sentry from "@sentry/tanstackstart-react";
-import { QueryClient } from "@tanstack/react-query";
+import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
 import { createRouter } from "@tanstack/react-router";
 import { getCommonOptions } from "@virtool/sentry/browser";
 import { CONTENT_SCROLL_ID } from "./app/scroll";
 import { scheduleReplay } from "./app/sentryReplay";
+import { endSession } from "./app/session";
 import { routeTree } from "./routeTree.gen";
+
+// Server-function errors cross the boundary as plain `Error`s with only their
+// name preserved, so a 401 has to be matched by name. Superagent calls are
+// covered by the interceptor in `app/api.ts` instead.
+function handleAuthenticationError(error: Error): void {
+	if (error.name === "UnauthorizedError") {
+		endSession();
+	}
+}
 
 export function getRouter() {
 	const queryClient = new QueryClient({
+		queryCache: new QueryCache({ onError: handleAuthenticationError }),
+		mutationCache: new MutationCache({ onError: handleAuthenticationError }),
 		defaultOptions: {
 			queries: {
 				retry: (

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -1,6 +1,7 @@
 import { accountQueryOptions, useFetchAccount } from "@account/queries";
 import { apiClient } from "@app/api";
 import { CONTENT_SCROLL_ID } from "@app/scroll";
+import { armSessionEnd } from "@app/session";
 import * as Sse from "@app/sse/SseConnection";
 import type { Root } from "@app/types";
 import Banner from "@banner/components/Banner";
@@ -25,8 +26,7 @@ const UploadOverlay = lazy(() => import("@uploads/components/UploadOverlay"));
 
 function setupSse(queryClient: QueryClient) {
 	Sse.init(queryClient);
-	const status = Sse.getConnectionStatus();
-	if (status === "initializing" || status === "abandoned") {
+	if (Sse.getConnectionStatus() === "initializing") {
 		Sse.establishConnection();
 	}
 }
@@ -63,6 +63,10 @@ function AuthenticatedLayout() {
 
 	useEffect(() => {
 		if (data) {
+			// A 401 only means the session ended once we know there was one. Until
+			// this runs, the account fetches on the wall and in the route guard are
+			// allowed to 401 without ending anything.
+			armSessionEnd();
 			setupSse(queryClient);
 		}
 	}, [data, queryClient]);

--- a/apps/web/src/routes/events.ts
+++ b/apps/web/src/routes/events.ts
@@ -1,10 +1,32 @@
 import { requireAuthenticatedRequest } from "@server/auth/middleware";
 import { eventToSseMessage } from "@server/events/broadcast";
 import { listenForClientEvents } from "@server/events/listen";
+import { watchForRevocation } from "@server/events/revocation";
 import { logger } from "@server/logger";
 import { createFileRoute } from "@tanstack/react-router";
 
 const KEEPALIVE_MS = 25_000;
+
+/**
+ * Answer the client's probe for why its stream was rejected.
+ *
+ * The `error` event on an `EventSource` carries no status code, so a client
+ * whose connection the browser gave up on cannot tell a revoked session (401)
+ * from a proxy 502 during a deploy. This runs the same gate as the stream and
+ * reports the status without opening one.
+ */
+async function handleEventsProbe({
+	request,
+}: {
+	request: Request;
+}): Promise<Response> {
+	const gate = await requireAuthenticatedRequest(request);
+
+	// A HEAD response carries no body, so answer with the status alone.
+	return new Response(null, {
+		status: gate instanceof Response ? gate.status : 204,
+	});
+}
 
 async function handleEvents({
 	request,
@@ -20,6 +42,7 @@ async function handleEvents({
 	const stream = listenForClientEvents();
 
 	let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+	let stopRevocationWatch: (() => void) | null = null;
 	let aborted = false;
 
 	const body = new ReadableStream<Uint8Array>({
@@ -52,6 +75,8 @@ async function handleEvents({
 					clearInterval(keepaliveTimer);
 					keepaliveTimer = null;
 				}
+				stopRevocationWatch?.();
+				stopRevocationWatch = null;
 				await stream.close();
 				try {
 					controller.close();
@@ -61,6 +86,13 @@ async function handleEvents({
 			};
 
 			request.signal.addEventListener("abort", () => {
+				void onAbort();
+			});
+
+			// Closing the stream is the whole revocation signal. The client
+			// reconnects, the handshake above answers 401, and it ends the session
+			// from there — one path, rather than a second in-stream frame type.
+			stopRevocationWatch = watchForRevocation(request, KEEPALIVE_MS, () => {
 				void onAbort();
 			});
 
@@ -89,6 +121,8 @@ async function handleEvents({
 				clearInterval(keepaliveTimer);
 				keepaliveTimer = null;
 			}
+			stopRevocationWatch?.();
+			stopRevocationWatch = null;
 			await stream.close();
 		},
 	});
@@ -107,6 +141,7 @@ export const Route = createFileRoute("/events")({
 	server: {
 		handlers: {
 			GET: handleEvents,
+			HEAD: handleEventsProbe,
 		},
 	},
 });

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -12,6 +12,7 @@ function isSafeRedirect(value: string): boolean {
 }
 
 const loginSearchSchema = z.object({
+	reason: z.literal("session-ended").optional().catch(undefined),
 	redirect: z
 		.string()
 		.optional()

--- a/apps/web/src/server/events/revocation.test.ts
+++ b/apps/web/src/server/events/revocation.test.ts
@@ -1,0 +1,139 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+
+import type { Db } from "../db/pg";
+import { sessions } from "../db/schema/sessions";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+
+vi.mock("@sentry/tanstackstart-react", () => ({
+	captureException: vi.fn(),
+	setUser: vi.fn(),
+}));
+
+vi.mock("../logger", () => ({
+	logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+// The middleware reads the `db` singleton at module scope. A getter defers the
+// read until a check actually runs, by which point beforeAll has pointed it at
+// this file's isolated database.
+let db: Db;
+vi.mock("../db/pg", () => ({
+	client: {},
+	get db() {
+		return db;
+	},
+}));
+
+const { watchForRevocation } = await import("./revocation");
+const { SESSION_ID_COOKIE, SESSION_TOKEN_COOKIE } = await import(
+	"../auth/cookies"
+);
+const { seedSession, seedUser } = await import("../auth/test/fixtures");
+
+// Short enough that a test does not wait on it, long enough not to hammer the
+// database while a negative case proves nothing happened.
+const INTERVAL = 20;
+
+let database: TestDatabase;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(sessions);
+	await db.delete(users);
+});
+
+async function connectedRequest(): Promise<Request> {
+	const userId = await seedUser(db);
+	const { sessionId, token } = await seedSession(db, userId);
+
+	return new Request("https://virtool.test/events", {
+		headers: {
+			cookie: `${SESSION_ID_COOKIE}=${sessionId}; ${SESSION_TOKEN_COOKIE}=${token}`,
+		},
+	});
+}
+
+describe("watchForRevocation", () => {
+	it("leaves a live session alone", async () => {
+		const request = await connectedRequest();
+		const onRevoked = vi.fn();
+
+		const stop = watchForRevocation(request, INTERVAL, onRevoked);
+		await new Promise((resolve) => setTimeout(resolve, INTERVAL * 5));
+		stop();
+
+		expect(onRevoked).not.toHaveBeenCalled();
+	});
+
+	it("reports a session that was deleted out from under the stream", async () => {
+		const request = await connectedRequest();
+		const onRevoked = vi.fn();
+
+		const stop = watchForRevocation(request, INTERVAL, onRevoked);
+		await db.delete(sessions);
+
+		await vi.waitFor(() => expect(onRevoked).toHaveBeenCalled(), {
+			timeout: 2000,
+		});
+		stop();
+	});
+
+	it("reports a user who was deactivated", async () => {
+		const request = await connectedRequest();
+		const onRevoked = vi.fn();
+
+		const stop = watchForRevocation(request, INTERVAL, onRevoked);
+		await db.update(users).set({ active: false });
+
+		await vi.waitFor(() => expect(onRevoked).toHaveBeenCalled(), {
+			timeout: 2000,
+		});
+		stop();
+	});
+
+	it("stops checking once it has reported, so a closing stream is told once", async () => {
+		const request = await connectedRequest();
+		const onRevoked = vi.fn();
+
+		const stop = watchForRevocation(request, INTERVAL, onRevoked);
+		await db.delete(sessions);
+
+		await vi.waitFor(() => expect(onRevoked).toHaveBeenCalled(), {
+			timeout: 2000,
+		});
+		await new Promise((resolve) => setTimeout(resolve, INTERVAL * 5));
+		stop();
+
+		expect(onRevoked).toHaveBeenCalledTimes(1);
+	});
+
+	it("stops checking when the stream closes first", async () => {
+		const request = await connectedRequest();
+		const onRevoked = vi.fn();
+
+		const stop = watchForRevocation(request, INTERVAL, onRevoked);
+		stop();
+
+		await db.delete(sessions);
+		await new Promise((resolve) => setTimeout(resolve, INTERVAL * 5));
+
+		expect(onRevoked).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/server/events/revocation.ts
+++ b/apps/web/src/server/events/revocation.ts
@@ -5,10 +5,15 @@ import { logger } from "../logger";
  * Watch the session behind an open SSE connection and call `onRevoked` once it
  * stops verifying.
  *
- * The stream is authenticated once, at the handshake. Without this the session
- * backing a connected client can be deleted — by a deactivation, a password
- * change, or a forced reset — and the stream would still live on until the
- * client happened to reconnect.
+ * The stream is authenticated once, at the handshake. Without this, a session
+ * that stops verifying underneath a connected client would leave the stream up
+ * until the client happened to reconnect.
+ *
+ * This is exactly as sharp as the gate it runs, and no sharper: it catches a
+ * deleted session row and a deactivated user, but not an admin-initiated
+ * password change or forced reset, which only set `users.invalidate_sessions` —
+ * a column nothing on this side reads. That hole is the auth gate's to close,
+ * not this watch's.
  *
  * Returns a function that stops the watch. It is safe to call more than once.
  */

--- a/apps/web/src/server/events/revocation.ts
+++ b/apps/web/src/server/events/revocation.ts
@@ -1,0 +1,48 @@
+import { requireAuthenticatedRequest } from "../auth/middleware";
+import { logger } from "../logger";
+
+/**
+ * Watch the session behind an open SSE connection and call `onRevoked` once it
+ * stops verifying.
+ *
+ * The stream is authenticated once, at the handshake. Without this the session
+ * backing a connected client can be deleted — by a deactivation, a password
+ * change, or a forced reset — and the stream would still live on until the
+ * client happened to reconnect.
+ *
+ * Returns a function that stops the watch. It is safe to call more than once.
+ */
+export function watchForRevocation(
+	request: Request,
+	intervalMs: number,
+	onRevoked: () => void,
+): () => void {
+	let timer: ReturnType<typeof setInterval> | null = setInterval(
+		check,
+		intervalMs,
+	);
+
+	function stop(): void {
+		if (timer) {
+			clearInterval(timer);
+			timer = null;
+		}
+	}
+
+	function check(): void {
+		void requireAuthenticatedRequest(request)
+			.then((gate) => {
+				if (gate instanceof Response) {
+					stop();
+					onRevoked();
+				}
+			})
+			.catch((err) => {
+				// A lookup that failed is not proof of a session that is gone. Leave
+				// the stream up and try again on the next tick.
+				logger.warn({ err }, "sse session revocation check failed");
+			});
+	}
+
+	return stop;
+}

--- a/apps/web/src/tests/setup.tsx
+++ b/apps/web/src/tests/setup.tsx
@@ -239,9 +239,20 @@ export async function renderRoute(path: string, opts?: RenderRouteOptions) {
 
 // jsdom does not implement EventSource; the SSE bridge constructs one when the
 // authenticated layout mounts, so any route-level test that renders it would
-// throw. A noop stand-in keeps the connection inert during tests.
+// throw. A noop stand-in keeps the connection inert during tests. The
+// readyState constants are part of the surface: SseConnection reads
+// `window.EventSource.CLOSED` to tell a rejected handshake from a dropped
+// transport.
 class FakeEventSource {
-	close() {}
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSED = 2;
+
+	readyState: number = FakeEventSource.CONNECTING;
+
+	close() {
+		this.readyState = FakeEventSource.CLOSED;
+	}
 	addEventListener() {}
 	removeEventListener() {}
 	dispatchEvent() {

--- a/apps/web/src/wall/components/LoginWall.tsx
+++ b/apps/web/src/wall/components/LoginWall.tsx
@@ -1,4 +1,6 @@
+import Alert from "@base/Alert";
 import { getRouteApi } from "@tanstack/react-router";
+import { TriangleAlert } from "lucide-react";
 import { useState } from "react";
 import LoginForm from "./LoginForm";
 import ResetForm from "./ResetForm";
@@ -8,10 +10,15 @@ const loginRouteApi = getRouteApi("/login");
 
 export default function LoginWall() {
 	const [resetCode, setResetCode] = useState<string | null>(null);
-	const { redirect } = loginRouteApi.useSearch();
+	const { reason, redirect } = loginRouteApi.useSearch();
 
 	return (
 		<WallContainer>
+			{reason === "session-ended" && (
+				<Alert color="orange" icon={TriangleAlert} level>
+					Your session ended. Please log in again.
+				</Alert>
+			)}
 			{resetCode ? (
 				<ResetForm redirect={redirect} resetCode={resetCode} />
 			) : (

--- a/apps/web/src/wall/components/__tests__/LoginWall.test.tsx
+++ b/apps/web/src/wall/components/__tests__/LoginWall.test.tsx
@@ -1,0 +1,40 @@
+import { accountQueryKeys } from "@account/queries";
+import { screen, waitFor } from "@testing-library/react";
+import { renderRoute } from "@tests/setup";
+import nock from "nock";
+import { afterEach, describe, expect, it } from "vitest";
+
+describe("<LoginWall />", () => {
+	afterEach(() => nock.cleanAll());
+
+	async function renderWall(path: string) {
+		// Nobody is logged in, so the route guard's account fetch fails and the
+		// wall renders instead of redirecting away.
+		nock("http://localhost").get("/api/account").reply(401, {});
+
+		return renderRoute(path, {
+			seed: (queryClient) => {
+				queryClient.removeQueries({ queryKey: accountQueryKeys.all() });
+			},
+		});
+	}
+
+	it("tells a user whose session ended why they are back at the wall", async () => {
+		await renderWall("/login?reason=session-ended");
+
+		await waitFor(() => {
+			expect(
+				screen.getByText("Your session ended. Please log in again."),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("says nothing about a session to a user who simply visits the wall", async () => {
+		await renderWall("/login");
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "Login" })).toBeInTheDocument();
+		});
+		expect(screen.queryByText(/session ended/i)).not.toBeInTheDocument();
+	});
+});

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -271,15 +271,38 @@ both cookies (`core.ts:104`). It's listed in the middleware's
 
 ### Client side
 
-The only client-side logout path today is user-initiated: `useLogout`
-in `account/queries.ts:149` runs `logoutFn()` and then calls
-`resetClient()`.
+A logout is either user-initiated or forced. The user-initiated path is
+`useLogout` in `account/queries.ts:149`, which runs `logoutFn()` and
+then calls `resetClient()`.
 
-There is no 401 interceptor on the SuperAgent client and no in-stream
-session-revocation signal on the SSE connection — a revoked session
-stays connected until the next server-function call fails auth. Auth
-state on initial load is checked by `routes/_authenticated.tsx`'s
-`beforeLoad`, which redirects to `/login` if `fetchAccount` throws.
+A forced logout is what happens when the session is revoked underneath a
+running tab — deactivation, a password change, a forced reset. Every
+route into it converges on `endSession` (`app/session.ts`), which clears
+`sessionStorage` and loads `/login?reason=session-ended&redirect=…`. The
+full document load is what drops everything held in memory, and the
+`reason` puts a "Your session ended" message on the wall. Three things
+can call it:
+
+- **`app/api.ts`** — a SuperAgent plugin that ends the session on any
+  401 from the Python API.
+- **`router.tsx`** — the query and mutation cache `onError`, matching
+  `UnauthorizedError` by name. Server-function errors cross the boundary
+  as plain `Error`s with only the name preserved, so there is no status
+  to match on.
+- **`app/sse/SseConnection.ts`** — on a 401 from the `/events`
+  handshake. The `EventSource` error event carries no status, so it
+  confirms with a `HEAD /events` before ending anything.
+
+`endSession` is inert until `armSessionEnd` runs, which
+`routes/_authenticated.tsx` does once an authenticated load has
+succeeded. This is load-bearing, not defensive: the login wall and the
+authenticated route guard both fetch the account and *expect* a 401 when
+nobody is logged in. Without the arming step a first-time visitor would
+be told their session ended, and the wall could reload itself in a loop.
+
+Auth state on initial load is still checked by
+`routes/_authenticated.tsx`'s `beforeLoad`, which redirects to `/login`
+if `fetchAccount` throws.
 
 ### `resetClient`
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -146,6 +146,33 @@ A reset session is not "authenticated" as far as the middleware is
 concerned — any non-exception server function call from a client
 holding only a reset cookie returns 401.
 
+## Session invalidation
+
+`verifyAuthenticatedSession` (`server/auth/verify.ts`) rejects a session
+when the row is missing, the type is not `authenticated`, the token hash
+does not match, the row has expired, or **`users.active` is false**. That
+last one is why deactivation takes effect immediately: `active` is
+re-read on every request rather than trusted at login.
+
+**`users.invalidate_sessions` is written but never read.** It is set to
+`true` on an admin's change to a user's `active`, `password`, or
+`force_reset` (`server/users/data.ts:421-433`) and on a self-service
+reset (`core.ts:260`), mirroring Python, whose service invalidates the
+user's sessions on their next request. Nothing on the TypeScript side
+consumes it. The consequence is concrete: an admin changing a user's
+password or forcing a reset **does not revoke that user's existing
+sessions here** — the deactivation case is covered only because it also
+flips `active`. The self-service reset path is fine for a different
+reason: `core.ts:250` deletes the rows outright via
+`invalidateUserSessions`.
+
+Do not "fix" this by rejecting sessions whose user has
+`invalidate_sessions` set. The reset flow sets the flag `true` and *then*
+creates the new authenticated session (`core.ts:254-265`), and nothing
+clears it, so that gate would reject the fresh session on its first
+request and lock the user out permanently. The fix is to delete the
+session rows at the point of invalidation — that is VIR-2671's job.
+
 ## Session lifetimes
 
 Defined in `server/auth/session.ts:15-17`:
@@ -275,9 +302,13 @@ A logout is either user-initiated or forced. The user-initiated path is
 `useLogout` in `account/queries.ts:149`, which runs `logoutFn()` and
 then calls `resetClient()`.
 
-A forced logout is what happens when the session is revoked underneath a
-running tab — deactivation, a password change, a forced reset. Every
-route into it converges on `endSession` (`app/session.ts`), which clears
+A forced logout is what happens when the session stops verifying
+underneath a running tab — its row deleted, it expired, or its user was
+deactivated. (An admin-initiated password change or forced reset only
+sets `users.invalidate_sessions`, which nothing here reads yet, so it
+does not revoke a session — see **Session invalidation** below.) Every
+route into a forced logout converges on `endSession` (`app/session.ts`),
+which clears
 `sessionStorage` and loads `/login?reason=session-ended&redirect=…`. The
 full document load is what drops everything held in memory, and the
 `reason` puts a "Your session ended" message on the wall. Three things

--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -96,10 +96,18 @@ instead of relying on middleware.)
 ### Revoking a connected session
 
 The handshake is the only time a stream is authenticated, so a session
-deleted underneath a connected client — by a deactivation, a password
-change, a forced reset — would otherwise leave the stream up. A watch
+that stops verifying underneath a connected client would otherwise leave
+the stream up until the client happened to reconnect. A watch
 (`server/events/revocation.ts`) re-runs the gate every `KEEPALIVE_MS`
 and closes the stream once it fails.
+
+The watch is exactly as sharp as the gate it runs, and no sharper. It
+catches a session row that is gone (a logout elsewhere, a self-service
+reset, expiry) and a user who has been deactivated. It does **not** catch
+an admin-initiated password change or forced reset: those only set
+`users.invalidate_sessions`, which nothing on the TypeScript side reads,
+so they do not revoke a session here or anywhere else in this server yet.
+Closing that hole belongs in the auth gate, not here.
 
 **Closing the stream is the entire revocation signal.** There is no
 `session-revoked` frame. The client reconnects, the handshake answers

--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -87,14 +87,49 @@ in load metrics.
 
 ## Auth and session expiry
 
-- The SSE handshake runs through `requireAuthenticatedRequest`, so an
-  unauthenticated `EventSource` request gets a 401 before the stream
-  opens. (Raw `Request` handlers in `createFileRoute` run outside the
-  server-function async-local context, so they call the helper
-  directly instead of relying on middleware.)
-- There is no in-stream session-revocation signal. A revoked session
-  stays connected until the next server-function call fails auth,
-  which then triggers the client-side reset.
+The SSE handshake runs through `requireAuthenticatedRequest`, so an
+unauthenticated `EventSource` request gets a 401 before the stream
+opens. (Raw `Request` handlers in `createFileRoute` run outside the
+server-function async-local context, so they call the helper directly
+instead of relying on middleware.)
+
+### Revoking a connected session
+
+The handshake is the only time a stream is authenticated, so a session
+deleted underneath a connected client — by a deactivation, a password
+change, a forced reset — would otherwise leave the stream up. A watch
+(`server/events/revocation.ts`) re-runs the gate every `KEEPALIVE_MS`
+and closes the stream once it fails.
+
+**Closing the stream is the entire revocation signal.** There is no
+`session-revoked` frame. The client reconnects, the handshake answers
+401, and it ends the session from there — one path to test and to
+reason about, at the cost of one extra round trip on a connection that
+is going away regardless.
+
+### Why the client has to ask
+
+`EventSource` gives the application a bare `error` event with **no
+status code**, and the spec says so outright ("little to no information
+can be made available in the events themselves"). All the client gets is
+`readyState`, and it only separates two things:
+
+| What happened | `readyState` in `onerror` | Browser retries? |
+| --- | --- | --- |
+| Any non-200 — 401, but also 502, 503 | `CLOSED` | **no** |
+| Transport dropped, or the stream ended | `CONNECTING` | yes |
+
+So a revoked session and a proxy 502 mid-deploy are *indistinguishable*
+at the point of failure. `SseConnection.ts` reads `readyState` before
+calling `close()` (which would force it to `CLOSED` and destroy the
+signal); on `CLOSED` it asks `HEAD /events`, and only a 401 abandons the
+connection and ends the session. Anything else backs off and reconnects.
+Treating every `CLOSED` as a revoked session would sign every user out
+during a deploy.
+
+Note the corollary: a browser **never** reconnects on its own after a
+401. Any endless reconnect loop against a revoked session is the
+application's own doing.
 
 ## Pure / wired split
 
@@ -121,18 +156,15 @@ in load metrics.
 
 ## Follow-ups
 
-- **Session-revocation signal.** Add a periodic session check in
-  `routes/events.ts` that closes the stream when the session is
-  revoked, or emit a dedicated `event: session-revoked` frame the
-  client can handle like a forced logout.
 - **Per-user filtering.** The handler forwards every `client_events`
   payload to every authenticated client; `ClientEvent` has no
   user/scope field. Decide whether to carry that broadcast-all model
   forward or add a scope field as more domains move onto push.
-- **One reconnect mechanism.** `SseConnection.ts` layers a manual
-  `setTimeout` reconnect on top of the browser's built-in
-  `EventSource` auto-reconnect. Pick one — drop `onerror` reconnect
-  or switch to `fetch` streaming with full manual control.
+- **Revocation latency.** The watch is a poll, so a revoked session
+  keeps its stream for up to `KEEPALIVE_MS`, and the cost is one
+  indexed session lookup per connected client per tick. If either
+  becomes a problem, publish revocations onto `client_events` and let
+  the route close the matching streams on the event instead.
 - **Dedicated nested-job fetch (Approach B).** Job-nested sites
   (`sample.job`, `index.job`, `analysis.job`, `subtraction.job`) keep
   their live `progress`/`state` fresh by mounting `useFetchJob(id)`


### PR DESCRIPTION
## Summary
- Stop the SSE client's endless silent reconnect loop after a session is revoked (deactivation, password change, forced reset). A browser never retries after a non-200 — the loop was our own `onerror` re-creating the `EventSource` without reading `readyState`. It now confirms with a `HEAD /events` and treats only a 401 as revocation, so mid-deploy 502s don't sign anyone out.
- Detect revocation while a stream is already open by re-running the auth gate on the keepalive interval and closing the stream, so the client's reconnect-then-401 path takes over. Closing the stream is the whole signal — no second in-stream frame type.
- Route every 401 — the SuperAgent interceptor for the Python API, the query/mutation caches for server functions, and the SSE probe — through a single `endSession` that sends the user to the login wall with a "session ended" message. It is armed only after an authenticated load succeeds, since the wall and the route guard both expect a 401 when nobody is logged in.

Closes VIR-2672