### PR TITLE
chore: speed up tests by not loading the route tree everywhere

### DIFF
--- a/apps/web/src/tests/setup.tsx
+++ b/apps/web/src/tests/setup.tsx
@@ -21,7 +21,6 @@ import userEvent from "@testing-library/user-event";
 import nock from "nock";
 import { createContext, type ReactNode, useContext, useState } from "react";
 import { beforeEach, vi } from "vitest";
-import { routeTree } from "@/routeTree.gen";
 import { createFakeAccount } from "./fake/account";
 import { authServerFnMocks } from "./server-fn/auth";
 import { groupServerFnMocks } from "./server-fn/groups";
@@ -244,6 +243,11 @@ type RenderRouteOptions = {
 };
 
 export async function renderRoute(path: string, opts?: RenderRouteOptions) {
+	// Imported lazily so the ~1,449-line route tree — and the route modules it
+	// pulls in — only loads for the handful of tests that render a real route,
+	// not every test file that imports this shared setup.
+	const { routeTree } = await import("@/routeTree.gen");
+
 	const history: string[] = [];
 	const queryClient = createTestQueryClient();
 


### PR DESCRIPTION
## Summary
- The shared test setup imported the 1,449-line `routeTree.gen` at module scope, forcing all ~118 test files to load it (and its transitive route modules) even though only the 9 that call `renderRoute` need it.
- Moved the import to a lazy `await import("@/routeTree.gen")` inside `renderRoute`, so only route-rendering tests pay the cost. Mock hoisting via `vi.mock` is unaffected.
- Cumulative Vitest setup time drops from ~82s to ~30s; full web suite (129 files / 661 tests) still passes.