### PR TITLE
fix: speed up analysis viewer rendering

### DIFF
--- a/apps/web/src/analyses/queries.ts
+++ b/apps/web/src/analyses/queries.ts
@@ -78,12 +78,10 @@ export function analysisQueryOptions(analysisId: string) {
 }
 
 export function useGetAnalysis(analysisId: string) {
-	const queryResult = useQuery(analysisQueryOptions(analysisId));
-
-	return {
-		...queryResult,
-		data: formatData(queryResult.data) as Analysis,
-	};
+	return useQuery({
+		...analysisQueryOptions(analysisId),
+		select: formatData,
+	});
 }
 
 export type CreateAnalysisParams = {

--- a/apps/web/src/analyses/utils.ts
+++ b/apps/web/src/analyses/utils.ts
@@ -12,6 +12,7 @@ import {
 	sumBy,
 } from "es-toolkit/compat";
 import type {
+	Analysis,
 	AnalysisWorkflow,
 	FormattedPathoscopeAnalysis,
 	FormattedPathoscopeIsolate,
@@ -301,7 +302,7 @@ export function formatPathoscopeData(detail): FormattedPathoscopeAnalysis {
 	};
 }
 
-export function formatData(detail) {
+export function formatData(detail: Analysis): Analysis {
 	if (detail?.workflow === "pathoscope") {
 		return formatPathoscopeData(detail);
 	}


### PR DESCRIPTION
## Summary
- Move `formatData` out of `useGetAnalysis`'s hook body and into React Query's `select`, so the map/reduce over every OTU, isolate, and sequence memoizes on query data instead of re-running on every render.
- Pass `select` the module-level `formatData` reference (not an inline arrow) since `queries.ts` is skipped by the React Compiler and an arrow would recompute every render, defeating the fix.
- Type `formatData`'s parameter and return as `Analysis` instead of leaving `detail` implicitly `any`.

Closes VIR-2699.