### PR TITLE
fix: make the test harness fail loudly on unmocked requests and errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -663,7 +663,11 @@ and make commits easier to find later.
 - **Imports:** Use explicit vitest imports (`import { describe, it,
   expect, vi } from "vitest"`).
 - **Setup:** `apps/web/src/tests/setup.tsx` provides
-  `renderWithProviders()`, `renderWithRouter()`, and `MemoryRouter`.
+  `renderWithProviders()`, `renderWithRouter()`, and `MemoryRouter`. It
+  also calls `nock.disableNetConnect()` (an unmocked request fails
+  instead of hitting the network) and gives the test `QueryClient`
+  `retry: false` (a failed query surfaces its error immediately), so
+  error paths are testable and under-mocked tests fail loudly.
 - **Test doubles** split three ways by what they do, and a helper lives
   in exactly one of them:
   - `src/tests/fake/` — `createFake*` data generators. No mocking.

--- a/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
+++ b/apps/web/src/samples/components/__tests__/SamplesList.test.tsx
@@ -229,6 +229,9 @@ describe("<SamplesList />", () => {
 		});
 
 		it("should show a chip for the search term", async () => {
+			// One interceptor per samples fetch: the initial empty-term render plus a
+			// refetch for each of the three keystrokes in "Foo".
+			mockApiGetSamples(samples);
 			mockApiGetSamples(samples);
 			mockApiGetSamples(samples);
 			await renderWithRouter(<SamplesListHarness labels={labels} />, path);

--- a/apps/web/src/tests/setup.tsx
+++ b/apps/web/src/tests/setup.tsx
@@ -18,6 +18,7 @@ import {
 	render as rtlRender,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import nock from "nock";
 import { createContext, type ReactNode, useContext, useState } from "react";
 import { beforeEach, vi } from "vitest";
 import { routeTree } from "@/routeTree.gen";
@@ -83,7 +84,23 @@ beforeEach(() => {
 
 process.env.TZ = "UTC";
 
+// Fail loudly when a request escapes its nock mock instead of falling through to
+// the real network, where it would pass or hang silently. Every superagent call
+// in a component test must have a matching interceptor.
+nock.disableNetConnect();
+
 faker.seed(1);
+
+/**
+ * A `QueryClient` configured for tests: retries are off so an error-state test
+ * asserts the failure immediately instead of waiting through three retries with
+ * backoff.
+ */
+export function createTestQueryClient() {
+	return new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+}
 
 /**
  * Return the element at `index`, throwing if the array has no such element.
@@ -100,7 +117,7 @@ export function at<T>(items: readonly T[], index: number): T {
 }
 
 export function wrapWithProviders(ui: ReactNode) {
-	const queryClient = new QueryClient();
+	const queryClient = createTestQueryClient();
 
 	return <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>;
 }
@@ -108,7 +125,7 @@ export function wrapWithProviders(ui: ReactNode) {
 export function renderWithProviders(ui: ReactNode) {
 	// The client is built once and reused, so `rerender` re-renders the same tree
 	// instead of handing React a new provider on every call.
-	const queryClient = new QueryClient();
+	const queryClient = createTestQueryClient();
 
 	function wrap(node: ReactNode) {
 		return (
@@ -228,9 +245,7 @@ type RenderRouteOptions = {
 
 export async function renderRoute(path: string, opts?: RenderRouteOptions) {
 	const history: string[] = [];
-	const queryClient = new QueryClient({
-		defaultOptions: { queries: { retry: false } },
-	});
+	const queryClient = createTestQueryClient();
 
 	queryClient.setQueryData(rootQueryKeys.all(), { first_user: false });
 	queryClient.setQueryData(

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -112,6 +112,26 @@ HTTP mock just to keep the test shape familiar.
 If a feature is half-migrated, mock at whichever boundary the code
 path under test actually crosses.
 
+### The harness fails loudly, so error paths are testable
+
+`setup.tsx` calls `nock.disableNetConnect()` once per test file: any
+superagent request without a matching interceptor errors instead of
+falling through to the real network, where it would pass or hang
+silently. A test that types into a search box or pages through a list
+fires one request per resulting refetch, and each needs its own
+interceptor (nock interceptors are single-use unless `.persist()`).
+
+The test `QueryClient` (`createTestQueryClient`, used by
+`wrapWithProviders`, `renderWithProviders`, and `renderRoute`) sets
+`retry: false`, so a failed query surfaces its error immediately rather
+than after three retries with backoff. This is what makes error-state
+assertions practical — mock a `500`, render, and assert the error UI
+without waiting out the retries.
+
+The two together mean a request the test forgot to mock now shows the
+error state right away instead of masking it behind retries — so
+under-mocked tests fail where they used to pass by accident.
+
 ## Don't snapshot response shapes
 
 Inferred zod / TS types already pin response shapes; a snapshot adds


### PR DESCRIPTION
## Summary
- Set `retry: false` on the test `QueryClient` (via a shared `createTestQueryClient` used by `wrapWithProviders`, `renderWithProviders`, and `renderRoute`) so a failed query surfaces its error immediately instead of after three retries with backoff, making error-state assertions practical.
- Call `nock.disableNetConnect()` in the shared setup so an unmocked superagent request errors instead of silently falling through to the real network.
- Fix the one under-mocked test these surfaced (`SamplesList` search-term chip), which had relied on retry backoff to outrun a missing nock interceptor.