### PR TITLE
fix: raise gray icon contrast to meet WCAG AA

### DIFF
--- a/apps/web/src/base/BoxGroupSearch.tsx
+++ b/apps/web/src/base/BoxGroupSearch.tsx
@@ -35,7 +35,7 @@ export default function BoxGroupSearch({
 					className="flex justify-center justify-items-center absolute"
 					IconComponent={X}
 					tip="Clear"
-					color="grayDark"
+					color="gray"
 					onClick={() => onChange("")}
 					aria-label="clear"
 				/>

--- a/apps/web/src/base/Circle.tsx
+++ b/apps/web/src/base/Circle.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@app/cn";
 import type React from "react";
+import { iconVariants } from "./iconVariants";
 import type { IconColor } from "./types";
 
 export type CircleProps = {
@@ -34,16 +35,7 @@ export default function Circle({
 			className={cn(
 				"bg-inherit",
 				"inline-block",
-				{
-					"text-blue-500": color === "blue",
-					"text-black": color === "black",
-					"text-green-500": color === "green",
-					"text-gray-400": color === "gray" || color === "grey",
-					"text-gray-500": color === "grayDark",
-					"text-red-500": color === "red",
-					"text-orange-500": color === "orange",
-					"text-purple-500": color === "purple",
-				},
+				iconVariants({ color }),
 				className,
 			)}
 			{...props}

--- a/apps/web/src/base/Icon.tsx
+++ b/apps/web/src/base/Icon.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@app/cn";
 import type { LucideIcon } from "lucide-react";
-import { iconTextColor } from "./styles";
+import { iconVariants } from "./iconVariants";
 import type { IconColor } from "./types";
 
 export type IconProps = {
@@ -25,7 +25,7 @@ export default function Icon({
 				"text-inherit",
 				"inline-block",
 				"align-middle",
-				color && iconTextColor[color],
+				iconVariants({ color }),
 				className,
 			)}
 			size={size}

--- a/apps/web/src/base/IconButton.tsx
+++ b/apps/web/src/base/IconButton.tsx
@@ -28,7 +28,7 @@ export default function IconButton({
 	ariaLabel,
 	as = "button",
 	className,
-	color = "black",
+	color,
 	IconComponent,
 	onDark,
 	onClick,

--- a/apps/web/src/base/IconButton.tsx
+++ b/apps/web/src/base/IconButton.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@app/cn";
 import type { LucideIcon } from "lucide-react";
 import type { ElementType } from "react";
+import { iconButtonVariants } from "./iconButtonVariants";
 import Tooltip from "./Tooltip";
 import type { IconColor } from "./types";
 
@@ -12,6 +13,8 @@ export type IconButtonProps = {
 	className?: string;
 	color?: IconColor;
 	IconComponent: LucideIcon;
+	/** Restyle for a dark background: a white icon and white focus ring. */
+	onDark?: boolean;
 	onClick?: () => void;
 	size?: number;
 	tip: string;
@@ -27,6 +30,7 @@ export default function IconButton({
 	className,
 	color = "black",
 	IconComponent,
+	onDark,
 	onClick,
 	size,
 	tip,
@@ -36,35 +40,7 @@ export default function IconButton({
 
 	const iconButton = (
 		<As
-			className={cn(
-				"bg-inherit",
-				"border-none",
-				"cursor-pointer",
-				"items-center",
-				"outline-none",
-				"p-2.5",
-				"rounded-full",
-				"text-inherit",
-
-				{
-					"text-blue-500 hover:text-blue-600 hover:bg-blue-500/10 focus:bg-blue-500/20":
-						color === "blue",
-					"text-black hover:bg-black/10 focus:bg-black/20": color === "black",
-					"text-green-500 hover:text-green-600 hover:bg-green-500/10 focus:bg-green-500/20":
-						color === "green",
-					"text-gray-400 hover:text-gray-500 hover:bg-gray-400/10 focus:bg-gray-400/20":
-						color === "gray",
-					"text-gray-500 hover:text-gray-600 hover:bg-gray-500/10 focus:bg-gray-500/20":
-						color === "grayDark",
-					"text-red-500 hover:text-red-600 hover:bg-red-500/10 focus:bg-red-500/20":
-						color === "red",
-					"text-orange-500 hover:text-orange-600 hover:bg-orange-500/10 focus:bg-orange-500/20":
-						color === "orange",
-					"text-purple-500 hover:text-purple-600 hover:bg-purple-500/10 focus:bg-purple-500/20":
-						color === "purple",
-				},
-				className,
-			)}
+			className={cn(iconButtonVariants({ color, onDark }), className)}
 			aria-label={ariaLabel ?? tip}
 			type="button"
 			onClick={onClick}

--- a/apps/web/src/base/Toast.tsx
+++ b/apps/web/src/base/Toast.tsx
@@ -112,7 +112,7 @@ export function ToastClose({ className }: ToastCloseProps) {
 		<ToastPrimitive.Close
 			aria-label="Close"
 			className={cn(
-				"text-gray-400 hover:text-gray-600 cursor-pointer",
+				"text-gray-500 hover:text-gray-600 cursor-pointer",
 				className,
 			)}
 		>

--- a/apps/web/src/base/__tests__/IconButton.test.tsx
+++ b/apps/web/src/base/__tests__/IconButton.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Pencil } from "lucide-react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import IconButton from "../IconButton";
 
 describe("IconButton", () => {
@@ -23,5 +24,43 @@ describe("IconButton", () => {
 		const button = screen.getByRole("button", { name: "About" });
 		expect(button).toHaveClass("text-white");
 		expect(button).toHaveClass("focus-visible:ring-white");
+	});
+
+	it("lets onDark override an explicit color", () => {
+		render(
+			<IconButton IconComponent={Pencil} color="blue" tip="About" onDark />,
+		);
+		const button = screen.getByRole("button", { name: "About" });
+		expect(button).toHaveClass("text-white");
+		expect(button).not.toHaveClass("text-blue-500");
+	});
+
+	it("calls onClick when clicked", async () => {
+		const onClick = vi.fn();
+		render(<IconButton IconComponent={Pencil} tip="edit" onClick={onClick} />);
+		await userEvent.click(screen.getByRole("button", { name: "edit" }));
+		expect(onClick).toHaveBeenCalledOnce();
+	});
+
+	it("merges a provided className with the variant classes", () => {
+		render(
+			<IconButton
+				IconComponent={Pencil}
+				tip="edit"
+				className="my-extra-class"
+			/>,
+		);
+		const button = screen.getByRole("button", { name: "edit" });
+		expect(button).toHaveClass("text-black");
+		expect(button).toHaveClass("my-extra-class");
+	});
+
+	it("uses ariaLabel over tip for the accessible name", () => {
+		render(
+			<IconButton IconComponent={Pencil} tip="edit" ariaLabel="edit item" />,
+		);
+		expect(
+			screen.getByRole("button", { name: "edit item" }),
+		).toBeInTheDocument();
 	});
 });

--- a/apps/web/src/base/__tests__/IconButton.test.tsx
+++ b/apps/web/src/base/__tests__/IconButton.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { Pencil } from "lucide-react";
+import { describe, expect, it } from "vitest";
+import IconButton from "../IconButton";
+
+describe("IconButton", () => {
+	it("renders the gray variant at text-gray-500 so it meets non-text contrast", () => {
+		render(<IconButton IconComponent={Pencil} color="gray" tip="edit" />);
+		const button = screen.getByRole("button", { name: "edit" });
+		expect(button).toHaveClass("text-gray-500");
+		expect(button).not.toHaveClass("text-gray-400");
+	});
+
+	it("defaults to the black variant", () => {
+		render(<IconButton IconComponent={Pencil} tip="edit" />);
+		expect(screen.getByRole("button", { name: "edit" })).toHaveClass(
+			"text-black",
+		);
+	});
+
+	it("uses a white icon and focus ring on a dark background", () => {
+		render(<IconButton IconComponent={Pencil} tip="About" onDark />);
+		const button = screen.getByRole("button", { name: "About" });
+		expect(button).toHaveClass("text-white");
+		expect(button).toHaveClass("focus-visible:ring-white");
+	});
+});

--- a/apps/web/src/base/iconButtonVariants.ts
+++ b/apps/web/src/base/iconButtonVariants.ts
@@ -1,0 +1,31 @@
+import { cva } from "class-variance-authority";
+
+/**
+ * Variants for IconButton. `color` sets the resting/hover/focus treatment;
+ * `gray` is `text-gray-500` (4.84:1) so control icons meet WCAG 1.4.11. The
+ * `onDark` axis restyles the button for a dark background — a white icon and a
+ * white focus ring — rather than a one-off `white` colour member.
+ */
+export const iconButtonVariants = cva(
+	"bg-inherit border-none cursor-pointer items-center outline-none p-2.5 rounded-full text-inherit",
+	{
+		variants: {
+			color: {
+				black: "text-black hover:bg-black/10 focus:bg-black/20",
+				blue: "text-blue-500 hover:text-blue-600 hover:bg-blue-500/10 focus:bg-blue-500/20",
+				gray: "text-gray-500 hover:text-gray-600 hover:bg-gray-500/10 focus:bg-gray-500/20",
+				green:
+					"text-green-500 hover:text-green-600 hover:bg-green-500/10 focus:bg-green-500/20",
+				orange:
+					"text-orange-500 hover:text-orange-600 hover:bg-orange-500/10 focus:bg-orange-500/20",
+				purple:
+					"text-purple-500 hover:text-purple-600 hover:bg-purple-500/10 focus:bg-purple-500/20",
+				red: "text-red-500 hover:text-red-600 hover:bg-red-500/10 focus:bg-red-500/20",
+			},
+			onDark: {
+				true: "text-white hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-virtool focus-visible:ring-white",
+			},
+		},
+		defaultVariants: { color: "black" },
+	},
+);

--- a/apps/web/src/base/iconVariants.ts
+++ b/apps/web/src/base/iconVariants.ts
@@ -1,0 +1,19 @@
+import { cva } from "class-variance-authority";
+
+/**
+ * Text-color classes shared by Icon and Circle. `gray` is `text-gray-500`
+ * (4.84:1 on white) so meaningful icons meet WCAG 1.4.11 non-text contrast.
+ */
+export const iconVariants = cva("", {
+	variants: {
+		color: {
+			black: "text-black",
+			blue: "text-blue-500",
+			gray: "text-gray-500",
+			green: "text-green-500",
+			orange: "text-orange-500",
+			purple: "text-purple-500",
+			red: "text-red-500",
+		},
+	},
+});

--- a/apps/web/src/base/styles.ts
+++ b/apps/web/src/base/styles.ts
@@ -29,18 +29,3 @@ export const inputInvalidClasses =
  */
 export const selectItemStateClasses =
 	"relative select-none outline-none cursor-default hover:bg-gray-100 data-[highlighted]:bg-gray-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50";
-
-import type { IconColor } from "./types";
-
-/** Icon text color mapping shared by Icon and IconButton */
-export const iconTextColor: Record<IconColor, string> = {
-	black: "text-black",
-	blue: "text-blue-500",
-	gray: "text-gray-400",
-	grayDark: "text-gray-500",
-	green: "text-green-500",
-	grey: "text-gray-400",
-	orange: "text-orange-500",
-	purple: "text-purple-500",
-	red: "text-red-500",
-};

--- a/apps/web/src/base/types.ts
+++ b/apps/web/src/base/types.ts
@@ -3,8 +3,6 @@ export type IconColor =
 	| "blue"
 	| "green"
 	| "gray"
-	| "grayDark"
-	| "grey"
 	| "red"
 	| "orange"
 	| "purple";

--- a/apps/web/src/labels/components/EditLabel.tsx
+++ b/apps/web/src/labels/components/EditLabel.tsx
@@ -57,7 +57,7 @@ export function EditLabel({
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
 			<DialogTrigger asChild>
-				<IconButton IconComponent={Pencil} color="grayDark" tip="edit label" />
+				<IconButton IconComponent={Pencil} color="gray" tip="edit label" />
 			</DialogTrigger>
 			<DialogContent>
 				<DialogTitle>Edit a label</DialogTitle>

--- a/apps/web/src/nav/components/Nav.tsx
+++ b/apps/web/src/nav/components/Nav.tsx
@@ -49,7 +49,7 @@ export default function Nav({ administrator_role, handle }: NavBarProps) {
 					onClick={() => setAboutOpen(true)}
 					IconComponent={Info}
 					tip="About"
-					className="text-white hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-virtool focus-visible:ring-white"
+					onDark
 				/>
 
 				<Dropdown>

--- a/apps/web/src/otus/components/Detail/Isolates/IsolateDetail.tsx
+++ b/apps/web/src/otus/components/Detail/Isolates/IsolateDetail.tsx
@@ -81,7 +81,7 @@ export default function IsolateDetail() {
 						<>
 							<IconButton
 								IconComponent={Pencil}
-								color="grayDark"
+								color="gray"
 								tip="edit name"
 								onClick={() => setOpenEdit(true)}
 							/>

--- a/apps/web/src/otus/components/Detail/OtuHeaderIcons.tsx
+++ b/apps/web/src/otus/components/Detail/OtuHeaderIcons.tsx
@@ -38,7 +38,7 @@ export function OtuHeaderIcons({
 		<>
 			<IconButton
 				key="edit-icon"
-				color="grayDark"
+				color="gray"
 				IconComponent={Pencil}
 				tip="edit OTU"
 				onClick={() => setOpenEdit(true)}

--- a/apps/web/src/otus/components/Detail/Segment.tsx
+++ b/apps/web/src/otus/components/Detail/Segment.tsx
@@ -48,7 +48,7 @@ export function SegmentItem({
 					<button
 						type="button"
 						aria-label="drag to reorder"
-						className="flex items-center justify-center p-2.5 text-gray-400 hover:text-gray-600 cursor-grab active:cursor-grabbing outline-none"
+						className="flex items-center justify-center p-2.5 text-gray-500 hover:text-gray-600 cursor-grab active:cursor-grabbing outline-none"
 						{...dragHandleProps}
 					>
 						<GripVertical size="1.2em" />
@@ -70,7 +70,7 @@ export function SegmentItem({
 				<div className="flex">
 					<IconButton
 						IconComponent={Pencil}
-						color="grayDark"
+						color="gray"
 						tip="edit segment"
 						onClick={() => setEditSegmentName(segment.name)}
 					/>

--- a/apps/web/src/references/components/Detail/ArchiveReference.tsx
+++ b/apps/web/src/references/components/Detail/ArchiveReference.tsx
@@ -60,7 +60,7 @@ export default function ArchiveReference({ detail }: ArchiveReferenceProps) {
 	return (
 		<>
 			<IconButton
-				color="grayDark"
+				color="gray"
 				IconComponent={Icon}
 				tip={detail.archived ? "unarchive" : "archive"}
 				onClick={() => setOpen(true)}

--- a/apps/web/src/references/components/Detail/ArchivedReferenceDetailHeader.tsx
+++ b/apps/web/src/references/components/Detail/ArchivedReferenceDetailHeader.tsx
@@ -47,7 +47,7 @@ export default function ArchivedReferenceDetailHeader({
 				</Badge>
 				{showIcons && (
 					<ViewHeaderIcons>
-						{isRemote && <Icon color="grey" icon={Lock} aria-label="lock" />}
+						{isRemote && <Icon color="gray" icon={Lock} aria-label="lock" />}
 						{!isRemote && canModify && <ArchiveReference detail={detail} />}
 					</ViewHeaderIcons>
 				)}

--- a/apps/web/src/references/components/Detail/EditReference.tsx
+++ b/apps/web/src/references/components/Detail/EditReference.tsx
@@ -56,7 +56,7 @@ export default function EditReference({ detail }: EditReferenceProps) {
 	return (
 		<>
 			<IconButton
-				color="grayDark"
+				color="gray"
 				IconComponent={Pencil}
 				tip="modify"
 				onClick={() => setOpen(true)}

--- a/apps/web/src/references/components/Detail/MemberItem.tsx
+++ b/apps/web/src/references/components/Detail/MemberItem.tsx
@@ -46,7 +46,7 @@ export default function MemberItem({
 				<span className="flex items-center gap-1 ml-auto">
 					<IconButton
 						IconComponent={Pencil}
-						color="grayDark"
+						color="gray"
 						tip="edit member"
 						onClick={() => onEdit(id)}
 					/>

--- a/apps/web/src/references/components/Detail/ReferenceDetailHeader.tsx
+++ b/apps/web/src/references/components/Detail/ReferenceDetailHeader.tsx
@@ -44,7 +44,7 @@ export default function ReferenceDetailHeader({
 				{name}
 				{showIcons && (
 					<ViewHeaderIcons>
-						{isRemote && <Icon color="grey" icon={Lock} aria-label="lock" />}
+						{isRemote && <Icon color="gray" icon={Lock} aria-label="lock" />}
 						{!isRemote && canModify && (
 							<>
 								<EditReference detail={detail} />

--- a/apps/web/src/routes/_authenticated/samples/$sampleId.tsx
+++ b/apps/web/src/routes/_authenticated/samples/$sampleId.tsx
@@ -60,7 +60,7 @@ function SampleDetailLayout() {
 						{canModify && location.pathname.endsWith("/general") && (
 							<>
 								<IconButton
-									color="grayDark"
+									color="gray"
 									IconComponent={Pencil}
 									tip="modify"
 									onClick={() => setEditOpen(true)}

--- a/apps/web/src/samples/components/Filter/workflowStateIcons.ts
+++ b/apps/web/src/samples/components/Filter/workflowStateIcons.ts
@@ -12,7 +12,7 @@ export const workflowStateIcons: Record<
 	WorkflowFilterState,
 	WorkflowStateIcon
 > = {
-	none: { className: "text-gray-400", icon: CircleDashed },
+	none: { className: "text-gray-500", icon: CircleDashed },
 	pending: { className: "text-gray-600", icon: ClockFading },
 	ready: { className: "text-green-600", icon: CircleCheck },
 };

--- a/apps/web/src/sequences/components/SequenceButtons.tsx
+++ b/apps/web/src/sequences/components/SequenceButtons.tsx
@@ -42,7 +42,7 @@ export default function SequenceButtons({
 				<>
 					<IconButton
 						IconComponent={Pencil}
-						color="grayDark"
+						color="gray"
 						tip="Edit"
 						onClick={onEdit}
 					/>

--- a/apps/web/src/subtraction/components/Detail/EditSubtraction.tsx
+++ b/apps/web/src/subtraction/components/Detail/EditSubtraction.tsx
@@ -47,7 +47,7 @@ export default function EditSubtraction({ subtraction }: EditSubtractionProps) {
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogTrigger asChild>
-				<IconButton IconComponent={Pencil} color="grayDark" tip="modify" />
+				<IconButton IconComponent={Pencil} color="gray" tip="modify" />
 			</DialogTrigger>
 			<DialogContent>
 				<DialogTitle>Edit Subtraction</DialogTitle>


### PR DESCRIPTION
## Summary

- Gray control and meaning-bearing icons used `text-gray-400` (2.60:1 contrast), failing WCAG 1.4.11 non-text contrast; they now use `text-gray-500` (4.84:1).
- `IconColor` drops the redundant `grayDark` and `grey` spellings, and `IconButton`, `Icon`, and `Circle` move their variant dispatch to CVA.
- `IconButton` gains an `onDark` axis for dark backgrounds, replacing the About button's inline utility classes.