### PR TITLE
feat: log whether Sentry initialised on server start

### DIFF
--- a/apps/web/src/instrument.server.ts
+++ b/apps/web/src/instrument.server.ts
@@ -18,4 +18,14 @@ if (options.dsn) {
 		...options,
 		integrations: [nodeProfilingIntegration()],
 	});
+
+	// Import the logger lazily and only after `Sentry.init`. `@server/logger`
+	// transitively pulls in the Sentry SDK graph (via `sentryLog.ts`), so a
+	// top-level import would front-load it before Sentry's Node
+	// auto-instrumentation has a chance to install its import hooks.
+	const { logger } = await import("@server/logger");
+	logger.info({ environment: options.environment }, "sentry initialised");
+} else {
+	const { logger } = await import("@server/logger");
+	logger.info("sentry disabled (no VT_SENTRY_DSN)");
 }

--- a/apps/web/src/instrument.server.ts
+++ b/apps/web/src/instrument.server.ts
@@ -24,8 +24,14 @@ if (options.dsn) {
 	// top-level import would front-load it before Sentry's Node
 	// auto-instrumentation has a chance to install its import hooks.
 	const { logger } = await import("@server/logger");
-	logger.info({ environment: options.environment }, "sentry initialised");
+	logger.info(
+		{ environment: options.environment, foundSentryDsn: true },
+		"sentry initialised",
+	);
 } else {
 	const { logger } = await import("@server/logger");
-	logger.info("sentry disabled (no VT_SENTRY_DSN)");
+	logger.info(
+		{ environment: options.environment, foundSentryDsn: false },
+		"sentry disabled",
+	);
 }


### PR DESCRIPTION
## Summary
- Log a message on server start confirming whether Sentry initialised, so a missing `VT_SENTRY_DSN` is visible without inferring it from silence.
- Import the logger lazily after `Sentry.init` so `@server/logger`'s transitive Sentry SDK graph doesn't front-load before Sentry's Node auto-instrumentation installs its import hooks.