### PR TITLE
fix: preload list views so paging and filtering don't flash

### DIFF
--- a/apps/web/src/hmm/components/HmmInstall.tsx
+++ b/apps/web/src/hmm/components/HmmInstall.tsx
@@ -3,27 +3,30 @@ import Alert from "@base/Alert";
 import Box from "@base/Box";
 import Button from "@base/Button";
 import Icon from "@base/Icon";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import ProgressBarAffixed from "@base/ProgressBarAffixed";
-import QueryError from "@base/QueryError";
 import { useQueryClient } from "@tanstack/react-query";
 import { useFetchTask } from "@tasks/queries";
 import { Info } from "lucide-react";
 import { useEffect } from "react";
 import { hmmQueryKeys } from "../keys";
-import { useInstallHmm, useListHmms } from "../queries";
+import { useInstallHmm } from "../queries";
+import type { HmmSearchResults } from "../types";
+
+type HmmInstallProps = {
+	/** The install status of the HMMs, read from the list the parent already fetched */
+	status: HmmSearchResults["status"];
+};
 
 /**
  * Displays the installation progress information or provides the option to install HMMs
  */
-export function HmmInstall() {
-	const { data, isPending, isError } = useListHmms(1, 25);
+export function HmmInstall({ status }: HmmInstallProps) {
 	const queryClient = useQueryClient();
 	const { hasPermission: canInstall } =
 		useCheckAdminRoleOrPermission("modify_hmm");
 	const installMutation = useInstallHmm();
 
-	const seedTask = data?.status?.task;
+	const seedTask = status.task;
 	const { data: task } = useFetchTask(
 		seedTask?.id ?? Number.NaN,
 		seedTask ?? undefined,
@@ -37,17 +40,7 @@ export function HmmInstall() {
 		}
 	}, [taskComplete, queryClient]);
 
-	if (isError && !data) {
-		return <QueryError noun="HMMs" />;
-	}
-
-	if (isPending) {
-		return <LoadingPlaceholder />;
-	}
-
-	const {
-		status: { installed },
-	} = data;
+	const { installed } = status;
 
 	if (task && !installed) {
 		const progress = task.progress;

--- a/apps/web/src/hmm/components/HmmList.tsx
+++ b/apps/web/src/hmm/components/HmmList.tsx
@@ -1,14 +1,12 @@
 import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
 import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "@base/Empty";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Pagination from "@base/Pagination";
-import QueryError from "@base/QueryError";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
 import { Boxes, SearchX } from "lucide-react";
-import { useListHmms } from "../queries";
+import { useSuspenseHmms } from "../queries";
 import { HmmInstall } from "./HmmInstall";
 import HmmItem from "./HmmItem";
 import HmmToolbar from "./HmmToolbar";
@@ -16,22 +14,17 @@ import HmmToolbar from "./HmmToolbar";
 type HmmListProps = {
 	find: string;
 	page: number;
-	setSearch: (next: { find?: string; page?: number }) => void;
+	setSearch: (
+		next: { find?: string; page?: number },
+		options?: { replace?: boolean },
+	) => void;
 };
 
 /**
  * A list of HMMs with filtering options
  */
 export default function HmmList({ find, page, setSearch }: HmmListProps) {
-	const { data, isPending, isError } = useListHmms(page, 25, find);
-
-	if (isError && !data) {
-		return <QueryError noun="HMMs" />;
-	}
-
-	if (isPending) {
-		return <LoadingPlaceholder />;
-	}
+	const { data } = useSuspenseHmms(page, 25, find);
 
 	const {
 		items,
@@ -57,7 +50,7 @@ export default function HmmList({ find, page, setSearch }: HmmListProps) {
 				<>
 					<HmmToolbar
 						term={find}
-						onChange={(e) => setSearch({ find: e.target.value })}
+						setTerm={(find) => setSearch({ find, page: 1 }, { replace: true })}
 					/>
 					{items.length ? (
 						<Pagination
@@ -92,7 +85,7 @@ export default function HmmList({ find, page, setSearch }: HmmListProps) {
 					)}
 				</>
 			) : (
-				<HmmInstall />
+				<HmmInstall status={status} />
 			)}
 		</div>
 	);

--- a/apps/web/src/hmm/components/HmmToolbar.tsx
+++ b/apps/web/src/hmm/components/HmmToolbar.tsx
@@ -1,25 +1,29 @@
+import { useDebouncedDraft } from "@app/hooks";
 import InputSearch from "@base/InputSearch";
 import Toolbar from "@base/Toolbar";
 
 type HmmToolbarProps = {
 	/** Current search term used for filtering */
 	term: string;
-	/** A callback function to handle changes in search input */
-	onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+
+	/** Update the search term in the url */
+	setTerm: (term: string) => void;
 };
 
 /**
  * A toolbar which allows the HMMs to be filtered by their names
  */
-export default function HmmToolbar({ term, onChange }: HmmToolbarProps) {
+export default function HmmToolbar({ term, setTerm }: HmmToolbarProps) {
+	const [draft, setDraft] = useDebouncedDraft(term, setTerm);
+
 	return (
 		<Toolbar>
 			<div className="flex-grow">
 				<InputSearch
 					aria-label="Search HMMs"
 					placeholder="Name"
-					onChange={onChange}
-					value={term}
+					value={draft}
+					onChange={(e) => setDraft(e.target.value)}
 				/>
 			</div>
 		</Toolbar>

--- a/apps/web/src/hmm/queries.ts
+++ b/apps/web/src/hmm/queries.ts
@@ -1,24 +1,28 @@
 import { apiClient } from "@app/api";
 import { hmmQueryKeys } from "@hmm/keys";
 import {
-	keepPreviousData,
+	queryOptions,
 	useMutation,
 	useQuery,
 	useQueryClient,
+	useSuspenseQuery,
 } from "@tanstack/react-query";
 import type { ErrorResponse } from "@/types/api";
 import type { HMMInstalled, Hmm, HmmSearchResults } from "./types";
 
 /**
- * Fetch a page of hmm search results from the API
+ * Query options for a page of HMM search results.
  *
  * @param page - The page to fetch
  * @param per_page - The number of hmms to fetch per page
  * @param term - The search term to filter the hmms by
- * @returns A page of hmms search results
  */
-export function useListHmms(page: number, per_page: number, term?: string) {
-	return useQuery<HmmSearchResults>({
+export function hmmsQueryOptions(
+	page: number,
+	per_page: number,
+	term?: string,
+) {
+	return queryOptions<HmmSearchResults, ErrorResponse>({
 		queryKey: hmmQueryKeys.list([page, per_page, term]),
 		queryFn: () =>
 			apiClient
@@ -28,8 +32,35 @@ export function useListHmms(page: number, per_page: number, term?: string) {
 					const { documents, ...rest } = res.body;
 					return { ...rest, items: documents };
 				}),
-		placeholderData: keepPreviousData,
 	});
+}
+
+/**
+ * Fetch a page of HMM search results.
+ *
+ * For secondary data — an HMM-install alert beside a list, a workflow
+ * compatibility check. Primary list data uses {@link useSuspenseHmms}.
+ *
+ * @param page - The page to fetch
+ * @param per_page - The number of hmms to fetch per page
+ * @param term - The search term to filter the hmms by
+ * @returns A page of hmms search results
+ */
+export function useListHmms(page: number, per_page: number, term?: string) {
+	return useQuery(hmmsQueryOptions(page, per_page, term));
+}
+
+/**
+ * Fetch a page of HMM search results, suspending until it resolves.
+ *
+ * `data` is always defined, and a failed request throws to the nearest route
+ * error boundary instead of resolving to `undefined`. Use this from components
+ * rendered under the HMM list route, whose loader prefetches the page —
+ * loading and errors are handled by the route's Suspense and `errorComponent`
+ * rather than inline.
+ */
+export function useSuspenseHmms(page: number, per_page: number, term?: string) {
+	return useSuspenseQuery(hmmsQueryOptions(page, per_page, term));
 }
 
 /**

--- a/apps/web/src/indexes/components/Indexes.tsx
+++ b/apps/web/src/indexes/components/Indexes.tsx
@@ -7,9 +7,7 @@ import {
 	EmptyMedia,
 	EmptyTitle,
 } from "@base/Empty";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Pagination from "@base/Pagination";
-import QueryError from "@base/QueryError";
 import Toolbar from "@base/Toolbar";
 import {
 	useCheckReferenceRight,
@@ -17,7 +15,7 @@ import {
 } from "@references/hooks";
 import { getRouteApi } from "@tanstack/react-router";
 import { Inbox } from "lucide-react";
-import { useFindIndexes } from "../queries";
+import { useSuspenseIndexes } from "../queries";
 import { IndexItem } from "./Item/IndexItem";
 import RebuildIndex from "./RebuildIndex";
 
@@ -33,17 +31,9 @@ type IndexesProps = {
  */
 export default function Indexes({ page, setSearch }: IndexesProps) {
 	const { refId } = routeApi.useParams();
-	const { data, isPending, isError } = useFindIndexes(page, 25, refId);
+	const { data } = useSuspenseIndexes(page, 25, refId);
 	const { hasPermission: canBuild } = useCheckReferenceRight(refId, "build");
 	const archived = useReferenceIsArchived(refId);
-
-	if (isError && !data) {
-		return <QueryError noun="indexes" />;
-	}
-
-	if (isPending) {
-		return <LoadingPlaceholder />;
-	}
 
 	const { items, change_count, page: storedPage, page_count } = data;
 

--- a/apps/web/src/indexes/queries.ts
+++ b/apps/web/src/indexes/queries.ts
@@ -1,6 +1,12 @@
 import { apiClient } from "@app/api";
 import { indexQueryKeys } from "@indexes/keys";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	queryOptions,
+	useMutation,
+	useQuery,
+	useQueryClient,
+	useSuspenseQuery,
+} from "@tanstack/react-query";
 import type { ErrorResponse } from "@/types/api";
 import type {
 	Index,
@@ -10,21 +16,20 @@ import type {
 } from "./types";
 
 /**
- * Gets a paginated list of indexes.
+ * Query options for a paginated list of indexes.
  *
  * @param page - The page to fetch
- * @param per_page - The number of hmms to fetch per page
+ * @param per_page - The number of indexes to fetch per page
  * @param refId - The reference id to fetch the indexes of
  * @param term - The search term to filter indexes by
- * @returns The paginated list of indexes
  */
-export function useFindIndexes(
+export function indexesQueryOptions(
 	page: number,
 	per_page: number,
 	refId: string,
 	term?: string,
 ) {
-	return useQuery<IndexSearchResult>({
+	return queryOptions<IndexSearchResult, ErrorResponse>({
 		queryKey: indexQueryKeys.list([page, per_page, refId, term]),
 		queryFn: () =>
 			apiClient
@@ -35,6 +40,45 @@ export function useFindIndexes(
 					return { ...rest, items: documents };
 				}),
 	});
+}
+
+/**
+ * Gets a paginated list of indexes.
+ *
+ * For secondary data — the unbuilt-changes alert beside a list. Primary list
+ * data uses {@link useSuspenseIndexes}.
+ *
+ * @param page - The page to fetch
+ * @param per_page - The number of indexes to fetch per page
+ * @param refId - The reference id to fetch the indexes of
+ * @param term - The search term to filter indexes by
+ * @returns The paginated list of indexes
+ */
+export function useFindIndexes(
+	page: number,
+	per_page: number,
+	refId: string,
+	term?: string,
+) {
+	return useQuery(indexesQueryOptions(page, per_page, refId, term));
+}
+
+/**
+ * Fetch a paginated list of indexes, suspending until it resolves.
+ *
+ * `data` is always defined, and a failed request throws to the nearest route
+ * error boundary instead of resolving to `undefined`. Use this from components
+ * rendered under the index list route, whose loader prefetches the page —
+ * loading and errors are handled by the route's Suspense and `errorComponent`
+ * rather than inline.
+ */
+export function useSuspenseIndexes(
+	page: number,
+	per_page: number,
+	refId: string,
+	term?: string,
+) {
+	return useSuspenseQuery(indexesQueryOptions(page, per_page, refId, term));
 }
 
 type ListIndexesOptions = {

--- a/apps/web/src/jobs/components/JobList.tsx
+++ b/apps/web/src/jobs/components/JobList.tsx
@@ -2,13 +2,11 @@ import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
 import ContainerNarrow from "@base/ContainerNarrow";
 import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "@base/Empty";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Pagination from "@base/Pagination";
-import QueryError from "@base/QueryError";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import { Cog, SearchX } from "lucide-react";
-import { useFindJobs } from "../queries";
+import { useSuspenseJobs } from "../queries";
 import type { JobState } from "../types";
 import { JobFilters } from "./Filters/JobFilters";
 import JobItem from "./JobItem";
@@ -26,15 +24,7 @@ export default function JobsList({
 	setSearch = () => {},
 	states = initialState,
 }: JobsListProps) {
-	const { data, isPending, isError } = useFindJobs(page, 25, states);
-
-	if (isError && !data) {
-		return <QueryError noun="jobs" />;
-	}
-
-	if (isPending) {
-		return <LoadingPlaceholder />;
-	}
+	const { data } = useSuspenseJobs(page, 25, states);
 
 	const {
 		items,

--- a/apps/web/src/jobs/components/__tests__/JobList.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobList.test.tsx
@@ -1,9 +1,8 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { createFakeServerJobMinimal } from "@tests/fake/jobs";
 import { mockFindJobs } from "@tests/server-fn/jobs";
-import { renderWithRouter } from "@tests/setup";
+import { renderRoute } from "@tests/setup";
 import { describe, expect, it } from "vitest";
-import JobsList from "../JobList";
 
 describe("<JobsList />", () => {
 	it("should render", async () => {
@@ -15,29 +14,19 @@ describe("<JobsList />", () => {
 			}),
 		]);
 
-		await renderWithRouter(<JobsList />);
+		await renderRoute("/jobs");
 
-		await waitFor(() =>
-			expect(screen.queryByLabelText("loading")).not.toBeInTheDocument(),
-		);
-		expect(screen.getByText("Create Sample")).toBeInTheDocument();
+		expect(await screen.findByText("Create Sample")).toBeInTheDocument();
 
 		expect(findJobs).toHaveBeenCalled();
 	});
 
-	it("should show spinner while loading", async () => {
-		await renderWithRouter(<JobsList />);
-		expect(screen.getByLabelText("loading")).toBeInTheDocument();
-	});
-
 	it("should show message when there are no unarchived jobs", async () => {
 		const findJobs = mockFindJobs([]);
-		await renderWithRouter(<JobsList />);
 
-		await waitFor(() =>
-			expect(screen.queryByLabelText("loading")).not.toBeInTheDocument(),
-		);
-		expect(screen.getByText("No jobs found")).toBeInTheDocument();
+		await renderRoute("/jobs");
+
+		expect(await screen.findByText("No jobs found")).toBeInTheDocument();
 
 		expect(findJobs).toHaveBeenCalled();
 	});
@@ -48,11 +37,8 @@ describe("<JobsList />", () => {
 			0,
 		);
 
-		await renderWithRouter(<JobsList />);
+		await renderRoute("/jobs");
 
-		await waitFor(() =>
-			expect(screen.queryByLabelText("loading")).not.toBeInTheDocument(),
-		);
 		expect(
 			await screen.findByText("No jobs match your filters."),
 		).toBeInTheDocument();

--- a/apps/web/src/jobs/queries.ts
+++ b/apps/web/src/jobs/queries.ts
@@ -1,6 +1,10 @@
 import { jobQueryKeys } from "@jobs/keys";
 import { findJobs, getJob } from "@server/jobs/functions";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import {
+	queryOptions,
+	useQuery,
+	useSuspenseQuery,
+} from "@tanstack/react-query";
 import {
 	JobSchema,
 	JobSearchResultSchema,
@@ -10,24 +14,39 @@ import {
 } from "./types";
 
 /**
- * Fetch a page of job search results from the API
+ * Query options for a page of job search results.
  *
  * @param page - The page to fetch
  * @param per_page - The number of jobs to fetch per page
  * @param states - The states to filter jobs by
- * @returns A page of job search results
  */
-export function useFindJobs(
+export function jobsQueryOptions(
 	page: number,
 	per_page: number,
 	states: JobState[],
 ) {
-	return useQuery({
+	return queryOptions({
 		queryKey: jobQueryKeys.list([page, per_page, ...states]),
 		queryFn: () => findJobs({ data: { page, perPage: per_page, states } }),
-		placeholderData: keepPreviousData,
 		select: JobSearchResultSchema.parse,
 	});
+}
+
+/**
+ * Fetch a page of job search results, suspending until it resolves.
+ *
+ * `data` is always defined, and a failed request throws to the nearest route
+ * error boundary instead of resolving to `undefined`. Use this from components
+ * rendered under the job list route, whose loader prefetches the page —
+ * loading and errors are handled by the route's Suspense and `errorComponent`
+ * rather than inline.
+ */
+export function useSuspenseJobs(
+	page: number,
+	per_page: number,
+	states: JobState[],
+) {
+	return useSuspenseQuery(jobsQueryOptions(page, per_page, states));
 }
 
 /**

--- a/apps/web/src/otus/components/OtuList.tsx
+++ b/apps/web/src/otus/components/OtuList.tsx
@@ -9,16 +9,14 @@ import {
 	EmptyMedia,
 	EmptyTitle,
 } from "@base/Empty";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Pagination from "@base/Pagination";
-import QueryError from "@base/QueryError";
 import RebuildAlert from "@indexes/components/RebuildAlert";
-import { useListOtus } from "@otus/queries";
+import { useSuspenseOtus } from "@otus/queries";
 import {
 	useCheckReferenceRight,
 	useReferenceIsArchived,
 } from "@references/hooks";
-import { useFetchReference } from "@references/queries";
+import { useSuspenseReference } from "@references/queries";
 import { getRouteApi } from "@tanstack/react-router";
 import { Inbox, SearchX } from "lucide-react";
 import { useState } from "react";
@@ -43,29 +41,13 @@ type OtuListProps = {
 export default function OtuList({ find, page, setSearch }: OtuListProps) {
 	const { refId } = routeApi.useParams();
 	const [openCreate, setOpenCreate] = useState(false);
-	const {
-		data: reference,
-		isPending: isPendingReference,
-		isError: isErrorReference,
-	} = useFetchReference(refId);
-	const {
-		data: otus,
-		isPending: isPendingOtus,
-		isError: isErrorOtus,
-	} = useListOtus(refId, page, 25, find);
+	const { data: reference } = useSuspenseReference(refId);
+	const { data: otus } = useSuspenseOtus(refId, page, 25, find);
 	const { hasPermission: canModifyOtu } = useCheckReferenceRight(
 		refId,
 		"modify_otu",
 	);
 	const archived = useReferenceIsArchived(refId);
-
-	if ((isErrorReference || isErrorOtus) && (!reference || !otus)) {
-		return <QueryError noun="OTUs" />;
-	}
-
-	if (isPendingOtus || isPendingReference) {
-		return <LoadingPlaceholder />;
-	}
 
 	const { items, page: storedPage, page_count } = otus;
 

--- a/apps/web/src/otus/queries.ts
+++ b/apps/web/src/otus/queries.ts
@@ -1,6 +1,5 @@
 import { apiClient } from "@app/api";
 import {
-	keepPreviousData,
 	queryOptions,
 	useMutation,
 	useQuery,
@@ -36,21 +35,20 @@ export function useGetGenbank() {
 }
 
 /**
- * Fetches a page of OTU search results from the API
+ * Query options for a page of OTU search results.
  *
  * @param refId - The reference id to fetch the OTUs of
  * @param page - The page to fetch
- * @param per_page - The number of hmms to fetch per page
- * @param term - The search term to filter indexes by
- * @returns A page of OTU search results
+ * @param per_page - The number of OTUs to fetch per page
+ * @param term - The search term to filter the OTUs by
  */
-export function useListOtus(
+export function otusQueryOptions(
 	refId: string,
 	page: number,
 	per_page: number,
 	term: string,
 ) {
-	return useQuery<OtuSearchResult>({
+	return queryOptions<OtuSearchResult, ErrorResponse>({
 		queryKey: otuQueryKeys.list([page, per_page, term]),
 		queryFn: () =>
 			apiClient
@@ -60,8 +58,25 @@ export function useListOtus(
 					const { documents, ...rest } = res.body;
 					return { ...rest, items: documents };
 				}),
-		placeholderData: keepPreviousData,
 	});
+}
+
+/**
+ * Fetch a page of OTU search results, suspending until it resolves.
+ *
+ * `data` is always defined, and a failed request throws to the nearest route
+ * error boundary instead of resolving to `undefined`. Use this from components
+ * rendered under the OTU list route, whose loader prefetches the page —
+ * loading and errors are handled by the route's Suspense and `errorComponent`
+ * rather than inline.
+ */
+export function useSuspenseOtus(
+	refId: string,
+	page: number,
+	per_page: number,
+	term: string,
+) {
+	return useSuspenseQuery(otusQueryOptions(refId, page, per_page, term));
 }
 
 export function otuQueryOptions(otuId: string) {

--- a/apps/web/src/otus/queries.ts
+++ b/apps/web/src/otus/queries.ts
@@ -49,7 +49,7 @@ export function otusQueryOptions(
 	term: string,
 ) {
 	return queryOptions<OtuSearchResult, ErrorResponse>({
-		queryKey: otuQueryKeys.list([page, per_page, term]),
+		queryKey: otuQueryKeys.list([refId, page, per_page, term]),
 		queryFn: () =>
 			apiClient
 				.get(`/refs/${refId}/otus`)

--- a/apps/web/src/references/components/ReferenceList.tsx
+++ b/apps/web/src/references/components/ReferenceList.tsx
@@ -2,15 +2,13 @@ import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
 import ContainerNarrow from "@base/ContainerNarrow";
 import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "@base/Empty";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Pagination from "@base/Pagination";
-import QueryError from "@base/QueryError";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
 import { Library } from "lucide-react";
 import { useState } from "react";
-import { useFindReferences } from "../queries";
+import { useSuspenseReferences } from "../queries";
 import Clone from "./CloneReference";
 import { CreateReference } from "./CreateReference";
 import { ReferenceItem } from "./ReferenceItem";
@@ -42,20 +40,7 @@ export default function ReferenceList({
 	const [isCreateReferenceOpen, setIsCreateReferenceOpen] = useState(false);
 	const [cloneReferenceId, setCloneReferenceId] = useState<string>();
 
-	const { data, isPending, isError } = useFindReferences(
-		page,
-		25,
-		find,
-		archived,
-	);
-
-	if (isError && !data) {
-		return <QueryError noun="references" />;
-	}
-
-	if (isPending) {
-		return <LoadingPlaceholder />;
-	}
+	const { data } = useSuspenseReferences(page, 25, find, archived);
 
 	const { items, page: storedPage, page_count, total_count } = data;
 

--- a/apps/web/src/references/queries.ts
+++ b/apps/web/src/references/queries.ts
@@ -3,7 +3,6 @@ import type { Settings } from "@administration/types";
 import { apiClient } from "@app/api";
 import { referenceQueryKeys } from "@references/keys";
 import {
-	keepPreviousData,
 	queryOptions,
 	useMutation,
 	useQuery,
@@ -87,21 +86,20 @@ function removeReferenceGroup(
 }
 
 /**
- * Gets a paginated list of references
+ * Query options for a paginated list of references.
  *
  * @param page - The page to fetch
  * @param per_page - The number of references to fetch per page
  * @param term - The search term to filter references by
  * @param archived - Lifecycle filter; `true` for archived only, `false` for active only
- * @returns The paginated list of references
  */
-export function useFindReferences(
+export function referencesQueryOptions(
 	page: number,
 	per_page: number,
 	term: string,
 	archived?: boolean,
 ) {
-	return useQuery<ReferenceSearchResult>({
+	return queryOptions<ReferenceSearchResult, ErrorResponse>({
 		queryKey: referenceQueryKeys.list([page, per_page, term, archived]),
 		queryFn: () =>
 			apiClient
@@ -111,8 +109,27 @@ export function useFindReferences(
 					const { documents, ...rest } = response.body;
 					return { ...rest, items: documents };
 				}),
-		placeholderData: keepPreviousData,
 	});
+}
+
+/**
+ * Fetch a paginated list of references, suspending until it resolves.
+ *
+ * `data` is always defined, and a failed request throws to the nearest route
+ * error boundary instead of resolving to `undefined`. Use this from components
+ * rendered under the reference list route, whose loader prefetches the page —
+ * loading and errors are handled by the route's Suspense and `errorComponent`
+ * rather than inline.
+ */
+export function useSuspenseReferences(
+	page: number,
+	per_page: number,
+	term: string,
+	archived?: boolean,
+) {
+	return useSuspenseQuery(
+		referencesQueryOptions(page, per_page, term, archived),
+	);
 }
 
 /**

--- a/apps/web/src/routes/_authenticated/administration/users/index.tsx
+++ b/apps/web/src/routes/_authenticated/administration/users/index.tsx
@@ -7,6 +7,7 @@ import { ManageUsers } from "@users/components/ManageUsers";
 type UsersSearch = {
 	status: string;
 	page: number;
+	term: string;
 };
 
 function validateUsersSearch(
@@ -15,13 +16,17 @@ function validateUsersSearch(
 	return {
 		status: str(input.status, "active"),
 		page: num(input.page, 1),
+		term: str(input.term, ""),
 	};
 }
 
 export const Route = createFileRoute("/_authenticated/administration/users/")({
 	validateSearch: validateUsersSearch,
-	loaderDeps: ({ search: { page, status } }) => ({ page, status }),
-	loader: async ({ context: { queryClient }, deps: { page, status } }) => {
+	loaderDeps: ({ search: { page, status, term } }) => ({ page, status, term }),
+	loader: async ({
+		context: { queryClient },
+		deps: { page, status, term },
+	}) => {
 		const [{ usersQueryOptions }, { passwordPolicyQueryOptions }] =
 			await Promise.all([
 				import("@users/queries"),
@@ -30,7 +35,7 @@ export const Route = createFileRoute("/_authenticated/administration/users/")({
 
 		return Promise.all([
 			queryClient.ensureQueryData(
-				usersQueryOptions(page, 25, "", undefined, status === "active"),
+				usersQueryOptions(page, 25, term, undefined, status === "active"),
 			),
 			// For the create-user form. Prefetched, not ensured: a failure here must
 			// not take down the page.
@@ -47,8 +52,14 @@ function UsersRoute() {
 	return (
 		<ManageUsers
 			page={search.page}
-			setSearch={(next) => navigate({ search: { ...search, ...next } })}
+			setSearch={(next, options) =>
+				navigate({
+					search: { ...search, ...next },
+					replace: options?.replace,
+				})
+			}
 			status={search.status}
+			term={search.term}
 		/>
 	);
 }

--- a/apps/web/src/routes/_authenticated/hmms/index.tsx
+++ b/apps/web/src/routes/_authenticated/hmms/index.tsx
@@ -20,6 +20,11 @@ function validateHmmSearch(
 
 export const Route = createFileRoute("/_authenticated/hmms/")({
 	validateSearch: validateHmmSearch,
+	loaderDeps: ({ search: { find, page } }) => ({ find, page }),
+	loader: async ({ context: { queryClient }, deps: { find, page } }) => {
+		const { hmmsQueryOptions } = await import("@hmm/queries");
+		await queryClient.ensureQueryData(hmmsQueryOptions(page, 25, find));
+	},
 	component: HmmRoute,
 });
 
@@ -31,7 +36,12 @@ function HmmRoute() {
 		<HmmList
 			find={search.find}
 			page={search.page}
-			setSearch={(next) => navigate({ search: { ...search, ...next } })}
+			setSearch={(next, options) =>
+				navigate({
+					search: { ...search, ...next },
+					replace: options?.replace,
+				})
+			}
 		/>
 	);
 }

--- a/apps/web/src/routes/_authenticated/jobs/index.tsx
+++ b/apps/web/src/routes/_authenticated/jobs/index.tsx
@@ -31,6 +31,11 @@ function validateJobsSearch(
 
 export const Route = createFileRoute("/_authenticated/jobs/")({
 	validateSearch: validateJobsSearch,
+	loaderDeps: ({ search: { page, state } }) => ({ page, state }),
+	loader: async ({ context: { queryClient }, deps: { page, state } }) => {
+		const { jobsQueryOptions } = await import("@jobs/queries");
+		await queryClient.ensureQueryData(jobsQueryOptions(page, 25, state));
+	},
 	component: JobsRoute,
 });
 

--- a/apps/web/src/routes/_authenticated/refs/$refId/indexes/index.tsx
+++ b/apps/web/src/routes/_authenticated/refs/$refId/indexes/index.tsx
@@ -16,6 +16,15 @@ function validateIndexesSearch(
 
 export const Route = createFileRoute("/_authenticated/refs/$refId/indexes/")({
 	validateSearch: validateIndexesSearch,
+	loaderDeps: ({ search: { page } }) => ({ page }),
+	loader: async ({
+		context: { queryClient },
+		params: { refId },
+		deps: { page },
+	}) => {
+		const { indexesQueryOptions } = await import("@indexes/queries");
+		await queryClient.ensureQueryData(indexesQueryOptions(page, 25, refId));
+	},
 	component: IndexesRoute,
 });
 

--- a/apps/web/src/routes/_authenticated/refs/$refId/otus/index.tsx
+++ b/apps/web/src/routes/_authenticated/refs/$refId/otus/index.tsx
@@ -20,6 +20,15 @@ function validateOtuListSearch(
 
 export const Route = createFileRoute("/_authenticated/refs/$refId/otus/")({
 	validateSearch: validateOtuListSearch,
+	loaderDeps: ({ search: { find, page } }) => ({ find, page }),
+	loader: async ({
+		context: { queryClient },
+		params: { refId },
+		deps: { find, page },
+	}) => {
+		const { otusQueryOptions } = await import("@otus/queries");
+		await queryClient.ensureQueryData(otusQueryOptions(refId, page, 25, find));
+	},
 	component: OtusRoute,
 });
 

--- a/apps/web/src/routes/_authenticated/refs/index.tsx
+++ b/apps/web/src/routes/_authenticated/refs/index.tsx
@@ -22,6 +22,20 @@ function validateRefsSearch(
 
 export const Route = createFileRoute("/_authenticated/refs/")({
 	validateSearch: validateRefsSearch,
+	loaderDeps: ({ search: { archived, find, page } }) => ({
+		archived,
+		find,
+		page,
+	}),
+	loader: async ({
+		context: { queryClient },
+		deps: { archived, find, page },
+	}) => {
+		const { referencesQueryOptions } = await import("@references/queries");
+		await queryClient.ensureQueryData(
+			referencesQueryOptions(page, 25, find, archived),
+		);
+	},
 	component: ReferencesRoute,
 });
 

--- a/apps/web/src/routes/_authenticated/subtractions/index.tsx
+++ b/apps/web/src/routes/_authenticated/subtractions/index.tsx
@@ -20,6 +20,11 @@ function validateSubtractionsSearch(
 
 export const Route = createFileRoute("/_authenticated/subtractions/")({
 	validateSearch: validateSubtractionsSearch,
+	loaderDeps: ({ search: { find, page } }) => ({ find, page }),
+	loader: async ({ context: { queryClient }, deps: { find, page } }) => {
+		const { subtractionsQueryOptions } = await import("@subtraction/queries");
+		await queryClient.ensureQueryData(subtractionsQueryOptions(page, 25, find));
+	},
 	component: SubtractionsRoute,
 });
 
@@ -31,7 +36,12 @@ function SubtractionsRoute() {
 		<SubtractionList
 			find={search.find}
 			page={search.page}
-			setSearch={(next) => navigate({ search: { ...search, ...next } })}
+			setSearch={(next, options) =>
+				navigate({
+					search: { ...search, ...next },
+					replace: options?.replace,
+				})
+			}
 		/>
 	);
 }

--- a/apps/web/src/server/events/revocation.ts
+++ b/apps/web/src/server/events/revocation.ts
@@ -24,6 +24,7 @@ export function watchForRevocation(
 		check,
 		intervalMs,
 	);
+	let checking = false;
 
 	function stop(): void {
 		if (timer) {
@@ -33,9 +34,18 @@ export function watchForRevocation(
 	}
 
 	function check(): void {
+		// A check outlives its interval when the database is slow, so ticks would
+		// otherwise pile up and each report the same revocation. Run at most one at
+		// a time, and ignore a result that lands after the watch has stopped.
+		if (checking || timer === null) {
+			return;
+		}
+
+		checking = true;
+
 		void requireAuthenticatedRequest(request)
 			.then((gate) => {
-				if (gate instanceof Response) {
+				if (timer !== null && gate instanceof Response) {
 					stop();
 					onRevoked();
 				}
@@ -44,6 +54,9 @@ export function watchForRevocation(
 				// A lookup that failed is not proof of a session that is gone. Leave
 				// the stream up and try again on the next tick.
 				logger.warn({ err }, "sse session revocation check failed");
+			})
+			.finally(() => {
+				checking = false;
 			});
 	}
 

--- a/apps/web/src/subtraction/components/SubtractionList.tsx
+++ b/apps/web/src/subtraction/components/SubtractionList.tsx
@@ -1,21 +1,22 @@
 import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
 import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "@base/Empty";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Pagination from "@base/Pagination";
-import QueryError from "@base/QueryError";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import ViewHeaderTitleBadge from "@base/ViewHeaderTitleBadge";
 import { Scissors } from "lucide-react";
-import { useFindSubtractions } from "../queries";
+import { useSuspenseSubtractions } from "../queries";
 import { SubtractionItem } from "./SubtractionItem";
 import SubtractionToolbar from "./SubtractionToolbar";
 
 type SubtractionListProps = {
 	find?: string;
 	page?: number;
-	setSearch?: (next: { find?: string; page?: number }) => void;
+	setSearch?: (
+		next: { find?: string; page?: number },
+		options?: { replace?: boolean },
+	) => void;
 };
 
 /**
@@ -26,19 +27,7 @@ export default function SubtractionList({
 	page = 1,
 	setSearch = () => {},
 }: SubtractionListProps) {
-	const { data, isPending, isError } = useFindSubtractions(page, 25, find);
-
-	if (isError && !data) {
-		return <QueryError noun="subtractions" />;
-	}
-
-	if (isPending) {
-		return <LoadingPlaceholder />;
-	}
-
-	function handleChange(e) {
-		setSearch({ find: e.target.value });
-	}
+	const { data } = useSuspenseSubtractions(page, 25, find);
 
 	const { items, total_count, page: storedPage, page_count } = data;
 
@@ -51,7 +40,10 @@ export default function SubtractionList({
 				</ViewHeaderTitle>
 			</ViewHeader>
 
-			<SubtractionToolbar term={find} handleChange={handleChange} />
+			<SubtractionToolbar
+				term={find}
+				setTerm={(find) => setSearch({ find, page: 1 }, { replace: true })}
+			/>
 
 			{!items.length ? (
 				<Box key="subtractions">

--- a/apps/web/src/subtraction/components/SubtractionToolbar.tsx
+++ b/apps/web/src/subtraction/components/SubtractionToolbar.tsx
@@ -1,26 +1,32 @@
 import { useCheckAdminRoleOrPermission } from "@administration/hooks";
+import { useDebouncedDraft } from "@app/hooks";
 import InputSearch from "@base/InputSearch";
 import Toolbar from "@base/Toolbar";
 import SubtractionCreate from "./SubtractionCreate";
 
 type SubtractionToolbarProps = {
-	handleChange: (any) => void;
+	/** Current search term used for filtering */
 	term: string;
+
+	/** Update the search term in the url */
+	setTerm: (term: string) => void;
 };
 
 export default function SubtractionToolbar({
-	handleChange,
+	setTerm,
 	term,
 }: SubtractionToolbarProps) {
 	const { hasPermission } = useCheckAdminRoleOrPermission("modify_subtraction");
+
+	const [draft, setDraft] = useDebouncedDraft(term, setTerm);
 
 	return (
 		<Toolbar>
 			<div className="flex-grow">
 				<InputSearch
 					aria-label="Search subtractions"
-					value={term}
-					onChange={handleChange}
+					value={draft}
+					onChange={(e) => setDraft(e.target.value)}
 					placeholder="Name"
 				/>
 			</div>

--- a/apps/web/src/subtraction/components/__tests__/SubtractionList.test.tsx
+++ b/apps/web/src/subtraction/components/__tests__/SubtractionList.test.tsx
@@ -3,26 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { mockApiGetSubtractions } from "@tests/api/subtractions";
 import { createFakeAccount } from "@tests/fake/account";
 import { createFakeSubtractionMinimal } from "@tests/fake/subtractions";
-import { mockGetAccount } from "@tests/server-fn/users";
-import { renderWithRouter } from "@tests/setup";
-import { useState } from "react";
-import { beforeEach, describe, expect, it } from "vitest";
-import SubtractionList from "../SubtractionList";
-
-type SubtractionListSearch = {
-	find?: string;
-	page?: number;
-};
-
-function SubtractionListHarness() {
-	const [search, setSearch] = useState<SubtractionListSearch>({ find: "" });
-
-	function handleSetSearch(next: SubtractionListSearch) {
-		setSearch((prev) => ({ ...prev, ...next }));
-	}
-
-	return <SubtractionList {...search} setSearch={handleSetSearch} />;
-}
+import { renderRoute } from "@tests/setup";
+import nock from "nock";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("<SubtractionList />", () => {
 	let subtractions: ReturnType<typeof createFakeSubtractionMinimal>;
@@ -31,52 +14,49 @@ describe("<SubtractionList />", () => {
 		subtractions = createFakeSubtractionMinimal();
 	});
 
+	afterEach(() => nock.cleanAll());
+
 	it("renders correctly", async () => {
 		const scope = mockApiGetSubtractions([subtractions]);
-		await renderWithRouter(<SubtractionList />);
 
-		await waitFor(() =>
-			expect(screen.queryByLabelText("loading")).not.toBeInTheDocument(),
-		);
+		await renderRoute("/subtractions");
 
-		expect(screen.getByText("Subtractions")).toBeInTheDocument();
+		expect(
+			await screen.findByRole("heading", { name: /Subtractions/ }),
+		).toBeInTheDocument();
 		expect(screen.getByText("1")).toBeInTheDocument();
 		expect(screen.getByText(subtractions.name)).toBeInTheDocument();
 
 		scope.done();
 	});
 
-	it("should call handleChange when search input changes in toolbar", async () => {
-		const scope = mockApiGetSubtractions([subtractions]);
+	it("should put the search term in the url once typing settles", async () => {
 		mockApiGetSubtractions([subtractions]);
+		// The debounced term commits as one navigation, whose loader refetches.
 		mockApiGetSubtractions([subtractions]);
-		mockApiGetSubtractions([subtractions]);
-		mockApiGetSubtractions([subtractions]);
-		await renderWithRouter(<SubtractionListHarness />);
-		await waitFor(() =>
-			expect(screen.queryByLabelText("loading")).not.toBeInTheDocument(),
-		);
 
-		const inputElement = screen.getByPlaceholderText("Name");
+		const { router } = await renderRoute("/subtractions");
+
+		const inputElement = await screen.findByPlaceholderText("Name");
 		expect(inputElement).toHaveValue("");
 
 		await userEvent.type(inputElement, "Foo");
+
+		// The input tracks the draft immediately, ahead of the url.
 		expect(inputElement).toHaveValue("Foo");
 
-		await userEvent.clear(inputElement);
-		scope.done();
+		await waitFor(() =>
+			expect(router.state.location.search).toMatchObject({
+				find: "Foo",
+			}),
+		);
 	});
 
 	it("should render create button when [canModify=true]", async () => {
 		const scope = mockApiGetSubtractions([subtractions]);
-		const account = createFakeAccount({
-			administrator_role: "full",
-		});
-		mockGetAccount(account);
-		await renderWithRouter(<SubtractionList />);
-		await waitFor(() =>
-			expect(screen.queryByLabelText("loading")).not.toBeInTheDocument(),
-		);
+		const account = createFakeAccount({ administrator_role: "full" });
+
+		await renderRoute("/subtractions", { account });
 
 		expect(
 			await screen.findByRole("button", { name: "Create" }),
@@ -88,37 +68,11 @@ describe("<SubtractionList />", () => {
 	it("should not render create button when [canModify=false]", async () => {
 		const scope = mockApiGetSubtractions([subtractions]);
 		const account = createFakeAccount({ administrator_role: null });
-		mockGetAccount(account);
-		await renderWithRouter(<SubtractionList />);
-		await waitFor(() =>
-			expect(screen.queryByLabelText("loading")).not.toBeInTheDocument(),
-		);
 
-		const createButton = screen.queryByLabelText("Create");
-		expect(createButton).toBeNull();
+		await renderRoute("/subtractions", { account });
 
-		scope.done();
-	});
-
-	it("should handle toolbar updates correctly", async () => {
-		const scope = mockApiGetSubtractions([subtractions]);
-		mockApiGetSubtractions([subtractions]);
-		mockApiGetSubtractions([subtractions]);
-		mockApiGetSubtractions([subtractions]);
-		mockApiGetSubtractions([subtractions]);
-		mockApiGetSubtractions([subtractions]);
-		mockApiGetSubtractions([subtractions]);
-		await renderWithRouter(<SubtractionListHarness />);
-		await waitFor(() =>
-			expect(screen.queryByLabelText("loading")).not.toBeInTheDocument(),
-		);
-
-		const inputElement = screen.getByPlaceholderText("Name");
-		expect(inputElement).toHaveValue("");
-
-		await userEvent.type(inputElement, "Foobar");
-		expect(inputElement).toHaveValue("Foobar");
-		expect(screen.getByPlaceholderText("Name")).toHaveValue("Foobar");
+		expect(await screen.findByText(subtractions.name)).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Create" })).toBeNull();
 
 		scope.done();
 	});

--- a/apps/web/src/subtraction/queries.ts
+++ b/apps/web/src/subtraction/queries.ts
@@ -1,10 +1,11 @@
 import { apiClient } from "@app/api";
 import { subtractionQueryKeys } from "@subtraction/keys";
 import {
-	keepPreviousData,
+	queryOptions,
 	useMutation,
 	useQuery,
 	useQueryClient,
+	useSuspenseQuery,
 } from "@tanstack/react-query";
 import type { ErrorResponse } from "@/types/api";
 import type {
@@ -40,19 +41,18 @@ export function useCreateSubtraction() {
 }
 
 /**
- * Fetch a page of subtraction search results from the API
+ * Query options for a page of subtraction search results.
  *
  * @param page - The page to fetch
- * @param per_page - The number of hmms to fetch per page
- * @param term - The search term to filter the hmms by
- * @returns A page of subtraction search results
+ * @param per_page - The number of subtractions to fetch per page
+ * @param term - The search term to filter the subtractions by
  */
-export function useFindSubtractions(
+export function subtractionsQueryOptions(
 	page: number,
 	per_page: number,
 	term: string,
 ) {
-	return useQuery<SubtractionSearchResult>({
+	return queryOptions<SubtractionSearchResult, ErrorResponse>({
 		queryKey: subtractionQueryKeys.list([page, per_page, term]),
 		queryFn: () =>
 			apiClient
@@ -62,8 +62,24 @@ export function useFindSubtractions(
 					const { documents, ...rest } = response.body;
 					return { ...rest, items: documents };
 				}),
-		placeholderData: keepPreviousData,
 	});
+}
+
+/**
+ * Fetch a page of subtraction search results, suspending until it resolves.
+ *
+ * `data` is always defined, and a failed request throws to the nearest route
+ * error boundary instead of resolving to `undefined`. Use this from components
+ * rendered under the subtraction list route, whose loader prefetches the page —
+ * loading and errors are handled by the route's Suspense and `errorComponent`
+ * rather than inline.
+ */
+export function useSuspenseSubtractions(
+	page: number,
+	per_page: number,
+	term: string,
+) {
+	return useSuspenseQuery(subtractionsQueryOptions(page, per_page, term));
 }
 
 /**

--- a/apps/web/src/users/components/ManageUsers.tsx
+++ b/apps/web/src/users/components/ManageUsers.tsx
@@ -1,4 +1,5 @@
 import { useCheckAdminRole } from "@administration/hooks";
+import { useDebouncedDraft } from "@app/hooks";
 import Alert from "@base/Alert";
 import InputSearch from "@base/InputSearch";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
@@ -6,14 +7,17 @@ import ToggleGroup from "@base/ToggleGroup";
 import ToggleGroupItem from "@base/ToggleGroupItem";
 import Toolbar from "@base/Toolbar";
 import { CircleAlert } from "lucide-react";
-import { useState } from "react";
 import CreateUser from "./CreateUser";
 import UsersList from "./UsersList";
 
 type ManageUsersProps = {
 	page?: number;
-	setSearch?: (next: { page?: number; status?: string }) => void;
+	setSearch?: (
+		next: { page?: number; status?: string; term?: string },
+		options?: { replace?: boolean },
+	) => void;
 	status?: string;
+	term?: string;
 };
 
 /**
@@ -23,9 +27,12 @@ export function ManageUsers({
 	page = 1,
 	setSearch = () => {},
 	status = "active",
+	term = "",
 }: ManageUsersProps) {
-	const [term, setTerm] = useState("");
 	const { hasPermission, isPending } = useCheckAdminRole("users");
+	const [draft, setDraft] = useDebouncedDraft(term, (term) =>
+		setSearch({ term, page: 1 }, { replace: true }),
+	);
 
 	if (isPending) {
 		return <LoadingPlaceholder />;
@@ -39,8 +46,8 @@ export function ManageUsers({
 						<InputSearch
 							name="search"
 							aria-label="search"
-							value={term}
-							onChange={(e) => setTerm(e.target.value)}
+							value={draft}
+							onChange={(e) => setDraft(e.target.value)}
 						/>
 					</div>
 					<ToggleGroup

--- a/apps/web/src/users/components/UsersList.tsx
+++ b/apps/web/src/users/components/UsersList.tsx
@@ -1,10 +1,8 @@
 import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
 import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "@base/Empty";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Pagination from "@base/Pagination";
-import QueryError from "@base/QueryError";
-import { useFindUsers } from "@users/queries";
+import { useSuspenseUsers } from "@users/queries";
 import { Users } from "lucide-react";
 import type { User } from "../types";
 import { UserItem } from "./UserItem";
@@ -26,21 +24,13 @@ export default function UsersList({
 	status,
 	term,
 }: UsersListProps) {
-	const { data, isPending, isError } = useFindUsers(
+	const { data } = useSuspenseUsers(
 		urlPage,
 		25,
 		term,
 		undefined,
 		status === "active",
 	);
-
-	if (isError && !data) {
-		return <QueryError noun="users" />;
-	}
-
-	if (isPending) {
-		return <LoadingPlaceholder />;
-	}
 
 	const { items, page, page_count } = data;
 

--- a/apps/web/src/users/components/__tests__/ManageUsers.test.tsx
+++ b/apps/web/src/users/components/__tests__/ManageUsers.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import { createFakeAccount } from "@tests/fake/account";
 import { createFakeUsers } from "@tests/fake/user";
 import { mockFindUsers, mockGetAccount } from "@tests/server-fn/users";
-import { at, renderWithRouter } from "@tests/setup";
+import { at, renderRoute, renderWithRouter } from "@tests/setup";
 import { describe, expect, it } from "vitest";
 import { ManageUsers } from "../ManageUsers";
 
@@ -10,13 +10,10 @@ describe("<ManageUsers />", () => {
 	it("should render correctly with 3 users", async () => {
 		const users = createFakeUsers(3);
 		at(users, 0).administrator_role = "full";
-		await mockFindUsers(users);
-		const account = createFakeAccount({
-			administrator_role: "full",
-		});
-		mockGetAccount(account);
+		mockFindUsers(users);
+		const account = createFakeAccount({ administrator_role: "full" });
 
-		await renderWithRouter(<ManageUsers />);
+		await renderRoute("/administration/users", { account });
 
 		expect(await screen.findByLabelText("search")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Create" })).toBeInTheDocument();
@@ -26,20 +23,9 @@ describe("<ManageUsers />", () => {
 		});
 	});
 
-	it("should render correctly when items = null", async () => {
-		const account = createFakeAccount({
-			administrator_role: "full",
-		});
-		mockGetAccount(account);
-
-		await renderWithRouter(<ManageUsers />);
-
-		expect(await screen.findByLabelText("search")).toBeInTheDocument();
-		expect(screen.getByRole("button")).toBeInTheDocument();
-		expect(screen.getByLabelText("loading")).toBeInTheDocument();
-		expect(screen.queryByText("Administrator")).not.toBeInTheDocument();
-	});
-
+	// Rendered directly rather than through the route: `/administration`'s
+	// `beforeLoad` redirects an account without the role away before this branch
+	// could render. It holds no list query, so nothing suspends.
 	it("should render correctly if account has insufficient permissions", async () => {
 		const users = createFakeUsers(3);
 

--- a/apps/web/src/users/queries.ts
+++ b/apps/web/src/users/queries.ts
@@ -80,28 +80,26 @@ export function usersQueryOptions(
 			findUsers({
 				data: { page, per_page, term, administrator, active },
 			}),
-		placeholderData: keepPreviousData,
 	});
 }
 
 /**
- * Fetch a page of user search results.
+ * Fetch a page of user search results, suspending until it resolves.
  *
- * @param page - The page to fetch
- * @param per_page - The number of users to fetch per page
- * @param term - The search term to filter users by
- * @param administrator - Filter the users by administrator status
- * @param active - Filter the users by whether they are active
- * @returns A page of user search results
+ * `data` is always defined, and a failed request throws to the nearest route
+ * error boundary instead of resolving to `undefined`. Use this from components
+ * rendered under the user administration route, whose loader prefetches the
+ * page — loading and errors are handled by the route's Suspense and
+ * `errorComponent` rather than inline.
  */
-export function useFindUsers(
+export function useSuspenseUsers(
 	page: number,
 	per_page: number,
 	term: string,
 	administrator?: boolean,
 	active?: boolean,
 ) {
-	return useQuery(
+	return useSuspenseQuery(
 		usersQueryOptions(page, per_page, term, administrator, active),
 	);
 }


### PR DESCRIPTION
## Summary
- Move seven list views (hmm, indexes, jobs, otus, references, subtraction, users) onto `useSuspenseQuery` with route-loader prefetch, so the router's configured `defaultPreload: "intent"` finally does something: the loader warms the cache on hover, and a page or filter change keeps the previous rows on screen while it runs instead of blanking to a placeholder. Loading and errors land on the route's Suspense boundary and `defaultErrorComponent` rather than each list's inline gates.
- `useSuspenseQuery` does not accept `placeholderData`, so `keepPreviousData` is gone from these lists — the router's pending state replaces it. The user administration search term moves into the url, since it was component state and the only Suspense boundary sits above `<Outlet/>`, so suspending per keystroke would unmount the search input mid-type.
- The hmm and subtraction search boxes gain `useDebouncedDraft`, matching the otu and reference toolbars; under a loader an undebounced box lags the url by one request per keystroke.

Samples is deliberately left out: `renderRoute` plus a Radix dropdown hangs the event loop, which is VIR-2732's territory.