### PR TITLE
fix: revoke sessions on deactivation, password change, or forced reset

### DIFF
--- a/apps/web/src/server/auth/core.test.ts
+++ b/apps/web/src/server/auth/core.test.ts
@@ -176,7 +176,6 @@ describe("resetPassword", () => {
 		);
 		expect(after?.forceReset).toBe(true);
 		expect(after?.lastPasswordChange).toEqual(before?.lastPasswordChange);
-		expect(after?.invalidateSessions).toBe(before?.invalidateSessions);
 
 		// The session deletion rolled back with it.
 		const surviving = await db

--- a/apps/web/src/server/auth/core.ts
+++ b/apps/web/src/server/auth/core.ts
@@ -285,7 +285,6 @@ export async function resetPassword(
 					password: newHash,
 					forceReset: false,
 					lastPasswordChange: new Date(),
-					invalidateSessions: true,
 				})
 				.where(eq(users.id, userId));
 

--- a/apps/web/src/server/auth/verify.ts
+++ b/apps/web/src/server/auth/verify.ts
@@ -28,9 +28,11 @@ export async function verifyAuthenticatedSession(
 		return null;
 	}
 
-	// Deactivating a user does not delete their sessions, so `active` has to be
-	// checked on every request rather than trusted at login. The inner join only
-	// drops anonymous sessions, which carry no user_id and are rejected anyway.
+	// A TS-side deactivation deletes the user's sessions, but Python's does not,
+	// so `active` still has to be checked on every request rather than trusted at
+	// login — a session Python left behind must stop verifying the moment the user
+	// goes inactive. The inner join only drops anonymous sessions, which carry no
+	// user_id and are rejected anyway.
 	const [row] = await db
 		.select({
 			userId: sessions.userId,

--- a/apps/web/src/server/db/schema/users.ts
+++ b/apps/web/src/server/db/schema/users.ts
@@ -51,6 +51,11 @@ export const users = pgTable(
 			.$defaultFn(() => false)
 			.notNull(),
 		handle: text("handle").notNull(),
+		// NOT NULL with no server_default on the Python side, so the `$defaultFn`
+		// is load-bearing: `createUser` never sets this column and would violate
+		// the constraint without it. Nothing on either side reads the value —
+		// sessions are revoked directly (`invalidateUserSessions`) rather than via
+		// this flag — so dropping the column is Python's Alembic change to make.
 		invalidateSessions: boolean("invalidate_sessions")
 			.$defaultFn(() => false)
 			.notNull(),

--- a/apps/web/src/server/events/revocation.ts
+++ b/apps/web/src/server/events/revocation.ts
@@ -10,10 +10,8 @@ import { logger } from "../logger";
  * until the client happened to reconnect.
  *
  * This is exactly as sharp as the gate it runs, and no sharper: it catches a
- * deleted session row and a deactivated user, but not an admin-initiated
- * password change or forced reset, which only set `users.invalidate_sessions` —
- * a column nothing on this side reads. That hole is the auth gate's to close,
- * not this watch's.
+ * deleted session row — including one deleted by an admin-initiated
+ * deactivation, password change, or forced reset — and a deactivated user.
  *
  * Returns a function that stops the watch. It is safe to call more than once.
  */

--- a/apps/web/src/server/users/data.test.ts
+++ b/apps/web/src/server/users/data.test.ts
@@ -1,10 +1,18 @@
+import { eq } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-import { seedUser } from "../auth/test/fixtures";
+import { verifyPassword } from "../auth/password";
+import { seedSession, seedUser } from "../auth/test/fixtures";
 import type { Db } from "../db/pg";
+import { sessions } from "../db/schema/sessions";
 import { users } from "../db/schema/users";
 import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
-import { getAccount, UserNotFoundError } from "./data";
+import {
+	GroupMembershipError,
+	getAccount,
+	UserNotFoundError,
+	updateUser,
+} from "./data";
 
 let database: TestDatabase;
 let db: Db;
@@ -66,5 +74,103 @@ describe("getAccount", () => {
 	// is signed in", so this must throw rather than resolve undefined.
 	it("throws when the user does not exist", async () => {
 		await expect(getAccount(db, 404)).rejects.toBeInstanceOf(UserNotFoundError);
+	});
+});
+
+async function countSessions(userId: number): Promise<number> {
+	const rows = await db
+		.select({ sessionId: sessions.sessionId })
+		.from(sessions)
+		.where(eq(sessions.userId, userId));
+	return rows.length;
+}
+
+async function readUser(userId: number) {
+	const [row] = await db.select().from(users).where(eq(users.id, userId));
+	return row;
+}
+
+describe("updateUser", () => {
+	it("deletes the user's sessions when they are deactivated", async () => {
+		const userId = await seedUser(db);
+		await seedSession(db, userId);
+		await seedSession(db, userId);
+
+		await updateUser(db, userId, { active: false });
+
+		expect(await countSessions(userId)).toBe(0);
+		expect((await readUser(userId))?.active).toBe(false);
+	});
+
+	it("deletes the user's sessions when their password changes", async () => {
+		const userId = await seedUser(db);
+		await seedSession(db, userId);
+		const before = await readUser(userId);
+
+		await updateUser(db, userId, { password: "new-password-1234" });
+
+		expect(await countSessions(userId)).toBe(0);
+		const after = await readUser(userId);
+		expect(
+			await verifyPassword("new-password-1234", after?.password as Buffer),
+		).toBe(true);
+		expect(after?.lastPasswordChange.getTime()).toBeGreaterThan(
+			before?.lastPasswordChange.getTime() ?? 0,
+		);
+	});
+
+	it("deletes the user's sessions when force_reset is set", async () => {
+		const userId = await seedUser(db);
+		await seedSession(db, userId);
+
+		await updateUser(db, userId, { force_reset: true });
+
+		expect(await countSessions(userId)).toBe(0);
+		expect((await readUser(userId))?.forceReset).toBe(true);
+	});
+
+	it("leaves sessions alone when only the handle changes", async () => {
+		const userId = await seedUser(db);
+		await seedSession(db, userId);
+
+		await updateUser(db, userId, { handle: "renamed" });
+
+		expect(await countSessions(userId)).toBe(1);
+		expect((await readUser(userId))?.handle).toBe("renamed");
+	});
+
+	it("leaves sessions alone when only group membership changes", async () => {
+		const userId = await seedUser(db);
+		await seedSession(db, userId);
+
+		await updateUser(db, userId, { groups: [] });
+
+		expect(await countSessions(userId)).toBe(1);
+	});
+
+	it("revokes only the target user's sessions", async () => {
+		const alice = await seedUser(db, { handle: "alice" });
+		const bob = await seedUser(db, { handle: "bob" });
+		await seedSession(db, alice);
+		await seedSession(db, bob);
+
+		await updateUser(db, alice, { active: false });
+
+		expect(await countSessions(alice)).toBe(0);
+		expect(await countSessions(bob)).toBe(1);
+	});
+
+	it("rolls back the deactivation and the session deletion together on failure", async () => {
+		const userId = await seedUser(db);
+		await seedSession(db, userId);
+
+		// Pairing the deactivation with a primary_group the user does not belong to
+		// makes the promote fail inside the same transaction, so nothing commits.
+		await expect(
+			updateUser(db, userId, { active: false, primary_group: 999 }),
+		).rejects.toBeInstanceOf(GroupMembershipError);
+
+		expect(await countSessions(userId)).toBe(1);
+		expect((await readUser(userId))?.active).toBe(true);
 	});
 });

--- a/apps/web/src/server/users/data.ts
+++ b/apps/web/src/server/users/data.ts
@@ -13,6 +13,7 @@ import {
 } from "drizzle-orm";
 import type { PostgresError } from "postgres";
 import { hashPassword } from "../auth/password";
+import { invalidateUserSessions } from "../auth/session";
 import type { Db } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import {
@@ -453,16 +454,15 @@ export async function updateUser(
 		throw new UserNotFoundError();
 	}
 
-	// Match the Python service: changes to credentials or activation invalidate
-	// the user's existing sessions on their next request.
+	// Changing credentials or activation revokes every existing session for the
+	// user, in the same transaction as the change that triggered it, so there is
+	// no window where the old password still authenticates.
 	const patch: Partial<typeof usersTable.$inferInsert> = {};
 	if (values.active !== undefined) {
 		patch.active = values.active;
-		patch.invalidateSessions = true;
 	}
 	if (values.force_reset !== undefined) {
 		patch.forceReset = values.force_reset;
-		patch.invalidateSessions = true;
 	}
 	if (values.handle !== undefined) {
 		patch.handle = values.handle;
@@ -470,8 +470,12 @@ export async function updateUser(
 	if (values.password !== undefined) {
 		patch.password = await hashPassword(values.password);
 		patch.lastPasswordChange = new Date();
-		patch.invalidateSessions = true;
 	}
+
+	const revokeSessions =
+		values.active !== undefined ||
+		values.force_reset !== undefined ||
+		values.password !== undefined;
 
 	await db.transaction(async (tx) => {
 		if (Object.keys(patch).length > 0) {
@@ -483,6 +487,10 @@ export async function updateUser(
 				}
 				throw error;
 			}
+		}
+
+		if (revokeSessions) {
+			await invalidateUserSessions(tx, userId);
 		}
 
 		if (values.groups !== undefined) {

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -232,27 +232,25 @@ holding only a reset cookie returns 401.
 `verifyAuthenticatedSession` (`server/auth/verify.ts`) rejects a session
 when the row is missing, the type is not `authenticated`, the token hash
 does not match, the row has expired, or **`users.active` is false**. That
-last one is why deactivation takes effect immediately: `active` is
-re-read on every request rather than trusted at login.
+last one is why deactivation takes effect immediately even for a session
+that has slipped through revocation: `active` is re-read on every request
+rather than trusted at login.
 
-**`users.invalidate_sessions` is written but never read.** It is set to
-`true` on an admin's change to a user's `active`, `password`, or
-`force_reset` (`server/users/data.ts:421-433`) and on a self-service
-reset (`core.ts:260`), mirroring Python, whose service invalidates the
-user's sessions on their next request. Nothing on the TypeScript side
-consumes it. The consequence is concrete: an admin changing a user's
-password or forcing a reset **does not revoke that user's existing
-sessions here** — the deactivation case is covered only because it also
-flips `active`. The self-service reset path is fine for a different
-reason: `core.ts:250` deletes the rows outright via
-`invalidateUserSessions`.
+**An admin's change to a user's `active`, `password`, or `force_reset`
+deletes that user's sessions outright.** `updateUser`
+(`server/users/data.ts`) calls `invalidateUserSessions` inside the same
+transaction as the change, so revocation is atomic with the change that
+triggered it — there is no window where the old password still
+authenticates. The self-service reset path does the same
+(`invalidateUserSessions` in `core.ts` before minting the new session).
 
-Do not "fix" this by rejecting sessions whose user has
-`invalidate_sessions` set. The reset flow sets the flag `true` and *then*
-creates the new authenticated session (`core.ts:254-265`), and nothing
-clears it, so that gate would reject the fresh session on its first
-request and lock the user out permanently. The fix is to delete the
-session rows at the point of invalidation — that is VIR-2671's job.
+`users.invalidate_sessions` is a NOT NULL column with no server default
+that Python still writes but nothing on either side reads; the TypeScript
+mirror keeps a `$defaultFn(() => false)` only so `createUser` inserts
+satisfy the constraint. Dropping the column is Python's Alembic change to
+make. Do not resurrect it as a gate: rejecting sessions whose user has
+the flag set would lock users out, because the reset flow would set it
+and then mint a fresh session that the gate immediately rejects.
 
 ## Session lifetimes
 
@@ -329,8 +327,8 @@ password and the `resetCode` returned from the previous login.
    (`PasswordReuseError`).
 5. Invalidates **all** of the user's existing sessions
    (`invalidateUserSessions`), updates the password / clears
-   `forceReset` / sets `lastPasswordChange` / sets `invalidateSessions`,
-   then mints a new authenticated session and rotates both cookies.
+   `forceReset` / sets `lastPasswordChange`, then mints a new
+   authenticated session and rotates both cookies.
 
 Step (5) must match the Python order in
 `virtool.account.data.AccountData.reset` so a user mid-reset sees the
@@ -421,11 +419,11 @@ A logout is either user-initiated or forced. The user-initiated path is
 then calls `resetClient()`.
 
 A forced logout is what happens when the session stops verifying
-underneath a running tab — its row deleted, it expired, or its user was
-deactivated. (An admin-initiated password change or forced reset only
-sets `users.invalidate_sessions`, which nothing here reads yet, so it
-does not revoke a session — see **Session invalidation** below.) Every
-route into a forced logout converges on `endSession` (`app/session.ts`),
+underneath a running tab — its row deleted (including by an
+admin-initiated deactivation, password change, or forced reset, all of
+which now delete the user's session rows; see **Session invalidation**
+below), it expired, or its user was deactivated. Every route into a
+forced logout converges on `endSession` (`app/session.ts`),
 which clears
 `sessionStorage` and loads `/login?reason=session-ended&redirect=…`. The
 full document load is what drops everything held in memory, and the

--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -103,11 +103,10 @@ and closes the stream once it fails.
 
 The watch is exactly as sharp as the gate it runs, and no sharper. It
 catches a session row that is gone (a logout elsewhere, a self-service
-reset, expiry) and a user who has been deactivated. It does **not** catch
-an admin-initiated password change or forced reset: those only set
-`users.invalidate_sessions`, which nothing on the TypeScript side reads,
-so they do not revoke a session here or anywhere else in this server yet.
-Closing that hole belongs in the auth gate, not here.
+reset, an admin-initiated deactivation, password change, or forced reset
+— all of which now delete the user's session rows) and a user who has
+been deactivated. It closes on the next tick after the gate stops
+verifying.
 
 **Closing the stream is the entire revocation signal.** There is no
 `session-revoked` frame. The client reconnects, the handshake answers


### PR DESCRIPTION
## Summary
- Deactivating a user, changing their password, or forcing a reset now deletes that user's sessions in the same transaction as the change, closing the window where the old credentials still authenticated.
- Replaces the write-only `invalidate_sessions` flag (which nothing read) with a direct `invalidateUserSessions` call, matching the self-service reset path. The column stays in the Drizzle mirror only to satisfy the NOT NULL insert default; dropping it and fixing the parallel Python bug are tracked in VIR-2750 and VIR-2751.
- Adds `updateUser` tests (session revocation, non-revoking edits, per-user isolation, transaction rollback) and updates `docs/auth.md` / `docs/server-push.md`.

Closes VIR-2671.