### PR TITLE
fix: standardize chart, progress, and label colours on the palette

### DIFF
--- a/apps/web/src/analyses/components/Create/CreateAnalysisDialogContent.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysisDialogContent.tsx
@@ -8,7 +8,7 @@ export default function CreateAnalysisDialogContent({
 	children: ReactNode;
 }) {
 	return (
-		<DialogContent className={cn("max-h-[90vh]", "overflow-auto", "w-[700px]")}>
+		<DialogContent className="w-[700px]">
 			<div className={cn("flex", "flex-col")}>{children}</div>
 		</DialogContent>
 	);

--- a/apps/web/src/base/Dialog.tsx
+++ b/apps/web/src/base/Dialog.tsx
@@ -85,6 +85,8 @@ export function DialogContent({
 					"w-[600px]",
 					{ "w-[900px]": size === "lg" },
 					"max-w-[90vw]",
+					"max-h-[90vh]",
+					"overflow-y-auto",
 					className,
 				)}
 			>

--- a/apps/web/src/base/InputIconButton.tsx
+++ b/apps/web/src/base/InputIconButton.tsx
@@ -9,7 +9,7 @@ export default function InputIconButton({
 	return (
 		<IconButton
 			className={cn(
-				"absolute mx-[6px] flex items-center justify-center",
+				"absolute mx-1.5 flex items-center justify-center",
 				className,
 			)}
 			size={size}

--- a/apps/web/src/base/ProgressCircle.tsx
+++ b/apps/web/src/base/ProgressCircle.tsx
@@ -4,15 +4,15 @@ import { Progress } from "radix-ui";
 
 export type sizes = "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
 
-const colorToHex: Record<string, string> = {
-	blue: "#0B7FE5",
-	blueLightest: "#CDF1FD",
-	green: "#1DAD57",
-	greenLightest: "#D1FAD1",
-	grey: "#A0AEC0",
-	greyLight: "#CBD5E0",
-	red: "#E0282E",
-	redLightest: "#FDE1D3",
+const colorToVar: Record<string, string> = {
+	blue: "var(--color-blue-600)",
+	blueLightest: "var(--color-blue-100)",
+	green: "var(--color-green-600)",
+	greenLightest: "var(--color-green-100)",
+	grey: "var(--color-gray-400)",
+	greyLight: "var(--color-gray-300)",
+	red: "var(--color-red-600)",
+	redLightest: "var(--color-red-100)",
 };
 
 const progressCircleSizes: Record<sizes, number> = {
@@ -54,12 +54,12 @@ function getProgressColor(state: JobState): string {
 }
 
 function getTrackColor(color: string): string {
-	const fallback = colorToHex.greyLight ?? "#CBD5E0";
+	const fallback = colorToVar.greyLight ?? "var(--color-gray-300)";
 
 	if (color === "grey") {
 		return fallback;
 	}
-	return colorToHex[`${color}Lightest`] ?? fallback;
+	return colorToVar[`${color}Lightest`] ?? fallback;
 }
 
 type ProgressCircleProps = {
@@ -119,7 +119,7 @@ export default function ProgressCircle({
 						cx={center}
 						cy={center}
 						r={radius / 2.5}
-						fill={colorToHex.blue}
+						fill={colorToVar.blue}
 						className="animate-fade"
 						style={{
 							vectorEffect: "non-scaling-stroke",
@@ -132,7 +132,7 @@ export default function ProgressCircle({
 					<circle
 						{...baseCircleStyle}
 						className="transition-[stroke-dashoffset,stroke] duration-1000"
-						stroke={colorToHex[color]}
+						stroke={colorToVar[color]}
 						strokeDashoffset={calculateStrokeDashOffset(
 							circleSize,
 							progress / 100,

--- a/apps/web/src/base/ScrollArea.tsx
+++ b/apps/web/src/base/ScrollArea.tsx
@@ -20,7 +20,7 @@ export default function ScrollArea({ children, className }: ScrollAreaProps) {
 				"overflow-hidden",
 				"p-0",
 				"flex-none",
-				"mr-[15px]",
+				"mr-4",
 				"border",
 				"border-gray-300",
 				className,

--- a/apps/web/src/base/SelectBox.tsx
+++ b/apps/web/src/base/SelectBox.tsx
@@ -62,7 +62,7 @@ export function SelectBoxItem({
 				"p-4",
 				"cursor-pointer",
 				"data-[state=on]:border-blue-600",
-				"data-[state=on]:shadow-[inset_0_1px_1px_rgba(0,0,0,0.075),0_0_8px_rgba(59,130,246,0.6)]",
+				"data-[state=on]:shadow-[inset_0_1px_1px_rgba(0,0,0,0.075),0_0_8px_color-mix(in_srgb,var(--color-blue-500)_60%,transparent)]",
 				"[&>div:first-child]:font-semibold",
 				"[&>div:first-child]:pb-1",
 				"[&>span]:text-gray-700",

--- a/apps/web/src/labels/components/LabelForm.tsx
+++ b/apps/web/src/labels/components/LabelForm.tsx
@@ -6,6 +6,7 @@ import InputError from "@base/InputError";
 import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import InputSimple from "@base/InputSimple";
+import { DEFAULT_LABEL_COLOR } from "@labels/constants";
 import SampleLabel from "@samples/components/Label/SampleLabel";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
@@ -26,7 +27,7 @@ type LabelFormProps = {
  * A form for creating or updating a label
  */
 export function LabelForm({
-	color = "#D1D5DB",
+	color = DEFAULT_LABEL_COLOR,
 	description = "",
 	error = "",
 	name = "",
@@ -44,7 +45,7 @@ export function LabelForm({
 	return (
 		<form
 			onSubmit={handleSubmit((values) =>
-				onSubmit({ ...values, color: newColor || "#D1D5DB" }),
+				onSubmit({ ...values, color: newColor || DEFAULT_LABEL_COLOR }),
 			)}
 		>
 			<InputGroup>
@@ -75,7 +76,7 @@ export function LabelForm({
 			<p className="font-medium">Preview</p>
 			<Box className="p-2.5">
 				<SampleLabel
-					color={newColor || "#D1D5DB"}
+					color={newColor || DEFAULT_LABEL_COLOR}
 					name={watch("name") || "Preview"}
 				/>
 			</Box>

--- a/apps/web/src/labels/components/__tests__/CreateLabel.test.tsx
+++ b/apps/web/src/labels/components/__tests__/CreateLabel.test.tsx
@@ -1,3 +1,4 @@
+import { DEFAULT_LABEL_COLOR } from "@labels/constants";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@tests/setup";
@@ -45,7 +46,7 @@ describe("<CreateLabel>", () => {
 			expect(onSubmit).toHaveBeenCalledWith({
 				name: "Foo",
 				description: "This is a description",
-				color: "#D1D5DB",
+				color: DEFAULT_LABEL_COLOR,
 			}),
 		);
 	});

--- a/apps/web/src/labels/constants.ts
+++ b/apps/web/src/labels/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * The colour a label falls back to when none is chosen — Tailwind `gray-300`.
+ *
+ * Shared by the client-side label form (its initial value) and the server-side
+ * `normalizeColor` fallback (for rows with a null colour) so the two cannot
+ * drift apart.
+ */
+export const DEFAULT_LABEL_COLOR = "#D1D5DB";

--- a/apps/web/src/quality/components/Bases.ts
+++ b/apps/web/src/quality/components/Bases.ts
@@ -8,10 +8,10 @@ import { area, axisBottom, axisLeft, line, scaleLinear } from "d3";
 import { min } from "es-toolkit/compat";
 
 const series = [
-	{ label: "Mean", color: "#E0282E" },
-	{ label: "Median", color: "#0B7FE5" },
-	{ label: "Quartile", color: "#1DAD57" },
-	{ label: "Decile", color: "#FFE030" },
+	{ label: "Mean", color: "var(--color-red-600)" },
+	{ label: "Median", color: "var(--color-blue-600)" },
+	{ label: "Quartile", color: "var(--color-green-600)" },
+	{ label: "Decile", color: "var(--color-yellow-400)" },
 ];
 
 function getArea(name: string, areaX, y, a, b) {

--- a/apps/web/src/quality/components/Nucleotides.ts
+++ b/apps/web/src/quality/components/Nucleotides.ts
@@ -8,10 +8,10 @@ import { axisBottom, axisLeft, line, scaleLinear } from "d3";
 import { unzip } from "es-toolkit";
 
 const series = [
-	{ label: "Guanine", color: "#0B7FE5" },
-	{ label: "Adenine", color: "#E0282E" },
-	{ label: "Thymine", color: "#1DAD57" },
-	{ label: "Cytosine", color: "#718096" },
+	{ label: "Guanine", color: "var(--color-blue-600)" },
+	{ label: "Adenine", color: "var(--color-red-600)" },
+	{ label: "Thymine", color: "var(--color-green-600)" },
+	{ label: "Cytosine", color: "var(--color-gray-500)" },
 ];
 
 export function drawNucleotidesChart(

--- a/apps/web/src/quality/components/Sequences.ts
+++ b/apps/web/src/quality/components/Sequences.ts
@@ -32,7 +32,7 @@ export function drawSequencesChart(element, data, baseWidth) {
 		.append("path")
 		.attr("d", lineDrawer(data))
 		.attr("class", "graph-line")
-		.attr("stroke", "#718096");
+		.attr("stroke", "var(--color-gray-500)");
 
 	// Append a labelled x-axis to the SVG.
 	svg

--- a/apps/web/src/references/components/SourceTypes/LocalSourceTypes.tsx
+++ b/apps/web/src/references/components/SourceTypes/LocalSourceTypes.tsx
@@ -98,7 +98,7 @@ export function LocalSourceTypes() {
 							<label className="block mb-1" htmlFor="sourceType">
 								Add Source Type{" "}
 							</label>
-							<InputContainer className="flex mb-[5px]">
+							<InputContainer className="flex mb-1.5">
 								<span className="flex flex-auto mr-2.5 flex-col">
 									<InputSimple id="sourceType" {...register("sourceType")} />
 									<InputError>{error}</InputError>

--- a/apps/web/src/references/components/SourceTypes/SourceTypeItem.tsx
+++ b/apps/web/src/references/components/SourceTypes/SourceTypeItem.tsx
@@ -18,7 +18,7 @@ export function SourceTypeItem({
 			className="flex items-center capitalize"
 			disabled={disabled}
 		>
-			<span className="mr-[5px]">{sourceType}</span>
+			<span className="mr-1.5">{sourceType}</span>
 			{disabled ? null : (
 				<IconButton
 					className="ml-auto"

--- a/apps/web/src/samples/components/Create/CreateSample.tsx
+++ b/apps/web/src/samples/components/Create/CreateSample.tsx
@@ -207,7 +207,7 @@ export default function CreateSample({ labels }: CreateSampleProps) {
 							onOpenChange={setShowMetadata}
 						>
 							<CollapsibleTrigger>Show Metadata Fields</CollapsibleTrigger>
-							<CollapsibleContent className="grid grid-cols-2 gap-x-[15px] pt-4">
+							<CollapsibleContent className="grid grid-cols-2 gap-x-4 pt-4">
 								<InputGroup>
 									<InputLabel htmlFor="locale">Locale</InputLabel>
 									<InputSimple id="locale" {...register("locale")} />

--- a/apps/web/src/samples/components/Create/CreateSampleFromFile.tsx
+++ b/apps/web/src/samples/components/Create/CreateSampleFromFile.tsx
@@ -261,7 +261,7 @@ export default function CreateSampleFromFile({
 				IconComponent={CirclePlus}
 				tip="create sample"
 			/>
-			<DialogContent size="lg" className="max-h-[90vh] overflow-y-auto">
+			<DialogContent size="lg">
 				<CreateSampleFromFileForm
 					labels={labels}
 					onClose={() => setOpen(false)}

--- a/apps/web/src/samples/components/Detail/SampleDetailGeneral.tsx
+++ b/apps/web/src/samples/components/Detail/SampleDetailGeneral.tsx
@@ -119,7 +119,7 @@ export default function SampleDetailGeneral({
 				)}
 			</ContainerNarrow>
 
-			<ContainerSide className="pl-[15px]">
+			<ContainerSide className="pl-4">
 				<Sidebar
 					labels={labels}
 					sampleId={data.id}

--- a/apps/web/src/server/labels/data.ts
+++ b/apps/web/src/server/labels/data.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_LABEL_COLOR } from "@labels/constants";
 import { asc, eq, ilike } from "drizzle-orm";
 import type { PostgresError } from "postgres";
 import type { Db } from "../db/pg";
@@ -38,7 +39,7 @@ function isUniqueViolation(error: unknown): boolean {
 
 function normalizeColor(color: string | null): string {
 	if (!color) {
-		return "#D1D5DB";
+		return DEFAULT_LABEL_COLOR;
 	}
 	return color.startsWith("#") ? color : `#${color}`;
 }


### PR DESCRIPTION
## Summary
- Replace the hardcoded hex colours (and the hidden blue in the SelectBox focus glow) across `ProgressCircle` and the quality charts (`Bases`, `Nucleotides`, `Sequences`) with Tailwind palette tokens, matching how `Button`, `Badge`, and the quality-chart CSS already work. This shifts the charts and progress circles slightly by design (most visibly the azure blue).
- Extract the label default colour into a shared `DEFAULT_LABEL_COLOR` constant, imported by both the client form and the server fallback so the two can't drift apart.
- Centralize `max-h-[90vh]` onto `DialogContent` and normalize stray small-px arbitrary Tailwind values onto the standard spacing scale.