### PR TITLE
fix: show tooltips above the dialogs they appear in

### DIFF
--- a/apps/web/src/app/style.css
+++ b/apps/web/src/app/style.css
@@ -11,6 +11,18 @@
 		"Inter Variable", sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
 	--color-virtool: #387e7d;
 	--color-virtool-dark: #2a5e5d;
+
+	/* Z-index scale. Portalled and fixed overlays share the root stacking
+	   context, so their order is decided here by named layer rather than
+	   ad-hoc per-component values that relied on DOM insertion order. Page
+	   content sits at the default 0. Dropdowns sit above dialog content so
+	   selects and menus opened inside a dialog stay visible. */
+	--z-overlay: 30; /* dialog backdrop */
+	--z-nav: 40; /* app header/nav — above the backdrop, below dialogs */
+	--z-dialog: 50; /* dialog content */
+	--z-dropdown: 60; /* dropdown menus, selects, comboboxes */
+	--z-popover: 70; /* tooltips and popovers — above dialog content */
+	--z-toast: 80; /* toasts and upload progress — topmost */
 }
 
 html {
@@ -19,6 +31,30 @@ html {
 
 @utility scrollbar-gutter-stable {
 	scrollbar-gutter: stable;
+}
+
+@utility z-overlay {
+	z-index: var(--z-overlay);
+}
+
+@utility z-nav {
+	z-index: var(--z-nav);
+}
+
+@utility z-dialog {
+	z-index: var(--z-dialog);
+}
+
+@utility z-dropdown {
+	z-index: var(--z-dropdown);
+}
+
+@utility z-popover {
+	z-index: var(--z-popover);
+}
+
+@utility z-toast {
+	z-index: var(--z-toast);
 }
 
 /* Shared column tracks for the samples list. Applied to every row and to the

--- a/apps/web/src/base/ComboBox.tsx
+++ b/apps/web/src/base/ComboBox.tsx
@@ -104,7 +104,7 @@ export default function ComboBox({
 			/>
 			<ul
 				className={cn(
-					"origin-top animate-comboBoxContentOpen top-full p-0 mt-0 absolute bg-white w-full max-h-80 overflow-y-auto overflow-x-hidden outline-0 transition-opacity duration-100 ease-in shadow-md border border-gray-300 rounded-md z-50",
+					"origin-top animate-comboBoxContentOpen top-full p-0 mt-0 absolute bg-white w-full max-h-80 overflow-y-auto overflow-x-hidden outline-0 transition-opacity duration-100 ease-in shadow-md border border-gray-300 rounded-md z-dropdown",
 					isOpen ? "block" : "hidden",
 				)}
 				{...getMenuProps()}

--- a/apps/web/src/base/Dialog.tsx
+++ b/apps/web/src/base/Dialog.tsx
@@ -25,7 +25,7 @@ export function DialogOverlay() {
 				"bg-gray-500/60",
 				"fixed",
 				"inset-0",
-				"z-40",
+				"z-overlay",
 			)}
 		/>
 	);
@@ -80,7 +80,7 @@ export function DialogContent({
 					"p-8",
 					"shadow-2xl",
 					"focus:outline-none",
-					"z-50",
+					"z-dialog",
 					"w-[600px]",
 					{ "w-[900px]": size === "lg" },
 					"max-w-[90vw]",

--- a/apps/web/src/base/DropdownMenuContent.tsx
+++ b/apps/web/src/base/DropdownMenuContent.tsx
@@ -32,7 +32,7 @@ export default function DropdownMenuContent({
 					"rounded-md",
 					"shadow-lg",
 					"text-sm",
-					"z-50",
+					"z-dropdown",
 					"data-[state=closed]:animate-dropdownMenuClose",
 					"data-[state=open]:animate-dropdownMenuOpen",
 					className,

--- a/apps/web/src/base/MultiSelectComboBox.tsx
+++ b/apps/web/src/base/MultiSelectComboBox.tsx
@@ -209,7 +209,7 @@ export default function MultiSelectComboBox<Item>({
 				<ul
 					className={cn(
 						"absolute",
-						"z-50",
+						"z-dropdown",
 						"w-full",
 						"mt-1",
 						"max-h-60",

--- a/apps/web/src/base/Popover.tsx
+++ b/apps/web/src/base/Popover.tsx
@@ -29,7 +29,7 @@ export default function Popover({
 						"shadow-lg",
 						"m-1.5",
 						"w-[320px]",
-						"z-10",
+						"z-popover",
 					)}
 					sideOffset={15}
 					align={align}

--- a/apps/web/src/base/SelectContent.tsx
+++ b/apps/web/src/base/SelectContent.tsx
@@ -11,7 +11,7 @@ export default function SelectContent({ children }: SelectContentProps) {
 	return (
 		<SelectPrimitive.Portal>
 			<SelectPrimitive.Content
-				className="origin-top bg-white rounded-md border border-gray-300 shadow-md overflow-hidden z-50 max-h-96 min-w-32 data-[state=open]:animate-contentShow"
+				className="origin-top bg-white rounded-md border border-gray-300 shadow-md overflow-hidden z-dropdown max-h-96 min-w-32 data-[state=open]:animate-contentShow"
 				data-slot="select-content"
 			>
 				<SelectPrimitive.ScrollUpButton className="my-1 flex justify-center hover:bg-gray-50">

--- a/apps/web/src/base/Toast.tsx
+++ b/apps/web/src/base/Toast.tsx
@@ -18,7 +18,7 @@ export function ToastViewport({ className }: ToastViewportProps) {
 	return (
 		<ToastPrimitive.Viewport
 			className={cn(
-				"fixed bottom-0 right-0 z-50",
+				"fixed bottom-0 right-0 z-toast",
 				"flex flex-col gap-2",
 				"m-0 p-6 w-full sm:max-w-md",
 				"list-none outline-none",

--- a/apps/web/src/base/Tooltip.tsx
+++ b/apps/web/src/base/Tooltip.tsx
@@ -18,7 +18,7 @@ export default function Tooltip({
 				<TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
 				<TooltipPrimitive.Portal>
 					<TooltipPrimitive.Content
-						className="rounded px-4 py-2 text-sm leading-none bg-black/80 text-white shadow-lg will-change-[transform,opacity] capitalize z-20 data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade"
+						className="rounded px-4 py-2 text-sm leading-none bg-black/80 text-white shadow-lg will-change-[transform,opacity] capitalize z-popover data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade"
 						side={position}
 						sideOffset={5}
 					>

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -99,7 +99,7 @@ function AuthenticatedLayout() {
 			<UpdateToast />
 
 			<div className="flex flex-col h-screen">
-				<div className="shrink-0 z-50">
+				<div className="shrink-0 z-nav">
 					<Banner />
 					<Nav
 						administrator_role={data.administrator_role}

--- a/apps/web/src/uploads/components/UploadOverlay.tsx
+++ b/apps/web/src/uploads/components/UploadOverlay.tsx
@@ -16,7 +16,7 @@ export default function UploadOverlay(): ReactElement | null {
 	}
 
 	return (
-		<div className={cn("fixed bottom-0 right-0 w-96 pr-4 pb-4 z-50")}>
+		<div className={cn("fixed bottom-0 right-0 w-96 pr-4 pb-4 z-toast")}>
 			<UploaderDialog remaining={remaining} speed={speed} uploads={uploads} />
 		</div>
 	);


### PR DESCRIPTION
## Summary
- Portalled and fixed overlays (dialog, dropdown, tooltip, popover, toast, nav) each independently claimed `z-50` (or `z-20`/`z-10`), so their stacking depended on DOM insertion order — a tooltip triggered inside a dialog rendered below the dialog overlay and was hidden.
- Introduce a named z-index scale in `style.css` (`overlay < nav < dialog < dropdown < popover < toast`) and swap every ad-hoc `z-*` utility for the matching layer name.
- Dropdowns/selects sit above dialog content (60 > 50) so they keep working inside dialogs; nav stacking is preserved, while toasts and the upload-progress overlay move to the top layer so a dialog can no longer occlude them.