### PR TITLE
refactor: drop unused items prop from Pagination

### DIFF
--- a/apps/web/src/analyses/components/AnalysisList.tsx
+++ b/apps/web/src/analyses/components/AnalysisList.tsx
@@ -85,7 +85,6 @@ export default function AnalysesList({
 			</div>
 			{analyses.found_count ? (
 				<Pagination
-					items={analyses.items}
 					storedPage={analyses.page}
 					currentPage={page}
 					pageCount={analyses.page_count}

--- a/apps/web/src/base/Pagination.tsx
+++ b/apps/web/src/base/Pagination.tsx
@@ -23,7 +23,6 @@ function getPageRange(
 
 type PaginationProps = {
 	children?: ReactNode;
-	items: object[];
 	storedPage: number;
 	currentPage: number;
 	pageCount: number;

--- a/apps/web/src/base/__tests__/Pagination.test.tsx
+++ b/apps/web/src/base/__tests__/Pagination.test.tsx
@@ -5,7 +5,6 @@ import Pagination from "../Pagination";
 
 type PaginationTestProps = {
 	currentPage: number;
-	items: object[];
 	pageCount: number;
 	storedPage: number;
 };
@@ -17,7 +16,6 @@ describe("<Pagination />", () => {
 		props = {
 			pageCount: 6,
 			currentPage: 1,
-			items: [],
 			storedPage: 1,
 		};
 	});

--- a/apps/web/src/hmm/components/HmmList.tsx
+++ b/apps/web/src/hmm/components/HmmList.tsx
@@ -55,7 +55,6 @@ export default function HmmList({ term, page, setSearch }: HmmListProps) {
 					/>
 					{items.length ? (
 						<Pagination
-							items={items}
 							storedPage={storedPage}
 							currentPage={page}
 							pageCount={page_count}

--- a/apps/web/src/indexes/components/Indexes.tsx
+++ b/apps/web/src/indexes/components/Indexes.tsx
@@ -42,7 +42,6 @@ export default function Indexes({ page, setSearch }: IndexesProps) {
 			)}
 			{items.length ? (
 				<Pagination
-					items={items}
 					storedPage={storedPage}
 					currentPage={page}
 					pageCount={page_count}

--- a/apps/web/src/jobs/components/JobList.tsx
+++ b/apps/web/src/jobs/components/JobList.tsx
@@ -56,7 +56,6 @@ export default function JobsList({
 						/>
 					) : (
 						<Pagination
-							items={items}
 							storedPage={storedPage}
 							currentPage={page}
 							pageCount={pageCount}

--- a/apps/web/src/otus/components/OtuList.tsx
+++ b/apps/web/src/otus/components/OtuList.tsx
@@ -63,7 +63,6 @@ export default function OtuList({ term, page, setSearch }: OtuListProps) {
 
 			{items.length ? (
 				<Pagination
-					items={items}
 					storedPage={storedPage}
 					currentPage={page}
 					pageCount={page_count}

--- a/apps/web/src/references/components/ReferenceList.tsx
+++ b/apps/web/src/references/components/ReferenceList.tsx
@@ -75,7 +75,6 @@ export default function ReferenceList({
 					/>
 				) : (
 					<Pagination
-						items={items}
 						storedPage={storedPage}
 						currentPage={page}
 						pageCount={page_count}

--- a/apps/web/src/samples/components/SamplesList.tsx
+++ b/apps/web/src/samples/components/SamplesList.tsx
@@ -240,7 +240,6 @@ export default function SamplesList({
 					</ListEmpty>
 				) : (
 					<Pagination
-						items={items}
 						storedPage={page}
 						currentPage={urlPage}
 						pageCount={page_count}

--- a/apps/web/src/subtraction/components/SubtractionList.tsx
+++ b/apps/web/src/subtraction/components/SubtractionList.tsx
@@ -52,7 +52,6 @@ export default function SubtractionList({
 				/>
 			) : (
 				<Pagination
-					items={items}
 					storedPage={storedPage}
 					currentPage={page}
 					pageCount={page_count}

--- a/apps/web/src/uploads/components/FileManager.tsx
+++ b/apps/web/src/uploads/components/FileManager.tsx
@@ -147,7 +147,6 @@ export function FileManager({
 				</Box>
 			) : (
 				<Pagination
-					items={files.items}
 					storedPage={files.page}
 					currentPage={page}
 					pageCount={files.page_count}

--- a/apps/web/src/users/components/UsersList.tsx
+++ b/apps/web/src/users/components/UsersList.tsx
@@ -35,7 +35,6 @@ export default function UsersList({
 
 	return items.length ? (
 		<Pagination
-			items={items}
 			storedPage={page}
 			currentPage={urlPage}
 			pageCount={page_count}


### PR DESCRIPTION
## Summary
- `Pagination`'s `items` prop was never read by the component — it renders rows via `children` and derives paging from `pageCount`/`currentPage`/`storedPage`, so every call site passed `items` for nothing.
- Removes the prop from `Pagination` and its test, and drops the now-pointless `items={...}` from all ten call sites (analyses, hmm, indexes, jobs, otus, references, samples, subtraction, uploads, users).