### PR TITLE
refactor: share the paginated route schema and per-page constant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,11 @@ So, in a route's critical exports:
   dependency-free coercion helpers in `@app/searchParams` and type the function
   as `(input: Partial<T> & SearchSchemaInput) => T` — the `SearchSchemaInput`
   tag is what keeps `<Link search={{ page: 2 }}>` partial.
+- **Paginated list routes share `@app/pagination`.** Spread `paginated(input)`
+  into the returned object and intersect the route's search type with
+  `Paginated` (`type FooSearch = Paginated & { term: string }`) rather than
+  re-declaring `page: num(input.page, 1)`. Loaders pass `DEFAULT_PER_PAGE` from
+  the same module, not a literal `25`.
 
 `src/server/**` is reachable from the browser program via `start.ts`, so the
 same rule applies there: reach server-function modules through

--- a/apps/web/src/app/pagination.ts
+++ b/apps/web/src/app/pagination.ts
@@ -1,0 +1,17 @@
+import { num } from "@app/searchParams";
+
+/** The number of items a list view requests per page. */
+export const DEFAULT_PER_PAGE = 25;
+
+/** Search params shared by every paginated list route. */
+export type Paginated = {
+	page: number;
+};
+
+/**
+ * Coerce the shared `page` search param for a paginated route's
+ * `validateSearch`. Spread the result alongside the route's own params.
+ */
+export function paginated(input: { page?: unknown }): Paginated {
+	return { page: num(input.page, 1) };
+}

--- a/apps/web/src/routes/_authenticated/administration/users/index.tsx
+++ b/apps/web/src/routes/_authenticated/administration/users/index.tsx
@@ -1,12 +1,12 @@
-import { num, str } from "@app/searchParams";
+import { DEFAULT_PER_PAGE, type Paginated, paginated } from "@app/pagination";
+import { str } from "@app/searchParams";
 import type { SearchSchemaInput } from "@tanstack/react-router";
 import { createFileRoute } from "@tanstack/react-router";
 import { ManageUsers } from "@users/components/ManageUsers";
 
 /** Search params for the user administration list. */
-type UsersSearch = {
+type UsersSearch = Paginated & {
 	status: string;
-	page: number;
 	term: string;
 };
 
@@ -14,8 +14,8 @@ function validateUsersSearch(
 	input: Partial<UsersSearch> & SearchSchemaInput,
 ): UsersSearch {
 	return {
+		...paginated(input),
 		status: str(input.status, "active"),
-		page: num(input.page, 1),
 		term: str(input.term, ""),
 	};
 }
@@ -35,7 +35,13 @@ export const Route = createFileRoute("/_authenticated/administration/users/")({
 
 		return Promise.all([
 			queryClient.ensureQueryData(
-				usersQueryOptions(page, 25, term, undefined, status === "active"),
+				usersQueryOptions(
+					page,
+					DEFAULT_PER_PAGE,
+					term,
+					undefined,
+					status === "active",
+				),
 			),
 			// For the create-user form. Prefetched, not ensured: a failure here must
 			// not take down the page.

--- a/apps/web/src/routes/_authenticated/hmms/index.tsx
+++ b/apps/web/src/routes/_authenticated/hmms/index.tsx
@@ -1,20 +1,20 @@
-import { num, str } from "@app/searchParams";
+import { DEFAULT_PER_PAGE, type Paginated, paginated } from "@app/pagination";
+import { str } from "@app/searchParams";
 import HmmList from "@hmm/components/HmmList";
 import type { SearchSchemaInput } from "@tanstack/react-router";
 import { createFileRoute } from "@tanstack/react-router";
 
 /** Search params for this route. */
-type HmmSearch = {
+type HmmSearch = Paginated & {
 	term: string;
-	page: number;
 };
 
 function validateHmmSearch(
 	input: Partial<HmmSearch> & SearchSchemaInput,
 ): HmmSearch {
 	return {
+		...paginated(input),
 		term: str(input.term, ""),
-		page: num(input.page, 1),
 	};
 }
 
@@ -23,7 +23,9 @@ export const Route = createFileRoute("/_authenticated/hmms/")({
 	loaderDeps: ({ search: { term, page } }) => ({ term, page }),
 	loader: async ({ context: { queryClient }, deps: { term, page } }) => {
 		const { hmmsQueryOptions } = await import("@hmm/queries");
-		await queryClient.ensureQueryData(hmmsQueryOptions(page, 25, term));
+		await queryClient.ensureQueryData(
+			hmmsQueryOptions(page, DEFAULT_PER_PAGE, term),
+		);
 	},
 	component: HmmRoute,
 });

--- a/apps/web/src/routes/_authenticated/jobs/index.tsx
+++ b/apps/web/src/routes/_authenticated/jobs/index.tsx
@@ -1,4 +1,5 @@
-import { num, oneOfArray } from "@app/searchParams";
+import { DEFAULT_PER_PAGE, type Paginated, paginated } from "@app/pagination";
+import { oneOfArray } from "@app/searchParams";
 import JobsList from "@jobs/components/JobList";
 import type { JobState } from "@jobs/types";
 import type { SearchSchemaInput } from "@tanstack/react-router";
@@ -15,17 +16,16 @@ const jobStates = [
 const initialState: JobState[] = ["pending", "running"];
 
 /** Search params for the jobs list. */
-type JobsSearch = {
+type JobsSearch = Paginated & {
 	state: JobState[];
-	page: number;
 };
 
 function validateJobsSearch(
 	input: Partial<JobsSearch> & SearchSchemaInput,
 ): JobsSearch {
 	return {
+		...paginated(input),
 		state: oneOfArray(input.state, jobStates, initialState),
-		page: num(input.page, 1),
 	};
 }
 
@@ -34,7 +34,9 @@ export const Route = createFileRoute("/_authenticated/jobs/")({
 	loaderDeps: ({ search: { page, state } }) => ({ page, state }),
 	loader: async ({ context: { queryClient }, deps: { page, state } }) => {
 		const { jobsQueryOptions } = await import("@jobs/queries");
-		await queryClient.ensureQueryData(jobsQueryOptions(page, 25, state));
+		await queryClient.ensureQueryData(
+			jobsQueryOptions(page, DEFAULT_PER_PAGE, state),
+		);
 	},
 	component: JobsRoute,
 });

--- a/apps/web/src/routes/_authenticated/refs/$refId/indexes/index.tsx
+++ b/apps/web/src/routes/_authenticated/refs/$refId/indexes/index.tsx
@@ -1,17 +1,12 @@
-import { num } from "@app/searchParams";
+import { DEFAULT_PER_PAGE, type Paginated, paginated } from "@app/pagination";
 import Indexes from "@indexes/components/Indexes";
 import type { SearchSchemaInput } from "@tanstack/react-router";
 import { createFileRoute } from "@tanstack/react-router";
 
-/** Search params for this route. */
-type IndexesSearch = {
-	page: number;
-};
-
 function validateIndexesSearch(
-	input: Partial<IndexesSearch> & SearchSchemaInput,
-): IndexesSearch {
-	return { page: num(input.page, 1) };
+	input: Partial<Paginated> & SearchSchemaInput,
+): Paginated {
+	return paginated(input);
 }
 
 export const Route = createFileRoute("/_authenticated/refs/$refId/indexes/")({
@@ -23,7 +18,9 @@ export const Route = createFileRoute("/_authenticated/refs/$refId/indexes/")({
 		deps: { page },
 	}) => {
 		const { indexesQueryOptions } = await import("@indexes/queries");
-		await queryClient.ensureQueryData(indexesQueryOptions(page, 25, refId));
+		await queryClient.ensureQueryData(
+			indexesQueryOptions(page, DEFAULT_PER_PAGE, refId),
+		);
 	},
 	component: IndexesRoute,
 });

--- a/apps/web/src/routes/_authenticated/refs/$refId/otus/index.tsx
+++ b/apps/web/src/routes/_authenticated/refs/$refId/otus/index.tsx
@@ -1,20 +1,20 @@
-import { num, str } from "@app/searchParams";
+import { DEFAULT_PER_PAGE, type Paginated, paginated } from "@app/pagination";
+import { str } from "@app/searchParams";
 import OtuList from "@otus/components/OtuList";
 import type { SearchSchemaInput } from "@tanstack/react-router";
 import { createFileRoute } from "@tanstack/react-router";
 
 /** Search params for this route. */
-type OtuListSearch = {
+type OtuListSearch = Paginated & {
 	term: string;
-	page: number;
 };
 
 function validateOtuListSearch(
 	input: Partial<OtuListSearch> & SearchSchemaInput,
 ): OtuListSearch {
 	return {
+		...paginated(input),
 		term: str(input.term, ""),
-		page: num(input.page, 1),
 	};
 }
 
@@ -27,7 +27,9 @@ export const Route = createFileRoute("/_authenticated/refs/$refId/otus/")({
 		deps: { term, page },
 	}) => {
 		const { otusQueryOptions } = await import("@otus/queries");
-		await queryClient.ensureQueryData(otusQueryOptions(refId, page, 25, term));
+		await queryClient.ensureQueryData(
+			otusQueryOptions(refId, page, DEFAULT_PER_PAGE, term),
+		);
 	},
 	component: OtusRoute,
 });

--- a/apps/web/src/routes/_authenticated/refs/index.tsx
+++ b/apps/web/src/routes/_authenticated/refs/index.tsx
@@ -1,22 +1,22 @@
-import { bool, num, str } from "@app/searchParams";
+import { DEFAULT_PER_PAGE, type Paginated, paginated } from "@app/pagination";
+import { bool, str } from "@app/searchParams";
 import ReferenceList from "@references/components/ReferenceList";
 import type { SearchSchemaInput } from "@tanstack/react-router";
 import { createFileRoute } from "@tanstack/react-router";
 
 /** Search params for the references list. */
-type RefsSearch = {
+type RefsSearch = Paginated & {
 	archived: boolean;
 	term: string;
-	page: number;
 };
 
 function validateRefsSearch(
 	input: Partial<RefsSearch> & SearchSchemaInput,
 ): RefsSearch {
 	return {
+		...paginated(input),
 		archived: bool(input.archived, false),
 		term: str(input.term, ""),
-		page: num(input.page, 1),
 	};
 }
 
@@ -33,7 +33,7 @@ export const Route = createFileRoute("/_authenticated/refs/")({
 	}) => {
 		const { referencesQueryOptions } = await import("@references/queries");
 		await queryClient.ensureQueryData(
-			referencesQueryOptions(page, 25, term, archived),
+			referencesQueryOptions(page, DEFAULT_PER_PAGE, term, archived),
 		);
 	},
 	component: ReferencesRoute,

--- a/apps/web/src/routes/_authenticated/samples/$sampleId/analyses/index.tsx
+++ b/apps/web/src/routes/_authenticated/samples/$sampleId/analyses/index.tsx
@@ -1,17 +1,12 @@
 import AnalysesList from "@analyses/components/AnalysisList";
-import { num } from "@app/searchParams";
+import { type Paginated, paginated } from "@app/pagination";
 import type { SearchSchemaInput } from "@tanstack/react-router";
 import { createFileRoute } from "@tanstack/react-router";
 
-/** Search params for this route. */
-type AnalysesListSearch = {
-	page: number;
-};
-
 function validateAnalysesListSearch(
-	input: Partial<AnalysesListSearch> & SearchSchemaInput,
-): AnalysesListSearch {
-	return { page: num(input.page, 1) };
+	input: Partial<Paginated> & SearchSchemaInput,
+): Paginated {
+	return paginated(input);
 }
 
 export const Route = createFileRoute(

--- a/apps/web/src/routes/_authenticated/samples/files.tsx
+++ b/apps/web/src/routes/_authenticated/samples/files.tsx
@@ -1,4 +1,4 @@
-import { num } from "@app/searchParams";
+import { type Paginated, paginated } from "@app/pagination";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
 import { useFetchLabels } from "@labels/queries";
@@ -6,15 +6,10 @@ import SampleFileManager from "@samples/components/SampleFileManager";
 import type { SearchSchemaInput } from "@tanstack/react-router";
 import { createFileRoute } from "@tanstack/react-router";
 
-/** Search params for this route. */
-type SampleFilesSearch = {
-	page: number;
-};
-
 function validateSampleFilesSearch(
-	input: Partial<SampleFilesSearch> & SearchSchemaInput,
-): SampleFilesSearch {
-	return { page: num(input.page, 1) };
+	input: Partial<Paginated> & SearchSchemaInput,
+): Paginated {
+	return paginated(input);
 }
 
 export const Route = createFileRoute("/_authenticated/samples/files")({

--- a/apps/web/src/routes/_authenticated/samples/index.tsx
+++ b/apps/web/src/routes/_authenticated/samples/index.tsx
@@ -1,12 +1,12 @@
-import { num, numberArray, str, stringArray } from "@app/searchParams";
+import { type Paginated, paginated } from "@app/pagination";
+import { numberArray, str, stringArray } from "@app/searchParams";
 import SamplesList from "@samples/components/SamplesList";
 import type { SearchSchemaInput } from "@tanstack/react-router";
 import { createFileRoute } from "@tanstack/react-router";
 
 /** Search params for the samples list. */
-type SamplesSearch = {
+type SamplesSearch = Paginated & {
 	term: string;
-	page: number;
 	labels: number[];
 	users: number[];
 	workflows: string[];
@@ -16,8 +16,8 @@ function validateSamplesSearch(
 	input: Partial<SamplesSearch> & SearchSchemaInput,
 ): SamplesSearch {
 	return {
+		...paginated(input),
 		term: str(input.term, ""),
-		page: num(input.page, 1),
 		labels: numberArray(input.labels, []),
 		users: numberArray(input.users, []),
 		workflows: stringArray(input.workflows, []),

--- a/apps/web/src/routes/_authenticated/subtractions/files.tsx
+++ b/apps/web/src/routes/_authenticated/subtractions/files.tsx
@@ -1,17 +1,12 @@
-import { num } from "@app/searchParams";
+import { type Paginated, paginated } from "@app/pagination";
 import { SubtractionFileManager } from "@subtraction/components/SubtractionFileManager";
 import type { SearchSchemaInput } from "@tanstack/react-router";
 import { createFileRoute } from "@tanstack/react-router";
 
-/** Search params for this route. */
-type SubtractionFilesSearch = {
-	page: number;
-};
-
 function validateSubtractionFilesSearch(
-	input: Partial<SubtractionFilesSearch> & SearchSchemaInput,
-): SubtractionFilesSearch {
-	return { page: num(input.page, 1) };
+	input: Partial<Paginated> & SearchSchemaInput,
+): Paginated {
+	return paginated(input);
 }
 
 export const Route = createFileRoute("/_authenticated/subtractions/files")({

--- a/apps/web/src/routes/_authenticated/subtractions/index.tsx
+++ b/apps/web/src/routes/_authenticated/subtractions/index.tsx
@@ -1,20 +1,20 @@
-import { num, str } from "@app/searchParams";
+import { DEFAULT_PER_PAGE, type Paginated, paginated } from "@app/pagination";
+import { str } from "@app/searchParams";
 import SubtractionList from "@subtraction/components/SubtractionList";
 import type { SearchSchemaInput } from "@tanstack/react-router";
 import { createFileRoute } from "@tanstack/react-router";
 
 /** Search params for this route. */
-type SubtractionsSearch = {
+type SubtractionsSearch = Paginated & {
 	term: string;
-	page: number;
 };
 
 function validateSubtractionsSearch(
 	input: Partial<SubtractionsSearch> & SearchSchemaInput,
 ): SubtractionsSearch {
 	return {
+		...paginated(input),
 		term: str(input.term, ""),
-		page: num(input.page, 1),
 	};
 }
 
@@ -23,7 +23,9 @@ export const Route = createFileRoute("/_authenticated/subtractions/")({
 	loaderDeps: ({ search: { term, page } }) => ({ term, page }),
 	loader: async ({ context: { queryClient }, deps: { term, page } }) => {
 		const { subtractionsQueryOptions } = await import("@subtraction/queries");
-		await queryClient.ensureQueryData(subtractionsQueryOptions(page, 25, term));
+		await queryClient.ensureQueryData(
+			subtractionsQueryOptions(page, DEFAULT_PER_PAGE, term),
+		);
 	},
 	component: SubtractionsRoute,
 });


### PR DESCRIPTION
## Summary
- Adds `@app/pagination` with a shared `Paginated` type, `paginated()` search-schema helper, and `DEFAULT_PER_PAGE` constant so list routes stop re-declaring `page: number` and hardcoding `25`.
- Migrates all eleven paginated routes (users, hmms, jobs, indexes, otus, refs, sample analyses/files, samples, subtractions/files) onto the shared helper and constant.
- Documents the convention in `AGENTS.md` so new paginated routes follow it by default.