### PR TITLE
fix: use indeterminate progress indicator during index builds

### DIFF
--- a/apps/web/src/indexes/components/Item/IndexItem.tsx
+++ b/apps/web/src/indexes/components/Item/IndexItem.tsx
@@ -2,7 +2,6 @@ import Attribution from "@base/Attribution";
 import BoxGroupSection from "@base/BoxGroupSection";
 import Link from "@base/Link";
 import type { IndexMinimal } from "@indexes/types";
-import { useFetchJob } from "@jobs/queries";
 import { IndexItemDescription } from "./IndexItemDescription";
 import { IndexItemIcon } from "./IndexItemIcon";
 
@@ -22,8 +21,6 @@ type IndexItemProps = {
  */
 
 export function IndexItem({ activeId, index, refId }: IndexItemProps) {
-	const { data: job } = useFetchJob(index.job?.id ?? Number.NaN, index.job);
-
 	return (
 		<BoxGroupSection>
 			<h3 className="grid grid-cols-3 mb-2 text-lg">
@@ -38,13 +35,7 @@ export function IndexItem({ activeId, index, refId }: IndexItemProps) {
 					changeCount={index.change_count}
 					modifiedCount={index.modified_otu_count}
 				/>
-				<IndexItemIcon
-					activeId={activeId}
-					id={index.id}
-					ready={index.ready}
-					progress={job?.progress}
-					state={job?.state}
-				/>
+				<IndexItemIcon activeId={activeId} id={index.id} ready={index.ready} />
 			</h3>
 			<Attribution time={index.created_at} user={index.user.handle} />
 		</BoxGroupSection>

--- a/apps/web/src/indexes/components/Item/IndexItemIcon.tsx
+++ b/apps/web/src/indexes/components/Item/IndexItemIcon.tsx
@@ -1,4 +1,5 @@
-import { CircleCheck, CircleDashed } from "lucide-react";
+import Loader from "@base/Loader";
+import { CircleCheck } from "lucide-react";
 
 type IndexItemIconProps = {
 	activeId?: string;
@@ -24,9 +25,9 @@ export function IndexItemIcon({ activeId, id, ready }: IndexItemIconProps) {
 			{ready ? (
 				<CircleCheck className="stroke-green-600" size={18} />
 			) : (
-				<CircleDashed className="stroke-gray-500" size={18} />
+				<Loader size="16px" />
 			)}
-			<span className="font-medium">{ready ? "Active" : "Not Ready"}</span>
+			<span className="font-medium">{ready ? "Active" : "Building"}</span>
 		</div>
 	);
 }

--- a/apps/web/src/indexes/components/Item/IndexItemIcon.tsx
+++ b/apps/web/src/indexes/components/Item/IndexItemIcon.tsx
@@ -1,13 +1,9 @@
-import ProgressCircle from "@base/ProgressCircle";
-import type { JobState } from "@jobs/types";
-import { CircleCheck } from "lucide-react";
+import { CircleCheck, CircleDashed } from "lucide-react";
 
 type IndexItemIconProps = {
 	activeId?: string;
 	id: string;
 	ready: boolean;
-	progress?: number;
-	state?: JobState;
 };
 
 /**
@@ -16,17 +12,9 @@ type IndexItemIconProps = {
  * @param activeId - The id of the active index
  * @param id - The id of the index
  * @param ready - Whether the index is ready
- * @param progress - The progress of the building job
- * @param state - The state of the building job
  * @returns The index item's icon
  */
-export function IndexItemIcon({
-	activeId,
-	id,
-	ready,
-	progress,
-	state,
-}: IndexItemIconProps) {
+export function IndexItemIcon({ activeId, id, ready }: IndexItemIconProps) {
 	if (ready && id !== activeId) {
 		return null;
 	}
@@ -36,13 +24,9 @@ export function IndexItemIcon({
 			{ready ? (
 				<CircleCheck className="stroke-green-600" size={18} />
 			) : (
-				<ProgressCircle
-					progress={progress ?? 0}
-					state={state ?? "pending"}
-					size="md"
-				/>
+				<CircleDashed className="stroke-gray-500" size={18} />
 			)}
-			<span className="font-medium">{ready ? "Active" : "Building"}</span>
+			<span className="font-medium">{ready ? "Active" : "Not Ready"}</span>
 		</div>
 	);
 }

--- a/apps/web/src/indexes/components/Item/__tests__/IndexItemIcon.test.tsx
+++ b/apps/web/src/indexes/components/Item/__tests__/IndexItemIcon.test.tsx
@@ -1,0 +1,25 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@tests/setup";
+import { describe, expect, it } from "vitest";
+import { IndexItemIcon } from "../IndexItemIcon";
+
+describe("<IndexItemIcon />", () => {
+	it("renders the active status for the current ready index", () => {
+		renderWithProviders(<IndexItemIcon activeId="foo" id="foo" ready />);
+
+		expect(screen.getByText("Active")).toBeInTheDocument();
+	});
+
+	it("hides the status for ready indexes that are not active", () => {
+		renderWithProviders(<IndexItemIcon activeId="foo" id="bar" ready />);
+
+		expect(screen.queryByText("Active")).not.toBeInTheDocument();
+	});
+
+	it("renders the not-ready status for a not-ready index", () => {
+		renderWithProviders(<IndexItemIcon id="foo" ready={false} />);
+
+		expect(screen.getByText("Not Ready")).toBeInTheDocument();
+		expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+	});
+});

--- a/apps/web/src/indexes/components/Item/__tests__/IndexItemIcon.test.tsx
+++ b/apps/web/src/indexes/components/Item/__tests__/IndexItemIcon.test.tsx
@@ -16,10 +16,11 @@ describe("<IndexItemIcon />", () => {
 		expect(screen.queryByText("Active")).not.toBeInTheDocument();
 	});
 
-	it("renders the not-ready status for a not-ready index", () => {
+	it("renders the building status for a not-ready index", () => {
 		renderWithProviders(<IndexItemIcon id="foo" ready={false} />);
 
-		expect(screen.getByText("Not Ready")).toBeInTheDocument();
+		expect(screen.getByText("Building")).toBeInTheDocument();
+		expect(screen.getByRole("status", { name: "loading" })).toBeInTheDocument();
 		expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
 	});
 });

--- a/apps/web/src/indexes/components/Item/__tests__/IndexItemIcon.test.tsx
+++ b/apps/web/src/indexes/components/Item/__tests__/IndexItemIcon.test.tsx
@@ -11,9 +11,11 @@ describe("<IndexItemIcon />", () => {
 	});
 
 	it("hides the status for ready indexes that are not active", () => {
-		renderWithProviders(<IndexItemIcon activeId="foo" id="bar" ready />);
+		const { container } = renderWithProviders(
+			<IndexItemIcon activeId="foo" id="bar" ready />,
+		);
 
-		expect(screen.queryByText("Active")).not.toBeInTheDocument();
+		expect(container).toBeEmptyDOMElement();
 	});
 
 	it("renders the building status for a not-ready index", () => {

--- a/apps/web/src/indexes/types.ts
+++ b/apps/web/src/indexes/types.ts
@@ -1,4 +1,3 @@
-import type { ServerJobNested } from "@jobs/types";
 import type { HistoryNested, OtuNested } from "@otus/types";
 import type { ReferenceNested } from "@references/types";
 import type { UserNested } from "@users/types";
@@ -23,9 +22,6 @@ export type IndexMinimal = IndexNested & {
 
 	/** Whether there are downloadable uploads */
 	has_files: boolean;
-
-	/** The job responsible for creation */
-	job?: ServerJobNested;
 
 	/** A count of individual OTUs changed */
 	modified_otu_count: number;

--- a/apps/web/src/tests/fake/indexes.ts
+++ b/apps/web/src/tests/fake/indexes.ts
@@ -1,6 +1,5 @@
 import { faker } from "@faker-js/faker";
 import type { IndexFile, IndexMinimal, IndexNested } from "@indexes/types";
-import { createFakeServerJobNested } from "./jobs";
 import { createFakeReferenceNested } from "./references";
 import { createFakeUserNested } from "./user";
 
@@ -23,7 +22,6 @@ export function createFakeIndexMinimal(
 		change_count: faker.number.int({ min: 2, max: 10 }),
 		created_at: faker.date.past().toISOString(),
 		has_files: faker.datatype.boolean(),
-		job: createFakeServerJobNested({ workflow: "build_index" }),
 		modified_otu_count: faker.number.int({ min: 2, max: 10 }),
 		reference: createFakeReferenceNested(),
 		user: createFakeUserNested(),


### PR DESCRIPTION
## Summary

- use an indeterminte loader during index builds
- Moves indication of index status solely onto the ready field of the index

Building:

<img width="1068" height="140" alt="image" src="https://github.com/user-attachments/assets/ce8b536d-e719-401e-9957-6282091c05e2" />


Complete:

<img width="1043" height="162" alt="image" src="https://github.com/user-attachments/assets/6b84948e-4ff6-44da-974e-19fc229360d5" />
