### PR TITLE
fix: use a consistent search param name across list-view URLs

### DIFF
--- a/apps/web/src/base/ListEmpty.tsx
+++ b/apps/web/src/base/ListEmpty.tsx
@@ -1,0 +1,51 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import Box from "./Box";
+import {
+	Empty,
+	EmptyContent,
+	EmptyDescription,
+	EmptyMedia,
+	EmptyTitle,
+} from "./Empty";
+
+type ListEmptyProps = {
+	/** Recovery actions rendered below the text, e.g. a create or rebuild button. */
+	children?: ReactNode;
+
+	/** Optional secondary line explaining why the list is empty. */
+	description?: ReactNode;
+
+	/** The muted icon shown above the title. */
+	icon: LucideIcon;
+
+	/** The primary line, announced by assistive technology. */
+	title: ReactNode;
+};
+
+/**
+ * The standard empty state for a paginated list: a boxed, fixed-height `Empty`
+ * with a large muted icon, a title, and optional description and actions.
+ *
+ * Composes the `Empty*` primitives so a change to how every list looks when it
+ * is empty is a single edit here rather than one per list view.
+ */
+export default function ListEmpty({
+	children,
+	description,
+	icon: Icon,
+	title,
+}: ListEmptyProps) {
+	return (
+		<Box>
+			<Empty className="h-72">
+				<EmptyMedia className="text-gray-400">
+					<Icon size={40} strokeWidth={1.5} />
+				</EmptyMedia>
+				<EmptyTitle>{title}</EmptyTitle>
+				{description && <EmptyDescription>{description}</EmptyDescription>}
+				{children && <EmptyContent>{children}</EmptyContent>}
+			</Empty>
+		</Box>
+	);
+}

--- a/apps/web/src/hmm/components/HmmList.tsx
+++ b/apps/web/src/hmm/components/HmmList.tsx
@@ -1,6 +1,5 @@
-import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
-import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "@base/Empty";
+import ListEmpty from "@base/ListEmpty";
 import Pagination from "@base/Pagination";
 import SearchToolbar from "@base/SearchToolbar";
 import ViewHeader from "@base/ViewHeader";
@@ -12,10 +11,10 @@ import { HmmInstall } from "./HmmInstall";
 import HmmItem from "./HmmItem";
 
 type HmmListProps = {
-	find: string;
+	term: string;
 	page: number;
 	setSearch: (
-		next: { find?: string; page?: number },
+		next: { term?: string; page?: number },
 		options?: { replace?: boolean },
 	) => void;
 };
@@ -23,8 +22,8 @@ type HmmListProps = {
 /**
  * A list of HMMs with filtering options
  */
-export default function HmmList({ find, page, setSearch }: HmmListProps) {
-	const { data } = useSuspenseHmms(page, 25, find);
+export default function HmmList({ term, page, setSearch }: HmmListProps) {
+	const { data } = useSuspenseHmms(page, 25, term);
 
 	const {
 		items,
@@ -50,9 +49,9 @@ export default function HmmList({ find, page, setSearch }: HmmListProps) {
 				<>
 					<SearchToolbar
 						aria-label="Search HMMs"
-						onChange={(find) => setSearch({ find, page: 1 }, { replace: true })}
+						onChange={(term) => setSearch({ term, page: 1 }, { replace: true })}
 						placeholder="Name"
-						value={find}
+						value={term}
 					/>
 					{items.length ? (
 						<Pagination
@@ -69,21 +68,13 @@ export default function HmmList({ find, page, setSearch }: HmmListProps) {
 							</BoxGroup>
 						</Pagination>
 					) : (
-						<Box>
-							<Empty className="h-72">
-								<EmptyMedia className="text-gray-400">
-									{find ? (
-										<SearchX size={40} strokeWidth={1.5} />
-									) : (
-										<Boxes size={40} strokeWidth={1.5} />
-									)}
-								</EmptyMedia>
-								<EmptyTitle>No HMMs found</EmptyTitle>
-								<EmptyDescription>
-									{find ? "No HMMs match your search." : "No HMMs to show."}
-								</EmptyDescription>
-							</Empty>
-						</Box>
+						<ListEmpty
+							icon={term ? SearchX : Boxes}
+							title="No HMMs found"
+							description={
+								term ? "No HMMs match your search." : "No HMMs to show."
+							}
+						/>
 					)}
 				</>
 			) : (

--- a/apps/web/src/indexes/components/Indexes.tsx
+++ b/apps/web/src/indexes/components/Indexes.tsx
@@ -1,12 +1,5 @@
-import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
-import {
-	Empty,
-	EmptyContent,
-	EmptyDescription,
-	EmptyMedia,
-	EmptyTitle,
-} from "@base/Empty";
+import ListEmpty from "@base/ListEmpty";
 import Pagination from "@base/Pagination";
 import Toolbar from "@base/Toolbar";
 import {
@@ -69,24 +62,17 @@ export default function Indexes({ page, setSearch }: IndexesProps) {
 					</BoxGroup>
 				</Pagination>
 			) : (
-				<Box>
-					<Empty className="h-72">
-						<EmptyMedia className="text-gray-400">
-							<Inbox size={40} strokeWidth={1.5} />
-						</EmptyMedia>
-						<EmptyTitle>No indexes found</EmptyTitle>
-						<EmptyDescription>
-							{change_count > 0
-								? "This reference has unbuilt changes."
-								: "This reference has no indexes yet."}
-						</EmptyDescription>
-						{canBuildIndex && (
-							<EmptyContent>
-								<RebuildIndex refId={refId} />
-							</EmptyContent>
-						)}
-					</Empty>
-				</Box>
+				<ListEmpty
+					icon={Inbox}
+					title="No indexes found"
+					description={
+						change_count > 0
+							? "This reference has unbuilt changes."
+							: "This reference has no indexes yet."
+					}
+				>
+					{canBuildIndex && <RebuildIndex refId={refId} />}
+				</ListEmpty>
 			)}
 		</>
 	);

--- a/apps/web/src/jobs/components/JobList.tsx
+++ b/apps/web/src/jobs/components/JobList.tsx
@@ -1,7 +1,6 @@
-import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
 import ContainerNarrow from "@base/ContainerNarrow";
-import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "@base/Empty";
+import ListEmpty from "@base/ListEmpty";
 import Pagination from "@base/Pagination";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
@@ -46,23 +45,15 @@ export default function JobsList({
 			<div className="flex gap-4">
 				<ContainerNarrow>
 					{isEmpty ? (
-						<Box>
-							<Empty className="h-72">
-								<EmptyMedia className="text-gray-400">
-									{isFiltered ? (
-										<SearchX size={40} strokeWidth={1.5} />
-									) : (
-										<Cog size={40} strokeWidth={1.5} />
-									)}
-								</EmptyMedia>
-								<EmptyTitle>No jobs found</EmptyTitle>
-								<EmptyDescription>
-									{isFiltered
-										? "No jobs match your filters."
-										: "No jobs have been run yet."}
-								</EmptyDescription>
-							</Empty>
-						</Box>
+						<ListEmpty
+							icon={isFiltered ? SearchX : Cog}
+							title="No jobs found"
+							description={
+								isFiltered
+									? "No jobs match your filters."
+									: "No jobs have been run yet."
+							}
+						/>
 					) : (
 						<Pagination
 							items={items}

--- a/apps/web/src/otus/components/OtuList.tsx
+++ b/apps/web/src/otus/components/OtuList.tsx
@@ -1,14 +1,7 @@
-import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
 import Button from "@base/Button";
 import ContainerNarrow from "@base/ContainerNarrow";
-import {
-	Empty,
-	EmptyContent,
-	EmptyDescription,
-	EmptyMedia,
-	EmptyTitle,
-} from "@base/Empty";
+import ListEmpty from "@base/ListEmpty";
 import Pagination from "@base/Pagination";
 import RebuildAlert from "@indexes/components/RebuildAlert";
 import { useSuspenseOtus } from "@otus/queries";
@@ -27,10 +20,10 @@ import OtuToolbar from "./OtuToolbar";
 const routeApi = getRouteApi("/_authenticated/refs/$refId/otus/");
 
 type OtuListProps = {
-	find: string;
+	term: string;
 	page: number;
 	setSearch: (
-		next: { find?: string; page?: number },
+		next: { term?: string; page?: number },
 		options?: { replace?: boolean },
 	) => void;
 };
@@ -38,11 +31,11 @@ type OtuListProps = {
 /**
  * A list of OTUs with filtering
  */
-export default function OtuList({ find, page, setSearch }: OtuListProps) {
+export default function OtuList({ term, page, setSearch }: OtuListProps) {
 	const { refId } = routeApi.useParams();
 	const [openCreate, setOpenCreate] = useState(false);
 	const { data: reference } = useSuspenseReference(refId);
-	const { data: otus } = useSuspenseOtus(refId, page, 25, find);
+	const { data: otus } = useSuspenseOtus(refId, page, 25, term);
 	const { hasPermission: canModifyOtu } = useCheckReferenceRight(
 		refId,
 		"modify_otu",
@@ -52,15 +45,15 @@ export default function OtuList({ find, page, setSearch }: OtuListProps) {
 	const { items, page: storedPage, page_count } = otus;
 
 	const canCreate = canModifyOtu && !reference.remotes_from && !archived;
-	const isUnfilteredEmpty = !items.length && !find;
+	const isUnfilteredEmpty = !items.length && !term;
 
 	return (
 		<ContainerNarrow>
 			<RebuildAlert page={page} refId={refId} />
 			{!isUnfilteredEmpty && (
 				<OtuToolbar
-					term={find}
-					setTerm={(find) => setSearch({ find, page: 1 }, { replace: true })}
+					term={term}
+					setTerm={(term) => setSearch({ term, page: 1 }, { replace: true })}
 					onCreate={() => setOpenCreate(true)}
 					refId={refId}
 					remotesFrom={reference.remotes_from}
@@ -83,30 +76,21 @@ export default function OtuList({ find, page, setSearch }: OtuListProps) {
 					</BoxGroup>
 				</Pagination>
 			) : (
-				<Box>
-					<Empty className="h-72">
-						<EmptyMedia className="text-gray-400">
-							{find ? (
-								<SearchX size={40} strokeWidth={1.5} />
-							) : (
-								<Inbox size={40} strokeWidth={1.5} />
-							)}
-						</EmptyMedia>
-						<EmptyTitle>No OTUs found</EmptyTitle>
-						<EmptyDescription>
-							{find
-								? "No OTUs match your search."
-								: "This reference has no OTUs yet."}
-						</EmptyDescription>
-						{isUnfilteredEmpty && canCreate && (
-							<EmptyContent>
-								<Button color="blue" onClick={() => setOpenCreate(true)}>
-									Create OTU
-								</Button>
-							</EmptyContent>
-						)}
-					</Empty>
-				</Box>
+				<ListEmpty
+					icon={term ? SearchX : Inbox}
+					title="No OTUs found"
+					description={
+						term
+							? "No OTUs match your search."
+							: "This reference has no OTUs yet."
+					}
+				>
+					{isUnfilteredEmpty && canCreate && (
+						<Button color="blue" onClick={() => setOpenCreate(true)}>
+							Create OTU
+						</Button>
+					)}
+				</ListEmpty>
 			)}
 		</ContainerNarrow>
 	);

--- a/apps/web/src/references/components/ReferenceList.tsx
+++ b/apps/web/src/references/components/ReferenceList.tsx
@@ -1,7 +1,6 @@
-import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
 import ContainerNarrow from "@base/ContainerNarrow";
-import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "@base/Empty";
+import ListEmpty from "@base/ListEmpty";
 import Pagination from "@base/Pagination";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
@@ -16,12 +15,12 @@ import ReferenceToolbar from "./ReferenceToolbar";
 
 type ReferenceListProps = {
 	archived?: boolean;
-	find?: string;
+	term?: string;
 	page?: number;
 	setSearch?: (
 		next: {
 			archived?: boolean;
-			find?: string;
+			term?: string;
 			page?: number;
 		},
 		options?: { replace?: boolean },
@@ -33,14 +32,14 @@ type ReferenceListProps = {
  */
 export default function ReferenceList({
 	archived = false,
-	find = "",
+	term = "",
 	page = 1,
 	setSearch = () => {},
 }: ReferenceListProps) {
 	const [isCreateReferenceOpen, setIsCreateReferenceOpen] = useState(false);
 	const [cloneReferenceId, setCloneReferenceId] = useState<string>();
 
-	const { data } = useSuspenseReferences(page, 25, find, archived);
+	const { data } = useSuspenseReferences(page, 25, term, archived);
 
 	const { items, page: storedPage, page_count, total_count } = data;
 
@@ -55,31 +54,25 @@ export default function ReferenceList({
 				</ViewHeader>
 				<ReferenceToolbar
 					archived={archived}
-					find={find}
+					term={term}
 					onCreate={() => setIsCreateReferenceOpen(true)}
 					setArchived={(archived) => setSearch({ archived, page: 1 })}
-					setFind={(find) => setSearch({ find, page: 1 }, { replace: true })}
+					setTerm={(term) => setSearch({ term, page: 1 }, { replace: true })}
 				/>
 				<CreateReference
 					open={isCreateReferenceOpen}
 					onOpenChange={setIsCreateReferenceOpen}
 				/>
 				{!items.length ? (
-					<Box>
-						<Empty className="h-72">
-							<EmptyMedia className="text-gray-400">
-								<Library size={40} strokeWidth={1.5} />
-							</EmptyMedia>
-							<EmptyTitle>
-								No {archived ? "archived references" : "references"} found
-							</EmptyTitle>
-							<EmptyDescription>
-								{archived
-									? "No references have been archived yet."
-									: "No references have been created yet."}
-							</EmptyDescription>
-						</Empty>
-					</Box>
+					<ListEmpty
+						icon={Library}
+						title={`No ${archived ? "archived references" : "references"} found`}
+						description={
+							archived
+								? "No references have been archived yet."
+								: "No references have been created yet."
+						}
+					/>
 				) : (
 					<Pagination
 						items={items}

--- a/apps/web/src/references/components/ReferenceToolbar.tsx
+++ b/apps/web/src/references/components/ReferenceToolbar.tsx
@@ -6,10 +6,10 @@ import ToggleGroupItem from "@base/ToggleGroupItem";
 
 type ReferenceToolbarProps = {
 	archived: boolean;
-	find: string;
+	term: string;
 	onCreate: () => void;
 	setArchived: (archived: boolean) => void;
-	setFind: (find: string) => void;
+	setTerm: (term: string) => void;
 };
 
 /**
@@ -17,10 +17,10 @@ type ReferenceToolbarProps = {
  */
 export default function ReferenceToolbar({
 	archived,
-	find,
+	term,
 	onCreate,
 	setArchived,
-	setFind,
+	setTerm,
 }: ReferenceToolbarProps) {
 	const { hasPermission: canCreate } =
 		useCheckAdminRoleOrPermission("create_ref");
@@ -28,9 +28,9 @@ export default function ReferenceToolbar({
 	return (
 		<SearchToolbar
 			aria-label="Search references"
-			onChange={setFind}
+			onChange={setTerm}
 			placeholder="Reference name"
-			value={find}
+			value={term}
 		>
 			<ToggleGroup
 				value={archived ? "archived" : "active"}

--- a/apps/web/src/references/components/__tests__/ReferenceList.test.tsx
+++ b/apps/web/src/references/components/__tests__/ReferenceList.test.tsx
@@ -16,14 +16,14 @@ import ReferenceList from "../ReferenceList";
 
 type ReferenceListSearch = {
 	archived?: boolean;
-	find?: string;
+	term?: string;
 	page?: number;
 };
 
 function ReferenceListHarness() {
 	const [search, setSearch] = useState<ReferenceListSearch>({
 		archived: false,
-		find: "",
+		term: "",
 	});
 
 	function handleSetSearch(next: ReferenceListSearch) {

--- a/apps/web/src/routes/_authenticated/hmms/index.tsx
+++ b/apps/web/src/routes/_authenticated/hmms/index.tsx
@@ -5,7 +5,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 /** Search params for this route. */
 type HmmSearch = {
-	find: string;
+	term: string;
 	page: number;
 };
 
@@ -13,17 +13,17 @@ function validateHmmSearch(
 	input: Partial<HmmSearch> & SearchSchemaInput,
 ): HmmSearch {
 	return {
-		find: str(input.find, ""),
+		term: str(input.term, ""),
 		page: num(input.page, 1),
 	};
 }
 
 export const Route = createFileRoute("/_authenticated/hmms/")({
 	validateSearch: validateHmmSearch,
-	loaderDeps: ({ search: { find, page } }) => ({ find, page }),
-	loader: async ({ context: { queryClient }, deps: { find, page } }) => {
+	loaderDeps: ({ search: { term, page } }) => ({ term, page }),
+	loader: async ({ context: { queryClient }, deps: { term, page } }) => {
 		const { hmmsQueryOptions } = await import("@hmm/queries");
-		await queryClient.ensureQueryData(hmmsQueryOptions(page, 25, find));
+		await queryClient.ensureQueryData(hmmsQueryOptions(page, 25, term));
 	},
 	component: HmmRoute,
 });
@@ -34,7 +34,7 @@ function HmmRoute() {
 
 	return (
 		<HmmList
-			find={search.find}
+			term={search.term}
 			page={search.page}
 			setSearch={(next, options) =>
 				navigate({

--- a/apps/web/src/routes/_authenticated/refs/$refId/otus/index.tsx
+++ b/apps/web/src/routes/_authenticated/refs/$refId/otus/index.tsx
@@ -5,7 +5,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 /** Search params for this route. */
 type OtuListSearch = {
-	find: string;
+	term: string;
 	page: number;
 };
 
@@ -13,21 +13,21 @@ function validateOtuListSearch(
 	input: Partial<OtuListSearch> & SearchSchemaInput,
 ): OtuListSearch {
 	return {
-		find: str(input.find, ""),
+		term: str(input.term, ""),
 		page: num(input.page, 1),
 	};
 }
 
 export const Route = createFileRoute("/_authenticated/refs/$refId/otus/")({
 	validateSearch: validateOtuListSearch,
-	loaderDeps: ({ search: { find, page } }) => ({ find, page }),
+	loaderDeps: ({ search: { term, page } }) => ({ term, page }),
 	loader: async ({
 		context: { queryClient },
 		params: { refId },
-		deps: { find, page },
+		deps: { term, page },
 	}) => {
 		const { otusQueryOptions } = await import("@otus/queries");
-		await queryClient.ensureQueryData(otusQueryOptions(refId, page, 25, find));
+		await queryClient.ensureQueryData(otusQueryOptions(refId, page, 25, term));
 	},
 	component: OtusRoute,
 });
@@ -38,7 +38,7 @@ function OtusRoute() {
 
 	return (
 		<OtuList
-			find={search.find}
+			term={search.term}
 			page={search.page}
 			setSearch={(next, options) =>
 				navigate({

--- a/apps/web/src/routes/_authenticated/refs/index.tsx
+++ b/apps/web/src/routes/_authenticated/refs/index.tsx
@@ -6,7 +6,7 @@ import { createFileRoute } from "@tanstack/react-router";
 /** Search params for the references list. */
 type RefsSearch = {
 	archived: boolean;
-	find: string;
+	term: string;
 	page: number;
 };
 
@@ -15,25 +15,25 @@ function validateRefsSearch(
 ): RefsSearch {
 	return {
 		archived: bool(input.archived, false),
-		find: str(input.find, ""),
+		term: str(input.term, ""),
 		page: num(input.page, 1),
 	};
 }
 
 export const Route = createFileRoute("/_authenticated/refs/")({
 	validateSearch: validateRefsSearch,
-	loaderDeps: ({ search: { archived, find, page } }) => ({
+	loaderDeps: ({ search: { archived, term, page } }) => ({
 		archived,
-		find,
+		term,
 		page,
 	}),
 	loader: async ({
 		context: { queryClient },
-		deps: { archived, find, page },
+		deps: { archived, term, page },
 	}) => {
 		const { referencesQueryOptions } = await import("@references/queries");
 		await queryClient.ensureQueryData(
-			referencesQueryOptions(page, 25, find, archived),
+			referencesQueryOptions(page, 25, term, archived),
 		);
 	},
 	component: ReferencesRoute,
@@ -46,7 +46,7 @@ function ReferencesRoute() {
 	return (
 		<ReferenceList
 			archived={search.archived}
-			find={search.find}
+			term={search.term}
 			page={search.page}
 			setSearch={(next, options) =>
 				navigate({

--- a/apps/web/src/routes/_authenticated/subtractions/index.tsx
+++ b/apps/web/src/routes/_authenticated/subtractions/index.tsx
@@ -5,7 +5,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 /** Search params for this route. */
 type SubtractionsSearch = {
-	find: string;
+	term: string;
 	page: number;
 };
 
@@ -13,17 +13,17 @@ function validateSubtractionsSearch(
 	input: Partial<SubtractionsSearch> & SearchSchemaInput,
 ): SubtractionsSearch {
 	return {
-		find: str(input.find, ""),
+		term: str(input.term, ""),
 		page: num(input.page, 1),
 	};
 }
 
 export const Route = createFileRoute("/_authenticated/subtractions/")({
 	validateSearch: validateSubtractionsSearch,
-	loaderDeps: ({ search: { find, page } }) => ({ find, page }),
-	loader: async ({ context: { queryClient }, deps: { find, page } }) => {
+	loaderDeps: ({ search: { term, page } }) => ({ term, page }),
+	loader: async ({ context: { queryClient }, deps: { term, page } }) => {
 		const { subtractionsQueryOptions } = await import("@subtraction/queries");
-		await queryClient.ensureQueryData(subtractionsQueryOptions(page, 25, find));
+		await queryClient.ensureQueryData(subtractionsQueryOptions(page, 25, term));
 	},
 	component: SubtractionsRoute,
 });
@@ -34,7 +34,7 @@ function SubtractionsRoute() {
 
 	return (
 		<SubtractionList
-			find={search.find}
+			term={search.term}
 			page={search.page}
 			setSearch={(next, options) =>
 				navigate({

--- a/apps/web/src/samples/components/SamplesList.tsx
+++ b/apps/web/src/samples/components/SamplesList.tsx
@@ -1,14 +1,7 @@
 import QuickAnalyze from "@analyses/components/Create/QuickAnalyze";
-import Box from "@base/Box";
 import Button from "@base/Button";
 import ContainerNarrow from "@base/ContainerNarrow";
-import {
-	Empty,
-	EmptyContent,
-	EmptyDescription,
-	EmptyMedia,
-	EmptyTitle,
-} from "@base/Empty";
+import ListEmpty from "@base/ListEmpty";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import Pagination from "@base/Pagination";
 import QueryError from "@base/QueryError";
@@ -230,32 +223,21 @@ export default function SamplesList({
 					term={term}
 				/>
 				{!items.length ? (
-					<Box key="noSample">
-						<Empty className="h-72">
-							<EmptyMedia className="text-gray-400">
-								{isFiltered ? (
-									<SearchX size={40} strokeWidth={1.5} />
-								) : (
-									<FlaskConical size={40} strokeWidth={1.5} />
-								)}
-							</EmptyMedia>
-							<EmptyTitle>
-								{isFiltered ? "No matching samples" : "No samples"}
-							</EmptyTitle>
-							<EmptyDescription>
-								{isFiltered
-									? "No samples match the current filters."
-									: "No samples have been created yet."}
-							</EmptyDescription>
-							{isFiltered && (
-								<EmptyContent>
-									<Button onClick={clearFilters} size="small">
-										Clear filters
-									</Button>
-								</EmptyContent>
-							)}
-						</Empty>
-					</Box>
+					<ListEmpty
+						icon={isFiltered ? SearchX : FlaskConical}
+						title={isFiltered ? "No matching samples" : "No samples"}
+						description={
+							isFiltered
+								? "No samples match the current filters."
+								: "No samples have been created yet."
+						}
+					>
+						{isFiltered && (
+							<Button onClick={clearFilters} size="small">
+								Clear filters
+							</Button>
+						)}
+					</ListEmpty>
 				) : (
 					<Pagination
 						items={items}

--- a/apps/web/src/subtraction/components/SubtractionList.tsx
+++ b/apps/web/src/subtraction/components/SubtractionList.tsx
@@ -1,6 +1,5 @@
-import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
-import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "@base/Empty";
+import ListEmpty from "@base/ListEmpty";
 import Pagination from "@base/Pagination";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
@@ -11,10 +10,10 @@ import { SubtractionItem } from "./SubtractionItem";
 import SubtractionToolbar from "./SubtractionToolbar";
 
 type SubtractionListProps = {
-	find?: string;
+	term?: string;
 	page?: number;
 	setSearch?: (
-		next: { find?: string; page?: number },
+		next: { term?: string; page?: number },
 		options?: { replace?: boolean },
 	) => void;
 };
@@ -23,11 +22,11 @@ type SubtractionListProps = {
  * A list of subtractions.
  */
 export default function SubtractionList({
-	find = "",
+	term = "",
 	page = 1,
 	setSearch = () => {},
 }: SubtractionListProps) {
-	const { data } = useSuspenseSubtractions(page, 25, find);
+	const { data } = useSuspenseSubtractions(page, 25, term);
 
 	const { items, total_count, page: storedPage, page_count } = data;
 
@@ -41,22 +40,16 @@ export default function SubtractionList({
 			</ViewHeader>
 
 			<SubtractionToolbar
-				term={find}
-				onChange={(find) => setSearch({ find, page: 1 }, { replace: true })}
+				term={term}
+				onChange={(term) => setSearch({ term, page: 1 }, { replace: true })}
 			/>
 
 			{!items.length ? (
-				<Box key="subtractions">
-					<Empty className="h-72">
-						<EmptyMedia className="text-gray-400">
-							<Scissors size={40} strokeWidth={1.5} />
-						</EmptyMedia>
-						<EmptyTitle>No subtractions found</EmptyTitle>
-						<EmptyDescription>
-							No subtractions have been created yet.
-						</EmptyDescription>
-					</Empty>
-				</Box>
+				<ListEmpty
+					icon={Scissors}
+					title="No subtractions found"
+					description="No subtractions have been created yet."
+				/>
 			) : (
 				<Pagination
 					items={items}

--- a/apps/web/src/subtraction/components/__tests__/SubtractionList.test.tsx
+++ b/apps/web/src/subtraction/components/__tests__/SubtractionList.test.tsx
@@ -47,7 +47,7 @@ describe("<SubtractionList />", () => {
 
 		await waitFor(() =>
 			expect(router.state.location.search).toMatchObject({
-				find: "Foo",
+				term: "Foo",
 			}),
 		);
 	});

--- a/apps/web/src/users/components/UsersList.tsx
+++ b/apps/web/src/users/components/UsersList.tsx
@@ -1,6 +1,5 @@
-import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
-import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "@base/Empty";
+import ListEmpty from "@base/ListEmpty";
 import Pagination from "@base/Pagination";
 import { useSuspenseUsers } from "@users/queries";
 import { Users } from "lucide-react";
@@ -49,14 +48,10 @@ export default function UsersList({
 			</BoxGroup>
 		</Pagination>
 	) : (
-		<Box>
-			<Empty className="h-72">
-				<EmptyMedia className="text-gray-400">
-					<Users size={40} strokeWidth={1.5} />
-				</EmptyMedia>
-				<EmptyTitle>No users found</EmptyTitle>
-				<EmptyDescription>No users match your search.</EmptyDescription>
-			</Empty>
-		</Box>
+		<ListEmpty
+			icon={Users}
+			title="No users found"
+			description="No users match your search."
+		/>
 	);
 }


### PR DESCRIPTION
## Summary
- Standardize the list-view search param on `term`: the hmms, subtractions, refs, and otus routes/components previously used `find` in the URL. Existing `?find=` links no longer pre-fill the search box (they degrade to the unfiltered list); the Python API query param is unchanged at the HTTP boundary.
- Extract a shared `base/ListEmpty` component and adopt it across all eight paginated list views, replacing the byte-identical empty-state block that had been hand-copied into each one.