### PR TITLE
fix: add accessible names to search inputs

### DIFF
--- a/apps/web/src/analyses/components/Nuvs/NuvsToolbar.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsToolbar.tsx
@@ -24,6 +24,7 @@ export default function NuvsToolbar({
 		<Toolbar>
 			<div className="flex-grow">
 				<InputSearch
+					aria-label="Search results"
 					value={find}
 					onChange={(e) => setSearch({ find: e.target.value })}
 					placeholder="Name or family"

--- a/apps/web/src/analyses/components/Pathoscope/PathoscopeToolbar.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/PathoscopeToolbar.tsx
@@ -35,6 +35,7 @@ export function PathoscopeToolbar({ analysisId }: PathoscopeToolbarProps) {
 	return (
 		<Toolbar>
 			<InputSearch
+				aria-label="Search results"
 				value={find}
 				onChange={(e) => setSearch({ find: e.target.value })}
 			/>

--- a/apps/web/src/base/ComboBox.tsx
+++ b/apps/web/src/base/ComboBox.tsx
@@ -37,7 +37,7 @@ type ComboBoxSearchProps = {
 function ComboBoxSearch({ getInputProps }: ComboBoxSearchProps) {
 	return (
 		<div className="mx-1 my-2.5">
-			<InputSearch {...getInputProps()} />
+			<InputSearch {...getInputProps()} aria-label="Search" />
 		</div>
 	);
 }

--- a/apps/web/src/base/InputSearch.tsx
+++ b/apps/web/src/base/InputSearch.tsx
@@ -3,7 +3,13 @@ import Input, { type InputProps } from "./Input";
 import InputContainer from "./InputContainer";
 import InputIcon from "./InputIcon";
 
-export default function InputSearch(props: InputProps) {
+/** Props for the search input. Requires an `aria-label` so screen readers announce an accessible name. */
+export type InputSearchProps = InputProps & {
+	/** Accessible name for the search input, announced by assistive technology. */
+	"aria-label": string;
+};
+
+export default function InputSearch(props: InputSearchProps) {
 	return (
 		<InputContainer align="left" className="flex-grow">
 			<Input {...props} />

--- a/apps/web/src/base/__tests__/ComboBox.test.tsx
+++ b/apps/web/src/base/__tests__/ComboBox.test.tsx
@@ -32,4 +32,10 @@ describe("<ComboBox />", () => {
 		expect(input).toHaveAttribute("aria-controls");
 		expect(input).toHaveAttribute("aria-expanded", "false");
 	});
+
+	it("gives the search input an accessible name", () => {
+		const { getByRole } = renderComboBox();
+
+		expect(getByRole("combobox", { name: "Search" })).toBeInTheDocument();
+	});
 });

--- a/apps/web/src/hmm/components/HmmToolbar.tsx
+++ b/apps/web/src/hmm/components/HmmToolbar.tsx
@@ -15,7 +15,12 @@ export default function HmmToolbar({ term, onChange }: HmmToolbarProps) {
 	return (
 		<Toolbar>
 			<div className="flex-grow">
-				<InputSearch placeholder="Name" onChange={onChange} value={term} />
+				<InputSearch
+					aria-label="Search HMMs"
+					placeholder="Name"
+					onChange={onChange}
+					value={term}
+				/>
 			</div>
 		</Toolbar>
 	);

--- a/apps/web/src/otus/components/Detail/Isolates/IsolateList.tsx
+++ b/apps/web/src/otus/components/Detail/Isolates/IsolateList.tsx
@@ -86,6 +86,7 @@ export default function IsolateList() {
 			<SubviewHeader>
 				<Toolbar>
 					<InputSearch
+						aria-label="Search sequences"
 						placeholder="Name, accession, or definition"
 						value={term}
 						onChange={(e) => setTerm(e.target.value)}

--- a/apps/web/src/otus/components/OtuToolbar.tsx
+++ b/apps/web/src/otus/components/OtuToolbar.tsx
@@ -47,6 +47,7 @@ export default function OtuToolbar({
 		<Toolbar>
 			<div className="flex-grow">
 				<InputSearch
+					aria-label="Search OTUs"
 					placeholder="Name or abbreviation"
 					value={draft}
 					onChange={(e) => setDraft(e.target.value)}

--- a/apps/web/src/references/components/Detail/AddReferenceGroup.tsx
+++ b/apps/web/src/references/components/Detail/AddReferenceGroup.tsx
@@ -81,6 +81,7 @@ export default function AddReferenceGroup({
 				<Toolbar>
 					<InputSearch
 						name="search"
+						aria-label="Search groups"
 						value={term}
 						onChange={(e) => setTerm(e.target.value)}
 					/>

--- a/apps/web/src/references/components/Detail/AddReferenceUser.tsx
+++ b/apps/web/src/references/components/Detail/AddReferenceUser.tsx
@@ -82,6 +82,7 @@ export default function AddReferenceUser({
 					<div className="flex-grow">
 						<InputSearch
 							name="search"
+							aria-label="Search users"
 							value={term}
 							onChange={(e) => setTerm(e.target.value)}
 						/>

--- a/apps/web/src/references/components/ReferenceToolbar.tsx
+++ b/apps/web/src/references/components/ReferenceToolbar.tsx
@@ -33,6 +33,7 @@ export default function ReferenceToolbar({
 		<Toolbar>
 			<div className="flex-grow">
 				<InputSearch
+					aria-label="Search references"
 					placeholder="Reference name"
 					value={draft}
 					onChange={(e) => setDraft(e.target.value)}

--- a/apps/web/src/samples/components/Create/ReadSelector.tsx
+++ b/apps/web/src/samples/components/Create/ReadSelector.tsx
@@ -259,6 +259,7 @@ export default function ReadSelector({
 					<div className="flex-grow">
 						<InputSearch
 							id="read-files-search"
+							aria-label="Search read files"
 							placeholder="Filename"
 							value={term}
 							onChange={(e) => setTerm(e.target.value)}

--- a/apps/web/src/samples/components/SamplesToolbar.tsx
+++ b/apps/web/src/samples/components/SamplesToolbar.tsx
@@ -21,6 +21,7 @@ export default function SampleToolbar({ onChange, term }: SampleToolbarProps) {
 		<Toolbar>
 			<div className="flex-grow">
 				<InputSearch
+					aria-label="Search samples"
 					value={term || ""}
 					onChange={onChange}
 					placeholder="Sample name"

--- a/apps/web/src/subtraction/components/SubtractionToolbar.tsx
+++ b/apps/web/src/subtraction/components/SubtractionToolbar.tsx
@@ -17,7 +17,12 @@ export default function SubtractionToolbar({
 	return (
 		<Toolbar>
 			<div className="flex-grow">
-				<InputSearch value={term} onChange={handleChange} placeholder="Name" />
+				<InputSearch
+					aria-label="Search subtractions"
+					value={term}
+					onChange={handleChange}
+					placeholder="Name"
+				/>
 			</div>
 			{hasPermission && <SubtractionCreate />}
 		</Toolbar>


### PR DESCRIPTION
## Summary
- Require `aria-label` on `InputSearch` and supply a real label at every call site, so screen readers announce an accessible name for each search box.
- Add a label to the `PathoscopeToolbar` search input, which previously had neither a label nor a placeholder.

Closes VIR-2691.