### PR TITLE
fix: report malformed server-sent events to Sentry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -512,9 +512,16 @@ constraints, mappings, or decisions that apply to your work.
 
 The basics:
 
-- **Functions:** Use function declarations, not arrow functions. This is a
-  convention, not a lint rule — Biome has no `func-style` equivalent, so
-  nothing catches a violation but review.
+- **Functions:** Use function declarations, not arrow functions. For React
+  components this is enforced by Biome's
+  `useReactFunctionComponentDefinition`. Everywhere else it stays a
+  convention — Biome has no general `func-style` equivalent, so nothing
+  catches a violation in a plain function but review.
+- **Refs:** Don't use `forwardRef`. React 19 makes `ref` an ordinary prop:
+  type a wrapper's props with `ComponentPropsWithRef` and let `ref` flow
+  through the `...props` spread. `forwardRef` also trips
+  `useReactFunctionComponentDefinition`, because the component ends up as a
+  function expression rather than a declaration.
 - **Imports:** Biome organises imports automatically.
 - **Conditionals:** Always use curly braces with `if`/`else`.
 - **Prefer `const`** over `let`.
@@ -555,8 +562,10 @@ The only exception is upstream-defined names (e.g. `SENTRY_AUTH_TOKEN`,
 
 ## Logging
 
-Server code logs through `@virtool/logger`, not `console.*` — Biome's
-`noConsole` enforces this under `apps/web/src/server/`.
+Server code logs through `@virtool/logger`, not `console.*`. Biome's
+`noConsole` bans `console.*` across the whole repo; on the client, report
+unexpected conditions to Sentry (`Sentry.captureException`) rather than the
+user's console, which no one can read.
 
 Import the `logger` singleton from `@server/logger` and call it directly:
 

--- a/apps/web/scripts/check-api.mjs
+++ b/apps/web/scripts/check-api.mjs
@@ -11,19 +11,13 @@ const apiUrl = process.env.VT_UI_API_URL ?? "http://localhost:9950";
 
 const response = await fetch(apiUrl);
 if (!response.ok) {
-	console.error(`failed to reach api at ${apiUrl}: ${response.status}`);
 	process.exit(1);
 }
 
 const body = await response.json();
 if (!gte(body.version, minApiVersion)) {
-	console.error(
-		`found incompatible API version ${body.version}. Require ${minApiVersion}.`,
-	);
 	process.exit(1);
 }
-
-console.log(`found compatible api version ${body.version}`);
 
 // Minimal semver "greater-than-or-equal" for `major.minor.patch` strings,
 // ignoring prerelease/build suffixes. Inlined to avoid pulling `semver` into

--- a/apps/web/scripts/check-api.mjs
+++ b/apps/web/scripts/check-api.mjs
@@ -11,13 +11,21 @@ const apiUrl = process.env.VT_UI_API_URL ?? "http://localhost:9950";
 
 const response = await fetch(apiUrl);
 if (!response.ok) {
+	process.stderr.write(
+		`failed to reach api at ${apiUrl}: ${response.status}\n`,
+	);
 	process.exit(1);
 }
 
 const body = await response.json();
 if (!gte(body.version, minApiVersion)) {
+	process.stderr.write(
+		`found incompatible API version ${body.version}. Require ${minApiVersion}.\n`,
+	);
 	process.exit(1);
 }
+
+process.stdout.write(`found compatible api version ${body.version}\n`);
 
 // Minimal semver "greater-than-or-equal" for `major.minor.patch` strings,
 // ignoring prerelease/build suffixes. Inlined to avoid pulling `semver` into

--- a/apps/web/src/app/sse/SseConnection.ts
+++ b/apps/web/src/app/sse/SseConnection.ts
@@ -1,5 +1,6 @@
 import { useServerVersionStore } from "@app/serverVersion";
 import { endSession } from "@app/session";
+import * as Sentry from "@sentry/tanstackstart-react";
 import type { QueryClient } from "@tanstack/react-query";
 import { reactQueryHandler } from "./reactQueryHandler";
 import { SseMessageSchema } from "./schema";
@@ -27,7 +28,7 @@ export function init(queryClient: QueryClient): void {
 		if (parsed.success) {
 			handler(parsed.data);
 		} else {
-			window.console.warn("Invalid SSE message", parsed.error);
+			Sentry.captureException(parsed.error);
 		}
 	};
 }
@@ -111,7 +112,7 @@ export function establishConnection(): void {
 				useServerVersionStore.getState().setVersion(version);
 			}
 		} catch (error) {
-			window.console.error("Failed to parse SSE version", error);
+			Sentry.captureException(error);
 		}
 	});
 
@@ -119,7 +120,7 @@ export function establishConnection(): void {
 		try {
 			handleMessage?.(JSON.parse(e.data));
 		} catch (error) {
-			window.console.error("Failed to parse SSE message", error);
+			Sentry.captureException(error);
 		}
 	};
 

--- a/apps/web/src/app/sse/SseConnection.ts
+++ b/apps/web/src/app/sse/SseConnection.ts
@@ -28,7 +28,9 @@ export function init(queryClient: QueryClient): void {
 		if (parsed.success) {
 			handler(parsed.data);
 		} else {
-			Sentry.captureException(parsed.error);
+			Sentry.captureException(parsed.error, {
+				tags: { sse: "message-validation" },
+			});
 		}
 	};
 }
@@ -112,7 +114,7 @@ export function establishConnection(): void {
 				useServerVersionStore.getState().setVersion(version);
 			}
 		} catch (error) {
-			Sentry.captureException(error);
+			Sentry.captureException(error, { tags: { sse: "version-parse" } });
 		}
 	});
 
@@ -120,7 +122,7 @@ export function establishConnection(): void {
 		try {
 			handleMessage?.(JSON.parse(e.data));
 		} catch (error) {
-			Sentry.captureException(error);
+			Sentry.captureException(error, { tags: { sse: "message-parse" } });
 		}
 	};
 

--- a/apps/web/src/base/AccordionContent.tsx
+++ b/apps/web/src/base/AccordionContent.tsx
@@ -1,15 +1,14 @@
 import { cn } from "@app/cn";
 import { Accordion as AccordionPrimitive } from "radix-ui";
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import type { ComponentPropsWithRef } from "react";
 
 /** display the content of the accordion dropdown based on state */
-const AccordionContent = forwardRef<
-	HTMLDivElement,
-	ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
->(function AccordionContent({ className, ...props }, ref) {
+export default function AccordionContent({
+	className,
+	...props
+}: ComponentPropsWithRef<typeof AccordionPrimitive.Content>) {
 	return (
 		<AccordionPrimitive.Content
-			ref={ref}
 			className={cn(
 				"overflow-hidden px-4 data-[state=closed]:hidden",
 				className,
@@ -17,6 +16,4 @@ const AccordionContent = forwardRef<
 			{...props}
 		/>
 	);
-});
-
-export default AccordionContent;
+}

--- a/apps/web/src/base/AccordionTrigger.tsx
+++ b/apps/web/src/base/AccordionTrigger.tsx
@@ -1,15 +1,14 @@
 import { cn } from "@app/cn";
 import { Accordion as AccordionPrimitive } from "radix-ui";
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import type { ComponentPropsWithRef } from "react";
 
 /** button for toggling the display of accordion contents  */
-const AccordionTrigger = forwardRef<
-	HTMLButtonElement,
-	ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
->(function AccordionTrigger({ className, ...props }, ref) {
+export default function AccordionTrigger({
+	className,
+	...props
+}: ComponentPropsWithRef<typeof AccordionPrimitive.Trigger>) {
 	return (
 		<AccordionPrimitive.Trigger
-			ref={ref}
 			className={cn(
 				"flex items-center justify-between w-full bg-white border-none px-4 py-2.5 hover:bg-gray-50",
 				className,
@@ -17,6 +16,4 @@ const AccordionTrigger = forwardRef<
 			{...props}
 		/>
 	);
-});
-
-export default AccordionTrigger;
+}

--- a/apps/web/src/base/DropdownMenuCheckboxItem.tsx
+++ b/apps/web/src/base/DropdownMenuCheckboxItem.tsx
@@ -1,27 +1,26 @@
 import { Check, Minus } from "lucide-react";
 import { DropdownMenu } from "radix-ui";
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import type { ComponentPropsWithRef } from "react";
 import {
 	type DropdownMenuItemColor,
 	getDropdownMenuItemClassName,
 } from "./dropdownMenuItemStyles";
 
-type DropdownMenuCheckboxItemProps = ComponentPropsWithoutRef<
+type DropdownMenuCheckboxItemProps = ComponentPropsWithRef<
 	typeof DropdownMenu.CheckboxItem
 > & {
 	color?: DropdownMenuItemColor;
 };
 
-const DropdownMenuCheckboxItem = forwardRef<
-	HTMLDivElement,
-	DropdownMenuCheckboxItemProps
->(function DropdownMenuCheckboxItem(
-	{ checked, children, className, color = "gray", ...props },
-	ref,
-) {
+export default function DropdownMenuCheckboxItem({
+	checked,
+	children,
+	className,
+	color = "gray",
+	...props
+}: DropdownMenuCheckboxItemProps) {
 	return (
 		<DropdownMenu.CheckboxItem
-			ref={ref}
 			checked={checked}
 			className={getDropdownMenuItemClassName(color, className)}
 			{...props}
@@ -38,6 +37,4 @@ const DropdownMenuCheckboxItem = forwardRef<
 			{children}
 		</DropdownMenu.CheckboxItem>
 	);
-});
-
-export default DropdownMenuCheckboxItem;
+}

--- a/apps/web/src/base/DropdownMenuContent.tsx
+++ b/apps/web/src/base/DropdownMenuContent.tsx
@@ -1,22 +1,20 @@
 import { cn } from "@app/cn";
 import { DropdownMenu } from "radix-ui";
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import type { ComponentPropsWithRef } from "react";
 
 /**
  * The floating panel of a dropdown menu, portalled out of the trigger's
  * stacking context and aligned to the trigger's start edge.
  */
-const DropdownMenuContent = forwardRef<
-	HTMLDivElement,
-	ComponentPropsWithoutRef<typeof DropdownMenu.Content>
->(function DropdownMenuContent(
-	{ align = "start", className, sideOffset = 4, ...props },
-	ref,
-) {
+export default function DropdownMenuContent({
+	align = "start",
+	className,
+	sideOffset = 4,
+	...props
+}: ComponentPropsWithRef<typeof DropdownMenu.Content>) {
 	return (
 		<DropdownMenu.Portal>
 			<DropdownMenu.Content
-				ref={ref}
 				align={align}
 				sideOffset={sideOffset}
 				className={cn(
@@ -43,6 +41,4 @@ const DropdownMenuContent = forwardRef<
 			/>
 		</DropdownMenu.Portal>
 	);
-});
-
-export default DropdownMenuContent;
+}

--- a/apps/web/src/base/DropdownMenuGroup.tsx
+++ b/apps/web/src/base/DropdownMenuGroup.tsx
@@ -1,16 +1,13 @@
 import { DropdownMenu } from "radix-ui";
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import type { ComponentPropsWithRef } from "react";
 
 /**
  * Groups related menu items under `role="group"`. Pair with a
  * `DropdownMenuLabel` referenced by `aria-labelledby` so the section is
  * announced rather than only shown.
  */
-const DropdownMenuGroup = forwardRef<
-	HTMLDivElement,
-	ComponentPropsWithoutRef<typeof DropdownMenu.Group>
->(function DropdownMenuGroup(props, ref) {
-	return <DropdownMenu.Group ref={ref} {...props} />;
-});
-
-export default DropdownMenuGroup;
+export default function DropdownMenuGroup(
+	props: ComponentPropsWithRef<typeof DropdownMenu.Group>,
+) {
+	return <DropdownMenu.Group {...props} />;
+}

--- a/apps/web/src/base/DropdownMenuItem.tsx
+++ b/apps/web/src/base/DropdownMenuItem.tsx
@@ -1,26 +1,23 @@
 import { DropdownMenu } from "radix-ui";
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import type { ComponentPropsWithRef } from "react";
 import {
 	type DropdownMenuItemColor,
 	getDropdownMenuItemClassName,
 } from "./dropdownMenuItemStyles";
 
-type DropdownMenuItemProps = ComponentPropsWithoutRef<
-	typeof DropdownMenu.Item
-> & {
+type DropdownMenuItemProps = ComponentPropsWithRef<typeof DropdownMenu.Item> & {
 	color?: DropdownMenuItemColor;
 };
 
-const DropdownMenuItem = forwardRef<HTMLDivElement, DropdownMenuItemProps>(
-	function DropdownMenuItem({ className, color = "gray", ...props }, ref) {
-		return (
-			<DropdownMenu.Item
-				ref={ref}
-				className={getDropdownMenuItemClassName(color, className)}
-				{...props}
-			/>
-		);
-	},
-);
-
-export default DropdownMenuItem;
+export default function DropdownMenuItem({
+	className,
+	color = "gray",
+	...props
+}: DropdownMenuItemProps) {
+	return (
+		<DropdownMenu.Item
+			className={getDropdownMenuItemClassName(color, className)}
+			{...props}
+		/>
+	);
+}

--- a/apps/web/src/base/DropdownMenuLabel.tsx
+++ b/apps/web/src/base/DropdownMenuLabel.tsx
@@ -1,14 +1,13 @@
 import { cn } from "@app/cn";
 import { DropdownMenu } from "radix-ui";
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import type { ComponentPropsWithRef } from "react";
 
-const DropdownMenuLabel = forwardRef<
-	HTMLDivElement,
-	ComponentPropsWithoutRef<typeof DropdownMenu.Label>
->(function DropdownMenuLabel({ className, ...props }, ref) {
+export default function DropdownMenuLabel({
+	className,
+	...props
+}: ComponentPropsWithRef<typeof DropdownMenu.Label>) {
 	return (
 		<DropdownMenu.Label
-			ref={ref}
 			className={cn(
 				"font-medium px-2 py-1.5 text-gray-500 text-xs tracking-wide uppercase",
 				className,
@@ -16,6 +15,4 @@ const DropdownMenuLabel = forwardRef<
 			{...props}
 		/>
 	);
-});
-
-export default DropdownMenuLabel;
+}

--- a/apps/web/src/base/DropdownMenuRadioGroup.tsx
+++ b/apps/web/src/base/DropdownMenuRadioGroup.tsx
@@ -1,11 +1,8 @@
 import { DropdownMenu } from "radix-ui";
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import type { ComponentPropsWithRef } from "react";
 
-const DropdownMenuRadioGroup = forwardRef<
-	HTMLDivElement,
-	ComponentPropsWithoutRef<typeof DropdownMenu.RadioGroup>
->(function DropdownMenuRadioGroup(props, ref) {
-	return <DropdownMenu.RadioGroup ref={ref} {...props} />;
-});
-
-export default DropdownMenuRadioGroup;
+export default function DropdownMenuRadioGroup(
+	props: ComponentPropsWithRef<typeof DropdownMenu.RadioGroup>,
+) {
+	return <DropdownMenu.RadioGroup {...props} />;
+}

--- a/apps/web/src/base/DropdownMenuRadioItem.tsx
+++ b/apps/web/src/base/DropdownMenuRadioItem.tsx
@@ -1,27 +1,25 @@
 import { Circle } from "lucide-react";
 import { DropdownMenu } from "radix-ui";
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import type { ComponentPropsWithRef } from "react";
 import {
 	type DropdownMenuItemColor,
 	getDropdownMenuItemClassName,
 } from "./dropdownMenuItemStyles";
 
-type DropdownMenuRadioItemProps = ComponentPropsWithoutRef<
+type DropdownMenuRadioItemProps = ComponentPropsWithRef<
 	typeof DropdownMenu.RadioItem
 > & {
 	color?: DropdownMenuItemColor;
 };
 
-const DropdownMenuRadioItem = forwardRef<
-	HTMLDivElement,
-	DropdownMenuRadioItemProps
->(function DropdownMenuRadioItem(
-	{ children, className, color = "gray", ...props },
-	ref,
-) {
+export default function DropdownMenuRadioItem({
+	children,
+	className,
+	color = "gray",
+	...props
+}: DropdownMenuRadioItemProps) {
 	return (
 		<DropdownMenu.RadioItem
-			ref={ref}
 			className={getDropdownMenuItemClassName(color, className)}
 			{...props}
 		>
@@ -33,6 +31,4 @@ const DropdownMenuRadioItem = forwardRef<
 			{children}
 		</DropdownMenu.RadioItem>
 	);
-});
-
-export default DropdownMenuRadioItem;
+}

--- a/apps/web/src/base/DropdownMenuSeparator.tsx
+++ b/apps/web/src/base/DropdownMenuSeparator.tsx
@@ -1,18 +1,15 @@
 import { cn } from "@app/cn";
 import { DropdownMenu } from "radix-ui";
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import type { ComponentPropsWithRef } from "react";
 
-const DropdownMenuSeparator = forwardRef<
-	HTMLDivElement,
-	ComponentPropsWithoutRef<typeof DropdownMenu.Separator>
->(function DropdownMenuSeparator({ className, ...props }, ref) {
+export default function DropdownMenuSeparator({
+	className,
+	...props
+}: ComponentPropsWithRef<typeof DropdownMenu.Separator>) {
 	return (
 		<DropdownMenu.Separator
-			ref={ref}
 			className={cn("-mx-1 bg-gray-200 h-px my-1", className)}
 			{...props}
 		/>
 	);
-});
-
-export default DropdownMenuSeparator;
+}

--- a/apps/web/src/base/DropdownMenuTrigger.tsx
+++ b/apps/web/src/base/DropdownMenuTrigger.tsx
@@ -1,14 +1,13 @@
 import { cn } from "@app/cn";
 import { DropdownMenu } from "radix-ui";
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import type { ComponentPropsWithRef } from "react";
 
-const DropdownMenuTrigger = forwardRef<
-	HTMLButtonElement,
-	ComponentPropsWithoutRef<typeof DropdownMenu.Trigger>
->(function DropdownMenuTrigger({ className, ...props }, ref) {
+export default function DropdownMenuTrigger({
+	className,
+	...props
+}: ComponentPropsWithRef<typeof DropdownMenu.Trigger>) {
 	return (
 		<DropdownMenu.Trigger
-			ref={ref}
 			className={cn(
 				"flex cursor-pointer appearance-none border-none bg-transparent p-0",
 				className,
@@ -16,6 +15,4 @@ const DropdownMenuTrigger = forwardRef<
 			{...props}
 		/>
 	);
-});
-
-export default DropdownMenuTrigger;
+}

--- a/apps/web/src/base/InputSimple.tsx
+++ b/apps/web/src/base/InputSimple.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@app/cn";
-import React from "react";
+import type { ComponentPropsWithRef } from "react";
 import {
 	inputBaseClasses,
 	inputFocusClasses,
@@ -7,30 +7,23 @@ import {
 	inputInvalidClasses,
 } from "./styles";
 
-export type InputSimpleProps = React.InputHTMLAttributes<HTMLInputElement> & {
+export type InputSimpleProps = ComponentPropsWithRef<"input"> & {
 	className?: string;
 	as?: string;
 };
 
-const InputSimple = React.forwardRef<HTMLInputElement, InputSimpleProps>(
-	({ className, ...props }, ref) => {
-		return (
-			<input
-				ref={ref}
-				className={cn(
-					inputBaseClasses,
-					inputHeightClass,
-					inputFocusClasses,
-					inputInvalidClasses,
-					"read-only:bg-gray-100",
-					className,
-				)}
-				{...props}
-			/>
-		);
-	},
-);
-
-InputSimple.displayName = "InputSimple";
-
-export default InputSimple;
+export default function InputSimple({ className, ...props }: InputSimpleProps) {
+	return (
+		<input
+			className={cn(
+				inputBaseClasses,
+				inputHeightClass,
+				inputFocusClasses,
+				inputInvalidClasses,
+				"read-only:bg-gray-100",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}

--- a/biome.json
+++ b/biome.json
@@ -15,6 +15,9 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
+			"nursery": {
+				"useReactFunctionComponentDefinition": "error"
+			},
 			"style": {
 				"noRestrictedImports": {
 					"level": "error",
@@ -36,6 +39,7 @@
 				"useLiteralEnumMembers": "error"
 			},
 			"suspicious": {
+				"noConsole": "error",
 				"noImplicitAnyLet": "error",
 				"noExplicitAny": "error",
 				"noArrayIndexKey": "error",
@@ -67,17 +71,5 @@
 				"organizeImports": "on"
 			}
 		}
-	},
-	"overrides": [
-		{
-			"includes": ["apps/web/src/server/**"],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noConsole": "error"
-					}
-				}
-			}
-		}
-	]
+	}
 }

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -28,9 +28,11 @@ repeated context (a request id, a job id) across several call sites, but
 nothing in the server uses it today. Don't write code that assumes a
 per-request logger is threaded through for you.
 
-Biome's `noConsole` rule is enabled for `apps/web/src/server/` in
-`biome.json`, so reaching for `console.*` there fails `pnpm check`.
-Client code is unaffected.
+Biome's `noConsole` rule is enabled repo-wide in `biome.json`, so any
+`console.*` fails `pnpm check`. Server code logs through the package;
+client code reports unexpected conditions to Sentry
+(`Sentry.captureException`) instead of a console the user's browser hides
+from us.
 
 The default redaction paths are defined in
 `packages/logger/src/config.ts` (`DEFAULT_REDACT_PATHS`). Extra paths can


### PR DESCRIPTION
## Summary
- Malformed SSE frames were logged with `console.warn`/`console.error`, which lands in a user's browser console that no one on our side can read, so the errors were effectively lost — now reported with `Sentry.captureException` instead.
- Makes Biome enforce conventions AGENTS.md already claimed (VIR-2730): promotes `noConsole` from a `src/server`-only override to a repo-wide rule, and enables `useReactFunctionComponentDefinition`, unwrapping 12 `forwardRef` components in `src/base` into plain function declarations now that React 19 makes `ref` an ordinary prop.
- Updates `AGENTS.md` and `docs/logging.md` to match in the same commit.