### PR TITLE
fix: pass aria attributes through to form inputs

### DIFF
--- a/apps/web/src/base/ComboBox.tsx
+++ b/apps/web/src/base/ComboBox.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@app/cn";
-import { useCombobox } from "downshift";
+import { type UseComboboxReturnValue, useCombobox } from "downshift";
 import { ChevronDown } from "lucide-react";
 import type { ReactElement } from "react";
 import WrapRow from "./ComboBoxItem";
@@ -30,7 +30,11 @@ function ComboboxTriggerButton({
 	);
 }
 
-function ComboBoxSearch({ getInputProps }) {
+type ComboBoxSearchProps = {
+	getInputProps: UseComboboxReturnValue<unknown>["getInputProps"];
+};
+
+function ComboBoxSearch({ getInputProps }: ComboBoxSearchProps) {
 	return (
 		<div className="mx-1 my-2.5">
 			<InputSearch {...getInputProps()} />

--- a/apps/web/src/base/Input.tsx
+++ b/apps/web/src/base/Input.tsx
@@ -1,97 +1,34 @@
 import { cn } from "@app/cn";
-import { type ElementType, type ReactNode, type Ref, useContext } from "react";
-import type { UseFormRegisterReturn } from "react-hook-form";
-import InputContext from "./InputContext";
+import type { ComponentProps } from "react";
+import { useIsInvalid } from "./InputContext";
 import {
 	inputBaseClasses,
-	inputErrorClasses,
 	inputFocusClasses,
 	inputHeightClass,
+	inputInvalidClasses,
 } from "./styles";
 
-export type InputProps = {
-	"aria-label"?: string;
-	as?: ElementType;
-	autoFocus?: boolean;
-	children?: ReactNode;
-	className?: string;
-	disabled?: boolean;
+/** Props for the shared single-line text input. Accepts any native input attribute. */
+export type InputProps = ComponentProps<"input"> & {
+	/** Marks the input invalid, turning its border and focus ring red. Falls back to the error on a surrounding `InputGroup`. */
 	error?: string;
-	id?: string;
-	max?: number;
-	min?: number;
-	name?: string;
-	placeholder?: string;
-	readOnly?: boolean;
-	ref?: Ref<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>;
-	register?: UseFormRegisterReturn;
-	step?: number;
-	type?: string;
-	value?: string | number;
-	onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
-	onChange?: (event: React.ChangeEvent) => void;
-	onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
-	onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
 };
 
-export default function Input({
-	"aria-label": ariaLabel,
-	as: Component = "input",
-	autoFocus = false,
-	children,
-	className = "",
-	disabled = false,
-	error: errorProp,
-	id,
-	max,
-	min,
-	name,
-	placeholder,
-	readOnly = false,
-	ref,
-	step,
-	type,
-	value,
-	onBlur,
-	onChange,
-	onFocus,
-	onKeyDown,
-}: InputProps) {
-	const errorContext = useContext(InputContext);
-	const error = errorProp || errorContext;
+export default function Input({ className, error, ...props }: InputProps) {
+	const invalid = useIsInvalid(error);
 
 	return (
-		<Component
-			aria-label={ariaLabel}
-			ref={ref}
-			autoFocus={autoFocus}
+		<input
+			aria-invalid={invalid || undefined}
 			className={cn(
 				inputBaseClasses,
-				Component !== "textarea" && inputHeightClass,
-				error ? inputErrorClasses : inputFocusClasses,
-				{
-					"read-only:bg-gray-100": Component !== "select",
-				},
+				inputHeightClass,
+				inputFocusClasses,
+				inputInvalidClasses,
+				"read-only:bg-gray-100",
 				className,
 			)}
-			disabled={disabled}
-			id={id}
-			max={max}
-			min={min}
-			name={name}
-			placeholder={placeholder}
-			readOnly={readOnly}
-			step={step}
-			type={type}
-			value={value}
-			onBlur={onBlur}
-			onChange={onChange}
-			onFocus={onFocus}
-			onKeyDown={onKeyDown}
-		>
-			{children}
-		</Component>
+			{...props}
+		/>
 	);
 }
-
-Input.displayName = "Input";

--- a/apps/web/src/base/InputContext.ts
+++ b/apps/web/src/base/InputContext.ts
@@ -1,7 +1,16 @@
-import React from "react";
+import React, { useContext } from "react";
 
 const InputContext = React.createContext("");
 
 InputContext.displayName = "InputContext";
+
+/**
+ * Whether a form control should be marked invalid, given its own error and any
+ * error set on a surrounding `InputGroup`.
+ */
+export function useIsInvalid(error?: string): boolean {
+	const contextError = useContext(InputContext);
+	return Boolean(error || contextError);
+}
 
 export default InputContext;

--- a/apps/web/src/base/InputPassword.tsx
+++ b/apps/web/src/base/InputPassword.tsx
@@ -1,22 +1,20 @@
 import { Eye, EyeOff } from "lucide-react";
-import { type Ref, useState } from "react";
-import Input from "./Input";
+import { useState } from "react";
+import Input, { type InputProps } from "./Input";
 import InputContainer from "./InputContainer";
 import InputIconButton from "./InputIconButton";
 
-type InputPasswordProps = {
+type InputPasswordProps = Omit<InputProps, "type"> & {
 	id: string;
 	name: string;
-	autoComplete?: string;
-	ref?: Ref<HTMLInputElement>;
 };
 
-export default function InputPassword({ ref, ...props }: InputPasswordProps) {
+export default function InputPassword(props: InputPasswordProps) {
 	const [show, setShow] = useState(false);
 
 	return (
 		<InputContainer className="flex flex-grow-1">
-			<Input as="input" {...props} ref={ref} type={show ? "" : "password"} />
+			<Input {...props} type={show ? "text" : "password"} />
 			<InputIconButton
 				tip={show ? "Hide" : "Show"}
 				IconComponent={show ? Eye : EyeOff}

--- a/apps/web/src/base/InputSearch.tsx
+++ b/apps/web/src/base/InputSearch.tsx
@@ -1,35 +1,12 @@
 import { Search } from "lucide-react";
-import type { ReactNode, Ref } from "react";
-import Input from "./Input";
+import Input, { type InputProps } from "./Input";
 import InputContainer from "./InputContainer";
 import InputIcon from "./InputIcon";
 
-type InputSearchProps = {
-	"aria-label"?: string;
-	autoFocus?: boolean;
-	children?: ReactNode;
-	className?: string;
-	disabled?: boolean;
-	error?: string;
-	id?: string;
-	max?: number;
-	min?: number;
-	name?: string;
-	placeholder?: string;
-	readOnly?: boolean;
-	ref?: Ref<HTMLInputElement>;
-	step?: number;
-	type?: string;
-	value: string | number;
-	onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
-	onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-	onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
-};
-
-export default function InputSearch({ ref, ...props }: InputSearchProps) {
+export default function InputSearch(props: InputProps) {
 	return (
 		<InputContainer align="left" className="flex-grow">
-			<Input {...props} ref={ref} />
+			<Input {...props} />
 			<InputIcon size={18} icon={Search} />
 		</InputContainer>
 	);

--- a/apps/web/src/base/InputSimple.tsx
+++ b/apps/web/src/base/InputSimple.tsx
@@ -4,6 +4,7 @@ import {
 	inputBaseClasses,
 	inputFocusClasses,
 	inputHeightClass,
+	inputInvalidClasses,
 } from "./styles";
 
 export type InputSimpleProps = React.InputHTMLAttributes<HTMLInputElement> & {
@@ -20,6 +21,7 @@ const InputSimple = React.forwardRef<HTMLInputElement, InputSimpleProps>(
 					inputBaseClasses,
 					inputHeightClass,
 					inputFocusClasses,
+					inputInvalidClasses,
 					"read-only:bg-gray-100",
 					className,
 				)}

--- a/apps/web/src/base/SelectButton.tsx
+++ b/apps/web/src/base/SelectButton.tsx
@@ -3,7 +3,11 @@ import Icon from "@base/Icon";
 import type { LucideIcon } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
 import type { AriaAttributes } from "react";
-import { inputFocusClasses, inputHeightClass } from "./styles";
+import {
+	inputFocusClasses,
+	inputHeightClass,
+	inputInvalidClasses,
+} from "./styles";
 
 type SelectButtonProps = {
 	placeholder?: string;
@@ -31,8 +35,8 @@ export default function SelectButton({
 				"flex justify-between items-center px-2.5 bg-white border rounded font-medium capitalize [&_svg]:ml-1",
 				inputHeightClass,
 				inputFocusClasses,
+				inputInvalidClasses,
 				"data-[placeholder]:text-gray-500",
-				"aria-invalid:border-red-500 aria-invalid:focus-visible:border-red-500 aria-invalid:focus-visible:ring-2 aria-invalid:focus-visible:ring-red-500/50",
 				className,
 			)}
 			data-slot="select-trigger"

--- a/apps/web/src/base/TextArea.tsx
+++ b/apps/web/src/base/TextArea.tsx
@@ -1,29 +1,37 @@
 import { cn } from "@app/cn";
-import type { ElementType, ReactNode, Ref } from "react";
-import Input from "./Input";
+import type { ComponentProps } from "react";
+import { useIsInvalid } from "./InputContext";
+import {
+	inputBaseClasses,
+	inputFocusClasses,
+	inputInvalidClasses,
+} from "./styles";
 
-type TextAreaProps = {
-	"aria-label"?: string;
-	as?: ElementType;
-	children?: ReactNode;
-	className?: string;
+/** Props for the shared multi-line text input. Accepts any native textarea attribute. */
+export type TextAreaProps = ComponentProps<"textarea"> & {
+	/** Marks the textarea invalid, turning its border and focus ring red. Falls back to the error on a surrounding `InputGroup`. */
 	error?: string;
-	id?: string;
-	name?: string;
-	readOnly?: boolean;
-	ref?: Ref<HTMLInputElement>;
-	value?: string | number;
-	onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
-	onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
-export default function TextArea({ className, ref, ...props }: TextAreaProps) {
+export default function TextArea({
+	className,
+	error,
+	...props
+}: TextAreaProps) {
+	const invalid = useIsInvalid(error);
+
 	return (
-		<Input
-			as="textarea"
-			className={cn("h-56 resize-y overflow-y-scroll", className)}
+		<textarea
+			aria-invalid={invalid || undefined}
+			className={cn(
+				inputBaseClasses,
+				inputFocusClasses,
+				inputInvalidClasses,
+				"read-only:bg-gray-100",
+				"h-56 resize-y overflow-y-scroll",
+				className,
+			)}
 			{...props}
-			ref={ref}
 		/>
 	);
 }

--- a/apps/web/src/base/__tests__/ComboBox.test.tsx
+++ b/apps/web/src/base/__tests__/ComboBox.test.tsx
@@ -1,0 +1,35 @@
+import { renderWithProviders } from "@tests/setup";
+import { describe, expect, it, vi } from "vitest";
+import ComboBox from "../ComboBox";
+
+type Group = { id: number; name: string };
+
+function renderComboBox() {
+	const groups: Group[] = [
+		{ id: 1, name: "Managers" },
+		{ id: 2, name: "Technicians" },
+	];
+
+	return renderWithProviders(
+		<ComboBox
+			items={groups}
+			term=""
+			renderRow={(item: Group) => <span>{item.name}</span>}
+			itemToString={(item: Group) => item.name}
+			onFilter={vi.fn()}
+			onChange={vi.fn()}
+		/>,
+	);
+}
+
+describe("<ComboBox />", () => {
+	it("should expose the search input as a combobox to assistive technology", () => {
+		const { getByRole } = renderComboBox();
+
+		const input = getByRole("combobox");
+
+		expect(input).toHaveAttribute("aria-autocomplete", "list");
+		expect(input).toHaveAttribute("aria-controls");
+		expect(input).toHaveAttribute("aria-expanded", "false");
+	});
+});

--- a/apps/web/src/base/__tests__/Input.test.tsx
+++ b/apps/web/src/base/__tests__/Input.test.tsx
@@ -1,0 +1,54 @@
+import { renderWithProviders } from "@tests/setup";
+import { describe, expect, it } from "vitest";
+import Input from "../Input";
+import InputGroup from "../InputGroup";
+
+describe("<Input />", () => {
+	it("should forward aria attributes to the underlying input", () => {
+		const { getByRole } = renderWithProviders(
+			<Input
+				aria-activedescendant="option-2"
+				aria-controls="listbox"
+				aria-describedby="handle-error"
+				aria-expanded={true}
+				aria-label="Handle"
+				autoComplete="username"
+				required
+				role="combobox"
+			/>,
+		);
+
+		const input = getByRole("combobox");
+
+		expect(input).toHaveAttribute("aria-activedescendant", "option-2");
+		expect(input).toHaveAttribute("aria-controls", "listbox");
+		expect(input).toHaveAttribute("aria-describedby", "handle-error");
+		expect(input).toHaveAttribute("aria-expanded", "true");
+		expect(input).toHaveAttribute("autocomplete", "username");
+		expect(input).toBeRequired();
+	});
+
+	it("should not be marked invalid when there is no error", () => {
+		const { getByRole } = renderWithProviders(<Input aria-label="Handle" />);
+
+		expect(getByRole("textbox")).not.toHaveAttribute("aria-invalid");
+	});
+
+	it("should be marked invalid when passed an error", () => {
+		const { getByRole } = renderWithProviders(
+			<Input aria-label="Handle" error="Handle is required" />,
+		);
+
+		expect(getByRole("textbox")).toBeInvalid();
+	});
+
+	it("should be marked invalid when a surrounding InputGroup has an error", () => {
+		const { getByRole } = renderWithProviders(
+			<InputGroup error="Handle is required">
+				<Input aria-label="Handle" />
+			</InputGroup>,
+		);
+
+		expect(getByRole("textbox")).toBeInvalid();
+	});
+});

--- a/apps/web/src/base/__tests__/TextArea.test.tsx
+++ b/apps/web/src/base/__tests__/TextArea.test.tsx
@@ -1,0 +1,34 @@
+import { renderWithProviders } from "@tests/setup";
+import { describe, expect, it } from "vitest";
+import InputGroup from "../InputGroup";
+import TextArea from "../TextArea";
+
+describe("<TextArea />", () => {
+	it("should forward aria attributes to the underlying textarea", () => {
+		const { getByRole } = renderWithProviders(
+			<TextArea
+				aria-describedby="notes-error"
+				aria-label="Notes"
+				required
+				rows={4}
+			/>,
+		);
+
+		const textarea = getByRole("textbox");
+
+		expect(textarea.tagName).toBe("TEXTAREA");
+		expect(textarea).toHaveAttribute("aria-describedby", "notes-error");
+		expect(textarea).toHaveAttribute("rows", "4");
+		expect(textarea).toBeRequired();
+	});
+
+	it("should be marked invalid when a surrounding InputGroup has an error", () => {
+		const { getByRole } = renderWithProviders(
+			<InputGroup error="Notes are required">
+				<TextArea aria-label="Notes" />
+			</InputGroup>,
+		);
+
+		expect(getByRole("textbox")).toBeInvalid();
+	});
+});

--- a/apps/web/src/base/styles.ts
+++ b/apps/web/src/base/styles.ts
@@ -1,4 +1,4 @@
-/** Base classes shared by Input and InputSimple */
+/** Base classes shared by Input, InputSimple, and TextArea */
 export const inputBaseClasses =
 	"bg-white border rounded min-w-0 block outline-none py-2 px-2.5 relative transition-[color,box-shadow] w-full placeholder:text-gray-500 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50";
 
@@ -9,13 +9,17 @@ export const inputBaseClasses =
  */
 export const inputHeightClass = "h-10";
 
-/** Focus ring for inputs in normal (non-error) state */
+/** Border and focus ring for form controls in their normal state */
 export const inputFocusClasses =
 	"border-gray-300 focus-visible:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500/50";
 
-/** Focus ring + border for inputs in error state */
-export const inputErrorClasses =
-	"border-red-500 focus-visible:border-red-500 focus-visible:ring-2 focus-visible:ring-red-500/50";
+/**
+ * Border and focus ring for form controls marked invalid. Driven by
+ * `aria-invalid` so the red treatment and the announcement to assistive
+ * technology can never disagree — the attribute is the only source of truth.
+ */
+export const inputInvalidClasses =
+	"aria-invalid:border-red-500 aria-invalid:focus-visible:border-red-500 aria-invalid:focus-visible:ring-2 aria-invalid:focus-visible:ring-red-500/50";
 
 /**
  * Interaction and state classes shared by every Select item so hover,


### PR DESCRIPTION
## Summary
- `Input` and `TextArea` dropped every prop outside a fixed allowlist, silently discarding `role`, `aria-invalid`, `aria-describedby`, `aria-expanded`, `aria-activedescendant`, `required`, and `autoComplete` — breaking `ComboBox`'s combobox role/active-descendant for screen readers and password fields' autocomplete hints.
- Type `Input`/`TextArea` as their native element props and spread the rest through, drop the unused `as` prop and dead `register` prop, and type `ComboBoxSearch`'s `getInputProps` so a dropped prop fails the build instead of hiding behind an implicit `any`.
- Drive the invalid border/ring from `aria-invalid` via a shared `inputInvalidClasses` constant, folding a surrounding `InputGroup` error into it through `useIsInvalid`, so the visual and assistive-tech states can't disagree.