### PR TITLE
chore: stop biome from scanning build output

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,7 +22,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "npx biome check --fix --unsafe . 2>/dev/null || true",
+						"command": "pnpm exec biome check --fix --unsafe apps/web/src packages 2>/dev/null || true",
 						"statusMessage": "Formatting with biome..."
 					}
 				]

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist-types
 *.tsbuildinfo
 .output
 .nitro
+.tanstack
 doc
 coverage
 /data

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,16 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
 	"files": {
-		"includes": ["**", "!**/routeTree.gen.ts", "!**/node_modules", "!**/dist"]
+		"includes": [
+			"**",
+			"!**/routeTree.gen.ts",
+			"!**/node_modules",
+			"!**/dist",
+			"!**/dist-types",
+			"!**/.output",
+			"!**/.nitro",
+			"!**/.tanstack"
+		]
 	},
 	"css": {
 		"parser": {

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,10 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
 	"files": {
 		"includes": [
 			"**",


### PR DESCRIPTION
## Summary

- The Stop hook scanned the repo root, walking `apps/web/.output` (28M) and `apps/web/.nitro` (14M) of minified bundles and source maps. Both are gitignored, but `biome.json` sets no `vcs.useIgnoreFile`, so Biome never consults `.gitignore` and descends into them. Biome 2.5.3 deadlocks on that output — every worker thread parks in `futex` with no IO in flight and the process never returns.
- These artifacts have been present since May; 2.4.16 handled them in seconds. The regression arrived with `aab070a5`, bumping `@biomejs/biome` 2.4.16 → 2.5.3. Measured on `apps/web/.nitro`: **2.4.16 exits in 3s, 2.5.3 never returns.**
- Scope the hook to the paths the `check` script already uses, exclude the build-output directories so a bare `biome check .` cannot wedge either, and switch `npx` → `pnpm exec` to match the repo's package manager. `pnpm check` stays green; the hook now runs in ~2s.