### PR TITLE
fix: give d3 charts a text alternative for screen readers

### DIFF
--- a/apps/web/src/analyses/components/Nuvs/NuvsOrf.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsOrf.tsx
@@ -11,11 +11,19 @@ function draw(element, maxLength, pos, strand) {
 
 	const width = element.offsetWidth - 30;
 
+	const start = Math.min(pos[0], pos[1]);
+	const end = Math.max(pos[0], pos[1]);
+	const label = `Open reading frame from position ${start} to ${end} on the ${strand === 1 ? "forward" : "reverse"} strand.`;
+
 	// Construct the SVG canvas.
 	const svg = select(element)
 		.append("svg")
 		.attr("width", width + 30)
-		.attr("height", HEIGHT);
+		.attr("height", HEIGHT)
+		.attr("role", "img")
+		.attr("aria-label", label);
+
+	svg.append("title").text(label);
 
 	// Create a mother group that will hold all chart elements.
 	const group = svg.append("g").attr("transform", "translate(15,0)");

--- a/apps/web/src/analyses/components/Nuvs/NuvsOrf.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsOrf.tsx
@@ -1,4 +1,5 @@
 import Badge from "@base/Badge";
+import { labelSvg } from "@samples/charting";
 import { scaleLinear, select } from "d3";
 import { useEffect, useRef } from "react";
 import "./NuvsOrf.css";
@@ -19,11 +20,9 @@ function draw(element, maxLength, pos, strand) {
 	const svg = select(element)
 		.append("svg")
 		.attr("width", width + 30)
-		.attr("height", HEIGHT)
-		.attr("role", "img")
-		.attr("aria-label", label);
+		.attr("height", HEIGHT);
 
-	svg.append("title").text(label);
+	labelSvg(svg, label);
 
 	// Create a mother group that will hold all chart elements.
 	const group = svg.append("g").attr("transform", "translate(15,0)");

--- a/apps/web/src/analyses/components/Nuvs/NuvsSequence.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsSequence.tsx
@@ -1,3 +1,5 @@
+import { pluralize } from "@app/format";
+import { labelSvg } from "@samples/charting";
 import { axisTop, scaleLinear, select } from "d3";
 import { useEffect, useRef } from "react";
 
@@ -10,17 +12,15 @@ function draw(element: HTMLElement, maxLength: number, sequenceLength: number) {
 		.range([0, width - 30])
 		.domain([0, maxLength]);
 
-	const label = `Sequence ruler: a ${sequenceLength} nucleotide sequence on a scale up to ${maxLength} nucleotides.`;
+	const label = `Sequence ruler: a ${sequenceLength} nucleotide sequence on a scale up to ${pluralize(maxLength, "nucleotide")}.`;
 
 	// Construct the SVG canvas.
 	const svg = select(element)
 		.append("svg")
 		.attr("width", width)
-		.attr("height", 30)
-		.attr("role", "img")
-		.attr("aria-label", label);
+		.attr("height", 30);
 
-	svg.append("title").text(label);
+	labelSvg(svg, label);
 
 	// Create a group that will hold all chart elements.
 	const group = svg.append("g").attr("transform", "translate(15,3)");

--- a/apps/web/src/analyses/components/Nuvs/NuvsSequence.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsSequence.tsx
@@ -10,11 +10,17 @@ function draw(element: HTMLElement, maxLength: number, sequenceLength: number) {
 		.range([0, width - 30])
 		.domain([0, maxLength]);
 
+	const label = `Sequence ruler: a ${sequenceLength} nucleotide sequence on a scale up to ${maxLength} nucleotides.`;
+
 	// Construct the SVG canvas.
 	const svg = select(element)
 		.append("svg")
 		.attr("width", width)
-		.attr("height", 30);
+		.attr("height", 30)
+		.attr("role", "img")
+		.attr("aria-label", label);
+
+	svg.append("title").text(label);
 
 	// Create a group that will hold all chart elements.
 	const group = svg.append("g").attr("transform", "translate(15,3)");

--- a/apps/web/src/analyses/components/Nuvs/__tests__/NuvsOrf.test.tsx
+++ b/apps/web/src/analyses/components/Nuvs/__tests__/NuvsOrf.test.tsx
@@ -1,0 +1,40 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@tests/setup";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import NuvsOrf from "../NuvsOrf";
+
+/**
+ * jsdom does not lay out elements, so `offsetWidth` is always zero. The glyph
+ * measures its container to scale the arrow, so stub a realistic width.
+ */
+function mockElementWidth(width: number) {
+	vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(width);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("<NuvsOrf />", () => {
+	it("should render an accessible glyph describing the reading frame", () => {
+		mockElementWidth(400);
+
+		renderWithProviders(
+			<NuvsOrf
+				hits={[]}
+				maxSequenceLength={1000}
+				pos={[340, 920]}
+				strand={-1}
+			/>,
+		);
+
+		const svg = screen.getByRole("img");
+
+		expect(svg.getAttribute("aria-label")).toBe(
+			"Open reading frame from position 340 to 920 on the reverse strand.",
+		);
+		expect(svg.querySelector("title")?.textContent).toBe(
+			svg.getAttribute("aria-label"),
+		);
+	});
+});

--- a/apps/web/src/analyses/components/Nuvs/__tests__/NuvsSequence.test.tsx
+++ b/apps/web/src/analyses/components/Nuvs/__tests__/NuvsSequence.test.tsx
@@ -1,0 +1,35 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@tests/setup";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import NuvsSequence from "../NuvsSequence";
+
+/**
+ * jsdom does not lay out elements, so `offsetWidth` is always zero. The ruler
+ * measures its container to size the axis, so stub a realistic width.
+ */
+function mockElementWidth(width: number) {
+	vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(width);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("<NuvsSequence />", () => {
+	it("should render an accessible ruler with a data-informed label", () => {
+		mockElementWidth(400);
+
+		renderWithProviders(
+			<NuvsSequence maxSequenceLength={20} sequence="ATCGATCG" />,
+		);
+
+		const svg = screen.getByRole("img");
+
+		expect(svg.getAttribute("aria-label")).toBe(
+			"Sequence ruler: a 8 nucleotide sequence on a scale up to 20 nucleotides.",
+		);
+		expect(svg.querySelector("title")?.textContent).toBe(
+			svg.getAttribute("aria-label"),
+		);
+	});
+});

--- a/apps/web/src/analyses/components/Pathoscope/PathoscopeSequence.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/PathoscopeSequence.tsx
@@ -5,6 +5,7 @@ import "./area.css";
 type DrawParams = {
 	element: HTMLElement;
 	data: number[];
+	label: string;
 	length: number;
 	yMax: number;
 	xMin: number;
@@ -15,6 +16,7 @@ type DrawParams = {
 function draw({
 	element,
 	data,
+	label,
 	length,
 	yMax,
 	xMin,
@@ -39,12 +41,16 @@ function draw({
 
 	select(element).selectAll("*").remove();
 
-	const svg = select(element)
+	const svgRoot = select(element)
 		.append("svg")
 		.attr("width", width + margin)
 		.attr("height", height + margin)
-		.append("g")
-		.attr("transform", `translate(${margin},5)`);
+		.attr("role", "img")
+		.attr("aria-label", label);
+
+	svgRoot.append("title").text(label);
+
+	const svg = svgRoot.append("g").attr("transform", `translate(${margin},5)`);
 
 	if (data) {
 		const areaDrawer = area<number>()
@@ -104,6 +110,7 @@ export default function PathoscopeSequence({
 			draw({
 				element: chartEl.current,
 				data,
+				label: `Read depth coverage across the ${accession} sequence, ${length} nucleotides long.`,
 				length,
 				yMax,
 				xMin: chartEl.current.offsetWidth,
@@ -111,7 +118,7 @@ export default function PathoscopeSequence({
 				ratio,
 			});
 		}
-	}, [data, length, maxGenomeLength, ratio, yMax]);
+	}, [accession, data, length, maxGenomeLength, ratio, yMax]);
 
 	return (
 		<div className="bg-stone-50 inline-block rounded">

--- a/apps/web/src/analyses/components/Pathoscope/PathoscopeSequence.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/PathoscopeSequence.tsx
@@ -1,3 +1,5 @@
+import { pluralize } from "@app/format";
+import { labelSvg } from "@samples/charting";
 import { area, axisBottom, axisLeft, format, scaleLinear, select } from "d3";
 import { useEffect, useRef } from "react";
 import "./area.css";
@@ -44,11 +46,9 @@ function draw({
 	const svgRoot = select(element)
 		.append("svg")
 		.attr("width", width + margin)
-		.attr("height", height + margin)
-		.attr("role", "img")
-		.attr("aria-label", label);
+		.attr("height", height + margin);
 
-	svgRoot.append("title").text(label);
+	labelSvg(svgRoot, label);
 
 	const svg = svgRoot.append("g").attr("transform", `translate(${margin},5)`);
 
@@ -110,7 +110,7 @@ export default function PathoscopeSequence({
 			draw({
 				element: chartEl.current,
 				data,
-				label: `Read depth coverage across the ${accession} sequence, ${length} nucleotides long.`,
+				label: `Read depth coverage across the ${accession} sequence, ${pluralize(length, "nucleotide")} long.`,
 				length,
 				yMax,
 				xMin: chartEl.current.offsetWidth,

--- a/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeSequence.test.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeSequence.test.tsx
@@ -1,0 +1,44 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@tests/setup";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import PathoscopeSequence from "../PathoscopeSequence";
+
+/**
+ * jsdom does not lay out elements, so `offsetWidth` is always zero. The chart
+ * measures its container to size the plot, so stub a realistic width.
+ */
+function mockElementWidth(width: number) {
+	vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(width);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("<PathoscopeSequence />", () => {
+	it("should render an accessible coverage chart with a data-informed label", () => {
+		mockElementWidth(400);
+
+		renderWithProviders(
+			<PathoscopeSequence
+				accession="NC_001498"
+				data={[]}
+				definition="Measles virus"
+				id="foo"
+				length={1000}
+				maxGenomeLength={1000}
+				ratio={1}
+				yMax={12}
+			/>,
+		);
+
+		const svg = screen.getByRole("img");
+
+		expect(svg.getAttribute("aria-label")).toBe(
+			"Read depth coverage across the NC_001498 sequence, 1000 nucleotides long.",
+		);
+		expect(svg.querySelector("title")?.textContent).toBe(
+			svg.getAttribute("aria-label"),
+		);
+	});
+});

--- a/apps/web/src/app/__tests__/format.test.ts
+++ b/apps/web/src/app/__tests__/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	byteSize,
+	pluralize,
 	toGcContent,
 	toScientificNotation,
 	toThousand,
@@ -71,6 +72,21 @@ describe("toScientificNotation()", () => {
 
 	it("should not group the integer part of mid-range values", () => {
 		expect(toScientificNotation(1000)).toEqual("1000.000");
+	});
+});
+
+describe("pluralize()", () => {
+	it("should keep the singular noun when the count is one", () => {
+		expect(pluralize(1, "read position")).toEqual("1 read position");
+	});
+
+	it("should append 's' when the count is not one", () => {
+		expect(pluralize(3, "read position")).toEqual("3 read positions");
+		expect(pluralize(0, "nucleotide")).toEqual("0 nucleotides");
+	});
+
+	it("should use an explicit plural for irregular nouns", () => {
+		expect(pluralize(2, "index", "indices")).toEqual("2 indices");
 	});
 });
 

--- a/apps/web/src/app/format.ts
+++ b/apps/web/src/app/format.ts
@@ -69,6 +69,19 @@ export function toGcContent(fraction: number): string {
 }
 
 /**
+ * Prefix a noun with a count, appending "s" unless the count is exactly one
+ * (eg. `1 read position`, `3 read positions`). Pass `plural` for irregular
+ * nouns.
+ */
+export function pluralize(
+	count: number,
+	singular: string,
+	plural: string = `${singular}s`,
+): string {
+	return `${count} ${count === 1 ? singular : plural}`;
+}
+
+/**
  * Converts a ``number`` to a scientific notation string.
  */
 export function toScientificNotation(num: number): string {

--- a/apps/web/src/quality/components/Bases.ts
+++ b/apps/web/src/quality/components/Bases.ts
@@ -45,7 +45,9 @@ function lineDrawer(data, key, x, y) {
 }
 
 export function drawBasesChart(element: HTMLElement, data, baseWidth: number) {
-	const svg = createSvg(element, baseWidth);
+	const label = `Base quality distribution across ${data.length} read positions, showing mean and median quality with interquartile and interdecile ranges.`;
+
+	const svg = createSvg(element, baseWidth, label);
 
 	const width =
 		baseWidth - QUALITY_CHART_MARGIN.left - QUALITY_CHART_MARGIN.right;

--- a/apps/web/src/quality/components/Bases.ts
+++ b/apps/web/src/quality/components/Bases.ts
@@ -1,3 +1,4 @@
+import { pluralize } from "@app/format";
 import {
 	appendLegend,
 	createSvg,
@@ -45,7 +46,7 @@ function lineDrawer(data, key, x, y) {
 }
 
 export function drawBasesChart(element: HTMLElement, data, baseWidth: number) {
-	const label = `Base quality distribution across ${data.length} read positions, showing mean and median quality with interquartile and interdecile ranges.`;
+	const label = `Base quality distribution across ${pluralize(data.length, "read position")}, showing mean and median quality with interquartile and interdecile ranges.`;
 
 	const svg = createSvg(element, baseWidth, label);
 

--- a/apps/web/src/quality/components/Nucleotides.ts
+++ b/apps/web/src/quality/components/Nucleotides.ts
@@ -19,7 +19,9 @@ export function drawNucleotidesChart(
 	data: Array<[number, number, number, number]>,
 	baseWidth: number,
 ) {
-	const svg = createSvg(element, baseWidth);
+	const label = `Nucleotide composition across ${data.length} read positions, showing the percentage of guanine, adenine, thymine, and cytosine.`;
+
+	const svg = createSvg(element, baseWidth, label);
 
 	const width =
 		baseWidth - QUALITY_CHART_MARGIN.left - QUALITY_CHART_MARGIN.right;

--- a/apps/web/src/quality/components/Nucleotides.ts
+++ b/apps/web/src/quality/components/Nucleotides.ts
@@ -1,3 +1,4 @@
+import { pluralize } from "@app/format";
 import {
 	appendLegend,
 	createSvg,
@@ -19,7 +20,7 @@ export function drawNucleotidesChart(
 	data: Array<[number, number, number, number]>,
 	baseWidth: number,
 ) {
-	const label = `Nucleotide composition across ${data.length} read positions, showing the percentage of guanine, adenine, thymine, and cytosine.`;
+	const label = `Nucleotide composition across ${pluralize(data.length, "read position")}, showing the percentage of guanine, adenine, thymine, and cytosine.`;
 
 	const svg = createSvg(element, baseWidth, label);
 

--- a/apps/web/src/quality/components/Sequences.ts
+++ b/apps/web/src/quality/components/Sequences.ts
@@ -1,4 +1,4 @@
-import { toScientificNotation } from "@app/format";
+import { pluralize, toScientificNotation } from "@app/format";
 import {
 	createSvg,
 	QUALITY_CHART_HEIGHT,
@@ -8,7 +8,7 @@ import { axisBottom, axisLeft, line, scaleLinear } from "d3";
 import { max } from "es-toolkit/compat";
 
 export function drawSequencesChart(element, data, baseWidth) {
-	const label = `Number of reads at each of ${data.length} quality scores.`;
+	const label = `Number of reads at each of ${pluralize(data.length, "quality score")}.`;
 
 	const svg = createSvg(element, baseWidth, label);
 

--- a/apps/web/src/quality/components/Sequences.ts
+++ b/apps/web/src/quality/components/Sequences.ts
@@ -8,7 +8,9 @@ import { axisBottom, axisLeft, line, scaleLinear } from "d3";
 import { max } from "es-toolkit/compat";
 
 export function drawSequencesChart(element, data, baseWidth) {
-	const svg = createSvg(element, baseWidth);
+	const label = `Number of reads at each of ${data.length} quality scores.`;
+
+	const svg = createSvg(element, baseWidth, label);
 
 	const width =
 		baseWidth - QUALITY_CHART_MARGIN.right - QUALITY_CHART_MARGIN.left;

--- a/apps/web/src/quality/components/__tests__/Bases.test.ts
+++ b/apps/web/src/quality/components/__tests__/Bases.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { drawBasesChart } from "../Bases";
+
+describe("drawBasesChart()", () => {
+	it("should render an accessible chart with a data-informed label", () => {
+		const element = document.createElement("div");
+		const data = [
+			[30, 31, 28, 33, 26, 35],
+			[31, 32, 29, 34, 27, 36],
+			[29, 30, 27, 32, 25, 34],
+		];
+
+		drawBasesChart(element, data, 600);
+
+		const svg = element.querySelector("svg");
+
+		expect(svg?.getAttribute("role")).toBe("img");
+		expect(svg?.getAttribute("aria-label")).toBe(
+			"Base quality distribution across 3 read positions, showing mean and median quality with interquartile and interdecile ranges.",
+		);
+		expect(svg?.querySelector("title")?.textContent).toBe(
+			svg?.getAttribute("aria-label"),
+		);
+	});
+});

--- a/apps/web/src/quality/components/__tests__/Nucleotides.test.ts
+++ b/apps/web/src/quality/components/__tests__/Nucleotides.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { drawNucleotidesChart } from "../Nucleotides";
+
+describe("drawNucleotidesChart()", () => {
+	it("should render an accessible chart with a data-informed label", () => {
+		const element = document.createElement("div");
+		const data: Array<[number, number, number, number]> = [
+			[10, 20, 30, 40],
+			[15, 25, 30, 30],
+		];
+
+		drawNucleotidesChart(element, data, 600);
+
+		const svg = element.querySelector("svg");
+
+		expect(svg?.getAttribute("role")).toBe("img");
+		expect(svg?.getAttribute("aria-label")).toBe(
+			"Nucleotide composition across 2 read positions, showing the percentage of guanine, adenine, thymine, and cytosine.",
+		);
+		expect(svg?.querySelector("title")?.textContent).toBe(
+			svg?.getAttribute("aria-label"),
+		);
+	});
+});

--- a/apps/web/src/quality/components/__tests__/Sequences.test.ts
+++ b/apps/web/src/quality/components/__tests__/Sequences.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { drawSequencesChart } from "../Sequences";
+
+describe("drawSequencesChart()", () => {
+	it("should render an accessible chart with a data-informed label", () => {
+		const element = document.createElement("div");
+
+		drawSequencesChart(element, [5, 10, 3, 8], 600);
+
+		const svg = element.querySelector("svg");
+
+		expect(svg?.getAttribute("role")).toBe("img");
+		expect(svg?.getAttribute("aria-label")).toBe(
+			"Number of reads at each of 4 quality scores.",
+		);
+		expect(svg?.querySelector("title")?.textContent).toBe(
+			svg?.getAttribute("aria-label"),
+		);
+	});
+});

--- a/apps/web/src/samples/charting.ts
+++ b/apps/web/src/samples/charting.ts
@@ -34,6 +34,18 @@ export function appendLegend(
 	});
 }
 
+/**
+ * Give a d3-built `<svg>` a text alternative: `role="img"` plus an `aria-label`
+ * and a matching `<title>`. The role makes the SVG an atomic graphic, hiding
+ * its visual axis and legend text from the accessibility tree so the label is
+ * the whole alternative; the `<title>` is the equivalent for pointer hover and
+ * older assistive technology.
+ */
+export function labelSvg(svg, label: string) {
+	svg.attr("role", "img").attr("aria-label", label);
+	svg.append("title").text(label);
+}
+
 export function createSvg(element: HTMLElement, width: number, label: string) {
 	select(element).selectAll("*").remove();
 
@@ -48,15 +60,9 @@ export function createSvg(element: HTMLElement, width: number, label: string) {
 			QUALITY_CHART_HEIGHT +
 				QUALITY_CHART_MARGIN.top +
 				QUALITY_CHART_MARGIN.bottom,
-		)
-		.attr("role", "img")
-		.attr("aria-label", label);
+		);
 
-	// A screen reader announces the aria-label; the title is the equivalent
-	// for pointer hover and older assistive technology. The role="img" makes
-	// the SVG an atomic graphic, hiding the visual axis and legend text from
-	// the accessibility tree so the label is the whole alternative.
-	svg.append("title").text(label);
+	labelSvg(svg, label);
 
 	return svg
 		.append("g")

--- a/apps/web/src/samples/charting.ts
+++ b/apps/web/src/samples/charting.ts
@@ -34,10 +34,10 @@ export function appendLegend(
 	});
 }
 
-export function createSvg(element: HTMLElement, width: number) {
+export function createSvg(element: HTMLElement, width: number, label: string) {
 	select(element).selectAll("*").remove();
 
-	return select(element)
+	const svg = select(element)
 		.append("svg")
 		.attr(
 			"width",
@@ -49,6 +49,16 @@ export function createSvg(element: HTMLElement, width: number) {
 				QUALITY_CHART_MARGIN.top +
 				QUALITY_CHART_MARGIN.bottom,
 		)
+		.attr("role", "img")
+		.attr("aria-label", label);
+
+	// A screen reader announces the aria-label; the title is the equivalent
+	// for pointer hover and older assistive technology. The role="img" makes
+	// the SVG an atomic graphic, hiding the visual axis and legend text from
+	// the accessibility tree so the label is the whole alternative.
+	svg.append("title").text(label);
+
+	return svg
 		.append("g")
 		.attr(
 			"transform",


### PR DESCRIPTION
## Summary
- Sets `role="img"`, `aria-label`, and a `<title>` on the SVGs drawn by the quality, Nuvs, and Pathoscope d3 charts so screen readers announce a description instead of skipping the graphic entirely.
- Derives each label from the chart's underlying data (e.g. read position count, ORF strand and position range) so it stays accurate as the data changes.
- Adds tests covering the new labels for `Bases`, `Nucleotides`, `Sequences`, `NuvsOrf`, `NuvsSequence`, and `PathoscopeSequence`.