### PR TITLE
fix: use client-side navigation for reference and HMM links

### DIFF
--- a/apps/web/src/analyses/components/Nuvs/NuvsOrfLabel.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsOrfLabel.tsx
@@ -1,6 +1,11 @@
+import type { NuvsOrfHit } from "@analyses/types";
 import { Link } from "@tanstack/react-router";
 
-export default function NuvsOrfLabel({ hmm }) {
+type NuvsOrfLabelProps = {
+	hmm?: NuvsOrfHit;
+};
+
+export default function NuvsOrfLabel({ hmm }: NuvsOrfLabelProps) {
 	if (hmm) {
 		return (
 			<Link

--- a/apps/web/src/analyses/components/Nuvs/NuvsOrfLabel.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsOrfLabel.tsx
@@ -1,11 +1,15 @@
-import ExternalLink from "@base/ExternalLink";
+import { Link } from "@tanstack/react-router";
 
 export default function NuvsOrfLabel({ hmm }) {
 	if (hmm) {
 		return (
-			<ExternalLink className="capitalize" href={`/hmms/${hmm.hit}`}>
+			<Link
+				className="capitalize"
+				to="/hmms/$hmmId"
+				params={{ hmmId: hmm.hit }}
+			>
 				{hmm.names[0]}
-			</ExternalLink>
+			</Link>
 		);
 	}
 

--- a/apps/web/src/analyses/components/Nuvs/__tests__/NuVsViewer.test.tsx
+++ b/apps/web/src/analyses/components/Nuvs/__tests__/NuVsViewer.test.tsx
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event";
 import { mockApiBlastNuVs } from "@tests/api/analyses";
 import { createFakeFormattedNuVsAnalysis } from "@tests/fake/analyses";
 import { createFakeSample } from "@tests/fake/samples";
-import { at } from "@tests/setup";
+import { at, MemoryRouter } from "@tests/setup";
 import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -19,7 +19,7 @@ function renderWithAnalysisSearch(
 	return render(
 		<QueryClientProvider client={queryClient}>
 			<AnalysisSearchProvider search={search} setSearch={vi.fn()}>
-				{ui}
+				<MemoryRouter>{ui}</MemoryRouter>
 			</AnalysisSearchProvider>
 		</QueryClientProvider>,
 	);
@@ -81,7 +81,9 @@ describe("<NuvsViewer />", () => {
 				activeHit: String(firstHit.id),
 			});
 
-			await userEvent.click(screen.getByRole("button", { name: "Export" }));
+			await userEvent.click(
+				await screen.findByRole("button", { name: "Export" }),
+			);
 			expect(screen.getByText("Export Analysis")).toBeInTheDocument();
 			expect(
 				screen.getByRole("button", { name: "Download" }),

--- a/apps/web/src/references/components/Detail/Clone.tsx
+++ b/apps/web/src/references/components/Detail/Clone.tsx
@@ -1,6 +1,7 @@
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupHeader from "@base/BoxGroupHeader";
 import BoxGroupSection from "@base/BoxGroupSection";
+import { Link } from "@tanstack/react-router";
 
 type CloneProps = {
 	source: { id: string; name: string };
@@ -17,7 +18,9 @@ export function Clone({ source }: CloneProps) {
 				<strong>Source Reference</strong>
 				<span>
 					{" / "}
-					<a href={`/refs/${source.id}`}>{source.name}</a>
+					<Link to="/refs/$refId" params={{ refId: source.id }}>
+						{source.name}
+					</Link>
 				</span>
 			</BoxGroupSection>
 		</BoxGroup>


### PR DESCRIPTION
## Summary
- The reference "Source Reference" link and the NuVs ORF HMM label used plain `<a>` tags — the HMM link even wrongly used `ExternalLink`, opening the internal `/hmms/:id` route in a new tab with a cold app boot. Clicking either triggered a full page reload that discarded the React Query cache, upload store, and SSE connection.
- Both now navigate with typed `<Link>` from `@tanstack/react-router` (`/refs/$refId` and `/hmms/$hmmId`), preserving app state.