### PR TITLE
feat: make the subtraction file picker keyboard accessible

### DIFF
--- a/apps/web/src/base/BoxGroupSection.tsx
+++ b/apps/web/src/base/BoxGroupSection.tsx
@@ -6,6 +6,7 @@ type BoxGroupSectionProps = {
 	as?: ElementType;
 	children?: ReactNode;
 	className?: string;
+	id?: string;
 	onClick?: () => void;
 	onKeyDown?: (e: KeyboardEvent) => void;
 	ref?: Ref<HTMLDivElement>;

--- a/apps/web/src/base/CompactScrollList.tsx
+++ b/apps/web/src/base/CompactScrollList.tsx
@@ -3,7 +3,7 @@ import type {
 	FetchNextPageOptions,
 	InfiniteQueryObserverResult,
 } from "@tanstack/react-query/";
-import type { ReactElement } from "react";
+import type { ComponentPropsWithRef, ReactElement, UIEvent } from "react";
 import LoadingPlaceholder from "./LoadingPlaceholder";
 
 function getScrollRatio(scrollListElement: HTMLElement): number {
@@ -13,13 +13,7 @@ function getScrollRatio(scrollListElement: HTMLElement): number {
 	);
 }
 
-type CompactScrollListProps = {
-	/** The id of the element that labels the list */
-	"aria-labelledby"?: string;
-
-	/** The class name of the scroll list */
-	className?: string;
-
+type CompactScrollListProps = ComponentPropsWithRef<"div"> & {
 	/** A function which initiates fetching the next page */
 	fetchNextPage: (
 		options?: FetchNextPageOptions,
@@ -40,18 +34,25 @@ type CompactScrollListProps = {
 
 /**
  * An infinitely scrolling list of items.
+ *
+ * The container carries no ARIA role of its own — it is a plain scroll region.
+ * Callers that are genuine listboxes pass listbox props (`role`, `tabIndex`,
+ * `aria-activedescendant`, `onKeyDown`) through, e.g. via `useListboxNavigation`.
  */
 export default function CompactScrollList({
-	"aria-labelledby": ariaLabelledby,
 	className,
 	fetchNextPage,
 	isFetchingNextPage,
 	isPending,
 	items,
 	renderRow,
+	onScroll,
+	...props
 }: CompactScrollListProps) {
-	function onScroll(e) {
-		const scrollListElement = e.target;
+	function handleScroll(e: UIEvent<HTMLDivElement>) {
+		onScroll?.(e);
+
+		const scrollListElement = e.target as HTMLElement;
 		if (getScrollRatio(scrollListElement) > 0.8 && !isFetchingNextPage) {
 			void fetchNextPage();
 		}
@@ -61,7 +62,6 @@ export default function CompactScrollList({
 
 	return (
 		<div
-			aria-labelledby={ariaLabelledby}
 			className={cn(
 				"mb-2",
 				"relative",
@@ -71,8 +71,8 @@ export default function CompactScrollList({
 				"rounded-md",
 				className,
 			)}
-			onScroll={onScroll}
-			role="listbox"
+			onScroll={handleScroll}
+			{...props}
 		>
 			{entries}
 			{isPending && <LoadingPlaceholder className="mt-5" />}

--- a/apps/web/src/base/SelectBoxGroupSection.tsx
+++ b/apps/web/src/base/SelectBoxGroupSection.tsx
@@ -1,43 +1,47 @@
 import { cn } from "@app/cn";
-import type { KeyboardEvent, ReactNode } from "react";
+import type { ReactNode } from "react";
 import BoxGroupSection from "./BoxGroupSection";
 
 type SelectBoxGroupSectionProps = {
+	/** Whether the option is selected */
 	active?: boolean;
 	children: ReactNode;
 	className?: string;
+	/** Whether the option is the keyboard cursor's active descendant */
+	highlighted?: boolean;
+	/** The option's DOM id, referenced by the listbox's `aria-activedescendant` */
+	id?: string;
 	onClick?: () => void;
 };
 
+/**
+ * A single option in a listbox.
+ *
+ * The parent listbox owns keyboard focus and moves an `aria-activedescendant`
+ * cursor, so options are not individually focusable — `highlighted` renders the
+ * cursor and `active` reflects selection.
+ */
 export default function SelectBoxGroupSection({
 	active,
 	children,
 	className,
+	highlighted,
+	id,
 	onClick,
 }: SelectBoxGroupSectionProps) {
-	function onKeyDown(e: KeyboardEvent) {
-		if (e.key === "Enter" || e.key === " ") {
-			e.preventDefault();
-			onClick?.();
-		}
-	}
-
 	return (
 		<BoxGroupSection
 			aria-selected={active}
 			className={cn(
 				"cursor-pointer",
 				"w-full",
-				"focus:ring-2",
-				"focus:ring-inset",
-				"focus:ring-blue-600/50",
-				"focus:outline-none",
+				active && "bg-blue-50",
+				highlighted && "ring-2 ring-inset ring-blue-600/50",
 				className,
 			)}
+			id={id}
 			onClick={onClick}
-			onKeyDown={onKeyDown}
 			role="option"
-			tabIndex={0}
 		>
 			{children}
 		</BoxGroupSection>

--- a/apps/web/src/base/useListboxNavigation.ts
+++ b/apps/web/src/base/useListboxNavigation.ts
@@ -1,0 +1,119 @@
+import {
+	type KeyboardEvent,
+	type RefObject,
+	useId,
+	useRef,
+	useState,
+} from "react";
+
+/** The props to spread on the listbox container element. */
+type ListboxProps = {
+	ref: RefObject<HTMLDivElement | null>;
+	role: "listbox";
+	tabIndex: 0;
+	"aria-activedescendant": string | undefined;
+	onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
+};
+
+/** Keyboard navigation state for an ARIA listbox. */
+type ListboxNavigation = {
+	/** Props to spread on the listbox container. */
+	listboxProps: ListboxProps;
+
+	/** The DOM id of the active (highlighted) option, or undefined when none. */
+	activeOptionId: string | undefined;
+
+	/** Builds the DOM id of the option representing `key`. */
+	getOptionId: (key: string | number) => string;
+};
+
+function clamp(value: number, max: number): number {
+	return Math.max(0, Math.min(value, max));
+}
+
+/**
+ * Drives keyboard navigation for a single-select ARIA listbox using the
+ * `aria-activedescendant` pattern: focus stays on the container while the arrow,
+ * Home, and End keys move a virtual cursor, and Enter or Space selects the
+ * active option.
+ *
+ * The container owns the only tab stop; options are not individually focusable.
+ * Spread `listboxProps` on the scroll container, tag each option element with
+ * `id={getOptionId(key)}`, and highlight the one whose id equals
+ * `activeOptionId`.
+ */
+export default function useListboxNavigation<T>(
+	items: T[],
+	getKey: (item: T) => string | number,
+	onSelect: (item: T) => void,
+): ListboxNavigation {
+	const baseId = useId();
+	const ref = useRef<HTMLDivElement>(null);
+	const [activeKey, setActiveKey] = useState<string | number | null>(null);
+
+	function getOptionId(key: string | number): string {
+		return `${baseId}-${key}`;
+	}
+
+	const activeIndex = items.findIndex((item) => getKey(item) === activeKey);
+	const activeItem = activeIndex >= 0 ? items[activeIndex] : undefined;
+	const activeOptionId =
+		activeItem === undefined ? undefined : getOptionId(getKey(activeItem));
+
+	function moveTo(index: number) {
+		const item = items[clamp(index, items.length - 1)];
+		if (item === undefined) {
+			return;
+		}
+
+		const key = getKey(item);
+		setActiveKey(key);
+
+		const optionElement = ref.current?.querySelector(
+			`#${CSS.escape(getOptionId(key))}`,
+		);
+		optionElement?.scrollIntoView?.({ block: "nearest" });
+	}
+
+	function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+		switch (event.key) {
+			case "ArrowDown":
+				event.preventDefault();
+				moveTo(activeIndex < 0 ? 0 : activeIndex + 1);
+				break;
+			case "ArrowUp":
+				event.preventDefault();
+				moveTo(activeIndex < 0 ? items.length - 1 : activeIndex - 1);
+				break;
+			case "Home":
+				event.preventDefault();
+				moveTo(0);
+				break;
+			case "End":
+				event.preventDefault();
+				moveTo(items.length - 1);
+				break;
+			case "Enter":
+			case " ":
+				if (activeItem !== undefined) {
+					event.preventDefault();
+					onSelect(activeItem);
+				}
+				break;
+			default:
+				break;
+		}
+	}
+
+	return {
+		listboxProps: {
+			ref,
+			role: "listbox",
+			tabIndex: 0,
+			"aria-activedescendant": activeOptionId,
+			onKeyDown,
+		},
+		activeOptionId,
+		getOptionId,
+	};
+}

--- a/apps/web/src/references/components/Detail/AddReferenceGroup.tsx
+++ b/apps/web/src/references/components/Detail/AddReferenceGroup.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@app/cn";
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupSection from "@base/BoxGroupSection";
 import CompactScrollList from "@base/CompactScrollList";
@@ -6,7 +7,6 @@ import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "@base/Empty";
 import InitialIcon from "@base/InitialIcon";
 import QueryError from "@base/QueryError";
 import SearchToolbar from "@base/SearchToolbar";
-import SelectBoxGroupSection from "@base/SelectBoxGroupSection";
 import { useInfiniteFindGroups } from "@groups/queries";
 import { useAddReferenceMember } from "@references/queries";
 import type { ReferenceGroup } from "@references/types";
@@ -62,14 +62,21 @@ export default function AddReferenceGroup({
 
 	function renderRow(item) {
 		return (
-			<SelectBoxGroupSection
+			<button
 				key={item.id}
-				className="flex items-center [&_.InitialIcon]:mr-1"
+				type="button"
+				className={cn(
+					"flex w-full cursor-pointer items-center gap-1 px-6 py-3 text-left",
+					"border-b border-gray-300 last:border-b-0",
+					"hover:bg-gray-50",
+					"focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-600/50",
+					"[&_.InitialIcon]:mr-1",
+				)}
 				onClick={() => mutation.mutate({ id: item.id })}
 			>
 				<InitialIcon size="md" handle={item.name} />
 				{item.name}
-			</SelectBoxGroupSection>
+			</button>
 		);
 	}
 

--- a/apps/web/src/references/components/Detail/AddReferenceUser.tsx
+++ b/apps/web/src/references/components/Detail/AddReferenceUser.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@app/cn";
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupSection from "@base/BoxGroupSection";
 import CompactScrollList from "@base/CompactScrollList";
@@ -6,7 +7,6 @@ import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "@base/Empty";
 import InitialIcon from "@base/InitialIcon";
 import QueryError from "@base/QueryError";
 import SearchToolbar from "@base/SearchToolbar";
-import SelectBoxGroupSection from "@base/SelectBoxGroupSection";
 import { useAddReferenceMember } from "@references/queries";
 import type { ReferenceUser } from "@references/types";
 import { useInfiniteFindUsers } from "@users/queries";
@@ -62,14 +62,21 @@ export default function AddReferenceUser({
 
 	function renderRow(item) {
 		return (
-			<SelectBoxGroupSection
+			<button
 				key={item.id}
-				className="flex items-center [&_.InitialIcon]:mr-1"
+				type="button"
+				className={cn(
+					"flex w-full cursor-pointer items-center gap-1 px-6 py-3 text-left",
+					"border-b border-gray-300 last:border-b-0",
+					"hover:bg-gray-50",
+					"focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-600/50",
+					"[&_.InitialIcon]:mr-1",
+				)}
 				onClick={() => mutation.mutate({ id: item.id })}
 			>
 				<InitialIcon size="md" handle={item.handle} />
 				{item.handle}
-			</SelectBoxGroupSection>
+			</button>
 		);
 	}
 

--- a/apps/web/src/subtraction/components/SubtractionFileItem.tsx
+++ b/apps/web/src/subtraction/components/SubtractionFileItem.tsx
@@ -7,8 +7,12 @@ type SubtractionFileItemProps = {
 	active: boolean;
 	/** Error message to be displayed */
 	error: string;
+	/** Whether the option is the listbox's active descendant */
+	highlighted: boolean;
 	/** The unique identifier */
 	id: number;
+	/** The option's DOM id, referenced by the listbox's `aria-activedescendant` */
+	optionId: string;
 	/** The name of the file */
 	name: string;
 	/** A callback function to handle file selection */
@@ -24,7 +28,9 @@ type SubtractionFileItemProps = {
  */
 export function SubtractionFileItem({
 	active,
+	highlighted,
 	id,
+	optionId,
 	name,
 	onClick,
 	uploaded_at,
@@ -34,6 +40,8 @@ export function SubtractionFileItem({
 		<SelectBoxGroupSection
 			active={active}
 			className="flex justify-between"
+			highlighted={highlighted}
+			id={optionId}
 			onClick={() => onClick([id])}
 		>
 			<strong>{name}</strong>

--- a/apps/web/src/subtraction/components/SubtractionFileSelector.tsx
+++ b/apps/web/src/subtraction/components/SubtractionFileSelector.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@app/cn";
 import Box from "@base/Box";
 import CompactScrollList from "@base/CompactScrollList";
 import {
@@ -9,6 +10,7 @@ import {
 } from "@base/Empty";
 import InputError from "@base/InputError";
 import Link from "@base/Link";
+import useListboxNavigation from "@base/useListboxNavigation";
 import type { InfiniteData } from "@tanstack/react-query";
 import type {
 	FetchNextPageOptions,
@@ -68,12 +70,22 @@ export function SubtractionFileSelector({
 
 	const items = files.pages.flatMap((page) => page.items);
 
+	const { listboxProps, activeOptionId, getOptionId } = useListboxNavigation(
+		items,
+		(item) => item.id,
+		(item) => onClick([item.id]),
+	);
+
 	function renderRow(item: Upload) {
+		const optionId = getOptionId(item.id);
+
 		return (
 			<SubtractionFileItem
 				key={item.id}
 				{...item}
 				active={selected?.includes(item.id)}
+				highlighted={activeOptionId === optionId}
+				optionId={optionId}
 				onClick={onClick}
 				error={error}
 			/>
@@ -98,8 +110,15 @@ export function SubtractionFileSelector({
 	) : (
 		<>
 			<CompactScrollList
+				{...listboxProps}
 				aria-labelledby={ariaLabelledby}
-				className="max-h-96"
+				className={cn(
+					"max-h-96",
+					"outline-none",
+					"focus-visible:ring-2",
+					"focus-visible:ring-inset",
+					"focus-visible:ring-blue-500/30",
+				)}
 				fetchNextPage={fetchNextPage}
 				isFetchingNextPage={isFetchingNextPage}
 				isPending={isPending}

--- a/apps/web/src/subtraction/components/__tests__/SubtractionFileSelector.test.tsx
+++ b/apps/web/src/subtraction/components/__tests__/SubtractionFileSelector.test.tsx
@@ -76,23 +76,25 @@ describe("<SubtractionFileSelector>", () => {
 		renderWithProviders(<Harness files={files} />);
 
 		const listbox = screen.getByRole("listbox", { name: "Files" });
-		const options = screen.getAllByRole("option");
+		const alpha = screen.getByRole("option", { name: /alpha\.fa\.gz/ });
+		const beta = screen.getByRole("option", { name: /beta\.fa\.gz/ });
+		const gamma = screen.getByRole("option", { name: /gamma\.fa\.gz/ });
 		listbox.focus();
 
 		await userEvent.keyboard("{ArrowDown}");
-		expect(listbox).toHaveAttribute("aria-activedescendant", options[0].id);
+		expect(listbox).toHaveAttribute("aria-activedescendant", alpha.id);
 
 		await userEvent.keyboard("{ArrowDown}");
-		expect(listbox).toHaveAttribute("aria-activedescendant", options[1].id);
+		expect(listbox).toHaveAttribute("aria-activedescendant", beta.id);
 
 		await userEvent.keyboard("{End}");
-		expect(listbox).toHaveAttribute("aria-activedescendant", options[2].id);
+		expect(listbox).toHaveAttribute("aria-activedescendant", gamma.id);
 
 		await userEvent.keyboard("{ArrowUp}");
-		expect(listbox).toHaveAttribute("aria-activedescendant", options[1].id);
+		expect(listbox).toHaveAttribute("aria-activedescendant", beta.id);
 
 		await userEvent.keyboard("{Home}");
-		expect(listbox).toHaveAttribute("aria-activedescendant", options[0].id);
+		expect(listbox).toHaveAttribute("aria-activedescendant", alpha.id);
 	});
 
 	it("selects the active option with Enter", async () => {
@@ -109,9 +111,12 @@ describe("<SubtractionFileSelector>", () => {
 
 		await userEvent.keyboard("{ArrowDown}{ArrowDown}{Enter}");
 
-		const options = screen.getAllByRole("option");
-		expect(options[1]).toHaveAttribute("aria-selected", "true");
-		expect(options[0]).toHaveAttribute("aria-selected", "false");
+		expect(
+			screen.getByRole("option", { name: /beta\.fa\.gz/ }),
+		).toHaveAttribute("aria-selected", "true");
+		expect(
+			screen.getByRole("option", { name: /alpha\.fa\.gz/ }),
+		).toHaveAttribute("aria-selected", "false");
 	});
 
 	it("selects an option on click", async () => {

--- a/apps/web/src/subtraction/components/__tests__/SubtractionFileSelector.test.tsx
+++ b/apps/web/src/subtraction/components/__tests__/SubtractionFileSelector.test.tsx
@@ -1,0 +1,131 @@
+import type { InfiniteData } from "@tanstack/react-query";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { mockApiListFiles } from "@tests/api/files";
+import { createFakeFile } from "@tests/fake/files";
+import { renderWithProviders } from "@tests/setup";
+import type { FileResponse, Upload } from "@uploads/types";
+import nock from "nock";
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SubtractionFileSelector } from "../SubtractionFileSelector";
+
+function makeData(files: Upload[]): InfiniteData<FileResponse> {
+	return {
+		pages: [
+			{
+				found_count: files.length,
+				page: 1,
+				page_count: 1,
+				per_page: 25,
+				total_count: files.length,
+				items: files,
+			},
+		],
+		pageParams: [1],
+	};
+}
+
+function Harness({ files }: { files: Upload[] }) {
+	const [selected, setSelected] = useState<number[]>([]);
+
+	return (
+		<>
+			<span id="files-label">Files</span>
+			<SubtractionFileSelector
+				aria-labelledby="files-label"
+				files={makeData(files)}
+				foundCount={files.length}
+				selected={selected}
+				onClick={setSelected}
+				error=""
+				fetchNextPage={vi.fn()}
+				isPending={false}
+				isFetchingNextPage={false}
+			/>
+		</>
+	);
+}
+
+describe("<SubtractionFileSelector>", () => {
+	afterEach(() => nock.cleanAll());
+
+	it("exposes an ARIA listbox with an option per file", () => {
+		const files = [
+			createFakeFile({ name: "alpha.fa.gz" }),
+			createFakeFile({ name: "beta.fa.gz" }),
+		];
+		mockApiListFiles(files);
+
+		renderWithProviders(<Harness files={files} />);
+
+		const listbox = screen.getByRole("listbox", { name: "Files" });
+		expect(listbox).toHaveAttribute("tabindex", "0");
+		expect(listbox).not.toHaveAttribute("aria-activedescendant");
+		expect(screen.getAllByRole("option")).toHaveLength(2);
+	});
+
+	it("moves the active descendant with the arrow, Home, and End keys", async () => {
+		const files = [
+			createFakeFile({ name: "alpha.fa.gz" }),
+			createFakeFile({ name: "beta.fa.gz" }),
+			createFakeFile({ name: "gamma.fa.gz" }),
+		];
+		mockApiListFiles(files);
+
+		renderWithProviders(<Harness files={files} />);
+
+		const listbox = screen.getByRole("listbox", { name: "Files" });
+		const options = screen.getAllByRole("option");
+		listbox.focus();
+
+		await userEvent.keyboard("{ArrowDown}");
+		expect(listbox).toHaveAttribute("aria-activedescendant", options[0].id);
+
+		await userEvent.keyboard("{ArrowDown}");
+		expect(listbox).toHaveAttribute("aria-activedescendant", options[1].id);
+
+		await userEvent.keyboard("{End}");
+		expect(listbox).toHaveAttribute("aria-activedescendant", options[2].id);
+
+		await userEvent.keyboard("{ArrowUp}");
+		expect(listbox).toHaveAttribute("aria-activedescendant", options[1].id);
+
+		await userEvent.keyboard("{Home}");
+		expect(listbox).toHaveAttribute("aria-activedescendant", options[0].id);
+	});
+
+	it("selects the active option with Enter", async () => {
+		const files = [
+			createFakeFile({ name: "alpha.fa.gz" }),
+			createFakeFile({ name: "beta.fa.gz" }),
+		];
+		mockApiListFiles(files);
+
+		renderWithProviders(<Harness files={files} />);
+
+		const listbox = screen.getByRole("listbox", { name: "Files" });
+		listbox.focus();
+
+		await userEvent.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+
+		const options = screen.getAllByRole("option");
+		expect(options[1]).toHaveAttribute("aria-selected", "true");
+		expect(options[0]).toHaveAttribute("aria-selected", "false");
+	});
+
+	it("selects an option on click", async () => {
+		const files = [createFakeFile({ name: "alpha.fa.gz" })];
+		mockApiListFiles(files);
+
+		renderWithProviders(<Harness files={files} />);
+
+		await userEvent.click(
+			screen.getByRole("option", { name: /alpha\.fa\.gz/ }),
+		);
+
+		expect(
+			screen.getByRole("option", { name: /alpha\.fa\.gz/ }),
+		).toHaveAttribute("aria-selected", "true");
+	});
+});


### PR DESCRIPTION
## Summary
- `CompactScrollList` hardcoded `role="listbox"` on a plain div with no keyboard support, even though three of its four call sites weren't real listboxes.
- Turn `CompactScrollList` into a neutral scroll region, and drive the one genuine listbox (subtraction file selection) with a new `useListboxNavigation` hook using `aria-activedescendant` for arrow-key/Home/End navigation.
- Render the reference member pickers (`AddReferenceGroup`, `AddReferenceUser`) as button lists instead of a fake listbox, since they were never single-selection listboxes to begin with.