### PR TITLE
fix: stop job progress firing a request per running job

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -509,8 +509,15 @@ enforced on the refetch instead of in a fanout broadcast. Both
 Python and Node publish onto the Postgres `client_events` channel;
 `routes/events.ts` is the sole consumer.
 
+`jobs` update frames are the one exception: a running job emits one per
+progress wave and every job on screen holds its own `detail(id)` query,
+so invalidating per frame cost a request per running job. They route
+through `createJobRefreshQueue` (`jobs/refresh.ts`), which buffers ids
+and reads them with the batched `getJobs` server function instead. Don't
+add a `detail(id)` invalidation back for jobs.
+
 See [docs/server-push.md](docs/server-push.md) for the wire format,
-auth on the SSE side, and the follow-up TODOs.
+auth on the SSE side, the job-batching queue, and the follow-up TODOs.
 
 ## Projects
 

--- a/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
+++ b/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
@@ -48,10 +48,6 @@ describe("reactQueryHandler", () => {
 				queryKey: indexQueryKeys.lists(),
 			},
 			{
-				message: { domain: "jobs", operation: "update", id: 42 },
-				queryKey: jobQueryKeys.detail(42),
-			},
-			{
 				message: { domain: "jobs", operation: "insert", id: 42 },
 				queryKey: jobQueryKeys.lists(),
 			},
@@ -226,6 +222,24 @@ describe("reactQueryHandler", () => {
 		).toBe(true);
 		expect(
 			queryClient.getQueryState(userQueryKeys.detail(8))?.isInvalidated,
+		).toBe(false);
+	});
+
+	// Every on-screen job holds its own detail query, so invalidating the frame's
+	// detail is a request per running job per progress wave. These frames go to
+	// the batching queue instead — see `jobs/__tests__/refresh.test.ts`.
+	it("batches job updates rather than invalidating a detail per frame", () => {
+		queryClient.setQueryData(jobQueryKeys.detail(42), { id: 42 });
+
+		reactQueryHandler(queryClient)({
+			domain: "jobs",
+			operation: "update",
+			id: 42,
+		});
+
+		expect(invalidate).not.toHaveBeenCalled();
+		expect(
+			queryClient.getQueryState(jobQueryKeys.detail(42))?.isInvalidated,
 		).toBe(false);
 	});
 

--- a/apps/web/src/app/sse/reactQueryHandler.ts
+++ b/apps/web/src/app/sse/reactQueryHandler.ts
@@ -5,6 +5,7 @@ import { bannerQueryKeys } from "@banner/keys";
 import { groupQueryKeys } from "@groups/keys";
 import { indexQueryKeys } from "@indexes/keys";
 import { jobQueryKeys } from "@jobs/keys";
+import { createJobRefreshQueue } from "@jobs/refresh";
 import { labelQueryKeys } from "@labels/keys";
 import { referenceQueryKeys } from "@references/keys";
 import { samplesQueryKeys } from "@samples/keys";
@@ -64,11 +65,23 @@ function selectQueryKey(
 }
 
 export function reactQueryHandler(queryClient: QueryClient) {
+	const queueJobRefresh = createJobRefreshQueue(queryClient);
+
 	return (message: SseMessage) => {
 		const domain = domains[message.domain];
 		if (!domain) {
 			return;
 		}
+
+		// Jobs are the one domain where an update frame arrives per running job
+		// per progress wave, and every on-screen job holds its own detail query.
+		// Invalidating each one fans out to a request per row, so these frames go
+		// through a queue that batches the reads instead.
+		if (message.domain === "jobs" && message.operation === "update") {
+			queueJobRefresh(message.id);
+			return;
+		}
+
 		queryClient.invalidateQueries({
 			queryKey: selectQueryKey(domain, message.operation, message.id),
 		});

--- a/apps/web/src/jobs/__tests__/refresh.test.ts
+++ b/apps/web/src/jobs/__tests__/refresh.test.ts
@@ -1,9 +1,17 @@
 import { jobQueryKeys } from "@jobs/keys";
 import { createJobRefreshQueue } from "@jobs/refresh";
 import type { ServerJob } from "@jobs/types";
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import { jobServerFnMocks, mockGetJobs } from "@tests/server-fn/jobs";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type Mock,
+	vi,
+} from "vitest";
 
 const FLUSH_MS = 500;
 
@@ -26,22 +34,46 @@ function createJob(id: number, overrides?: Partial<ServerJob>): ServerJob {
 
 describe("createJobRefreshQueue", () => {
 	let queryClient: QueryClient;
+	let unsubscribes: (() => void)[];
+	let refetches: Map<number, Mock>;
 
 	beforeEach(() => {
 		vi.useFakeTimers();
 		queryClient = new QueryClient();
+		unsubscribes = [];
+		refetches = new Map();
 	});
 
 	afterEach(() => {
+		for (const unsubscribe of unsubscribes) {
+			unsubscribe();
+		}
 		vi.useRealTimers();
 	});
 
+	/**
+	 * Stand in for a rendered row's `useFetchJob`: seed the detail cache and hold
+	 * an active observer on it, pinned fresh the way a seeded call is. The queue
+	 * reads only jobs something is actually watching, so `setQueryData` alone
+	 * does not make a job on-screen.
+	 */
 	function watch(...ids: number[]): void {
 		for (const id of ids) {
 			queryClient.setQueryData(
 				jobQueryKeys.detail(id),
 				createJob(id, { progress: 0 }),
 			);
+
+			const queryFn = vi.fn(async () => createJob(id));
+			refetches.set(id, queryFn);
+
+			const observer = new QueryObserver(queryClient, {
+				queryKey: jobQueryKeys.detail(id),
+				queryFn,
+				staleTime: Number.POSITIVE_INFINITY,
+			});
+
+			unsubscribes.push(observer.subscribe(() => {}));
 		}
 	}
 
@@ -86,8 +118,23 @@ describe("createJobRefreshQueue", () => {
 	// The jobs list page renders its rows from the list query and mounts no
 	// detail queries, so this is what stops a frame per row becoming a read per
 	// row there.
-	it("does not read a job nothing has cached", async () => {
+	it("does not read a job nothing is watching", async () => {
 		mockGetJobs([createJob(1)]);
+
+		const queue = createJobRefreshQueue(queryClient);
+		queue(1);
+
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		expect(jobServerFnMocks.getJobs).not.toHaveBeenCalled();
+	});
+
+	// React Query holds a detail's data for the whole gcTime after its row
+	// unmounts. Reading those would be a fan-out per wave that the invalidation
+	// this replaced never had, since it only ever refetched active queries.
+	it("does not read a job whose detail is cached but unmounted", async () => {
+		mockGetJobs([createJob(1)]);
+		queryClient.setQueryData(jobQueryKeys.detail(1), createJob(1));
 
 		const queue = createJobRefreshQueue(queryClient);
 		queue(1);
@@ -129,7 +176,7 @@ describe("createJobRefreshQueue", () => {
 		).toEqual([100, 50]);
 	});
 
-	it("falls back to per-job invalidation when the batch fails", async () => {
+	it("falls back to refetching each job when the batch fails", async () => {
 		jobServerFnMocks.getJobs.mockRejectedValue(new Error("boom"));
 		watch(1, 2);
 
@@ -140,10 +187,44 @@ describe("createJobRefreshQueue", () => {
 		await vi.advanceTimersByTimeAsync(FLUSH_MS);
 
 		for (const id of [1, 2]) {
-			expect(
-				queryClient.getQueryState(jobQueryKeys.detail(id))?.isInvalidated,
-			).toBe(true);
+			expect(refetches.get(id)).toHaveBeenCalled();
 		}
+	});
+
+	// Two batches in flight at once can resolve out of order, and the loser
+	// would write a stale snapshot over a newer one — dragging a progress bar
+	// backwards, or reviving a finished job.
+	it("holds a later wave until the batch in flight resolves", async () => {
+		watch(1);
+
+		let resolveFirst: (jobs: ServerJob[]) => void = () => undefined;
+		jobServerFnMocks.getJobs
+			.mockImplementationOnce(
+				() =>
+					new Promise<ServerJob[]>((resolve) => {
+						resolveFirst = resolve;
+					}),
+			)
+			.mockResolvedValueOnce([createJob(1, { progress: 90 })]);
+
+		const queue = createJobRefreshQueue(queryClient);
+
+		queue(1);
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+		expect(jobServerFnMocks.getJobs).toHaveBeenCalledTimes(1);
+
+		queue(1);
+		await vi.advanceTimersByTimeAsync(FLUSH_MS * 3);
+
+		expect(jobServerFnMocks.getJobs).toHaveBeenCalledTimes(1);
+
+		resolveFirst([createJob(1, { progress: 10 })]);
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(jobServerFnMocks.getJobs).toHaveBeenCalledTimes(2);
+		expect(queryClient.getQueryData(jobQueryKeys.detail(1))).toMatchObject({
+			progress: 90,
+		});
 	});
 
 	it("opens a new window for frames arriving after a flush", async () => {

--- a/apps/web/src/jobs/__tests__/refresh.test.ts
+++ b/apps/web/src/jobs/__tests__/refresh.test.ts
@@ -1,0 +1,182 @@
+import { jobQueryKeys } from "@jobs/keys";
+import { createJobRefreshQueue } from "@jobs/refresh";
+import type { ServerJob } from "@jobs/types";
+import { QueryClient } from "@tanstack/react-query";
+import { jobServerFnMocks, mockGetJobs } from "@tests/server-fn/jobs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const FLUSH_MS = 500;
+
+function createJob(id: number, overrides?: Partial<ServerJob>): ServerJob {
+	return {
+		args: {},
+		id,
+		claim: null,
+		claimed_at: null,
+		created_at: "2022-12-22T21:37:49.429000Z",
+		finished_at: null,
+		progress: 50,
+		state: "running",
+		steps: null,
+		user: { id: 7, handle: "bob" },
+		workflow: "pathoscope",
+		...overrides,
+	};
+}
+
+describe("createJobRefreshQueue", () => {
+	let queryClient: QueryClient;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		queryClient = new QueryClient();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	function watch(...ids: number[]): void {
+		for (const id of ids) {
+			queryClient.setQueryData(
+				jobQueryKeys.detail(id),
+				createJob(id, { progress: 0 }),
+			);
+		}
+	}
+
+	it("collapses a wave of frames into a single batched read", async () => {
+		mockGetJobs([createJob(1), createJob(2), createJob(3)]);
+		watch(1, 2, 3);
+
+		const queue = createJobRefreshQueue(queryClient);
+		queue(1);
+		queue(2);
+		queue(3);
+		queue(1);
+
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		expect(jobServerFnMocks.getJobs).toHaveBeenCalledExactlyOnceWith({
+			data: { jobIds: [1, 2, 3] },
+		});
+	});
+
+	it("writes each fetched job into its own detail cache", async () => {
+		mockGetJobs([
+			createJob(1, { progress: 75 }),
+			createJob(2, { progress: 90 }),
+		]);
+		watch(1, 2);
+
+		const queue = createJobRefreshQueue(queryClient);
+		queue(1);
+		queue(2);
+
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		expect(queryClient.getQueryData(jobQueryKeys.detail(1))).toMatchObject({
+			progress: 75,
+		});
+		expect(queryClient.getQueryData(jobQueryKeys.detail(2))).toMatchObject({
+			progress: 90,
+		});
+	});
+
+	// The jobs list page renders its rows from the list query and mounts no
+	// detail queries, so this is what stops a frame per row becoming a read per
+	// row there.
+	it("does not read a job nothing has cached", async () => {
+		mockGetJobs([createJob(1)]);
+
+		const queue = createJobRefreshQueue(queryClient);
+		queue(1);
+
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		expect(jobServerFnMocks.getJobs).not.toHaveBeenCalled();
+	});
+
+	it("marks a cached jobs list stale so its counts and ordering catch up", async () => {
+		const listKey = jobQueryKeys.list([1, 25]);
+		queryClient.setQueryData(listKey, { items: [] });
+
+		const queue = createJobRefreshQueue(queryClient);
+		queue(1);
+
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		expect(queryClient.getQueryState(listKey)?.isInvalidated).toBe(true);
+	});
+
+	it("splits a wave larger than the request cap", async () => {
+		const ids = Array.from({ length: 150 }, (_, index) => index + 1);
+		mockGetJobs(ids.map((id) => createJob(id)));
+		watch(...ids);
+
+		const queue = createJobRefreshQueue(queryClient);
+		for (const id of ids) {
+			queue(id);
+		}
+
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		expect(jobServerFnMocks.getJobs).toHaveBeenCalledTimes(2);
+		expect(
+			jobServerFnMocks.getJobs.mock.calls.map(
+				([{ data }]) => data.jobIds.length,
+			),
+		).toEqual([100, 50]);
+	});
+
+	it("falls back to per-job invalidation when the batch fails", async () => {
+		jobServerFnMocks.getJobs.mockRejectedValue(new Error("boom"));
+		watch(1, 2);
+
+		const queue = createJobRefreshQueue(queryClient);
+		queue(1);
+		queue(2);
+
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		for (const id of [1, 2]) {
+			expect(
+				queryClient.getQueryState(jobQueryKeys.detail(id))?.isInvalidated,
+			).toBe(true);
+		}
+	});
+
+	it("opens a new window for frames arriving after a flush", async () => {
+		mockGetJobs([createJob(1), createJob(2)]);
+		watch(1, 2);
+
+		const queue = createJobRefreshQueue(queryClient);
+
+		queue(1);
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		queue(2);
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		expect(jobServerFnMocks.getJobs).toHaveBeenCalledTimes(2);
+		expect(jobServerFnMocks.getJobs).toHaveBeenNthCalledWith(2, {
+			data: { jobIds: [2] },
+		});
+	});
+
+	it("holds frames arriving inside an open window in the same batch", async () => {
+		mockGetJobs([createJob(1), createJob(2)]);
+		watch(1, 2);
+
+		const queue = createJobRefreshQueue(queryClient);
+
+		queue(1);
+		await vi.advanceTimersByTimeAsync(FLUSH_MS / 2);
+		queue(2);
+		await vi.advanceTimersByTimeAsync(FLUSH_MS / 2);
+
+		expect(jobServerFnMocks.getJobs).toHaveBeenCalledExactlyOnceWith({
+			data: { jobIds: [1, 2] },
+		});
+	});
+});

--- a/apps/web/src/jobs/refresh.ts
+++ b/apps/web/src/jobs/refresh.ts
@@ -1,0 +1,105 @@
+import { jobQueryKeys } from "@jobs/keys";
+import * as Sentry from "@sentry/tanstackstart-react";
+import { getJobs } from "@server/jobs/functions";
+import type { QueryClient } from "@tanstack/react-query";
+
+/**
+ * How long to collect job ids before fetching them.
+ *
+ * A running job emits a frame per step transition, and a page shows one job per
+ * row, so frames arrive in waves. Anything long enough to catch a wave collapses
+ * it into one request; 500 ms is well under the interval a progress bar is read
+ * at.
+ */
+const FLUSH_MS = 500;
+
+/** Ids per request, matching the cap `getJobs` validates. */
+const BATCH_SIZE = 100;
+
+function chunk(ids: number[], size: number): number[][] {
+	const chunks: number[][] = [];
+
+	for (let i = 0; i < ids.length; i += size) {
+		chunks.push(ids.slice(i, i + size));
+	}
+
+	return chunks;
+}
+
+/**
+ * Build a queue that coalesces `jobs` update frames into batched refreshes.
+ *
+ * Every on-screen job mounts its own `detail(id)` query, so invalidating each
+ * frame's detail fires one request per running job per progress wave. The queue
+ * collects the ids instead and reads them in a single `getJobs` call, writing
+ * each result straight into its detail cache.
+ *
+ * The queue holds its own buffer, so callers get one per `QueryClient`.
+ */
+export function createJobRefreshQueue(
+	queryClient: QueryClient,
+): (jobId: number) => void {
+	const pending = new Set<number>();
+	let windowOpen = false;
+
+	async function refreshBatch(jobIds: number[]): Promise<void> {
+		try {
+			const jobs = await getJobs({ data: { jobIds } });
+
+			for (const job of jobs) {
+				queryClient.setQueryData(jobQueryKeys.detail(job.id), job);
+			}
+		} catch (error) {
+			Sentry.captureException(error, { tags: { sse: "job-refresh" } });
+
+			// Fall back to the per-job refetch this batch replaced. It costs the
+			// fan-out again, but a failed batch leaving every progress bar frozen
+			// is worse than a slow window.
+			for (const jobId of jobIds) {
+				queryClient.invalidateQueries({ queryKey: jobQueryKeys.detail(jobId) });
+			}
+		}
+	}
+
+	async function flush(): Promise<void> {
+		windowOpen = false;
+
+		const ids = [...pending];
+		pending.clear();
+
+		// Counts, ordering, and state filters drift as jobs progress, and no
+		// amount of detail refetching fixes them. One invalidation per window
+		// covers every mounted jobs list, and is a no-op on the pages — samples,
+		// analyses, subtractions — that cache no jobs list at all.
+		queryClient.invalidateQueries({ queryKey: jobQueryKeys.lists() });
+
+		// A frame for a job nothing has cached has nothing to update. This is what
+		// keeps the jobs list page, whose rows render from the list query, from
+		// fetching a detail per row.
+		const watched = ids.filter(
+			(id) => queryClient.getQueryData(jobQueryKeys.detail(id)) !== undefined,
+		);
+
+		if (watched.length === 0) {
+			return;
+		}
+
+		await Promise.all(chunk(watched, BATCH_SIZE).map(refreshBatch));
+	}
+
+	return function queueJobRefresh(jobId: number): void {
+		pending.add(jobId);
+
+		// The window is never cancelled, only allowed to elapse, so the timer
+		// handle is not worth keeping — whether one is pending is the whole state.
+		if (windowOpen) {
+			return;
+		}
+
+		windowOpen = true;
+
+		setTimeout(() => {
+			void flush();
+		}, FLUSH_MS);
+	};
+}

--- a/apps/web/src/jobs/refresh.ts
+++ b/apps/web/src/jobs/refresh.ts
@@ -41,6 +41,7 @@ export function createJobRefreshQueue(
 ): (jobId: number) => void {
 	const pending = new Set<number>();
 	let windowOpen = false;
+	let draining = false;
 
 	async function refreshBatch(jobIds: number[]): Promise<void> {
 		try {
@@ -61,23 +62,25 @@ export function createJobRefreshQueue(
 		}
 	}
 
-	async function flush(): Promise<void> {
-		windowOpen = false;
-
-		const ids = [...pending];
-		pending.clear();
-
+	async function refresh(ids: number[]): Promise<void> {
 		// Counts, ordering, and state filters drift as jobs progress, and no
-		// amount of detail refetching fixes them. One invalidation per window
+		// amount of detail refetching fixes them. One invalidation per wave
 		// covers every mounted jobs list, and is a no-op on the pages — samples,
 		// analyses, subtractions — that cache no jobs list at all.
 		queryClient.invalidateQueries({ queryKey: jobQueryKeys.lists() });
 
-		// A frame for a job nothing has cached has nothing to update. This is what
-		// keeps the jobs list page, whose rows render from the list query, from
-		// fetching a detail per row.
+		// Only a mounted detail has anyone to show the result to. Cached-but-
+		// unmounted details would otherwise keep getting read for the whole
+		// gcTime after navigating off a job-heavy page — `invalidateQueries`
+		// defaults to `refetchType: "active"` and never refetched those, so
+		// reading them here would be a fan-out the old path did not have. It is
+		// also what keeps the jobs list page, whose rows render from the list
+		// query and mount no details, from reading one job per row.
+		const cache = queryClient.getQueryCache();
 		const watched = ids.filter(
-			(id) => queryClient.getQueryData(jobQueryKeys.detail(id)) !== undefined,
+			(id) =>
+				cache.find({ queryKey: jobQueryKeys.detail(id), type: "active" }) !==
+				undefined,
 		);
 
 		if (watched.length === 0) {
@@ -87,19 +90,45 @@ export function createJobRefreshQueue(
 		await Promise.all(chunk(watched, BATCH_SIZE).map(refreshBatch));
 	}
 
+	/**
+	 * Run waves one at a time until the buffer is empty.
+	 *
+	 * Batches must not overlap. Two in flight at once can resolve out of order,
+	 * and the loser's `setQueryData` would write a stale snapshot over a newer
+	 * one — dragging a progress bar backwards, or reviving a job that has already
+	 * finished. Serializing also means a slow server widens the window on its
+	 * own: everything that arrives during a batch coalesces into the next one.
+	 */
+	async function drain(): Promise<void> {
+		draining = true;
+
+		try {
+			while (pending.size > 0) {
+				const ids = [...pending];
+				pending.clear();
+
+				await refresh(ids);
+			}
+		} finally {
+			draining = false;
+		}
+	}
+
 	return function queueJobRefresh(jobId: number): void {
 		pending.add(jobId);
 
-		// The window is never cancelled, only allowed to elapse, so the timer
-		// handle is not worth keeping — whether one is pending is the whole state.
-		if (windowOpen) {
+		// A drain in flight takes these ids on its next pass, and an open window
+		// will take them when it elapses. The window is never cancelled, only
+		// allowed to elapse, so its timer handle is not worth keeping.
+		if (windowOpen || draining) {
 			return;
 		}
 
 		windowOpen = true;
 
 		setTimeout(() => {
-			void flush();
+			windowOpen = false;
+			void drain();
 		}, FLUSH_MS);
 	};
 }

--- a/apps/web/src/server/jobs/data.test.ts
+++ b/apps/web/src/server/jobs/data.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { seedUser } from "../auth/test/fixtures";
+import type { Db } from "../db/pg";
+import { jobs } from "../db/schema/jobs";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { getJob, getJobs, JobNotFoundError } from "./data";
+
+let database: TestDatabase;
+let db: Db;
+let userId: number;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(jobs);
+	await db.delete(users);
+
+	userId = await seedUser(db, { handle: "bob" });
+});
+
+async function seedJob(state: string, steps: { started: number; of: number }) {
+	const [job] = await db
+		.insert(jobs)
+		.values({
+			created_at: new Date(),
+			state,
+			steps: Array.from({ length: steps.of }, (_, index) => ({
+				description: `step ${index}`,
+				id: `step-${index}`,
+				name: `step-${index}`,
+				started_at: index < steps.started ? new Date().toISOString() : null,
+			})),
+			user_id: userId,
+			workflow: "pathoscope",
+		})
+		.returning({ id: jobs.id });
+
+	if (!job) {
+		throw new Error("failed to seed job");
+	}
+
+	return job.id;
+}
+
+describe("getJobs", () => {
+	it("reads every requested job in one call", async () => {
+		const first = await seedJob("running", { started: 1, of: 4 });
+		const second = await seedJob("running", { started: 3, of: 4 });
+
+		const result = await getJobs(db, [first, second]);
+
+		expect(
+			result.map(({ id, progress }) => ({ id, progress })).sort(byId),
+		).toEqual([
+			{ id: first, progress: 25 },
+			{ id: second, progress: 75 },
+		]);
+	});
+
+	// A batch is best-effort: one job deleted between the frame and the read
+	// must not cost the caller the rest of the wave.
+	it("omits ids that match no job rather than failing the batch", async () => {
+		const jobId = await seedJob("running", { started: 2, of: 4 });
+
+		const result = await getJobs(db, [jobId, jobId + 5000]);
+
+		expect(result.map(({ id }) => id)).toEqual([jobId]);
+	});
+
+	it("returns nothing for an empty id list without touching the database", async () => {
+		await expect(getJobs(db, [])).resolves.toEqual([]);
+	});
+});
+
+describe("getJob", () => {
+	it("returns the job", async () => {
+		const jobId = await seedJob("succeeded", { started: 0, of: 2 });
+
+		await expect(getJob(db, jobId)).resolves.toMatchObject({
+			id: jobId,
+			progress: 100,
+			state: "succeeded",
+			user: { id: userId, handle: "bob" },
+			workflow: "pathoscope",
+		});
+	});
+
+	it("throws JobNotFoundError when the job is absent", async () => {
+		await expect(getJob(db, 404_404)).rejects.toThrow(JobNotFoundError);
+	});
+});
+
+function byId(a: { id: number }, b: { id: number }) {
+	return a.id - b.id;
+}

--- a/apps/web/src/server/jobs/data.ts
+++ b/apps/web/src/server/jobs/data.ts
@@ -172,36 +172,11 @@ export async function findJobs(
 	};
 }
 
-export async function getJob(db: Db, jobId: number): Promise<Job> {
-	const [row] = await db
-		.select({
-			id: jobs.id,
-			claim: jobs.claim,
-			claimed_at: jobs.claimed_at,
-			created_at: jobs.created_at,
-			finished_at: jobs.finished_at,
-			state: jobs.state,
-			steps: jobs.steps,
-			workflow: jobs.workflow,
-			userId: users.id,
-			handle: users.handle,
-			sample_id: jobSamples.sample_id,
-			index_id: jobIndexes.index_id,
-			subtraction_id: subtractions.id,
-			analysis_id: analyses.legacy_id,
-		})
-		.from(jobs)
-		.innerJoin(users, eq(jobs.user_id, users.id))
-		.leftJoin(jobSamples, eq(jobs.id, jobSamples.job_id))
-		.leftJoin(jobIndexes, eq(jobs.id, jobIndexes.job_id))
-		.leftJoin(subtractions, eq(jobs.id, subtractions.job_id))
-		.leftJoin(analyses, eq(jobs.id, analyses.job_id))
-		.where(eq(jobs.id, jobId));
+type JobRowWithResources = Awaited<
+	ReturnType<typeof selectJobsWithResources>
+>[number];
 
-	if (!row) {
-		throw new JobNotFoundError();
-	}
-
+function toJob(row: JobRowWithResources): Job {
 	// `args` is reconstructed from the related resources — the legacy Mongo
 	// `args` field is not stored as a column. Samples and indexes come from the
 	// `job_*` junction tables; the subtraction and analysis are found on the
@@ -233,4 +208,69 @@ export async function getJob(db: Db, jobId: number): Promise<Job> {
 		user: { id: row.userId, handle: row.handle },
 		workflow: row.workflow,
 	};
+}
+
+function selectJobsWithResources(db: Db) {
+	return db
+		.select({
+			id: jobs.id,
+			claim: jobs.claim,
+			claimed_at: jobs.claimed_at,
+			created_at: jobs.created_at,
+			finished_at: jobs.finished_at,
+			state: jobs.state,
+			steps: jobs.steps,
+			workflow: jobs.workflow,
+			userId: users.id,
+			handle: users.handle,
+			sample_id: jobSamples.sample_id,
+			index_id: jobIndexes.index_id,
+			subtraction_id: subtractions.id,
+			analysis_id: analyses.legacy_id,
+		})
+		.from(jobs)
+		.innerJoin(users, eq(jobs.user_id, users.id))
+		.leftJoin(jobSamples, eq(jobs.id, jobSamples.job_id))
+		.leftJoin(jobIndexes, eq(jobs.id, jobIndexes.job_id))
+		.leftJoin(subtractions, eq(jobs.id, subtractions.job_id))
+		.leftJoin(analyses, eq(jobs.id, analyses.job_id));
+}
+
+/**
+ * Read several jobs by id in one query.
+ *
+ * Ids that match no job are simply absent from the result — a batch is a
+ * best-effort read, so one deleted job does not fail the rest. Order is not
+ * guaranteed; callers key off `id`.
+ */
+export async function getJobs(db: Db, jobIds: number[]): Promise<Job[]> {
+	if (jobIds.length === 0) {
+		return [];
+	}
+
+	const rows = await selectJobsWithResources(db).where(
+		inArray(jobs.id, jobIds),
+	);
+
+	// The resource joins are left joins on tables that hold at most one row per
+	// job, but nothing in this read-only mirror constrains that, so collapse to
+	// the first row per id rather than emitting a job twice.
+	const byId = new Map<number, JobRowWithResources>();
+	for (const row of rows) {
+		if (!byId.has(row.id)) {
+			byId.set(row.id, row);
+		}
+	}
+
+	return [...byId.values()].map(toJob);
+}
+
+export async function getJob(db: Db, jobId: number): Promise<Job> {
+	const [job] = await getJobs(db, [jobId]);
+
+	if (!job) {
+		throw new JobNotFoundError();
+	}
+
+	return job;
 }

--- a/apps/web/src/server/jobs/functions.ts
+++ b/apps/web/src/server/jobs/functions.ts
@@ -6,6 +6,7 @@ import { db } from "../db/pg";
 import {
 	findJobs as findJobsImpl,
 	getJob as getJobImpl,
+	getJobs as getJobsImpl,
 	JOB_STATES,
 	JobNotFoundError,
 } from "./data";
@@ -20,6 +21,13 @@ const findJobsSchema = z.object({
 
 const jobIdSchema = z.object({
 	jobId: z.number().int().positive(),
+});
+
+// Capped at the same 100 as a `findJobs` page: the batch exists to collapse one
+// refetch per on-screen job into one request, and no view shows more than a
+// page of them at once.
+const jobIdsSchema = z.object({
+	jobIds: z.array(z.number().int().positive()).min(1).max(100),
 });
 
 // Wrapped in createServerOnlyFn so the compiler can strip this body — and the
@@ -38,6 +46,11 @@ export const findJobs = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(findJobsSchema)
 	.handler(async ({ data }) => findJobsImpl(db, data));
+
+export const getJobs = createServerFn({ method: "GET" })
+	.middleware([authenticated()])
+	.validator(jobIdsSchema)
+	.handler(async ({ data }) => getJobsImpl(db, data.jobIds));
 
 export const getJob = createServerFn({ method: "GET" })
 	.middleware([authenticated()])

--- a/apps/web/src/tests/server-fn/jobs.ts
+++ b/apps/web/src/tests/server-fn/jobs.ts
@@ -9,6 +9,7 @@ import { type Mock, vi } from "vitest";
 export const jobServerFnMocks = {
 	findJobs: vi.fn(),
 	getJob: vi.fn(),
+	getJobs: vi.fn(),
 };
 
 /** Sets up findJobs to resolve with a single page containing the given jobs. */
@@ -26,6 +27,20 @@ export function mockFindJobs(
 		total_count: jobs.length,
 	});
 	return jobServerFnMocks.findJobs;
+}
+
+/**
+ * Sets up getJobs to resolve with whichever of the given jobs were asked for.
+ *
+ * Mirrors the real batch read: ids that match nothing are simply absent from
+ * the result rather than an error.
+ */
+export function mockGetJobs(jobs: ServerJob[]): Mock {
+	jobServerFnMocks.getJobs.mockImplementation(
+		async ({ data }: { data: { jobIds: number[] } }) =>
+			jobs.filter((job) => data.jobIds.includes(job.id)),
+	);
+	return jobServerFnMocks.getJobs;
 }
 
 /** Sets up getJob to resolve with the given job when matched by id. */

--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -160,6 +160,38 @@ application's own doing.
   `detail(id)`, `insert` and `delete` invalidate `lists()`. Factories
   that lack a method fall back to `all()`. Unknown domains are
   ignored.
+- `jobs/refresh.ts` is the one exception to that mapping. See below.
+
+## Job updates are batched, not invalidated
+
+Jobs are the only domain that emits an update frame per running job per
+progress wave, and every job on screen holds its own `detail(id)` query
+(see the nested-job sites below). Invalidating each frame's detail
+therefore cost one `getJob` request per running job per tick — 25 rows,
+25 requests.
+
+So `jobs`/`update` frames do not go through `selectQueryKey`. They go to
+a queue built by `createJobRefreshQueue` (`jobs/refresh.ts`), one per
+`QueryClient`, which:
+
+1. Buffers job ids for 500 ms, deduplicating them.
+2. Invalidates `jobQueryKeys.lists()` once per window. Progress moves a
+   job between states, so a jobs list's counts, ordering, and filters
+   drift no matter how many details are refreshed. This is a no-op on
+   pages that cache no jobs list.
+3. Drops ids nothing has cached under `detail(id)`, then reads the rest
+   through the `getJobs` server function — one request per window,
+   chunked at the 100-id cap `getJobs` validates. This is what keeps the
+   jobs list page, whose rows render from the list query, from fetching
+   a detail per row.
+4. Writes each result straight into its `detail(id)` cache. `getJobs`
+   returns the full `Job`, the same shape `getJob` returns, so
+   `detail(id)` stays one canonical shape and `JobDetail` — which
+   renders `args` and `steps` — reads the same entry as a sample row
+   rendering only `progress`.
+
+A failed batch falls back to invalidating each id's detail, taking the
+fan-out it was avoiding rather than leaving every progress bar frozen.
 
 ## Follow-ups
 
@@ -172,16 +204,17 @@ application's own doing.
   indexed session lookup per connected client per tick. If either
   becomes a problem, publish revocations onto `client_events` and let
   the route close the matching streams on the event instead.
-- **Dedicated nested-job fetch (Approach B).** Job-nested sites
+- **Nested-job over-fetch (Approach B).** Job-nested sites
   (`sample.job`, `index.job`, `analysis.job`, `subtraction.job`) keep
   their live `progress`/`state` fresh by mounting `useFetchJob(id)`
-  seeded with the nested object, so a `jobs` update frame invalidates
-  `jobQueryKeys.detail(id)` and refetches. That refetch hits
-  `/jobs/:id`, which returns the full `Job` (args, claim, steps) —
-  far more than the nested view needs. Add a lightweight server
-  function (or `?view=nested` param) that returns just the
-  `JobNested` shape, and point `useFetchJob`'s seeded callers at it to
-  drop the over-fetch.
+  seeded with the nested object, so a `jobs` update frame refreshes
+  `jobQueryKeys.detail(id)`. The round-trip fan-out that used to cost is
+  gone — see "Job updates are batched" above — but the payload is
+  unchanged: `getJobs` returns the full `Job` (args, claim, steps) for
+  every row, where a nested view renders two fields. Trimming it means
+  a second cache shape for `detail(id)`, which `JobDetail` also reads,
+  so it needs its own key rather than a narrower read. Not worth it
+  until a batch's size, rather than its count, shows up in metrics.
 - **`hmm` has no push domain.** Task-nested sites
   (`references/components/ReferenceItem.tsx`,
   `references/components/Detail/Remote.tsx`,

--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -175,15 +175,15 @@ a queue built by `createJobRefreshQueue` (`jobs/refresh.ts`), one per
 `QueryClient`, which:
 
 1. Buffers job ids for 500 ms, deduplicating them.
-2. Invalidates `jobQueryKeys.lists()` once per window. Progress moves a
+2. Invalidates `jobQueryKeys.lists()` once per wave. Progress moves a
    job between states, so a jobs list's counts, ordering, and filters
    drift no matter how many details are refreshed. This is a no-op on
    pages that cache no jobs list.
-3. Drops ids nothing has cached under `detail(id)`, then reads the rest
-   through the `getJobs` server function — one request per window,
-   chunked at the 100-id cap `getJobs` validates. This is what keeps the
-   jobs list page, whose rows render from the list query, from fetching
-   a detail per row.
+3. Drops ids whose `detail(id)` has no **active** observer, then reads
+   the rest through the `getJobs` server function — one request per
+   wave, chunked at the 100-id cap `getJobs` validates. This is what
+   keeps the jobs list page, whose rows render from the list query, from
+   fetching a detail per row.
 4. Writes each result straight into its `detail(id)` cache. `getJobs`
    returns the full `Job`, the same shape `getJob` returns, so
    `detail(id)` stays one canonical shape and `JobDetail` — which
@@ -192,6 +192,26 @@ a queue built by `createJobRefreshQueue` (`jobs/refresh.ts`), one per
 
 A failed batch falls back to invalidating each id's detail, taking the
 fan-out it was avoiding rather than leaving every progress bar frozen.
+
+Two properties of that queue are load-bearing, and both are easy to
+undo by accident:
+
+- **Active observers, not cached data.** Filtering on
+  `getQueryData(...) !== undefined` looks equivalent and is not.
+  React Query keeps a detail's data for the whole `gcTime` after its row
+  unmounts, and `invalidateQueries` defaults to `refetchType: "active"`
+  — so the invalidation this replaced never refetched those. Reading
+  them here would mean a batch per wave for minutes after navigating off
+  a job-heavy page: a fan-out the old path did not have.
+- **Batches never overlap.** `drain()` runs waves one at a time. Two
+  reads in flight at once can resolve out of order, and the loser's
+  `setQueryData` writes a stale snapshot over a newer one — dragging a
+  progress bar backwards, or reviving a job that has already finished.
+  Per-frame `invalidateQueries` had no such hazard, because React Query
+  resolves races within a query key itself; batching moves that
+  responsibility here. Serializing also lets a slow server widen the
+  window on its own, since everything arriving during a batch coalesces
+  into the next.
 
 ## Follow-ups
 


### PR DESCRIPTION
## Summary

- A running job emits an SSE update frame per progress wave, and every job on screen holds its own `detail(id)` query, so invalidating per frame cost one `GET /jobs/{id}` per running job per tick — 25 rows, 25 requests. Only details were invalidated, so a jobs list's counts and ordering drifted while its rows updated underneath it.
- Route `jobs` update frames through a queue that buffers ids for 500ms, drops the ones nothing has cached, and reads the rest through a new batched `getJobs` server function — one request per wave regardless of how many jobs are on screen. Flushing also invalidates the jobs list once, which is a no-op on pages that cache no jobs list.
- `getJobs` returns the full `Job`, as `getJob` does, so `detail(id)` stays one canonical shape. A failed batch falls back to per-job invalidation, taking the fan-out it was avoiding rather than freezing every progress bar.

Closes VIR-2709