### PR TITLE
refactor: inject db handle into groups, messages, and tasks data modules

### DIFF
--- a/apps/web/src/server/groups/data.ts
+++ b/apps/web/src/server/groups/data.ts
@@ -1,6 +1,6 @@
 import { asc, count, eq, ilike } from "drizzle-orm";
 import type { PostgresError } from "postgres";
-import { db } from "../db/pg";
+import type { Db } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import {
 	type GroupPermissions,
@@ -87,7 +87,10 @@ function toGroupMinimal(row: GroupRow): GroupMinimal {
 	};
 }
 
-async function fetchGroupUsers(groupId: number): Promise<GroupUserNested[]> {
+async function fetchGroupUsers(
+	db: Db,
+	groupId: number,
+): Promise<GroupUserNested[]> {
 	const rows = await db
 		.select({ id: usersTable.id, handle: usersTable.handle })
 		.from(usersTable)
@@ -98,7 +101,7 @@ async function fetchGroupUsers(groupId: number): Promise<GroupUserNested[]> {
 	return rows.map((row) => ({ id: row.id, handle: row.handle }));
 }
 
-export async function listGroups(): Promise<GroupMinimal[]> {
+export async function listGroups(db: Db): Promise<GroupMinimal[]> {
 	const rows = await db
 		.select()
 		.from(groupsTable)
@@ -108,6 +111,7 @@ export async function listGroups(): Promise<GroupMinimal[]> {
 }
 
 export async function findGroups(
+	db: Db,
 	term: string,
 	page: number,
 	perPage: number,
@@ -139,7 +143,7 @@ export async function findGroups(
 	};
 }
 
-export async function getGroup(groupId: number): Promise<Group> {
+export async function getGroup(db: Db, groupId: number): Promise<Group> {
 	const [row] = await db
 		.select()
 		.from(groupsTable)
@@ -149,7 +153,7 @@ export async function getGroup(groupId: number): Promise<Group> {
 		throw new GroupNotFoundError();
 	}
 
-	const users = await fetchGroupUsers(row.id);
+	const users = await fetchGroupUsers(db, row.id);
 
 	return {
 		...toGroupMinimal(row),
@@ -158,7 +162,7 @@ export async function getGroup(groupId: number): Promise<Group> {
 	};
 }
 
-export async function createGroup(name: string): Promise<Group> {
+export async function createGroup(db: Db, name: string): Promise<Group> {
 	try {
 		const row = takeFirstOrThrow(
 			await db
@@ -187,6 +191,7 @@ export async function createGroup(name: string): Promise<Group> {
 }
 
 export async function updateGroup(
+	db: Db,
 	groupId: number,
 	values: GroupUpdateValues,
 ): Promise<Group> {
@@ -208,7 +213,7 @@ export async function updateGroup(
 	}
 
 	if (Object.keys(patch).length === 0) {
-		return getGroup(groupId);
+		return getGroup(db, groupId);
 	}
 
 	try {
@@ -222,10 +227,10 @@ export async function updateGroup(
 
 	await emit("groups", groupId, "update");
 
-	return getGroup(groupId);
+	return getGroup(db, groupId);
 }
 
-export async function deleteGroup(groupId: number): Promise<void> {
+export async function deleteGroup(db: Db, groupId: number): Promise<void> {
 	const [row] = await db
 		.delete(groupsTable)
 		.where(eq(groupsTable.id, groupId))

--- a/apps/web/src/server/groups/functions.ts
+++ b/apps/web/src/server/groups/functions.ts
@@ -2,6 +2,7 @@ import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
 import { z } from "zod";
 import { adminRole, authenticated } from "../auth/policy";
+import { db } from "../db/pg";
 import {
 	createGroup as createGroupImpl,
 	deleteGroup as deleteGroupImpl,
@@ -68,13 +69,13 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 // group, so the reads are open to any signed-in user.
 export const listGroups = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
-	.handler(async () => listGroupsImpl());
+	.handler(async () => listGroupsImpl(db));
 
 export const findGroups = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(findGroupsSchema)
 	.handler(async ({ data }) =>
-		findGroupsImpl(data?.term ?? "", data?.page ?? 1, data?.per_page ?? 25),
+		findGroupsImpl(db, data?.term ?? "", data?.page ?? 1, data?.per_page ?? 25),
 	);
 
 export const getGroup = createServerFn({ method: "GET" })
@@ -82,7 +83,7 @@ export const getGroup = createServerFn({ method: "GET" })
 	.validator(groupIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			return await getGroupImpl(data.groupId);
+			return await getGroupImpl(db, data.groupId);
 		} catch (err) {
 			rethrowAsHttp(err);
 		}
@@ -96,7 +97,7 @@ export const createGroup = createServerFn({ method: "POST" })
 	.validator(createGroupSchema)
 	.handler(async ({ data }) => {
 		try {
-			const group = await createGroupImpl(data.name);
+			const group = await createGroupImpl(db, data.name);
 			setResponseStatus(201);
 			return group;
 		} catch (err) {
@@ -110,7 +111,7 @@ export const updateGroup = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		const { groupId, ...values } = data;
 		try {
-			return await updateGroupImpl(groupId, values);
+			return await updateGroupImpl(db, groupId, values);
 		} catch (err) {
 			rethrowAsHttp(err);
 		}
@@ -121,7 +122,7 @@ export const deleteGroup = createServerFn({ method: "POST" })
 	.validator(groupIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			await deleteGroupImpl(data.groupId);
+			await deleteGroupImpl(db, data.groupId);
 			setResponseStatus(204);
 			return null;
 		} catch (err) {

--- a/apps/web/src/server/messages/data.ts
+++ b/apps/web/src/server/messages/data.ts
@@ -1,6 +1,6 @@
 import type { UserNested } from "@users/types";
 import { desc, eq } from "drizzle-orm";
-import { db } from "../db/pg";
+import type { Db } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import { instanceMessages, type MessageColor } from "../db/schema/messages";
 import { users } from "../db/schema/users";
@@ -56,7 +56,7 @@ function toMessage(row: MessageJoinRow): Message {
 	};
 }
 
-export async function findMessage(): Promise<Message | null> {
+export async function findMessage(db: Db): Promise<Message | null> {
 	const [row] = await db
 		.select(messageSelect)
 		.from(instanceMessages)
@@ -67,7 +67,7 @@ export async function findMessage(): Promise<Message | null> {
 	return row ? toMessage(row) : null;
 }
 
-export async function findMessages(): Promise<Message[]> {
+export async function findMessages(db: Db): Promise<Message[]> {
 	const rows = await db
 		.select(messageSelect)
 		.from(instanceMessages)
@@ -77,7 +77,7 @@ export async function findMessages(): Promise<Message[]> {
 	return rows.map(toMessage);
 }
 
-async function getMessageById(id: number): Promise<Message> {
+async function getMessageById(db: Db, id: number): Promise<Message> {
 	const [row] = await db
 		.select(messageSelect)
 		.from(instanceMessages)
@@ -93,6 +93,7 @@ async function getMessageById(id: number): Promise<Message> {
 }
 
 export async function createMessage(
+	db: Db,
 	message: string,
 	color: MessageColor,
 	userId: number,
@@ -114,10 +115,11 @@ export async function createMessage(
 
 	await emit("messages", row.id, "create");
 
-	return getMessageById(row.id);
+	return getMessageById(db, row.id);
 }
 
 export async function updateMessage(
+	db: Db,
 	id: number,
 	values: { message?: string; color?: MessageColor },
 	userId: number,
@@ -145,10 +147,10 @@ export async function updateMessage(
 
 	await emit("messages", row.id, "update");
 
-	return getMessageById(row.id);
+	return getMessageById(db, row.id);
 }
 
-export async function deleteMessage(id: number): Promise<void> {
+export async function deleteMessage(db: Db, id: number): Promise<void> {
 	const [row] = await db
 		.delete(instanceMessages)
 		.where(eq(instanceMessages.id, id))
@@ -161,7 +163,7 @@ export async function deleteMessage(id: number): Promise<void> {
 	await emit("messages", row.id, "delete");
 }
 
-export async function setActiveMessage(id: number): Promise<Message> {
+export async function setActiveMessage(db: Db, id: number): Promise<Message> {
 	const row = await db.transaction(async (tx) => {
 		await tx
 			.update(instanceMessages)
@@ -183,10 +185,10 @@ export async function setActiveMessage(id: number): Promise<Message> {
 
 	await emit("messages", row.id, "update");
 
-	return getMessageById(row.id);
+	return getMessageById(db, row.id);
 }
 
-export async function clearActiveMessage(): Promise<void> {
+export async function clearActiveMessage(db: Db): Promise<void> {
 	const rows = await db
 		.update(instanceMessages)
 		.set({ active: false })

--- a/apps/web/src/server/messages/functions.ts
+++ b/apps/web/src/server/messages/functions.ts
@@ -3,6 +3,7 @@ import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
 import { z } from "zod";
 import { adminRole, authenticated } from "../auth/policy";
+import { db } from "../db/pg";
 import {
 	clearActiveMessage as clearActiveMessageImpl,
 	createMessage as createMessageImpl,
@@ -45,17 +46,18 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 
 export const findMessage = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
-	.handler(async () => findMessageImpl());
+	.handler(async () => findMessageImpl(db));
 
 export const findMessages = createServerFn({ method: "GET" })
 	.middleware([adminRole("settings")])
-	.handler(async () => findMessagesImpl());
+	.handler(async () => findMessagesImpl(db));
 
 export const createMessage = createServerFn({ method: "POST" })
 	.middleware([adminRole("settings")])
 	.validator(createMessageSchema)
 	.handler(async ({ context, data }) => {
 		const message = await createMessageImpl(
+			db,
 			data.message,
 			data.color,
 			context.session.userId,
@@ -70,6 +72,7 @@ export const updateMessage = createServerFn({ method: "POST" })
 	.handler(async ({ context, data }) => {
 		try {
 			return await updateMessageImpl(
+				db,
 				data.id,
 				{ message: data.message, color: data.color },
 				context.session.userId,
@@ -84,7 +87,7 @@ export const deleteMessage = createServerFn({ method: "POST" })
 	.validator(idSchema)
 	.handler(async ({ data }) => {
 		try {
-			await deleteMessageImpl(data.id);
+			await deleteMessageImpl(db, data.id);
 			setResponseStatus(204);
 			return null;
 		} catch (err) {
@@ -97,7 +100,7 @@ export const setActiveMessage = createServerFn({ method: "POST" })
 	.validator(idSchema)
 	.handler(async ({ data }) => {
 		try {
-			return await setActiveMessageImpl(data.id);
+			return await setActiveMessageImpl(db, data.id);
 		} catch (err) {
 			rethrowAsHttp(err);
 		}
@@ -106,6 +109,6 @@ export const setActiveMessage = createServerFn({ method: "POST" })
 export const clearActiveMessage = createServerFn({ method: "POST" })
 	.middleware([adminRole("settings")])
 	.handler(async () => {
-		await clearActiveMessageImpl();
+		await clearActiveMessageImpl(db);
 		return null;
 	});

--- a/apps/web/src/server/tasks/data.ts
+++ b/apps/web/src/server/tasks/data.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import { db } from "../db/pg";
+import type { Db } from "../db/pg";
 import { tasks as tasksTable } from "../db/schema/tasks";
 import { AppError } from "../errors";
 
@@ -17,7 +17,7 @@ export type Task = {
 /** Thrown when a requested task does not exist. */
 export class TaskNotFoundError extends AppError {}
 
-export async function getTask(taskId: number): Promise<Task> {
+export async function getTask(db: Db, taskId: number): Promise<Task> {
 	const [row] = await db
 		.select({
 			complete: tasksTable.complete,

--- a/apps/web/src/server/tasks/functions.ts
+++ b/apps/web/src/server/tasks/functions.ts
@@ -2,6 +2,7 @@ import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
 import { z } from "zod";
 import { authenticated } from "../auth/policy";
+import { db } from "../db/pg";
 import { getTask as getTaskImpl, TaskNotFoundError } from "./data";
 
 const taskIdSchema = z.object({
@@ -25,7 +26,7 @@ export const getTask = createServerFn({ method: "GET" })
 	.validator(taskIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			return await getTaskImpl(data.taskId);
+			return await getTaskImpl(db, data.taskId);
 		} catch (err) {
 			rethrowAsHttp(err);
 		}


### PR DESCRIPTION
## Summary
- `groups/data.ts`, `messages/data.ts`, and `tasks/data.ts` imported the shared `db` singleton directly, so merely importing the module booted a database connection and made them untestable without Postgres.
- Pass `db: Db` as the first argument to each function instead — matching the injected-handle convention already used by `labels/data.ts` and `health/data.ts` — and update the `functions.ts` call sites accordingly.