### PR TITLE
fix: surface query errors, redact session tokens, and cap pools

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,1 +1,3 @@
 VT_POSTGRES_URL=postgres://virtool:virtool@localhost:5432/virtool
+# Maximum size of the postgres-js connection pool. Defaults to 10.
+VT_POSTGRES_POOL_MAX=10

--- a/apps/web/src/account/components/ApiKeyAdministratorInfo.tsx
+++ b/apps/web/src/account/components/ApiKeyAdministratorInfo.tsx
@@ -1,12 +1,17 @@
 import { hasSufficientAdminRole } from "@administration/utils";
 import Alert from "@base/Alert";
+import QueryError from "@base/QueryError";
 import { useFetchAccount } from "../account";
 
 /**
  * Displays a banner with information for an admin user
  */
 export default function ApiKeyAdministratorInfo() {
-	const { data, isPending } = useFetchAccount();
+	const { data, isError, isPending } = useFetchAccount();
+
+	if (isError && !data) {
+		return <QueryError noun="account" />;
+	}
 
 	if (
 		!isPending &&

--- a/apps/web/src/administration/hooks.ts
+++ b/apps/web/src/administration/hooks.ts
@@ -8,6 +8,7 @@ import {
 
 export type PermissionQueryResult = {
 	hasPermission: boolean | null;
+	isError: boolean;
 	isPending: boolean;
 };
 
@@ -20,21 +21,25 @@ export type PermissionQueryResult = {
 export function useCheckAdminRole(
 	requiredRole: AdministratorRoleName,
 ): PermissionQueryResult {
-	const { data: account, isPending } = useFetchAccount();
+	const { data: account, isError, isPending } = useFetchAccount();
 	return {
 		hasPermission: account
 			? hasSufficientAdminRole(requiredRole, account.administrator_role)
 			: null,
+		isError,
 		isPending,
 	};
 }
 
-export function useCheckAdminRoleOrPermission(permission: Permission) {
-	const { data: account, isPending } = useFetchAccount();
+export function useCheckAdminRoleOrPermission(
+	permission: Permission,
+): PermissionQueryResult {
+	const { data: account, isError, isPending } = useFetchAccount();
 	return {
 		hasPermission: account
 			? checkAdminRoleOrPermissionsFromAccount(account, permission)
 			: null,
+		isError,
 		isPending,
 	};
 }

--- a/apps/web/src/analyses/components/Nuvs/NuvsBlastPending.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsBlastPending.tsx
@@ -1,11 +1,11 @@
+import { addSeconds, formatDistanceStrict } from "@app/date";
+import { useNow } from "@app/hooks";
 import Box from "@base/Box";
 import ExternalLink from "@base/ExternalLink";
 import Icon from "@base/Icon";
 import Loader from "@base/Loader";
 import RelativeTime from "@base/RelativeTime";
 import { ExternalLink as ExternalLinkIcon } from "lucide-react";
-import { addSeconds, formatDistanceStrict } from "@/app/date";
-import { useNow } from "@/app/hooks";
 
 const ridRoot =
 	"https://blast.ncbi.nlm.nih.gov/Blast.cgi?\

--- a/apps/web/src/analyses/components/Pathoscope/PathoscopeList.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/PathoscopeList.tsx
@@ -1,7 +1,7 @@
 import { useSortAndFilterPathoscopeHits } from "@analyses/hooks";
+import type { FormattedPathoscopeAnalysis } from "@analyses/types";
 import Accordion from "@base/Accordion";
-import type { FormattedPathoscopeAnalysis } from "@/analyses/types";
-import type { Sample } from "@/samples/types";
+import type { Sample } from "@samples/types";
 import { PathoscopeItem } from "./PathoscopeItem";
 
 type PathoscopeListProps = {

--- a/apps/web/src/app/sse/SseConnection.ts
+++ b/apps/web/src/app/sse/SseConnection.ts
@@ -16,12 +16,15 @@ let connection: EventSource | null = null;
 let connectionStatus: ConnectionStatus = "initializing";
 let interval = 500;
 let handleMessage: ((data: unknown) => void) | null = null;
+let client: QueryClient | null = null;
+let hasConnected = false;
 
 export function init(queryClient: QueryClient): void {
 	if (handleMessage) {
 		return;
 	}
 
+	client = queryClient;
 	const handler = reactQueryHandler(queryClient);
 	handleMessage = (data) => {
 		const parsed = SseMessageSchema.safeParse(data);
@@ -105,6 +108,16 @@ export function establishConnection(): void {
 	connection.onopen = () => {
 		interval = 500;
 		connectionStatus = "connected";
+
+		// A reconnect means the stream was down for a while, and any invalidation
+		// frames NOTIFYed during the gap — including a server-side queue overflow
+		// that dropped its backlog — never arrived. Refetch active queries so the
+		// client re-syncs. The first connect needs none of this: the route loaders
+		// have just populated the cache.
+		if (hasConnected) {
+			client?.invalidateQueries();
+		}
+		hasConnected = true;
 	};
 
 	connection.addEventListener("version", (event) => {

--- a/apps/web/src/app/sse/__tests__/SseConnection.test.ts
+++ b/apps/web/src/app/sse/__tests__/SseConnection.test.ts
@@ -35,6 +35,12 @@ class FakeEventSource {
 		this.readyState = FakeEventSource.CLOSED;
 	}
 
+	/** The server accepted the stream. */
+	open() {
+		this.readyState = FakeEventSource.OPEN;
+		this.onopen?.();
+	}
+
 	/** The server answered with something fatal. The browser will not retry. */
 	reject() {
 		this.readyState = FakeEventSource.CLOSED;
@@ -49,11 +55,12 @@ class FakeEventSource {
 }
 
 const fetchMock = vi.fn();
+const invalidateQueries = vi.fn();
 
 async function establish() {
 	vi.resetModules();
 	const sse = await import("../SseConnection");
-	sse.init({ invalidateQueries: vi.fn() } as unknown as QueryClient);
+	sse.init({ invalidateQueries } as unknown as QueryClient);
 	sse.establishConnection();
 
 	return sse;
@@ -73,6 +80,7 @@ describe("SseConnection", () => {
 		vi.useFakeTimers();
 		FakeEventSource.instances = [];
 		endSession.mockClear();
+		invalidateQueries.mockClear();
 		fetchMock.mockReset();
 		vi.stubGlobal("EventSource", FakeEventSource);
 		vi.stubGlobal("fetch", fetchMock);
@@ -95,6 +103,23 @@ describe("SseConnection", () => {
 		// Nothing about a dropped transport suggests the session is gone, so it is
 		// not worth asking.
 		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("refetches active queries on reconnect but not on the first connect", async () => {
+		await establish();
+
+		openConnection().open();
+		expect(invalidateQueries).not.toHaveBeenCalled();
+
+		openConnection().drop();
+		await vi.advanceTimersByTimeAsync(1000);
+
+		const second = FakeEventSource.instances[1];
+		if (!second) {
+			throw new Error("no reconnect was opened");
+		}
+		second.open();
+		expect(invalidateQueries).toHaveBeenCalledTimes(1);
 	});
 
 	it("abandons the stream and ends the session when the handshake is unauthorized", async () => {

--- a/apps/web/src/base/RelativeTime.tsx
+++ b/apps/web/src/base/RelativeTime.tsx
@@ -1,5 +1,5 @@
+import { formatDistanceStrict } from "@app/date";
 import { useSyncExternalStore } from "react";
-import { formatDistanceStrict } from "@/app/date";
 
 type RelativeTimeOptions = {
 	addSuffix?: boolean;

--- a/apps/web/src/hmm/types.ts
+++ b/apps/web/src/hmm/types.ts
@@ -1,7 +1,7 @@
 import type { ServerTask } from "@tasks/types";
 import type { UserNested } from "@users/types";
 
-import type { SearchResult } from "../types/api";
+import type { SearchResult } from "@/types/api";
 
 /** Minimal HMM used for resource listings */
 export type HMMMinimal = {

--- a/apps/web/src/indexes/components/RebuildIndex.tsx
+++ b/apps/web/src/indexes/components/RebuildIndex.tsx
@@ -8,6 +8,7 @@ import {
 	DialogTrigger,
 } from "@base/Dialog";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import { useState } from "react";
 import { useCreateIndex, useFetchUnbuiltChanges } from "../queries";
 import RebuildHistory from "./History";
@@ -22,7 +23,7 @@ type RebuildIndexProps = {
  */
 export default function RebuildIndex({ refId }: RebuildIndexProps) {
 	const [open, setOpen] = useState(false);
-	const { data, isPending } = useFetchUnbuiltChanges(refId);
+	const { data, isError, isPending } = useFetchUnbuiltChanges(refId);
 	const mutation = useCreateIndex();
 
 	function handleSubmit(e) {
@@ -44,7 +45,9 @@ export default function RebuildIndex({ refId }: RebuildIndexProps) {
 			</DialogTrigger>
 			<DialogContent>
 				<DialogTitle>Rebuild Index</DialogTitle>
-				{isPending ? (
+				{isError && !data ? (
+					<QueryError noun="unbuilt changes" />
+				) : isPending ? (
 					<LoadingPlaceholder />
 				) : (
 					<form onSubmit={handleSubmit}>

--- a/apps/web/src/jobs/components/JobDetail.tsx
+++ b/apps/web/src/jobs/components/JobDetail.tsx
@@ -1,14 +1,14 @@
 import { getWorkflowDisplayName } from "@app/utils";
+import Alert from "@base/Alert";
 import ContainerNarrow from "@base/ContainerNarrow";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NotFound from "@base/NotFound";
+import RelativeTime, { useRelativeTime } from "@base/RelativeTime";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderAttribution from "@base/ViewHeaderAttribution";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import { useFetchIndex } from "@indexes/queries";
 import { getRouteApi } from "@tanstack/react-router";
-import Alert from "@/base/Alert";
-import RelativeTime, { useRelativeTime } from "@/base/RelativeTime";
 import { useFetchJob } from "../queries";
 import type { JobState } from "../types";
 import JobArgs from "./JobArgs";

--- a/apps/web/src/jobs/components/JobStep.tsx
+++ b/apps/web/src/jobs/components/JobStep.tsx
@@ -1,8 +1,8 @@
+import { formatDate, formatTime } from "@app/date";
+import Badge from "@base/Badge";
 import BoxGroupSection from "@base/BoxGroupSection";
 import Markdown from "@base/Markdown";
 import { Calendar, Clock } from "lucide-react";
-import { formatDate, formatTime } from "@/app/date";
-import Badge from "@/base/Badge";
 import type { JobState, JobStep } from "../types";
 import JobStateIcon from "./JobStateIcon";
 

--- a/apps/web/src/otus/components/Detail/Segments.tsx
+++ b/apps/web/src/otus/components/Detail/Segments.tsx
@@ -1,4 +1,6 @@
+import Box from "@base/Box";
 import BoxGroup from "@base/BoxGroup";
+import Button from "@base/Button";
 import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "@base/Empty";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
@@ -28,8 +30,6 @@ import {
 import { getRouteApi } from "@tanstack/react-router";
 import { Component } from "lucide-react";
 import { useState } from "react";
-import Box from "@/base/Box";
-import Button from "@/base/Button";
 import RemoveSegment from "./RemoveSegment";
 import Segment, { SegmentItem } from "./Segment";
 import SegmentCreate from "./SegmentCreate";

--- a/apps/web/src/references/components/CreateReferenceForm.tsx
+++ b/apps/web/src/references/components/CreateReferenceForm.tsx
@@ -7,9 +7,9 @@ import ProgressBarAffixed from "@base/ProgressBarAffixed";
 import SaveButton from "@base/SaveButton";
 import TextArea from "@base/TextArea";
 import { useNavigate } from "@tanstack/react-router";
+import { UploadBar } from "@uploads/components/UploadBar";
 import { useId } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { UploadBar } from "@/uploads/components/UploadBar";
 import {
 	useCreateReference,
 	useImportReference,

--- a/apps/web/src/references/components/SourceTypes/ArchivedSourceTypes.tsx
+++ b/apps/web/src/references/components/SourceTypes/ArchivedSourceTypes.tsx
@@ -1,21 +1,16 @@
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupSection from "@base/BoxGroupSection";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import SectionHeader from "@base/SectionHeader";
-import { useFetchReference } from "@references/queries";
+import { useSuspenseReference } from "@references/queries";
 import { getRouteApi } from "@tanstack/react-router";
 
 const routeApi = getRouteApi("/_authenticated/refs/$refId");
 
 export function ArchivedSourceTypes() {
 	const { refId } = routeApi.useParams();
-	const { data, isPending } = useFetchReference(refId);
+	const { data } = useSuspenseReference(refId);
 
-	if (isPending) {
-		return <LoadingPlaceholder />;
-	}
-
-	const sourceTypes = data?.source_types ?? [];
+	const sourceTypes = data.source_types ?? [];
 
 	return (
 		<section>

--- a/apps/web/src/references/components/SourceTypes/LocalSourceTypes.tsx
+++ b/apps/web/src/references/components/SourceTypes/LocalSourceTypes.tsx
@@ -8,10 +8,9 @@ import IconButton from "@base/IconButton";
 import InputContainer from "@base/InputContainer";
 import InputError from "@base/InputError";
 import InputSimple from "@base/InputSimple";
-import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import SectionHeader from "@base/SectionHeader";
 import {
-	useFetchReference,
+	useSuspenseReference,
 	useUpdateReference,
 	useUpdateReferenceSourceTypes,
 } from "@references/queries";
@@ -25,12 +24,12 @@ const routeApi = getRouteApi("/_authenticated/refs/$refId");
 export function LocalSourceTypes() {
 	const { refId } = routeApi.useParams();
 
-	const { data, isPending } = useFetchReference(refId);
+	const { data } = useSuspenseReference(refId);
 
 	const { mutation: updateReferenceMutation } = useUpdateReference(refId);
 
-	const sourceTypes = data?.source_types ?? [];
-	const restrictSourceTypes = data?.restrict_source_types ?? false;
+	const sourceTypes = data.source_types ?? [];
+	const restrictSourceTypes = data.restrict_source_types ?? false;
 
 	const { mutate } = useUpdateReferenceSourceTypes(refId);
 
@@ -42,10 +41,6 @@ export function LocalSourceTypes() {
 		handleUndo,
 		register,
 	} = useSourceTypeEditor(sourceTypes, mutate);
-
-	if (isPending) {
-		return <LoadingPlaceholder />;
-	}
 
 	function handleToggle() {
 		updateReferenceMutation.mutate({

--- a/apps/web/src/references/types.ts
+++ b/apps/web/src/references/types.ts
@@ -1,5 +1,5 @@
 import type { UserNested } from "@users/types";
-import type { SearchResult, Task } from "../types/api";
+import type { SearchResult, Task } from "@/types/api";
 
 export type ReferenceClonedFrom = {
 	id: string;

--- a/apps/web/src/samples/components/Create/CreateSample.tsx
+++ b/apps/web/src/samples/components/Create/CreateSample.tsx
@@ -13,6 +13,7 @@ import InputIconButton from "@base/InputIconButton";
 import InputLabel from "@base/InputLabel";
 import InputSimple from "@base/InputSimple";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import SaveButton from "@base/SaveButton";
 import Switch from "@base/Switch";
 import {
@@ -75,10 +76,19 @@ type CreateSampleProps = {
 export default function CreateSample({ labels }: CreateSampleProps) {
 	const navigate = useNavigate();
 
-	const { data: groups, isPending: isPendingGroups } = useListGroups();
-	const { data: account, isPending: isPendingAccount } = useFetchAccount();
+	const {
+		data: groups,
+		isError: isErrorGroups,
+		isPending: isPendingGroups,
+	} = useListGroups();
+	const {
+		data: account,
+		isError: isErrorAccount,
+		isPending: isPendingAccount,
+	} = useFetchAccount();
 	const {
 		data: readsResponse,
+		isError: isErrorReads,
 		isPending: isPendingReads,
 		isFetchingNextPage,
 		fetchNextPage,
@@ -105,6 +115,10 @@ export default function CreateSample({ labels }: CreateSampleProps) {
 	}, [account, setValue]);
 
 	const reads = readsResponse?.pages.flatMap((page) => page.items) ?? [];
+	const isError =
+		(isErrorGroups && !groups) ||
+		(isErrorAccount && !account) ||
+		(isErrorReads && !readsResponse);
 	const isLoading =
 		isPendingReads ||
 		isPendingGroups ||
@@ -164,7 +178,9 @@ export default function CreateSample({ labels }: CreateSampleProps) {
 					</InputError>
 				</ViewHeader>
 
-				{isLoading ? (
+				{isError ? (
+					<QueryError noun="the sample form" />
+				) : isLoading ? (
 					<LoadingPlaceholder className="mt-9" />
 				) : (
 					<>

--- a/apps/web/src/samples/components/Create/CreateSampleFromFile.tsx
+++ b/apps/web/src/samples/components/Create/CreateSampleFromFile.tsx
@@ -17,6 +17,7 @@ import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import InputSimple from "@base/InputSimple";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import SaveButton from "@base/SaveButton";
 import { useListGroups } from "@groups/queries";
 import type { Label } from "@labels/types";
@@ -91,8 +92,16 @@ function CreateSampleFromFileForm({
 	onClose,
 	reads,
 }: CreateSampleFromFileFormProps) {
-	const { data: groups, isPending: isPendingGroups } = useListGroups();
-	const { data: account, isPending: isPendingAccount } = useFetchAccount();
+	const {
+		data: groups,
+		isError: isErrorGroups,
+		isPending: isPendingGroups,
+	} = useListGroups();
+	const {
+		data: account,
+		isError: isErrorAccount,
+		isPending: isPendingAccount,
+	} = useFetchAccount();
 
 	const {
 		control,
@@ -139,7 +148,9 @@ function CreateSampleFromFileForm({
 				{mutation.isError && mutation.error.response?.body.message}
 			</InputError>
 
-			{isPendingGroups || isPendingAccount || !groups ? (
+			{(isErrorGroups && !groups) || (isErrorAccount && !account) ? (
+				<QueryError noun="the sample form" />
+			) : isPendingGroups || isPendingAccount || !groups ? (
 				<LoadingPlaceholder className="mt-9" />
 			) : (
 				<form onSubmit={handleSubmit(onSubmit)}>

--- a/apps/web/src/samples/components/Create/ReadSelector.tsx
+++ b/apps/web/src/samples/components/Create/ReadSelector.tsx
@@ -28,11 +28,11 @@ import type {
 	InfiniteData,
 	InfiniteQueryObserverResult,
 } from "@tanstack/react-query/";
+import { useValidateFiles } from "@uploads/hooks";
 import { buildReadRows, detectMate, type ReadRow } from "@uploads/pairing";
+import type { FileResponse, Upload } from "@uploads/types";
 import { ChevronDown, Files, TriangleAlert, Undo } from "lucide-react";
 import { useCallback, useState } from "react";
-import { useValidateFiles } from "@/uploads/hooks";
-import type { FileResponse, Upload } from "@/uploads/types";
 import ReadPairBadge from "./ReadPairBadge";
 import ReadSelectorRow from "./ReadSelectorRow";
 import ReadSelectorSlots from "./ReadSelectorSlots";

--- a/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/CreateSample.test.tsx
@@ -71,9 +71,13 @@ describe("<CreateSample>", () => {
 		filesScope.done();
 	});
 
-	it("should show loader when there are no sample uploads to read", async () => {
+	it("should show an error when the read files fail to load", async () => {
+		nock("http://localhost").get("/api/uploads").query(true).reply(500);
+
 		await renderWithRouter(<CreateSample labels={labels} />);
-		expect(await screen.findByLabelText("loading")).toBeInTheDocument();
+		expect(
+			await screen.findByText("Couldn't load the sample form."),
+		).toBeInTheDocument();
 	});
 
 	it("should fail and show errors on empty submission", async () => {

--- a/apps/web/src/samples/components/Create/__tests__/LabelSelector.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/LabelSelector.test.tsx
@@ -1,9 +1,9 @@
+import type { Label } from "@labels/types";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithRouter } from "@tests/setup";
 import { useState } from "react";
 import { describe, expect, it } from "vitest";
-import type { Label } from "@/labels/types";
 import LabelSelector from "../LabelSelector";
 
 const labels: Label[] = [

--- a/apps/web/src/samples/components/Create/__tests__/ReadSelector.test.tsx
+++ b/apps/web/src/samples/components/Create/__tests__/ReadSelector.test.tsx
@@ -4,10 +4,10 @@ import userEvent from "@testing-library/user-event";
 import { mockApiListFiles } from "@tests/api/files";
 import { createFakeFile } from "@tests/fake/files";
 import { renderWithProviders } from "@tests/setup";
+import type { FileResponse, Upload } from "@uploads/types";
 import nock from "nock";
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { FileResponse, Upload } from "@/uploads/types";
 import ReadSelector from "../ReadSelector";
 
 function makeData(files: Upload[]): InfiniteData<FileResponse> {

--- a/apps/web/src/samples/types.ts
+++ b/apps/web/src/samples/types.ts
@@ -9,9 +9,9 @@
 import type { GroupMinimal } from "@groups/types";
 import type { ServerJobNested } from "@jobs/types";
 import type { LabelNested } from "@labels/types";
+import type { SubtractionNested } from "@subtraction/types";
 import type { UserNested } from "@users/types";
-import type { SubtractionNested } from "../subtraction/types";
-import type { SearchResult } from "../types/api";
+import type { SearchResult } from "@/types/api";
 
 /* All workflow states */
 export type WorkflowState = "complete" | "pending" | "none" | "incompatible";

--- a/apps/web/src/server/__tests__/config.test.ts
+++ b/apps/web/src/server/__tests__/config.test.ts
@@ -32,6 +32,28 @@ describe("parseServerConfig", () => {
 		).toThrow(/VT_STORAGE_BACKEND/);
 	});
 
+	it("defaults the postgres pool max when unset", () => {
+		expect(parseServerConfig(minimalS3).postgresPoolMax).toBe(10);
+	});
+
+	it("reads the postgres pool max from the environment", () => {
+		const config = parseServerConfig({
+			...minimalS3,
+			VT_POSTGRES_POOL_MAX: "25",
+		} as NodeJS.ProcessEnv);
+
+		expect(config.postgresPoolMax).toBe(25);
+	});
+
+	it("rejects a non-positive postgres pool max", () => {
+		expect(() =>
+			parseServerConfig({
+				...minimalS3,
+				VT_POSTGRES_POOL_MAX: "0",
+			} as NodeJS.ProcessEnv),
+		).toThrow(/VT_POSTGRES_POOL_MAX/);
+	});
+
 	it("rejects the removed local backend", () => {
 		expect(() =>
 			parseServerConfig({

--- a/apps/web/src/server/__tests__/config.test.ts
+++ b/apps/web/src/server/__tests__/config.test.ts
@@ -36,6 +36,15 @@ describe("parseServerConfig", () => {
 		expect(parseServerConfig(minimalS3).postgresPoolMax).toBe(10);
 	});
 
+	it("treats a blank postgres pool max as unset", () => {
+		const config = parseServerConfig({
+			...minimalS3,
+			VT_POSTGRES_POOL_MAX: "",
+		} as NodeJS.ProcessEnv);
+
+		expect(config.postgresPoolMax).toBe(10);
+	});
+
 	it("reads the postgres pool max from the environment", () => {
 		const config = parseServerConfig({
 			...minimalS3,

--- a/apps/web/src/server/config.ts
+++ b/apps/web/src/server/config.ts
@@ -18,14 +18,19 @@ export type StorageConfig =
 			endpoint?: string;
 	  };
 
+/** postgres-js pool size when `VT_POSTGRES_POOL_MAX` is unset. */
+const DEFAULT_POSTGRES_POOL_MAX = 10;
+
 /** Server-side configuration parsed from process.env. */
 export type ServerConfig = {
 	postgresUrl: string;
+	postgresPoolMax: number;
 	storage: StorageConfig;
 };
 
 const ServerEnv = z.object({
 	VT_POSTGRES_URL: z.string().url(),
+	VT_POSTGRES_POOL_MAX: z.coerce.number().int().positive().optional(),
 	VT_STORAGE_BACKEND: z.enum(["s3", "azure"]),
 	VT_STORAGE_S3_BUCKET: z.string().optional(),
 	VT_STORAGE_S3_REGION: z.string().optional(),
@@ -42,6 +47,7 @@ type StorageEnv = z.infer<typeof ServerEnv>;
 
 const ServerEnvSchema = ServerEnv.transform((raw, ctx) => ({
 	postgresUrl: raw.VT_POSTGRES_URL,
+	postgresPoolMax: raw.VT_POSTGRES_POOL_MAX ?? DEFAULT_POSTGRES_POOL_MAX,
 	storage: buildStorage(raw, ctx),
 }));
 

--- a/apps/web/src/server/config.ts
+++ b/apps/web/src/server/config.ts
@@ -30,7 +30,13 @@ export type ServerConfig = {
 
 const ServerEnv = z.object({
 	VT_POSTGRES_URL: z.string().url(),
-	VT_POSTGRES_POOL_MAX: z.coerce.number().int().positive().optional(),
+	// Deployment tooling routinely injects an empty string for a value it has
+	// nothing to put in; treat that as unset so the default applies rather than
+	// coercing "" to 0 and failing the `.positive()` check at startup.
+	VT_POSTGRES_POOL_MAX: z.preprocess(
+		(value) => (value === "" ? undefined : value),
+		z.coerce.number().int().positive().optional(),
+	),
 	VT_STORAGE_BACKEND: z.enum(["s3", "azure"]),
 	VT_STORAGE_S3_BUCKET: z.string().optional(),
 	VT_STORAGE_S3_REGION: z.string().optional(),

--- a/apps/web/src/server/db/pg.ts
+++ b/apps/web/src/server/db/pg.ts
@@ -4,7 +4,9 @@ import { config } from "../config";
 import { logger } from "../logger";
 import * as schema from "./schema";
 
-export const client = postgres(config.postgresUrl);
+export const client = postgres(config.postgresUrl, {
+	max: config.postgresPoolMax,
+});
 
 export const db = drizzle(client, { schema });
 

--- a/apps/web/src/server/events/listen.ts
+++ b/apps/web/src/server/events/listen.ts
@@ -2,6 +2,14 @@ import { client } from "../db/pg";
 import { logger } from "../logger";
 import { CLIENT_EVENTS_CHANNEL, type ClientEvent } from "./channel";
 
+/**
+ * Cap on events buffered for a consumer that has fallen behind. On overflow the
+ * stream is dropped rather than buffered without bound: the client reconnects
+ * and refetches, which re-syncs it far more cheaply than draining a giant
+ * backlog of stale invalidations would.
+ */
+const MAX_QUEUE = 1000;
+
 /** Stream of client events plus a cleanup hook to unlisten and close. */
 export type ClientEventStream = {
 	events: AsyncIterable<ClientEvent>;
@@ -23,9 +31,21 @@ export function listenForClientEvents(): ClientEventStream {
 			const r = resolveNext;
 			resolveNext = null;
 			r({ value: event, done: false });
-		} else {
-			queue.push(event);
+			return;
 		}
+
+		if (queue.length >= MAX_QUEUE) {
+			logger.warn(
+				{ max: MAX_QUEUE },
+				"sse client event queue overflowed; dropping connection",
+			);
+			closed = true;
+			queue.length = 0;
+			finish();
+			return;
+		}
+
+		queue.push(event);
 	}
 
 	function finish() {

--- a/apps/web/src/subtraction/components/SubtractionCreate.tsx
+++ b/apps/web/src/subtraction/components/SubtractionCreate.tsx
@@ -14,9 +14,9 @@ import InputSimple from "@base/InputSimple";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
 import SaveButton from "@base/SaveButton";
+import { useInfiniteFindFiles } from "@uploads/queries";
 import { useId, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { useInfiniteFindFiles } from "@/uploads/queries";
 import { useCreateSubtraction } from "../queries";
 import { SubtractionFileSelector } from "./SubtractionFileSelector";
 

--- a/apps/web/src/subtraction/components/SubtractionFileManager.tsx
+++ b/apps/web/src/subtraction/components/SubtractionFileManager.tsx
@@ -1,4 +1,4 @@
-import { FileManager } from "@/uploads/components/FileManager";
+import { FileManager } from "@uploads/components/FileManager";
 
 type SubtractionFileManagerProps = {
 	page?: number;

--- a/apps/web/src/subtraction/components/SubtractionFileSelector.tsx
+++ b/apps/web/src/subtraction/components/SubtractionFileSelector.tsx
@@ -14,9 +14,9 @@ import type {
 	FetchNextPageOptions,
 	InfiniteQueryObserverResult,
 } from "@tanstack/react-query/";
+import { useValidateFiles } from "@uploads/hooks";
+import type { FileResponse, Upload } from "@uploads/types";
 import { Files } from "lucide-react";
-import { useValidateFiles } from "@/uploads/hooks";
-import type { FileResponse, Upload } from "@/uploads/types";
 import { SubtractionFileItem } from "./SubtractionFileItem";
 
 type SubtractionFileSelectorProps = {

--- a/apps/web/src/subtraction/components/__tests__/SubtractionItem.test.tsx
+++ b/apps/web/src/subtraction/components/__tests__/SubtractionItem.test.tsx
@@ -1,8 +1,8 @@
+import type { SubtractionMinimal } from "@subtraction/types";
 import { screen } from "@testing-library/react";
 import { createFakeUserNested } from "@tests/fake/user";
 import { renderWithRouter } from "@tests/setup";
 import { beforeEach, describe, expect, it } from "vitest";
-import type { SubtractionMinimal } from "@/subtraction/types";
 import { SubtractionItem } from "../SubtractionItem";
 
 describe("<SubtractionItem />", () => {

--- a/apps/web/src/subtraction/types.ts
+++ b/apps/web/src/subtraction/types.ts
@@ -1,6 +1,6 @@
+import type { ServerJobNested } from "@jobs/types";
 import type { SampleNested } from "@samples/types";
 import type { UserNested } from "@users/types";
-import type { ServerJobNested } from "@/jobs/types";
 import type { SearchResult } from "@/types/api";
 
 /** The measurements of individual nucleotides (percentage) */

--- a/apps/web/src/tests/api/files.ts
+++ b/apps/web/src/tests/api/files.ts
@@ -1,5 +1,5 @@
+import type { Upload } from "@uploads/types";
 import nock from "nock";
-import type { Upload } from "@/uploads/types";
 
 /**
  * Creates a mocked API call for getting a paginated list of uploads.

--- a/apps/web/src/tests/fake/files.ts
+++ b/apps/web/src/tests/fake/files.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import type { Upload } from "@/uploads/types";
+import type { Upload } from "@uploads/types";
 import { createFakeUserNested } from "./user";
 
 /**

--- a/apps/web/src/users/components/ManageUsers.tsx
+++ b/apps/web/src/users/components/ManageUsers.tsx
@@ -1,6 +1,7 @@
 import { useCheckAdminRole } from "@administration/hooks";
 import Alert from "@base/Alert";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
+import QueryError from "@base/QueryError";
 import SearchToolbar from "@base/SearchToolbar";
 import ToggleGroup from "@base/ToggleGroup";
 import ToggleGroupItem from "@base/ToggleGroupItem";
@@ -27,7 +28,11 @@ export function ManageUsers({
 	status = "active",
 	term = "",
 }: ManageUsersProps) {
-	const { hasPermission, isPending } = useCheckAdminRole("users");
+	const { hasPermission, isError, isPending } = useCheckAdminRole("users");
+
+	if (isError && hasPermission === null) {
+		return <QueryError noun="users" />;
+	}
 
 	if (isPending) {
 		return <LoadingPlaceholder />;

--- a/apps/web/src/users/components/UserDetail.tsx
+++ b/apps/web/src/users/components/UserDetail.tsx
@@ -1,9 +1,9 @@
 import { useCheckAdminRole } from "@administration/hooks";
 import Alert from "@base/Alert";
 import InitialIcon from "@base/InitialIcon";
+import Label from "@base/Label";
 import { useSuspenseUser, useUpdateUser } from "@users/queries";
 import { CircleAlert, ShieldUserIcon } from "lucide-react";
-import Label from "@/base/Label";
 import Handle from "./Handle";
 import Password from "./Password";
 import { UserActivationBanner } from "./UserActivationBanner";

--- a/apps/web/src/users/components/__tests__/UserDetail.test.tsx
+++ b/apps/web/src/users/components/__tests__/UserDetail.test.tsx
@@ -1,3 +1,4 @@
+import type { Group } from "@groups/types";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeAccount } from "@tests/fake/account";
@@ -17,7 +18,6 @@ import UserDetail from "@users/components/UserDetail";
 import type { User } from "@users/types";
 import nock from "nock";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { Group } from "@/groups/types";
 
 describe("<UserDetail />", () => {
 	let groups: Group[];

--- a/apps/web/src/users/types.ts
+++ b/apps/web/src/users/types.ts
@@ -1,6 +1,6 @@
 import type { AdministratorRoleName } from "@administration/types";
-import type { GroupMinimal, Permissions } from "../groups/types";
-import type { SearchResult } from "../types/api";
+import type { GroupMinimal, Permissions } from "@groups/types";
+import type { SearchResult } from "@/types/api";
 
 /** Business to consumer provided user details */
 type UserB2c = {

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -4,9 +4,11 @@
 
 Server code should log through the package, not `console.*`. It wraps pino
 with sane defaults: JSON output, redaction of `password` / `token` /
-`secret` / `authorization` / `cookie` (and the `req.headers.*` /
-`headers.*` variants), level resolved from `VT_LOG_LEVEL` (falling back to
-`info` in production, `debug` elsewhere).
+`secret` / `authorization` / `cookie`, the session-credential field names
+this codebase uses (`sessionToken` / `session_token` / `tokenHash` /
+`resetCode`), and the `req.headers.*` / `headers.*` variants — each also
+matched one level deep via `*.`. Level is resolved from `VT_LOG_LEVEL`
+(falling back to `info` in production, `debug` elsewhere).
 
 The web app constructs one logger at bootstrap with a service `name`
 (`apps/web/src/server/logger.ts` exports it as `web`). Import that
@@ -68,9 +70,10 @@ Wiring:
 
 Redaction still applies. pino runs `DEFAULT_REDACT_PATHS` redaction before
 writing to any destination, so the records the Sentry stream receives
-already have `password` / `token` / `secret` / `authorization` / `cookie`
-(and the `req.headers.*` / `headers.*` variants) replaced with
-`[redacted]`.
+already have `password` / `token` / `secret` / `authorization` / `cookie`,
+the session-credential fields (`sessionToken` / `session_token` /
+`tokenHash` / `resetCode`), and the `req.headers.*` / `headers.*` variants
+replaced with `[redacted]`.
 
 Dev does not forward. The Tilt dev container runs Vite with no DSN, so the
 logger stays stdout-only and the Sentry SDK is never loaded.

--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -155,7 +155,11 @@ application's own doing.
 ## Client side
 
 - `app/sse/SseConnection.ts` opens the `EventSource`, manages
-  reconnect, and pipes parsed messages into `reactQueryHandler`.
+  reconnect, and pipes parsed messages into `reactQueryHandler`. On a
+  *reconnect* (not the first connect) it invalidates all queries, since
+  frames NOTIFYed while the stream was down — including a server-side
+  queue-overflow drop — never arrived; the initial connect skips this
+  because the route loaders just populated the cache.
 - `app/sse/schema.ts` defines `SseMessageSchema`, which validates the
   wire frame and strips unknown fields.
 - `app/sse/reactQueryHandler.ts` maps `message.domain` to a query-key

--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -142,7 +142,10 @@ application's own doing.
 
 - `server/events/channel.ts` — channel name + payload type. Pure.
 - `server/events/emit.ts` — publishes a `ClientEvent` via `NOTIFY`.
-- `server/events/listen.ts` — `LISTEN`-backed async iterable.
+- `server/events/listen.ts` — `LISTEN`-backed async iterable. Its
+  per-connection buffer is capped (`MAX_QUEUE`); a consumer that falls
+  that far behind has its stream dropped rather than buffered without
+  bound, and the client reconnects and refetches to re-sync.
 - `server/events/broadcast.ts` — pure `ClientEvent → SseMessage` shape
   conversion.
 - `routes/events.ts` — TanStack Start `createFileRoute` that owns the

--- a/packages/logger/src/config.ts
+++ b/packages/logger/src/config.ts
@@ -33,8 +33,11 @@ export function resolveLevel(env: Env): LogLevel {
 
 /**
  * Keys redacted from log records by default. Covers the obvious secret-bearing
- * fields plus common HTTP shapes (`req.headers.authorization`, `headers.cookie`)
- * so that incidental request logging does not leak credentials.
+ * fields, the session-credential field names this codebase actually uses
+ * (`sessionToken` / `session_token` / `tokenHash` / `resetCode`), and common
+ * HTTP shapes (`req.headers.authorization`, `headers.cookie`) so that incidental
+ * request logging does not leak credentials. Redaction runs before any
+ * destination — including the Sentry forwarding stream — sees the record.
  */
 export const DEFAULT_REDACT_PATHS: readonly string[] = [
 	"password",
@@ -42,11 +45,19 @@ export const DEFAULT_REDACT_PATHS: readonly string[] = [
 	"secret",
 	"authorization",
 	"cookie",
+	"sessionToken",
+	"session_token",
+	"tokenHash",
+	"resetCode",
 	"*.password",
 	"*.token",
 	"*.secret",
 	"*.authorization",
 	"*.cookie",
+	"*.sessionToken",
+	"*.session_token",
+	"*.tokenHash",
+	"*.resetCode",
 	"req.headers.authorization",
 	"req.headers.cookie",
 	"headers.authorization",

--- a/packages/logger/src/index.test.ts
+++ b/packages/logger/src/index.test.ts
@@ -76,6 +76,34 @@ describe("createLogger", () => {
 		);
 	});
 
+	it("redacts session-credential fields nested one level deep", () => {
+		const sink = makeSink();
+		const log = createLogger({
+			name: "web",
+			level: "info",
+			destination: sink.stream,
+		});
+
+		log.info(
+			{
+				sessionToken: "st",
+				row: {
+					session_token: "s_t",
+					tokenHash: "th",
+					resetCode: "rc",
+				},
+			},
+			"session",
+		);
+
+		const [record] = sink.records();
+		expect(record.sessionToken).toBe("[redacted]");
+		const row = record.row as Record<string, string>;
+		expect(row.session_token).toBe("[redacted]");
+		expect(row.tokenHash).toBe("[redacted]");
+		expect(row.resetCode).toBe("[redacted]");
+	});
+
 	it("merges caller-supplied redact paths with the defaults", () => {
 		const sink = makeSink();
 		const log = createLogger({


### PR DESCRIPTION
## Summary

- Seven components that handled only `isPending` now surface query failures instead of rendering an empty list, a misleading "no permission" notice, or spinning forever.
- Redact `sessionToken` / `session_token` / `tokenHash` / `resetCode` (and their one-level-deep variants) in the logger's default redact paths, closing a path that could forward live session tokens to Sentry.
- Make the Postgres pool size configurable via `VT_POSTGRES_POOL_MAX` (default 10), and bound the SSE per-connection queue, dropping the connection on overflow so the client reconnects and re-syncs instead of buffering without bound.
- Rewrite `@/<feature>` catch-all and cross-feature relative imports to their feature aliases.