### PR TITLE
fix: restore hover and focus feedback in the top navigation

### DIFF
--- a/apps/web/src/app/style.css
+++ b/apps/web/src/app/style.css
@@ -9,7 +9,8 @@
 @theme {
 	--font-sans:
 		"Inter Variable", sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
-	--color-virtool: #3c8786;
+	--color-virtool: #387e7d;
+	--color-virtool-dark: #2a5e5d;
 }
 
 html {

--- a/apps/web/src/base/Tabs.tsx
+++ b/apps/web/src/base/Tabs.tsx
@@ -21,7 +21,7 @@ const listVariants = cva("flex", {
 	variants: {
 		variant: {
 			segmented:
-				"bg-gray-100 h-12 items-center justify-center p-1 rounded-lg text-lg text-muted-foreground",
+				"bg-gray-100 h-12 items-center justify-center p-1 rounded-lg text-gray-500 text-lg",
 			vertical:
 				"bg-white border border-gray-300 col-span-1 flex-col overflow-hidden rounded-sm self-start",
 		},
@@ -33,7 +33,7 @@ const triggerVariants = cva("cursor-pointer", {
 	variants: {
 		variant: {
 			segmented:
-				"data-[state=active]:bg-white data-[state=active]:shadow data-[state=active]:text-foreground disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring font-medium inline-flex items-center justify-center px-3 py-1 ring-offset-background rounded-md transition-all whitespace-nowrap",
+				"data-[state=active]:bg-white data-[state=active]:shadow data-[state=active]:text-gray-900 disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600/50 font-medium hover:text-gray-700 inline-flex items-center justify-center px-3 py-1 rounded-md transition-all whitespace-nowrap",
 			vertical:
 				"data-[state=active]:font-medium data-[state=active]:shadow-[inset_3px_0_0_var(--color-virtool)] data-[state=active]:text-gray-900 focus-visible:ring-2 focus-visible:ring-blue-600/50 focus-visible:ring-inset focus:outline-none hover:bg-gray-50 hover:text-gray-700 px-6 py-3 text-gray-500 text-left transition-colors",
 		},
@@ -45,7 +45,7 @@ const contentVariants = cva("", {
 	variants: {
 		variant: {
 			segmented:
-				"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring mt-2 ring-offset-background",
+				"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600/50 mt-2",
 			vertical: "col-span-3 focus:outline-none",
 		},
 	},

--- a/apps/web/src/nav/components/Nav.tsx
+++ b/apps/web/src/nav/components/Nav.tsx
@@ -32,17 +32,19 @@ export default function Nav({ administrator_role, handle }: NavBarProps) {
 	}
 
 	return (
-		<nav className="bg-virtool flex justify-between text-white">
-			<div className="flex items-center">
-				<Logo className="pb-2.5 pl-10 pr-4" color="white" />
-				<NavLink to="/jobs?state=running">Jobs</NavLink>
+		<nav className="bg-virtool flex h-13 items-center justify-between text-white">
+			<div className="flex gap-3 items-center">
+				<Logo className="mt-0 pl-10 pr-4" color="white" height={28} />
+				<NavLink to="/jobs" search={{ state: "running" }}>
+					Jobs
+				</NavLink>
 				<NavLink to="/samples">Samples</NavLink>
 				<NavLink to="/refs">References</NavLink>
 				<NavLink to="/hmms">HMMs</NavLink>
 				<NavLink to="/subtractions">Subtractions</NavLink>
 			</div>
 
-			<div className="flex gap-2 pr-4">
+			<div className="flex gap-2 items-center pr-4">
 				<IconButton
 					onClick={() => setAboutOpen(true)}
 					IconComponent={Info}

--- a/apps/web/src/nav/components/NavLink.tsx
+++ b/apps/web/src/nav/components/NavLink.tsx
@@ -1,26 +1,49 @@
 import { useMatchPartialPath } from "@app/useMatchPartialPath";
 import { cn } from "@app/utils";
 import Link from "@base/Link";
+import type { ReactNode } from "react";
+
+type NavLinkProps = {
+	children: ReactNode;
+	search?: Record<string, string>;
+	to: string;
+};
 
 const baseClassName = cn(
 	"flex",
+	"focus-visible:outline-none",
+	"focus-visible:ring-2",
+	"focus-visible:ring-offset-2",
+	"focus-visible:ring-offset-virtool",
+	"focus-visible:ring-white",
 	"font-medium",
-	"h-full",
-	"hover:text-primary-darkest",
+	"hover:bg-black/10",
 	"items-center",
 	"justify-center",
-	"px-5",
+	"px-3",
+	"py-1",
+	"rounded-md",
 	"text-lg",
 	"text-white",
+	"transition-colors",
 );
 
-const activeClassName = cn(baseClassName, "bg-teal-800", "hover:text-white");
+const activeClassName = cn(
+	baseClassName,
+	"bg-white",
+	"hover:bg-white",
+	"text-virtool-dark",
+);
 
-export function NavLink({ children, to }) {
+export function NavLink({ children, search, to }: NavLinkProps) {
 	const active = useMatchPartialPath(to);
 
 	return (
-		<Link to={to} className={active ? activeClassName : baseClassName}>
+		<Link
+			className={active ? activeClassName : baseClassName}
+			search={search}
+			to={to}
+		>
 			{children}
 		</Link>
 	);


### PR DESCRIPTION
## Summary

- Top nav links had no hover or focus styling at all: the only hover class referenced `hover:text-primary-darkest`, a token that doesn't exist in `@theme`, and Tailwind v4 drops unknown tokens silently. Hover now paints a faint pill, the active route fills it solid white, and there's a visible focus ring. Closes VIR-2721.
- **The brand teal changed.** `--color-virtool` goes from `#3c8786` to `#387e7d`, taking white nav labels from 4.20:1 to 4.72:1 — the old value was below the WCAG AA 4.5:1 floor for a 15.75px medium label, so the nav has never passed AA at rest. Size and weight can't fix this (the large-text exemption needs 18.66px bold; the next step up, 17.5px, misses it). If the canonical brand colour is defined outside this repo — logo assets, favicon, marketing — it needs syncing to `#387e7d` or we knowingly accept the divergence.
- **`base/Tabs.tsx` is in this diff and is used well outside the nav.** It was an orphaned shadcn paste and the source of the other four dangling tokens (`text-muted-foreground`, `text-foreground`, `ring-ring`, `ring-offset-background`). Fixing them visibly changes segmented tabs: inactive labels were falling back to inherited near-black, making them nearly indistinguishable from the active tab, and now recede to `text-gray-500` as intended. Worth clicking through a page that uses them.

Every new utility was verified to emit CSS in the built bundle — the only reliable check against a silently dropped Tailwind v4 token.