### PR TITLE
test: cover the query client's retry and auth-error handling

### DIFF
--- a/apps/web/src/app/__tests__/queryErrors.test.ts
+++ b/apps/web/src/app/__tests__/queryErrors.test.ts
@@ -1,0 +1,94 @@
+import {
+	handleAuthenticationError,
+	type QueryError,
+	shouldRetryQuery,
+} from "@app/queryErrors";
+import {
+	FORBIDDEN_ERROR_NAME,
+	UNAUTHORIZED_ERROR_NAME,
+} from "@virtool/contracts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { endSession } = vi.hoisted(() => ({ endSession: vi.fn() }));
+
+vi.mock("@app/session", () => ({
+	armSessionEnd: vi.fn(),
+	endSession,
+}));
+
+// The auth errors arrive rebuilt by `authErrorSerializationAdapter`, which
+// carries `name` but nothing else — so a plain Error with the name set is
+// exactly what these functions see in production.
+function serializedAuthError(name: string, message: string): Error {
+	const error = new Error(message);
+	error.name = name;
+	return error;
+}
+
+function superagentError(status: number): QueryError {
+	return Object.assign(new Error(`Request failed: ${status}`), {
+		response: { status },
+	});
+}
+
+describe("shouldRetryQuery", () => {
+	it.each([
+		401, 403, 404,
+	])("gives up immediately on a %i from the Python API", (status) => {
+		expect(shouldRetryQuery(0, superagentError(status))).toBe(false);
+	});
+
+	it("retries a Python API failure that may yet succeed", () => {
+		expect(shouldRetryQuery(0, superagentError(500))).toBe(true);
+	});
+
+	it.each([
+		UNAUTHORIZED_ERROR_NAME,
+		FORBIDDEN_ERROR_NAME,
+	])("gives up immediately on a server function's %s", (name) => {
+		expect(shouldRetryQuery(0, serializedAuthError(name, name))).toBe(false);
+	});
+
+	it("keeps retrying an auth error whose name was lost in serialization", () => {
+		// Guards the adapter's whole reason for existing: without `name`, an
+		// UnauthorizedError is indistinguishable from a transient failure and is
+		// retried ~4× over ~15s before the user reaches the login wall. See
+		// VIR-2783 for the end-to-end coverage this cannot provide.
+		expect(shouldRetryQuery(0, new Error("Unauthorized"))).toBe(true);
+	});
+
+	it("retries an unrecognized failure a bounded number of times", () => {
+		const error = new Error("network down");
+
+		expect(shouldRetryQuery(3, error)).toBe(true);
+		expect(shouldRetryQuery(4, error)).toBe(false);
+	});
+});
+
+describe("handleAuthenticationError", () => {
+	afterEach(() => {
+		endSession.mockClear();
+	});
+
+	it("ends the session when a server function rejects the session", () => {
+		handleAuthenticationError(
+			serializedAuthError(UNAUTHORIZED_ERROR_NAME, "Unauthorized"),
+		);
+
+		expect(endSession).toHaveBeenCalledTimes(1);
+	});
+
+	it("leaves the session alone when the user merely lacks the role", () => {
+		handleAuthenticationError(
+			serializedAuthError(FORBIDDEN_ERROR_NAME, "Forbidden"),
+		);
+
+		expect(endSession).not.toHaveBeenCalled();
+	});
+
+	it("leaves the session alone when a query fails for any other reason", () => {
+		handleAuthenticationError(new Error("network down"));
+
+		expect(endSession).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/app/queryErrors.ts
+++ b/apps/web/src/app/queryErrors.ts
@@ -7,6 +7,8 @@ import {
 /** A failed query's error, carrying an HTTP status when superagent raised it. */
 export type QueryError = Error & { response?: { status?: number } };
 
+const NON_RETRYABLE_STATUSES = new Set([401, 403, 404]);
+
 /**
  * End the session when a query fails because the session is gone.
  *
@@ -32,7 +34,7 @@ export function shouldRetryQuery(
 ): boolean {
 	// Superagent (legacy Python API) errors carry the HTTP status here.
 	const status = error.response?.status;
-	if (status !== undefined && [401, 403, 404].includes(status)) {
+	if (status !== undefined && NON_RETRYABLE_STATUSES.has(status)) {
 		return false;
 	}
 	// TanStack Start server-function errors cross the boundary with only

--- a/apps/web/src/app/queryErrors.ts
+++ b/apps/web/src/app/queryErrors.ts
@@ -1,0 +1,53 @@
+import { endSession } from "@app/session";
+import {
+	FORBIDDEN_ERROR_NAME,
+	UNAUTHORIZED_ERROR_NAME,
+} from "@virtool/contracts";
+
+/** A failed query's error, carrying an HTTP status when superagent raised it. */
+export type QueryError = Error & { response?: { status?: number } };
+
+/**
+ * End the session when a query fails because the session is gone.
+ *
+ * Wired into the query and mutation caches' `onError`.
+ */
+// Server-function errors reach the client with their `name` preserved only
+// because `authErrorSerializationAdapter` (start.ts) carries it past Router's
+// ShallowErrorPlugin, so a 401 is matched by name here. Superagent calls are
+// covered by the interceptor in `app/api.ts` instead.
+//
+// A 403 is deliberately not handled: the session is valid, the user just lacks
+// the role, so bouncing them to the login wall would be wrong.
+export function handleAuthenticationError(error: Error): void {
+	if (error.name === UNAUTHORIZED_ERROR_NAME) {
+		endSession();
+	}
+}
+
+/** Decide whether React Query should retry a failed query. */
+export function shouldRetryQuery(
+	failureCount: number,
+	error: QueryError,
+): boolean {
+	// Superagent (legacy Python API) errors carry the HTTP status here.
+	const status = error.response?.status;
+	if (status !== undefined && [401, 403, 404].includes(status)) {
+		return false;
+	}
+	// TanStack Start server-function errors cross the boundary with only
+	// `message` preserved by default; the status set via `setResponseStatus` is
+	// not attached, and Router's ShallowErrorPlugin drops `name`.
+	// `authErrorSerializationAdapter` (registered in start.ts) keeps the auth
+	// errors' `name`, so matching by name here makes a 401/403 (e.g. after
+	// logout, or an unauthenticated first visit) reject immediately instead of
+	// retrying ~4× while the screen sits blank before the route can bounce to
+	// /login.
+	if (
+		error.name === UNAUTHORIZED_ERROR_NAME ||
+		error.name === FORBIDDEN_ERROR_NAME
+	) {
+		return false;
+	}
+	return failureCount <= 3;
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,27 +1,13 @@
+import { handleAuthenticationError, shouldRetryQuery } from "@app/queryErrors";
 import { readSentryDsn } from "@app/sentryDsn";
 import RouteError from "@base/RouteError";
 import * as Sentry from "@sentry/tanstackstart-react";
 import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
 import { createRouter } from "@tanstack/react-router";
-import {
-	FORBIDDEN_ERROR_NAME,
-	UNAUTHORIZED_ERROR_NAME,
-} from "@virtool/contracts";
 import { getCommonOptions } from "@virtool/sentry/browser";
 import { CONTENT_SCROLL_ID } from "./app/scroll";
 import { scheduleReplay } from "./app/sentryReplay";
-import { endSession } from "./app/session";
 import { routeTree } from "./routeTree.gen";
-
-// Server-function errors reach the client with their `name` preserved only
-// because `authErrorSerializationAdapter` (start.ts) carries it past Router's
-// ShallowErrorPlugin, so a 401 is matched by name here. Superagent calls are
-// covered by the interceptor in `app/api.ts` instead.
-function handleAuthenticationError(error: Error): void {
-	if (error.name === UNAUTHORIZED_ERROR_NAME) {
-		endSession();
-	}
-}
 
 export function getRouter() {
 	const queryClient = new QueryClient({
@@ -29,31 +15,7 @@ export function getRouter() {
 		mutationCache: new MutationCache({ onError: handleAuthenticationError }),
 		defaultOptions: {
 			queries: {
-				retry: (
-					failureCount: number,
-					error: Error & { response?: { status?: number } },
-				) => {
-					// Superagent (legacy Python API) errors carry the HTTP status here.
-					const status = error.response?.status;
-					if (status !== undefined && [401, 403, 404].includes(status)) {
-						return false;
-					}
-					// TanStack Start server-function errors cross the boundary with only
-					// `message` preserved by default; the status set via
-					// `setResponseStatus` is not attached, and Router's ShallowErrorPlugin
-					// drops `name`. `authErrorSerializationAdapter` (registered in
-					// start.ts) keeps the auth errors' `name`, so matching by name here
-					// makes a 401/403 (e.g. after logout, or an unauthenticated first
-					// visit) reject immediately instead of retrying ~4× while the screen
-					// sits blank before the route can bounce to /login.
-					if (
-						error.name === UNAUTHORIZED_ERROR_NAME ||
-						error.name === FORBIDDEN_ERROR_NAME
-					) {
-						return false;
-					}
-					return failureCount <= 3;
-				},
+				retry: shouldRetryQuery,
 				staleTime: 2000,
 			},
 		},


### PR DESCRIPTION
## Summary

- Extracts the retry predicate and `handleAuthenticationError` out of `router.tsx` into `app/queryErrors.ts` so they can be reached from a test. No behavior change — the VIR-2700 fix itself landed in 43a0c630.
- Covers both: the retry guard giving up on 401/403/404 from the Python API and on the auth error names carried across the server-function boundary, bounded retries otherwise, and `endSession` firing on a 401 but deliberately not on a 403 (a forbidden user's session is valid — they just lack the role).
- The real-boundary serialization test VIR-2700 also asked for can't be written at unit level: mocking the server function means nothing serializes, and the alternatives assert TanStack internals rather than behavior. Deferred to VIR-2783 (Playwright).