### PR TITLE
fix: keep file search results in sync with the search term

### DIFF
--- a/apps/web/src/uploads/queries.ts
+++ b/apps/web/src/uploads/queries.ts
@@ -43,7 +43,7 @@ export function useInfiniteFindFiles(
 	term?: string,
 ) {
 	return useInfiniteQuery<FileResponse>({
-		queryKey: fileQueryKeys.infiniteList([type, per_page]),
+		queryKey: fileQueryKeys.infiniteList([type, per_page, term]),
 		queryFn: ({ pageParam }) =>
 			findFiles(type, pageParam as number, per_page, term),
 		initialPageParam: 1,


### PR DESCRIPTION
## Summary

- `useInfiniteFindFiles` passed `term` to the request as the `find` query parameter but left it out of the React Query key, so searches for different terms shared a cache entry and served the previous term's pages without refetching.
- Adds `term` to the `infiniteList` key. `QueryKeyFilter` already permits `undefined`, so no signature change was needed.
- Latent today — none of the three call sites (`uploads/hooks.ts`, `CreateSample.tsx`, `SubtractionCreate.tsx`) passes `term`. The key gains a trailing `undefined` segment for them, retiring the current cache entries once and changing no behaviour.

Closes VIR-2707.