### PR TITLE
fix: respect prefers-reduced-motion for animations

### DIFF
--- a/apps/web/src/analyses/components/Pathoscope/PathoscopeViewScroller.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/PathoscopeViewScroller.tsx
@@ -1,4 +1,4 @@
-import { getContentScrollElement } from "@app/scroll";
+import { getContentScrollElement, getScrollBehavior } from "@app/scroll";
 import { ArrowUp } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -23,7 +23,10 @@ export function PathoscopeViewerScroller() {
 				aria-label="Scroll to top"
 				className="flex items-center justify-center fixed bottom-8 left-8 size-10 border border-gray-300 rounded-lg text-gray-500 cursor-pointer z-1 hover:bg-gray-100 hover:text-gray-600"
 				onClick={() =>
-					getContentScrollElement()?.scrollTo({ top: 0, behavior: "smooth" })
+					getContentScrollElement()?.scrollTo({
+						top: 0,
+						behavior: getScrollBehavior(),
+					})
 				}
 			>
 				<ArrowUp />

--- a/apps/web/src/app/animations.css
+++ b/apps/web/src/app/animations.css
@@ -173,6 +173,9 @@
    infinite pulse on a running job's progress circle. Durations are near-zero
    rather than zero so animationend/transitionend still fire.
 
+   Delays are zeroed too, so a delayed effect doesn't sit idle for its full
+   delay before completing near-instantly.
+
    !important is required and correct here: this universal selector has zero
    specificity, so without it the utility classes (animate-*, duration-*) and
    inline animation styles it must flatten would win the cascade. */
@@ -184,7 +187,11 @@
 		animation-duration: 0.01ms !important;
 		/* biome-ignore lint/complexity/noImportantStyles: override utility/inline animation styles */
 		animation-iteration-count: 1 !important;
+		/* biome-ignore lint/complexity/noImportantStyles: override utility/inline animation styles */
+		animation-delay: 0s !important;
 		/* biome-ignore lint/complexity/noImportantStyles: override utility/inline transition styles */
 		transition-duration: 0.01ms !important;
+		/* biome-ignore lint/complexity/noImportantStyles: override utility/inline transition styles */
+		transition-delay: 0s !important;
 	}
 }

--- a/apps/web/src/app/animations.css
+++ b/apps/web/src/app/animations.css
@@ -167,3 +167,24 @@
 		transform: translateX(0);
 	}
 }
+
+/* Honor the OS "reduce motion" setting. Flatten every animation and
+   transition so motion-sensitive users aren't subjected to effects like the
+   infinite pulse on a running job's progress circle. Durations are near-zero
+   rather than zero so animationend/transitionend still fire.
+
+   !important is required and correct here: this universal selector has zero
+   specificity, so without it the utility classes (animate-*, duration-*) and
+   inline animation styles it must flatten would win the cascade. */
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		/* biome-ignore lint/complexity/noImportantStyles: override utility/inline animation styles */
+		animation-duration: 0.01ms !important;
+		/* biome-ignore lint/complexity/noImportantStyles: override utility/inline animation styles */
+		animation-iteration-count: 1 !important;
+		/* biome-ignore lint/complexity/noImportantStyles: override utility/inline transition styles */
+		transition-duration: 0.01ms !important;
+	}
+}

--- a/apps/web/src/app/scroll.ts
+++ b/apps/web/src/app/scroll.ts
@@ -8,3 +8,19 @@ export function getContentScrollElement(): HTMLElement | null {
 	}
 	return document.getElementById(CONTENT_SCROLL_ID);
 }
+
+/**
+ * The `scrollTo` behavior to use for programmatic scrolling, honoring the
+ * user's `prefers-reduced-motion` setting. CSS media queries cannot flatten
+ * scripted smooth scrolls, so callers must consult this instead of hardcoding
+ * `"smooth"`.
+ */
+export function getScrollBehavior(): ScrollBehavior {
+	if (
+		typeof window !== "undefined" &&
+		window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+	) {
+		return "auto";
+	}
+	return "smooth";
+}

--- a/apps/web/src/base/AccordionScrollingItem.tsx
+++ b/apps/web/src/base/AccordionScrollingItem.tsx
@@ -1,4 +1,4 @@
-import { getContentScrollElement } from "@app/scroll";
+import { getContentScrollElement, getScrollBehavior } from "@app/scroll";
 import { Accordion as AccordionPrimitive } from "radix-ui";
 import { createRef, type ReactNode, useEffect } from "react";
 
@@ -19,7 +19,7 @@ function ComposedScrollingAccordionItem(props) {
 			const scrollerTop = scroller.getBoundingClientRect().top;
 			scroller.scrollTo({
 				top: itemTop - scrollerTop + scroller.scrollTop - 50,
-				behavior: "smooth",
+				behavior: getScrollBehavior(),
 			});
 		}
 	}, [props["data-state"], ref?.current]);


### PR DESCRIPTION
## Summary
- Honor the OS "reduce motion" setting by flattening all animations and transitions repo-wide via a `prefers-reduced-motion: reduce` media query in `apps/web/src/app/animations.css`.
- Protects motion-sensitive users from effects like the infinite pulse on a running job's progress circle.
- Durations are set to near-zero (`0.01ms`) rather than `0` so `animationend`/`transitionend` listeners still fire correctly.