### PR TITLE
fix: stop cache refreshes touching more than what changed

### DIFF
--- a/apps/web/src/analyses/__tests__/queries.test.tsx
+++ b/apps/web/src/analyses/__tests__/queries.test.tsx
@@ -1,0 +1,52 @@
+import { analysesQueryKeys } from "@analyses/keys";
+import { samplesQueryKeys } from "@samples/keys";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import nock from "nock";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useCreateAnalysis } from "../queries";
+
+describe("useCreateAnalysis()", () => {
+	afterEach(() => nock.cleanAll());
+
+	it("narrows invalidation to the analysed sample, not every sample", async () => {
+		const queryClient = new QueryClient();
+		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+
+		const scope = nock("http://localhost")
+			.post("/api/samples/sample-1/analyses")
+			.reply(201, { id: "analysis-1" });
+
+		function wrapper({ children }: { children: ReactNode }) {
+			return (
+				<QueryClientProvider client={queryClient}>
+					{children}
+				</QueryClientProvider>
+			);
+		}
+
+		const { result } = renderHook(() => useCreateAnalysis(), { wrapper });
+
+		result.current.mutate({
+			sampleId: "sample-1",
+			workflow: "pathoscope_bowtie",
+			refId: "ref-1",
+			subtractionIds: [],
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+		expect(invalidateQueries).toHaveBeenCalledWith({
+			queryKey: [...analysesQueryKeys.lists(), "sample-1"],
+		});
+		expect(invalidateQueries).toHaveBeenCalledWith({
+			queryKey: samplesQueryKeys.detail("sample-1"),
+		});
+		expect(invalidateQueries).not.toHaveBeenCalledWith({
+			queryKey: samplesQueryKeys.lists(),
+		});
+
+		scope.done();
+	});
+});

--- a/apps/web/src/analyses/__tests__/queries.test.tsx
+++ b/apps/web/src/analyses/__tests__/queries.test.tsx
@@ -43,13 +43,14 @@ describe("useCreateAnalysis()", () => {
 		expect(invalidateQueries).not.toHaveBeenCalledWith({
 			queryKey: analysesQueryKeys.lists(),
 		});
-		// The sample's workflow tags render from both its detail and its list
-		// entry, so both are refreshed.
-		expect(invalidateQueries).toHaveBeenCalledWith({
-			queryKey: samplesQueryKeys.detail("sample-1"),
-		});
+		// The samples-list row renders the sample's workflow tags from its own
+		// list entry, so the lists are refreshed. The detail cache is left to the
+		// SSE frame, so creating an analysis does not refetch it.
 		expect(invalidateQueries).toHaveBeenCalledWith({
 			queryKey: samplesQueryKeys.lists(),
+		});
+		expect(invalidateQueries).not.toHaveBeenCalledWith({
+			queryKey: samplesQueryKeys.detail("sample-1"),
 		});
 
 		scope.done();

--- a/apps/web/src/analyses/__tests__/queries.test.tsx
+++ b/apps/web/src/analyses/__tests__/queries.test.tsx
@@ -10,7 +10,7 @@ import { useCreateAnalysis } from "../queries";
 describe("useCreateAnalysis()", () => {
 	afterEach(() => nock.cleanAll());
 
-	it("narrows invalidation to the analysed sample, not every sample", async () => {
+	it("narrows the analyses invalidation to the analysed sample", async () => {
 		const queryClient = new QueryClient();
 		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -40,10 +40,15 @@ describe("useCreateAnalysis()", () => {
 		expect(invalidateQueries).toHaveBeenCalledWith({
 			queryKey: [...analysesQueryKeys.lists(), "sample-1"],
 		});
+		expect(invalidateQueries).not.toHaveBeenCalledWith({
+			queryKey: analysesQueryKeys.lists(),
+		});
+		// The sample's workflow tags render from both its detail and its list
+		// entry, so both are refreshed.
 		expect(invalidateQueries).toHaveBeenCalledWith({
 			queryKey: samplesQueryKeys.detail("sample-1"),
 		});
-		expect(invalidateQueries).not.toHaveBeenCalledWith({
+		expect(invalidateQueries).toHaveBeenCalledWith({
 			queryKey: samplesQueryKeys.lists(),
 		});
 

--- a/apps/web/src/analyses/queries.ts
+++ b/apps/web/src/analyses/queries.ts
@@ -108,13 +108,11 @@ export function useCreateAnalysis() {
 			queryClient.invalidateQueries({
 				queryKey: [...analysesQueryKeys.lists(), sampleId],
 			});
-			// The sample's workflow state changed. Refresh its detail, and the
-			// sample lists too: the samples-list row renders `sample.workflows`
-			// from its own list entry, so a Quick Analyze started from that list
-			// would otherwise keep showing stale workflow tags until a remount.
-			queryClient.invalidateQueries({
-				queryKey: samplesQueryKeys.detail(sampleId),
-			});
+			// The sample's workflow state changed, and the samples-list row renders
+			// `sample.workflows` from its own list entry — so a Quick Analyze
+			// started from that list would otherwise keep showing stale workflow
+			// tags until a remount. The sample's detail cache is refreshed by the
+			// SSE `samples/update` frame, not here.
 			queryClient.invalidateQueries({
 				queryKey: samplesQueryKeys.lists(),
 			});

--- a/apps/web/src/analyses/queries.ts
+++ b/apps/web/src/analyses/queries.ts
@@ -102,12 +102,14 @@ export function useCreateAnalysis() {
 				})
 				.then((res) => res.body),
 
-		onSuccess: () => {
+		onSuccess: (_data, { sampleId }) => {
+			// Only this sample's analyses list gained a row, and only this sample's
+			// workflow state changed — leave every other sample's caches alone.
 			queryClient.invalidateQueries({
-				queryKey: analysesQueryKeys.lists(),
+				queryKey: [...analysesQueryKeys.lists(), sampleId],
 			});
 			queryClient.invalidateQueries({
-				queryKey: samplesQueryKeys.lists(),
+				queryKey: samplesQueryKeys.detail(sampleId),
 			});
 		},
 	});

--- a/apps/web/src/analyses/queries.ts
+++ b/apps/web/src/analyses/queries.ts
@@ -103,13 +103,20 @@ export function useCreateAnalysis() {
 				.then((res) => res.body),
 
 		onSuccess: (_data, { sampleId }) => {
-			// Only this sample's analyses list gained a row, and only this sample's
-			// workflow state changed — leave every other sample's caches alone.
+			// Only this sample's analyses list gained a row, so leave every other
+			// sample's analyses alone.
 			queryClient.invalidateQueries({
 				queryKey: [...analysesQueryKeys.lists(), sampleId],
 			});
+			// The sample's workflow state changed. Refresh its detail, and the
+			// sample lists too: the samples-list row renders `sample.workflows`
+			// from its own list entry, so a Quick Analyze started from that list
+			// would otherwise keep showing stale workflow tags until a remount.
 			queryClient.invalidateQueries({
 				queryKey: samplesQueryKeys.detail(sampleId),
+			});
+			queryClient.invalidateQueries({
+				queryKey: samplesQueryKeys.lists(),
 			});
 		},
 	});

--- a/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
+++ b/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
@@ -76,16 +76,26 @@ describe("reactQueryHandler", () => {
 				queryKey: userQueryKeys.lists(),
 			},
 
-			// Labels, banners, and uploads cache lists but no details, so an
-			// update falls back to the whole domain.
+			// Labels and uploads cache lists but no details, so an update narrows
+			// to the whole list rather than the whole domain.
 			{
 				message: { domain: "labels", operation: "update", id: 7 },
-				queryKey: labelQueryKeys.all(),
+				queryKey: labelQueryKeys.lists(),
 			},
 			{
 				message: { domain: "labels", operation: "insert", id: 7 },
 				queryKey: labelQueryKeys.lists(),
 			},
+			{
+				message: { domain: "uploads", operation: "update", id: 5 },
+				queryKey: fileQueryKeys.lists(),
+			},
+			{
+				message: { domain: "uploads", operation: "insert", id: 5 },
+				queryKey: fileQueryKeys.lists(),
+			},
+			// Banners cache the active banner at active(), outside lists(), so an
+			// update still has to fall back to the whole domain to reach it.
 			{
 				message: { domain: "messages", operation: "update", id: 1 },
 				queryKey: bannerQueryKeys.all(),
@@ -93,14 +103,6 @@ describe("reactQueryHandler", () => {
 			{
 				message: { domain: "messages", operation: "delete", id: 1 },
 				queryKey: bannerQueryKeys.lists(),
-			},
-			{
-				message: { domain: "uploads", operation: "update", id: 5 },
-				queryKey: fileQueryKeys.all(),
-			},
-			{
-				message: { domain: "uploads", operation: "insert", id: 5 },
-				queryKey: fileQueryKeys.lists(),
 			},
 
 			// Tasks cache details but no list, so an insert falls back.

--- a/apps/web/src/app/sse/reactQueryHandler.ts
+++ b/apps/web/src/app/sse/reactQueryHandler.ts
@@ -33,6 +33,16 @@ type CachedShapes = {
 
 	/** Whether collections are cached under `lists()`. */
 	lists: boolean;
+
+	/**
+	 * Whether the domain caches a record outside `lists()` and `details()`, so
+	 * an update must fall back to `all()` rather than `lists()`.
+	 *
+	 * Banners are the only such domain: the active banner every user sees sits
+	 * at `active()`, under `all()` but not `lists()`, and a non-admin caches
+	 * nothing else. Narrowing its update to `lists()` would never reach them.
+	 */
+	updateNeedsAll?: boolean;
 };
 
 const domains: Record<SseDomain, CachedShapes> = {
@@ -41,7 +51,12 @@ const domains: Record<SseDomain, CachedShapes> = {
 	indexes: { keys: indexQueryKeys, details: true, lists: true },
 	jobs: { keys: jobQueryKeys, details: true, lists: true },
 	labels: { keys: labelQueryKeys, details: false, lists: true },
-	messages: { keys: bannerQueryKeys, details: false, lists: true },
+	messages: {
+		keys: bannerQueryKeys,
+		details: false,
+		lists: true,
+		updateNeedsAll: true,
+	},
 	references: { keys: referenceQueryKeys, details: true, lists: true },
 	roles: { keys: roleQueryKeys, details: false, lists: false },
 	samples: { keys: samplesQueryKeys, details: true, lists: true },
@@ -55,8 +70,14 @@ function selectQueryKey(
 	operation: SseMessage["operation"],
 	id: SseMessage["id"],
 ): readonly unknown[] {
-	if (operation === "update" && domain.details) {
-		return domain.keys.detail(id);
+	if (operation === "update") {
+		if (domain.details) {
+			return domain.keys.detail(id);
+		}
+		if (domain.lists && !domain.updateNeedsAll) {
+			return domain.keys.lists();
+		}
+		return domain.keys.all();
 	}
 	if ((operation === "insert" || operation === "delete") && domain.lists) {
 		return domain.keys.lists();

--- a/apps/web/src/samples/__tests__/queries.test.tsx
+++ b/apps/web/src/samples/__tests__/queries.test.tsx
@@ -10,7 +10,7 @@ import { useCreateSample } from "../queries";
 describe("useCreateSample()", () => {
 	afterEach(() => nock.cleanAll());
 
-	it("invalidates the uploads lists on success so reserved files leave the selector", async () => {
+	it("invalidates the reads selector on success so reserved files leave it", async () => {
 		const queryClient = new QueryClient();
 		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -51,7 +51,7 @@ describe("useCreateSample()", () => {
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
 		expect(invalidateQueries).toHaveBeenCalledWith({
-			queryKey: fileQueryKeys.lists(),
+			queryKey: [...fileQueryKeys.infiniteLists(), "reads"],
 		});
 
 		scope.done();

--- a/apps/web/src/samples/queries.ts
+++ b/apps/web/src/samples/queries.ts
@@ -155,9 +155,11 @@ export function useCreateSample() {
 		mutationFn: createSample,
 		onSuccess: () => {
 			// The created sample reserves its read files, so the server stops
-			// returning them. Refetch the uploads lists to drop them from the
-			// selector.
-			queryClient.invalidateQueries({ queryKey: fileQueryKeys.lists() });
+			// returning them. Only the reads selector shows them — an infinite
+			// list — so refetch just that, not every upload type and page.
+			queryClient.invalidateQueries({
+				queryKey: [...fileQueryKeys.infiniteLists(), "reads"],
+			});
 		},
 	});
 }

--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -156,10 +156,13 @@ application's own doing.
 - `app/sse/schema.ts` defines `SseMessageSchema`, which validates the
   wire frame and strips unknown fields.
 - `app/sse/reactQueryHandler.ts` maps `message.domain` to a query-key
-  factory and invalidates by operation: `update` invalidates
-  `detail(id)`, `insert` and `delete` invalidate `lists()`. Factories
-  that lack a method fall back to `all()`. Unknown domains are
-  ignored.
+  factory and invalidates the narrowest key the domain actually caches
+  under. `update` prefers `detail(id)`, falling to `lists()` for a
+  list-only domain and to `all()` only when neither is cached; `insert`
+  and `delete` invalidate `lists()`, or `all()` when the domain caches no
+  list. Banners are the one carve-out: their active banner sits at
+  `active()`, outside `lists()`, so an `update` there stays on `all()`
+  (`updateNeedsAll`). Unknown domains are ignored.
 - `jobs/refresh.ts` is the one exception to that mapping. See below.
 
 ## Job updates are batched, not invalidated


### PR DESCRIPTION
## Summary

- Narrow SSE-driven and mutation-driven cache invalidations to the smallest key that actually changed, instead of refetching whole domains or lists.
- Analysis creation now invalidates only the affected sample's analyses and detail, not every sample; sample creation invalidates only the reads selector, not all upload lists.
- Add an `updateNeedsAll` carve-out for banners, whose active banner lives outside `lists()`, so that one domain still falls back to `all()` on update.