### PR TITLE
fix: correct the account lookup that broke the build

### DIFF
--- a/apps/web/src/server/users/functions.ts
+++ b/apps/web/src/server/users/functions.ts
@@ -132,12 +132,9 @@ export const findUsers = createServerFn({ method: "GET" })
 // Not on the authentication exception list, so an anonymous call gets a 401.
 // The login wall and the authenticated route guard both rely on that: a
 // rejected call is how they learn there is no session.
-export const getAccount = createServerFn({ method: "GET" }).handler(
-	async () => {
-		const session = await requireSession();
-		return getAccountImpl(db, session.userId);
-	},
-);
+export const getAccount = createServerFn({ method: "GET" })
+	.middleware([authenticated()])
+	.handler(async ({ context }) => getAccountImpl(db, context.session.userId));
 
 export const getUser = createServerFn({ method: "GET" })
 	.middleware([adminRole("users")])


### PR DESCRIPTION
## Summary
- `getAccount` was added in 002509ca calling `requireSession()` without importing it, and without declaring an authorization policy at all — so `main` failed both the typecheck (`TS2304`) and `authorization.test.ts`, which calls every exported server function with no session and asserts it refuses.
- Declares `authenticated()` as its policy and reads the session from `context`, per the convention every other guarded function follows. The policy resolves the session upstream, so this also drops the redundant second lookup the handler was reaching for.
- The release gate added in 19870e1e kept the broken commit off production.

Closes VIR-2747.