### PR TITLE
feat: queue multiple analyses with a "Create more" switch

### DIFF
--- a/apps/web/src/analyses/components/Create/CreateAnalysis.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysis.tsx
@@ -35,6 +35,7 @@ export default function CreateAnalysis({
 				<HMMAlert installed={Boolean(hmms.status.task?.complete)} />
 				<CreateAnalysisForm
 					compatibleWorkflows={compatibleWorkflows}
+					onClose={() => setOpen(false)}
 					sampleCount={1}
 					sampleIds={[sampleId]}
 				/>

--- a/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
@@ -4,7 +4,17 @@ import Button from "@base/Button";
 import { DialogFooter } from "@base/Dialog";
 import InputError from "@base/InputError";
 import QueryError from "@base/QueryError";
+import Switch from "@base/Switch";
+import {
+	Toast,
+	ToastClose,
+	ToastDescription,
+	ToastProvider,
+	ToastTitle,
+	ToastViewport,
+} from "@base/Toast";
 import SubtractionSelector from "@subtraction/components/SubtractionSelector";
+import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { CreateAnalysisSummary } from "./CreateAnalysisSummary";
 import IndexSelector from "./IndexSelector";
@@ -17,9 +27,19 @@ type CreateAnalysisFormValues = {
 	workflow: string;
 };
 
+/** A dismissible confirmation shown after analyses are created with "Create more" on. */
+type CreatedAnalysis = {
+	id: string;
+	count: number;
+	workflow: string;
+};
+
 type CreateAnalysisFormProps = {
 	/** The workflows compatible with the selected sample(s) */
 	compatibleWorkflows: workflow[];
+
+	/** Closes the enclosing dialog. */
+	onClose: () => void;
 
 	/** The number of samples selected */
 	sampleCount: number;
@@ -35,6 +55,7 @@ type CreateAnalysisFormProps = {
  */
 export default function CreateAnalysisForm({
 	compatibleWorkflows,
+	onClose,
 	sampleCount,
 	sampleIds,
 }: CreateAnalysisFormProps) {
@@ -53,17 +74,23 @@ export default function CreateAnalysisForm({
 
 	const createAnalysis = useCreateAnalysis();
 
+	const defaultValues = {
+		indexId: "",
+		subtractionIds: defaultSubtractions.map((subtraction) => subtraction.id),
+		workflow: compatibleWorkflows[0]?.id,
+	};
+
 	const {
 		control,
 		handleSubmit,
 		formState: { errors },
+		reset,
 		watch,
-	} = useForm<CreateAnalysisFormValues>({
-		defaultValues: {
-			subtractionIds: defaultSubtractions.map((subtraction) => subtraction.id),
-			workflow: compatibleWorkflows[0]?.id,
-		},
-	});
+	} = useForm<CreateAnalysisFormValues>({ defaultValues });
+
+	const [createMore, setCreateMore] = useState(false);
+	const [createdAnalysis, setCreatedAnalysis] =
+		useState<CreatedAnalysis | null>(null);
 
 	if (isErrorIndexes || isErrorSubtractions) {
 		return <QueryError noun="analysis options" />;
@@ -73,7 +100,7 @@ export default function CreateAnalysisForm({
 		return null;
 	}
 
-	function onSubmit(values: CreateAnalysisFormValues) {
+	async function onSubmit(values: CreateAnalysisFormValues) {
 		const { indexId, subtractionIds, workflow } = values;
 
 		const index = indexes.find((index) => index.id === indexId);
@@ -82,14 +109,35 @@ export default function CreateAnalysisForm({
 		}
 		const refId = index.reference.id;
 
-		for (const sampleId of sampleIds) {
-			createAnalysis.mutate({
-				refId,
-				sampleId,
-				subtractionIds,
-				workflow,
-			});
+		let created: Awaited<ReturnType<typeof createAnalysis.mutateAsync>>[];
+		try {
+			created = await Promise.all(
+				sampleIds.map((sampleId) =>
+					createAnalysis.mutateAsync({
+						refId,
+						sampleId,
+						subtractionIds,
+						workflow,
+					}),
+				),
+			);
+		} catch {
+			return;
 		}
+
+		if (!createMore) {
+			onClose();
+			return;
+		}
+
+		reset(defaultValues);
+		setCreatedAnalysis({
+			id: created[0]?.id ?? "",
+			count: created.length,
+			workflow:
+				compatibleWorkflows.find((option) => option.id === workflow)?.name ??
+				workflow,
+		});
 	}
 
 	return (
@@ -139,14 +187,55 @@ export default function CreateAnalysisForm({
 			</InputError>
 
 			<DialogFooter className="items-center justify-between">
-				<CreateAnalysisSummary
-					sampleCount={sampleCount}
-					indexCount={watch("indexId") ? 1 : 0}
-				/>
-				<Button type="submit" color="blue">
-					Create
-				</Button>
+				<div className="flex items-center gap-2">
+					<Switch
+						id="create-more"
+						checked={createMore}
+						onCheckedChange={setCreateMore}
+					/>
+					<label
+						className="cursor-pointer text-gray-700 text-sm"
+						htmlFor="create-more"
+					>
+						Create more
+					</label>
+				</div>
+
+				<div className="flex items-center gap-4">
+					<CreateAnalysisSummary
+						sampleCount={sampleCount}
+						indexCount={watch("indexId") ? 1 : 0}
+					/>
+					<Button type="submit" color="blue">
+						Create
+					</Button>
+				</div>
 			</DialogFooter>
+
+			<ToastProvider>
+				{createdAnalysis && (
+					<Toast
+						key={createdAnalysis.id}
+						onOpenChange={(open) => {
+							if (!open) {
+								setCreatedAnalysis(null);
+							}
+						}}
+						open
+					>
+						<div>
+							<ToastTitle>
+								{createdAnalysis.count === 1
+									? "Analysis created"
+									: `${createdAnalysis.count} analyses created`}
+							</ToastTitle>
+							<ToastDescription>{createdAnalysis.workflow}</ToastDescription>
+						</div>
+						<ToastClose />
+					</Toast>
+				)}
+				<ToastViewport />
+			</ToastProvider>
 		</form>
 	);
 }

--- a/apps/web/src/analyses/components/Create/QuickAnalyze.tsx
+++ b/apps/web/src/analyses/components/Create/QuickAnalyze.tsx
@@ -59,6 +59,7 @@ export default function QuickAnalyze({
 
 				<CreateAnalysisForm
 					compatibleWorkflows={compatibleWorkflows}
+					onClose={() => setOpen(false)}
 					sampleCount={sampleIds.length}
 					sampleIds={sampleIds}
 				/>

--- a/apps/web/src/analyses/components/Create/__tests__/CreateAnalysisForm.test.tsx
+++ b/apps/web/src/analyses/components/Create/__tests__/CreateAnalysisForm.test.tsx
@@ -1,0 +1,81 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { mockApiCreateAnalysis } from "@tests/api/analyses";
+import { mockApiListIndexes } from "@tests/api/indexes";
+import { mockApiGetSampleDetail } from "@tests/api/samples";
+import { mockApiGetShortlistSubtractions } from "@tests/api/subtractions";
+import { createFakeAnalysisMinimal } from "@tests/fake/analyses";
+import { createFakeIndexMinimal } from "@tests/fake/indexes";
+import { createFakeSample } from "@tests/fake/samples";
+import { renderWithRouter } from "@tests/setup";
+import { describe, expect, it, vi } from "vitest";
+import CreateAnalysisForm from "../CreateAnalysisForm";
+import { getCompatibleWorkflows } from "../workflows";
+
+async function renderForm() {
+	const onClose = vi.fn();
+	const sample = createFakeSample({ subtractions: [] });
+	const index = createFakeIndexMinimal({
+		ready: true,
+		reference: { id: "ref-1", name: "Plant Viruses", data_type: "genome" },
+	});
+
+	mockApiListIndexes([index]);
+	mockApiGetShortlistSubtractions([]);
+	mockApiGetSampleDetail(sample);
+
+	await renderWithRouter(
+		<CreateAnalysisForm
+			compatibleWorkflows={getCompatibleWorkflows(false)}
+			onClose={onClose}
+			sampleCount={1}
+			sampleIds={[sample.id]}
+		/>,
+	);
+
+	return { onClose, sample };
+}
+
+async function selectReference() {
+	const comboboxes = await screen.findAllByRole("combobox");
+	const referenceTrigger = comboboxes.find(
+		(element) => element.tagName === "BUTTON",
+	);
+	await userEvent.click(referenceTrigger as HTMLElement);
+	await userEvent.click(
+		await screen.findByRole("option", { name: /Plant Viruses/ }),
+	);
+}
+
+describe("<CreateAnalysisForm>", () => {
+	it("closes the dialog after creating when 'Create more' is off", async () => {
+		const { onClose, sample } = await renderForm();
+
+		const scope = mockApiCreateAnalysis(
+			createFakeAnalysisMinimal({ sample: { id: sample.id } }),
+		);
+
+		await selectReference();
+		await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+		await waitFor(() => expect(onClose).toHaveBeenCalled());
+		scope.done();
+	});
+
+	it("keeps the dialog open and shows a toast when 'Create more' is on", async () => {
+		const { onClose, sample } = await renderForm();
+
+		const scope = mockApiCreateAnalysis(
+			createFakeAnalysisMinimal({ sample: { id: sample.id } }),
+		);
+
+		await selectReference();
+		await userEvent.click(screen.getByRole("switch", { name: "Create more" }));
+		await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+		expect(await screen.findByText("Analysis created")).toBeInTheDocument();
+		expect(onClose).not.toHaveBeenCalled();
+		expect(screen.getByText("Select a reference")).toBeInTheDocument();
+		scope.done();
+	});
+});

--- a/apps/web/src/tests/api/analyses.ts
+++ b/apps/web/src/tests/api/analyses.ts
@@ -26,6 +26,18 @@ export function mockApiGetAnalyses(analyses: AnalysisMinimal[]) {
 }
 
 /**
+ * Creates a mocked API call for creating an analysis on a sample
+ *
+ * @param analysis - The analysis returned by the request
+ * @returns The nock scope for the mocked API call
+ */
+export function mockApiCreateAnalysis(analysis: AnalysisMinimal) {
+	return nock("http://localhost")
+		.post(`/api/samples/${analysis.sample.id}/analyses`)
+		.reply(201, analysis);
+}
+
+/**
  * Creates a mocked API call for initiating a blast for a Nuvs sequence
  *
  * @param analysisId - The id of the analysis associated with the sequence


### PR DESCRIPTION
## Summary
- Add a "Create more" switch to the create-analysis dialog, mirroring the sample-creation pattern.
- With the switch on, a successful submit resets the form and shows a confirmation toast while keeping the dialog open; with it off the dialog closes as before.
- Applies to both the single-sample and quick-analyze dialogs, since the switch lives in the shared `CreateAnalysisForm`.