### PR TITLE
fix: unify base component colours on a shared palette type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,8 +341,11 @@ patterns.
 ### Base component color props
 
 Base components in `src/base/` that expose a `color` prop should accept the
-shared palette: `"blue" | "green" | "gray" | "orange" | "purple" | "red"`. Don't
-add one-off colors or trim the set per component — keep the surface uniform.
+shared `PaletteColor` type from `@base/types`
+(`"blue" | "green" | "gray" | "orange" | "purple" | "red"`). Don't redeclare the
+union locally, add one-off colors, or trim the set per component — keep the
+surface uniform. Icon-based components (`Icon`, `IconButton`, `Circle`) use
+`IconColor`, which is `PaletteColor | "black"`.
 
 If a component has multiple variants (e.g. `solid` / `soft`), `color` should
 work in every variant. A variant that silently ignores `color` is a footgun;

--- a/apps/web/src/base/Alert.tsx
+++ b/apps/web/src/base/Alert.tsx
@@ -2,10 +2,9 @@ import { cn } from "@app/cn";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import Icon from "./Icon";
+import type { PaletteColor } from "./types";
 
-type AlertColor = "blue" | "green" | "gray" | "orange" | "purple" | "red";
-
-const alertColorStyles: Record<AlertColor, string> = {
+const alertColorStyles: Record<PaletteColor, string> = {
 	blue: "bg-blue-100 text-blue-700",
 	green: "bg-green-100 text-green-700",
 	gray: "bg-gray-100 text-gray-600",
@@ -20,7 +19,7 @@ type AlertProps = {
 	block?: boolean;
 	children: ReactNode;
 	className?: string;
-	color?: AlertColor;
+	color?: PaletteColor;
 	icon?: LucideIcon;
 	level?: boolean;
 	outerClassName?: string;

--- a/apps/web/src/base/Badge.tsx
+++ b/apps/web/src/base/Badge.tsx
@@ -1,16 +1,15 @@
 import { cn } from "@app/cn";
 import type { ReactNode } from "react";
-
-type BadgeColor = "blue" | "green" | "gray" | "orange" | "purple" | "red";
+import type { PaletteColor } from "./types";
 
 type BadgeProps = {
 	children: ReactNode;
 	className?: string;
-	color?: BadgeColor;
+	color?: PaletteColor;
 	variant?: "solid" | "soft";
 };
 
-const solidColors: Record<BadgeColor, string> = {
+const solidColors: Record<PaletteColor, string> = {
 	blue: "bg-blue-600",
 	green: "bg-green-600",
 	gray: "bg-gray-500",
@@ -19,7 +18,7 @@ const solidColors: Record<BadgeColor, string> = {
 	red: "bg-red-600",
 };
 
-const softColors: Record<BadgeColor, string> = {
+const softColors: Record<PaletteColor, string> = {
 	blue: "bg-blue-50 text-blue-700 border-blue-200",
 	green: "bg-green-50 text-green-700 border-green-200",
 	gray: "bg-gray-100 text-gray-600 border-gray-200",

--- a/apps/web/src/base/Button.tsx
+++ b/apps/web/src/base/Button.tsx
@@ -1,13 +1,14 @@
 import { cn } from "@app/cn";
 import type { ElementType, ReactNode } from "react";
 import { buttonVariants } from "./buttonVariants";
+import type { PaletteColor } from "./types";
 
 export type ButtonProps = {
 	active?: boolean;
 	as?: ElementType;
 	children: ReactNode;
 	className?: string;
-	color?: "blue" | "green" | "gray" | "purple" | "red";
+	color?: PaletteColor;
 	disabled?: boolean;
 	onBlur?: () => void;
 	onClick?: () => void;

--- a/apps/web/src/base/DropdownMenuCheckboxItem.tsx
+++ b/apps/web/src/base/DropdownMenuCheckboxItem.tsx
@@ -1,15 +1,13 @@
 import { Check, Minus } from "lucide-react";
 import { DropdownMenu } from "radix-ui";
 import type { ComponentPropsWithRef } from "react";
-import {
-	type DropdownMenuItemColor,
-	getDropdownMenuItemClassName,
-} from "./dropdownMenuItemStyles";
+import { getDropdownMenuItemClassName } from "./dropdownMenuItemStyles";
+import type { PaletteColor } from "./types";
 
 type DropdownMenuCheckboxItemProps = ComponentPropsWithRef<
 	typeof DropdownMenu.CheckboxItem
 > & {
-	color?: DropdownMenuItemColor;
+	color?: PaletteColor;
 };
 
 export default function DropdownMenuCheckboxItem({

--- a/apps/web/src/base/DropdownMenuItem.tsx
+++ b/apps/web/src/base/DropdownMenuItem.tsx
@@ -1,12 +1,10 @@
 import { DropdownMenu } from "radix-ui";
 import type { ComponentPropsWithRef } from "react";
-import {
-	type DropdownMenuItemColor,
-	getDropdownMenuItemClassName,
-} from "./dropdownMenuItemStyles";
+import { getDropdownMenuItemClassName } from "./dropdownMenuItemStyles";
+import type { PaletteColor } from "./types";
 
 type DropdownMenuItemProps = ComponentPropsWithRef<typeof DropdownMenu.Item> & {
-	color?: DropdownMenuItemColor;
+	color?: PaletteColor;
 };
 
 export default function DropdownMenuItem({

--- a/apps/web/src/base/DropdownMenuRadioItem.tsx
+++ b/apps/web/src/base/DropdownMenuRadioItem.tsx
@@ -1,15 +1,13 @@
 import { Circle } from "lucide-react";
 import { DropdownMenu } from "radix-ui";
 import type { ComponentPropsWithRef } from "react";
-import {
-	type DropdownMenuItemColor,
-	getDropdownMenuItemClassName,
-} from "./dropdownMenuItemStyles";
+import { getDropdownMenuItemClassName } from "./dropdownMenuItemStyles";
+import type { PaletteColor } from "./types";
 
 type DropdownMenuRadioItemProps = ComponentPropsWithRef<
 	typeof DropdownMenu.RadioItem
 > & {
-	color?: DropdownMenuItemColor;
+	color?: PaletteColor;
 };
 
 export default function DropdownMenuRadioItem({

--- a/apps/web/src/base/ErrorState.tsx
+++ b/apps/web/src/base/ErrorState.tsx
@@ -2,10 +2,9 @@ import { cn } from "@app/cn";
 import { CircleAlert } from "lucide-react";
 import type { ReactNode } from "react";
 import { Empty, EmptyContent, EmptyMedia, EmptyTitle } from "./Empty";
+import type { PaletteColor } from "./types";
 
-type ErrorStateColor = "blue" | "green" | "gray" | "orange" | "purple" | "red";
-
-const iconColors: Record<ErrorStateColor, string> = {
+const iconColors: Record<PaletteColor, string> = {
 	blue: "text-blue-500",
 	green: "text-green-500",
 	gray: "text-gray-500",
@@ -17,7 +16,7 @@ const iconColors: Record<ErrorStateColor, string> = {
 type ErrorStateProps = {
 	children?: ReactNode;
 	className?: string;
-	color?: ErrorStateColor;
+	color?: PaletteColor;
 	icon?: ReactNode;
 	message?: string;
 };

--- a/apps/web/src/base/Label.tsx
+++ b/apps/web/src/base/Label.tsx
@@ -1,10 +1,20 @@
 import { cn } from "@app/cn";
 import type { ReactNode } from "react";
+import type { PaletteColor } from "./types";
+
+const colorToClass: Record<PaletteColor, string> = {
+	blue: "bg-blue-600",
+	green: "bg-green-600",
+	gray: "bg-gray-500",
+	orange: "bg-orange-600",
+	purple: "bg-purple-600",
+	red: "bg-red-600",
+};
 
 type LabelProps = {
 	children?: ReactNode;
 	className?: string;
-	color?: string;
+	color?: PaletteColor;
 };
 
 /**
@@ -29,13 +39,7 @@ export default function Label({
 				"text-sm",
 				"whitespace-nowrap",
 				"last-of-type:m-0",
-				{
-					"bg-blue-600": color === "blue",
-					"bg-green-600": color === "green",
-					"bg-gray-500": color === "gray",
-					"bg-purple-600": color === "purple",
-					"bg-red-600": color === "red",
-				},
+				colorToClass[color],
 				className,
 			)}
 		>

--- a/apps/web/src/base/Loader.tsx
+++ b/apps/web/src/base/Loader.tsx
@@ -1,14 +1,7 @@
 import { cn } from "@app/cn";
+import type { PaletteColor } from "./types";
 
-export type LoaderColor =
-	| "blue"
-	| "green"
-	| "gray"
-	| "orange"
-	| "purple"
-	| "red";
-
-export const colorToClass: Record<LoaderColor, string> = {
+export const colorToClass: Record<PaletteColor, string> = {
 	blue: "border-t-blue-600 border-x-blue-600",
 	green: "border-t-green-600 border-x-green-600",
 	gray: "border-t-gray-500 border-x-gray-500",
@@ -19,7 +12,7 @@ export const colorToClass: Record<LoaderColor, string> = {
 
 type LoaderProps = {
 	className?: string;
-	color?: LoaderColor;
+	color?: PaletteColor;
 	size?: string;
 };
 

--- a/apps/web/src/base/ProgressBarAffixed.tsx
+++ b/apps/web/src/base/ProgressBarAffixed.tsx
@@ -1,15 +1,19 @@
 import { cn } from "@app/cn";
+import type { PaletteColor } from "./types";
 
-const colorToClass: Record<string, string> = {
+const colorToClass: Record<PaletteColor, string> = {
 	blue: "bg-blue-600",
 	green: "bg-green-600",
+	gray: "bg-gray-500",
+	orange: "bg-orange-600",
+	purple: "bg-purple-600",
 	red: "bg-red-600",
 };
 
 type ProgressBarAffixedProps = {
 	bottom?: boolean;
 	className?: string;
-	color?: string;
+	color?: PaletteColor;
 	now: number;
 };
 
@@ -28,7 +32,7 @@ export default function ProgressBarAffixed({
 			)}
 		>
 			<div
-				className={cn("h-full", colorToClass[color] || "bg-blue-600")}
+				className={cn("h-full", colorToClass[color])}
 				style={{ width: `${now}%` }}
 			/>
 		</div>

--- a/apps/web/src/base/ProgressCircle.tsx
+++ b/apps/web/src/base/ProgressCircle.tsx
@@ -9,8 +9,8 @@ const colorToVar: Record<string, string> = {
 	blueLightest: "var(--color-blue-100)",
 	green: "var(--color-green-600)",
 	greenLightest: "var(--color-green-100)",
-	grey: "var(--color-gray-400)",
-	greyLight: "var(--color-gray-300)",
+	gray: "var(--color-gray-400)",
+	grayLight: "var(--color-gray-300)",
 	red: "var(--color-red-600)",
 	redLightest: "var(--color-red-100)",
 };
@@ -47,16 +47,16 @@ function getProgressColor(state: JobState): string {
 		case "running":
 			return "blue";
 		case "pending":
-			return "grey";
+			return "gray";
 		default:
 			return "red";
 	}
 }
 
 function getTrackColor(color: string): string {
-	const fallback = colorToVar.greyLight ?? "var(--color-gray-300)";
+	const fallback = colorToVar.grayLight ?? "var(--color-gray-300)";
 
-	if (color === "grey") {
+	if (color === "gray") {
 		return fallback;
 	}
 	return colorToVar[`${color}Lightest`] ?? fallback;

--- a/apps/web/src/base/ViewHeaderTitleBadge.tsx
+++ b/apps/web/src/base/ViewHeaderTitleBadge.tsx
@@ -1,11 +1,12 @@
 import { cn } from "@app/cn";
 import type { ReactNode } from "react";
 import Badge from "./Badge";
+import type { PaletteColor } from "./types";
 
 type ViewHeaderTitleBadge = {
 	children?: ReactNode;
 	className?: string;
-	color?: "blue" | "green" | "gray" | "orange" | "purple" | "red";
+	color?: PaletteColor;
 };
 
 /**

--- a/apps/web/src/base/buttonVariants.ts
+++ b/apps/web/src/base/buttonVariants.ts
@@ -8,6 +8,7 @@ export const buttonVariants = cva(
 				gray: "bg-gray-200 text-black hover:text-black",
 				blue: "bg-blue-600 text-white hover:text-white",
 				green: "bg-green-600 text-white hover:text-white",
+				orange: "bg-orange-600 text-white hover:text-white",
 				red: "bg-red-600 text-white hover:text-white",
 				purple: "bg-purple-600 text-white hover:text-white",
 			},

--- a/apps/web/src/base/dropdownMenuItemStyles.ts
+++ b/apps/web/src/base/dropdownMenuItemStyles.ts
@@ -1,15 +1,7 @@
 import { cn } from "@app/cn";
+import type { PaletteColor } from "./types";
 
-/** The palette shared by all selectable dropdown menu items. */
-export type DropdownMenuItemColor =
-	| "blue"
-	| "green"
-	| "gray"
-	| "orange"
-	| "purple"
-	| "red";
-
-const itemColors: Record<DropdownMenuItemColor, string> = {
+const itemColors: Record<PaletteColor, string> = {
 	blue: "text-blue-600 focus:bg-blue-50 focus:text-blue-700",
 	green: "text-green-600 focus:bg-green-50 focus:text-green-700",
 	gray: "text-gray-900 focus:bg-gray-100 focus:text-gray-900",
@@ -23,7 +15,7 @@ const itemColors: Record<DropdownMenuItemColor, string> = {
  * pointer enter, so `focus:` covers both hover and arrow-key highlighting.
  */
 export function getDropdownMenuItemClassName(
-	color: DropdownMenuItemColor,
+	color: PaletteColor,
 	className?: string,
 ): string {
 	return cn(

--- a/apps/web/src/base/types.ts
+++ b/apps/web/src/base/types.ts
@@ -1,8 +1,11 @@
-export type IconColor =
-	| "black"
+/** The shared colour palette every base component's `color` prop accepts. */
+export type PaletteColor =
 	| "blue"
 	| "green"
 	| "gray"
-	| "red"
 	| "orange"
-	| "purple";
+	| "purple"
+	| "red";
+
+/** The palette plus `black`, for icon-based components. */
+export type IconColor = PaletteColor | "black";


### PR DESCRIPTION
## Summary
- Introduce a shared `PaletteColor` type (`@base/types`) and have every base component consume it instead of redeclaring the colour union locally, so the palette stays uniform across the surface.
- Add `IconColor` (`PaletteColor | "black"`) for icon-based components (`Icon`, `IconButton`, `Circle`) that need black in addition to the shared palette.
- Add the missing `orange` variant to `Button`/`Label`, widen `ProgressBarAffixed` to the full palette, standardise `ProgressCircle` on `gray`, and document the convention in AGENTS.md.