### PR TITLE
ci: require lint and typecheck to pass before releasing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
         name: Publish / Release
         runs-on: ubuntu-24.04
         timeout-minutes: 15
-        needs: [test, build]
+        needs: [build, check-biome, check-typescript, test]
         if: github.event_name == 'push'
         outputs:
             git-tag: ${{ steps.semantic.outputs.git-tag }}


### PR DESCRIPTION
## Summary
- The `release` job depended only on `test` and `build`, so a push to `main` with a failing `pnpm check` or `pnpm typecheck` could still run `semantic-release` and cut a release.
- `release` now also needs `check-biome` and `check-typescript`. Since `publish-ghcr` depends on `release`, the container publish is gated too.
- Restores the guarantee `AGENTS.md` already documents: main always passes `pnpm check` cleanly.

Closes VIR-2736.