### PR TITLE
refactor: render list-only items as <li> without an as prop

### DIFF
--- a/apps/web/src/analyses/components/AnalysisItem.tsx
+++ b/apps/web/src/analyses/components/AnalysisItem.tsx
@@ -8,22 +8,19 @@ import ProgressCircle from "@base/ProgressCircle";
 import SlashList from "@base/SlashList";
 import { useFetchJob } from "@jobs/queries";
 import { Equal, EqualNot } from "lucide-react";
-import type { ElementType } from "react";
 import { useRemoveAnalysis } from "../queries";
 import type { AnalysisMinimal } from "../types";
 import { checkSupportedWorkflow } from "../utils";
 import { AnalysisItemRightIcon } from "./AnalysisItemRightIcon";
 
 type AnalysisItemProps = {
-	/** The element or component to render as the root (e.g. `"li"` in a list) */
-	as?: ElementType;
 	analysis: AnalysisMinimal;
 };
 
 /**
  * Condensed analysis item for use in a list of analyses
  */
-export default function AnalysisItem({ as, analysis }: AnalysisItemProps) {
+export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 	const {
 		id,
 		workflow,
@@ -59,7 +56,7 @@ export default function AnalysisItem({ as, analysis }: AnalysisItemProps) {
 	);
 
 	return (
-		<Box as={as} className="text-gray-600 mb-2.5">
+		<Box as="li" className="text-gray-600 mb-2.5">
 			<div className="grid grid-cols-5 items-center text-base font-medium [&_a]:font-medium">
 				<div className="col-span-2">{title}</div>
 				<Attribution

--- a/apps/web/src/analyses/components/AnalysisList.tsx
+++ b/apps/web/src/analyses/components/AnalysisList.tsx
@@ -93,7 +93,7 @@ export default function AnalysesList({
 				>
 					<ul className="list-none">
 						{analyses.items.map((item) => (
-							<AnalysisItem key={item.id} as="li" analysis={item} />
+							<AnalysisItem key={item.id} analysis={item} />
 						))}
 					</ul>
 				</Pagination>

--- a/apps/web/src/hmm/components/HmmItem.tsx
+++ b/apps/web/src/hmm/components/HmmItem.tsx
@@ -1,13 +1,9 @@
 import BoxGroupSection from "@base/BoxGroupSection";
 import Label from "@base/Label";
 import Link from "@base/Link";
-import type { ElementType } from "react";
 import type { HMMMinimal } from "../types";
 
 type HmmItemProps = {
-	/** The element or component to render as the root (e.g. `"li"` in a list) */
-	as?: ElementType;
-
 	/** Minimal hmm data */
 	hmm: HMMMinimal;
 };
@@ -15,7 +11,7 @@ type HmmItemProps = {
 /**
  * A condensed hmm item for use in a list of hmms
  */
-export default function HmmItem({ as, hmm }: HmmItemProps) {
+export default function HmmItem({ hmm }: HmmItemProps) {
 	const filteredFamilies = Object.keys(hmm.families).filter(
 		(family) => family !== "None",
 	);
@@ -25,7 +21,7 @@ export default function HmmItem({ as, hmm }: HmmItemProps) {
 		.map((family) => <Label key={family}>{family}</Label>);
 
 	return (
-		<BoxGroupSection as={as} className="flex text-lg">
+		<BoxGroupSection as="li" className="flex text-lg">
 			<strong className="shrink-0 grow-0 basis-12 font-bold">
 				{hmm.cluster}
 			</strong>

--- a/apps/web/src/hmm/components/HmmList.tsx
+++ b/apps/web/src/hmm/components/HmmList.tsx
@@ -63,7 +63,7 @@ export default function HmmList({ term, page, setSearch }: HmmListProps) {
 						>
 							<BoxGroup as="ul">
 								{items.map((item) => (
-									<HmmItem key={item.id} as="li" hmm={item} />
+									<HmmItem key={item.id} hmm={item} />
 								))}
 							</BoxGroup>
 						</Pagination>

--- a/apps/web/src/indexes/components/Indexes.tsx
+++ b/apps/web/src/indexes/components/Indexes.tsx
@@ -52,7 +52,6 @@ export default function Indexes({ page, setSearch }: IndexesProps) {
 						{items.map((item) => (
 							<IndexItem
 								key={item.id}
-								as="li"
 								index={item}
 								refId={refId}
 								activeId={

--- a/apps/web/src/indexes/components/Item/IndexItem.tsx
+++ b/apps/web/src/indexes/components/Item/IndexItem.tsx
@@ -2,13 +2,10 @@ import Attribution from "@base/Attribution";
 import BoxGroupSection from "@base/BoxGroupSection";
 import Link from "@base/Link";
 import type { IndexMinimal } from "@indexes/types";
-import type { ElementType } from "react";
 import { IndexItemDescription } from "./IndexItemDescription";
 import { IndexItemIcon } from "./IndexItemIcon";
 
 type IndexItemProps = {
-	/** The element or component to render as the root (e.g. `"li"` in a list) */
-	as?: ElementType;
 	activeId?: string;
 	index: IndexMinimal;
 	refId: string;
@@ -23,9 +20,9 @@ type IndexItemProps = {
  * @return The index item
  */
 
-export function IndexItem({ as, activeId, index, refId }: IndexItemProps) {
+export function IndexItem({ activeId, index, refId }: IndexItemProps) {
 	return (
-		<BoxGroupSection as={as}>
+		<BoxGroupSection as="li">
 			<h3 className="grid grid-cols-3 mb-2 text-lg">
 				<Link
 					className="font-medium"

--- a/apps/web/src/otus/components/OtuItem.tsx
+++ b/apps/web/src/otus/components/OtuItem.tsx
@@ -1,10 +1,7 @@
 import BoxGroupSection from "@base/BoxGroupSection";
 import Link from "@base/Link";
-import type { ElementType } from "react";
 
 type OtuItemProps = {
-	/** The element or component to render as the root (e.g. `"li"` in a list) */
-	as?: ElementType;
 	abbreviation: string;
 	id: string;
 	name: string;
@@ -16,7 +13,6 @@ type OtuItemProps = {
  * A condensed OTU item for use in a list of OTUs
  */
 export default function OtuItem({
-	as,
 	abbreviation,
 	id,
 	name,
@@ -25,7 +21,7 @@ export default function OtuItem({
 }: OtuItemProps) {
 	return (
 		<BoxGroupSection
-			as={as}
+			as="li"
 			className="grid items-center"
 			style={{ gridTemplateColumns: "5fr 2fr 1fr" }}
 		>

--- a/apps/web/src/otus/components/OtuList.tsx
+++ b/apps/web/src/otus/components/OtuList.tsx
@@ -71,7 +71,7 @@ export default function OtuList({ term, page, setSearch }: OtuListProps) {
 				>
 					<BoxGroup as="ul">
 						{items.map((item) => (
-							<OtuItem key={item.id} as="li" {...item} refId={refId} />
+							<OtuItem key={item.id} {...item} refId={refId} />
 						))}
 					</BoxGroup>
 				</Pagination>

--- a/apps/web/src/references/components/ReferenceItem.tsx
+++ b/apps/web/src/references/components/ReferenceItem.tsx
@@ -8,11 +8,9 @@ import ProgressCircle from "@base/ProgressCircle";
 import type { ReferenceMinimal } from "@references/types";
 import { useFetchTask } from "@tasks/queries";
 import { Copy } from "lucide-react";
-import type { ElementType, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 type ReferenceItemProps = {
-	/** The element or component to render as the root (e.g. `"li"` in a list) */
-	as?: ElementType;
 	onClone: (id: string) => void;
 	reference: ReferenceMinimal;
 };
@@ -20,7 +18,7 @@ type ReferenceItemProps = {
 /**
  * A condensed reference item for use in a list of references
  */
-export function ReferenceItem({ as, onClone, reference }: ReferenceItemProps) {
+export function ReferenceItem({ onClone, reference }: ReferenceItemProps) {
 	const { archived, created_at, id, name, task, user } = reference;
 
 	const { data: liveTask } = useFetchTask(task?.id ?? Number.NaN, task);
@@ -56,7 +54,7 @@ export function ReferenceItem({ as, onClone, reference }: ReferenceItemProps) {
 	}
 
 	return (
-		<BoxGroupSection as={as} className="grid grid-cols-3 items-center gap-x-4">
+		<BoxGroupSection as="li" className="grid grid-cols-3 items-center gap-x-4">
 			<Link
 				className="font-medium text-lg"
 				to="/refs/$refId"

--- a/apps/web/src/references/components/ReferenceList.tsx
+++ b/apps/web/src/references/components/ReferenceList.tsx
@@ -85,7 +85,6 @@ export default function ReferenceList({
 							{items.map((item) => (
 								<ReferenceItem
 									key={item.id}
-									as="li"
 									onClone={setCloneReferenceId}
 									reference={item}
 								/>

--- a/apps/web/src/samples/components/Item/SampleItem.tsx
+++ b/apps/web/src/samples/components/Item/SampleItem.tsx
@@ -4,16 +4,13 @@ import Checkbox from "@base/Checkbox";
 import Link from "@base/Link";
 import { useFetchJob } from "@jobs/queries";
 import type { SampleMinimal } from "@samples/types";
-import type { ElementType, MouseEvent } from "react";
+import type { MouseEvent } from "react";
 import SampleLabel from "../Label/SampleLabel";
 import SampleLibraryTypeLabel from "../Label/SampleLibraryTypeLabel";
 import WorkflowTags from "../Tag/WorkflowTags";
 import EndIcon from "./EndIcon";
 
 type SampleItemProps = {
-	/** The element or component to render as the root (e.g. `"li"` in a list) */
-	as?: ElementType;
-
 	/** Minimal sample data */
 	sample: SampleMinimal;
 
@@ -31,7 +28,6 @@ type SampleItemProps = {
  * A condensed sample item for use in a list of samples
  */
 export default function SampleItem({
-	as,
 	sample,
 	checked,
 	handleSelect,
@@ -41,7 +37,7 @@ export default function SampleItem({
 
 	return (
 		<Box
-			as={as}
+			as="li"
 			className="grid grid-cols-sample items-center gap-x-4 gap-y-2.5 border-0 mb-0 py-2.5 rounded-none"
 		>
 			<Checkbox

--- a/apps/web/src/samples/components/SamplesList.tsx
+++ b/apps/web/src/samples/components/SamplesList.tsx
@@ -179,7 +179,6 @@ export default function SamplesList({
 		return (
 			<SampleItem
 				key={item.id}
-				as="li"
 				sample={item}
 				checked={selection.isSelected(item)}
 				handleSelect={handleSelect}

--- a/apps/web/src/subtraction/components/SubtractionItem.tsx
+++ b/apps/web/src/subtraction/components/SubtractionItem.tsx
@@ -2,7 +2,6 @@ import BoxGroupSection from "@base/BoxGroupSection";
 import Link from "@base/Link";
 import ProgressCircle from "@base/ProgressCircle";
 import { useFetchJob } from "@jobs/queries";
-import type { ElementType } from "react";
 import type { SubtractionMinimal } from "../types";
 import { SubtractionAttribution } from "./Attribution";
 
@@ -10,21 +9,17 @@ import { SubtractionAttribution } from "./Attribution";
  * A condensed subtraction item for use in a list of subtractions
  */
 export function SubtractionItem({
-	as,
 	created_at,
 	id,
 	job,
 	name,
 	ready,
 	user,
-}: SubtractionMinimal & {
-	/** The element or component to render as the root (e.g. `"li"` in a list) */
-	as?: ElementType;
-}) {
+}: SubtractionMinimal) {
 	const { data: fetchedJob } = useFetchJob(job?.id ?? Number.NaN, job);
 
 	return (
-		<BoxGroupSection as={as} className="grid grid-cols-5 items-center">
+		<BoxGroupSection as="li" className="grid grid-cols-5 items-center">
 			<Link
 				className="col-span-2 text-lg font-medium"
 				to="/subtractions/$subtractionId"

--- a/apps/web/src/subtraction/components/SubtractionList.tsx
+++ b/apps/web/src/subtraction/components/SubtractionList.tsx
@@ -60,7 +60,7 @@ export default function SubtractionList({
 				>
 					<BoxGroup as="ul">
 						{items.map((item) => (
-							<SubtractionItem key={item.id} as="li" {...item} />
+							<SubtractionItem key={item.id} {...item} />
 						))}
 					</BoxGroup>
 				</Pagination>

--- a/apps/web/src/uploads/components/FileManager.tsx
+++ b/apps/web/src/uploads/components/FileManager.tsx
@@ -168,7 +168,6 @@ export function FileManager({
 							{files.items.map((item) => (
 								<UploadItem
 									{...item}
-									as="li"
 									action={renderItemAction?.(item, files.items)}
 									canDelete={canDelete}
 									checked={selection.isSelected(item)}

--- a/apps/web/src/uploads/components/UploadItem.tsx
+++ b/apps/web/src/uploads/components/UploadItem.tsx
@@ -6,15 +6,12 @@ import IconButton from "@base/IconButton";
 import RelativeTime from "@base/RelativeTime";
 import type { UserNested } from "@users/types";
 import { Trash } from "lucide-react";
-import type { ElementType, MouseEvent, ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import { useDeleteFile } from "../queries";
 
 export type UploadItemProps = {
 	/** An extra control shown beside the remove button. */
 	action?: ReactNode;
-
-	/** The element or component to render as the root (e.g. `"li"` in a list) */
-	as?: ElementType;
 	canDelete: boolean;
 	/** Whether the file is selected. */
 	checked?: boolean;
@@ -29,7 +26,6 @@ export type UploadItemProps = {
 
 export default function UploadItem({
 	action,
-	as,
 	canDelete,
 	checked = false,
 	id,
@@ -42,7 +38,7 @@ export default function UploadItem({
 	const { mutate: handleRemove } = useDeleteFile();
 
 	return (
-		<BoxGroupSection as={as}>
+		<BoxGroupSection as="li">
 			<div className="flex items-center gap-4">
 				{onSelect && (
 					<Checkbox

--- a/apps/web/src/users/components/UserItem.tsx
+++ b/apps/web/src/users/components/UserItem.tsx
@@ -5,11 +5,9 @@ import InitialIcon from "@base/InitialIcon";
 import Label from "@base/Label";
 import Link from "@base/Link";
 import type { GroupMinimal } from "@groups/types";
-import type { ElementType, ReactElement } from "react";
+import type { ReactElement } from "react";
 
 type UserItemProps = {
-	/** The element or component to render as the root (e.g. `"li"` in a list) */
-	as?: ElementType;
 	administrator_role: AdministratorRoleName | null;
 	handle: string;
 	id: number;
@@ -21,7 +19,6 @@ type UserItemProps = {
  * A condensed user item for use in a list of users
  */
 export function UserItem({
-	as,
 	administrator_role,
 	handle,
 	id,
@@ -32,7 +29,7 @@ export function UserItem({
 	);
 
 	return (
-		<BoxGroupSection as={as} className="grid grid-cols-4 items-center">
+		<BoxGroupSection as="li" className="grid grid-cols-4 items-center">
 			<div className="col-span-2 flex items-center gap-3">
 				<InitialIcon size="lg" handle={handle} />
 				{canEdit ? (

--- a/apps/web/src/users/components/UsersList.tsx
+++ b/apps/web/src/users/components/UsersList.tsx
@@ -43,7 +43,7 @@ export default function UsersList({
 		>
 			<BoxGroup as="ul">
 				{items.map((item: User) => (
-					<UserItem key={item.id} as="li" {...item} />
+					<UserItem key={item.id} {...item} />
 				))}
 			</BoxGroup>
 		</Pagination>


### PR DESCRIPTION
## Summary
- Follow-up to the document-structure accessibility work: the nine browse-list item components are only ever rendered as list rows, so they now hardcode a `<li>` root instead of taking an `as` prop that only ever received `"li"`.
- `JobItem` keeps its `as` prop — it is genuinely dual-use (a list row in `JobList`, a standalone `<div>` in `SampleDetailGeneral`).
- No behavior change: these items already rendered as `<li>`; this just drops the redundant indirection at the components and their call sites.