### PR TITLE
fix: select the first hit by default in the NuVs viewer

### DIFF
--- a/apps/web/src/analyses/components/Nuvs/NuvsDetail.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsDetail.tsx
@@ -1,4 +1,4 @@
-import { useGetActiveHit } from "@analyses/hooks";
+import { useActiveHit } from "@analyses/hooks";
 import type { FormattedNuvsHit, NuvsOrf as NuvsOrfType } from "@analyses/types";
 import { calculateAnnotatedOrfCount } from "@analyses/utils";
 import Badge from "@base/Badge";
@@ -45,7 +45,7 @@ export default function NuvsDetail({
 	matches,
 	maxSequenceLength,
 }: NuVsDetailProps) {
-	const hit = useGetActiveHit(matches);
+	const hit = useActiveHit(matches);
 
 	if (!hit) {
 		return <NuvsDetailContainer>No Hits</NuvsDetailContainer>;

--- a/apps/web/src/analyses/components/Nuvs/NuvsItem.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsItem.tsx
@@ -39,7 +39,7 @@ export default function NuvsItem({
 				<Badge>{sequence.length}</Badge>
 			</div>
 
-			<NuvsValues e={String(e)} orfCount={annotatedOrfCount} />
+			<NuvsValues e={e} orfCount={annotatedOrfCount} />
 		</Box>
 	);
 }

--- a/apps/web/src/analyses/components/Nuvs/NuvsList.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsList.tsx
@@ -2,7 +2,7 @@ import { useAnalysisSearch } from "@analyses/components/AnalysisSearchContext";
 import NuvsDetail from "@analyses/components/Nuvs/NuvsDetail";
 import NuvsItem from "@analyses/components/Nuvs/NuvsItem";
 import { useKeyNavigation } from "@analyses/components/Viewer/hooks";
-import { useSortAndFilterNuVsHits } from "@analyses/hooks";
+import { useActiveHit, useSortAndFilterNuVsHits } from "@analyses/hooks";
 import type { FormattedNuvsAnalysis } from "@analyses/types";
 import Key from "@base/Key";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -20,8 +20,8 @@ export default function NuvsList({ detail }: NuVsListProps) {
 	const sortedHits = useSortAndFilterNuVsHits(detail);
 	const { search, setSearch } = useAnalysisSearch();
 
-	const firstHitId = sortedHits[0]?.id ? String(sortedHits[0].id) : undefined;
-	const activeHit = search.activeHit ?? firstHitId;
+	const hit = useActiveHit(sortedHits);
+	const activeHit = hit ? String(hit.id) : undefined;
 
 	let nextId: string | undefined;
 	let nextIndex: number | undefined;

--- a/apps/web/src/analyses/components/Nuvs/NuvsValues.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsValues.tsx
@@ -1,5 +1,5 @@
 type NuVsValuesProps = {
-	e: string;
+	e: number;
 	orfCount: number;
 };
 

--- a/apps/web/src/analyses/components/Nuvs/__tests__/NuVsViewer.test.tsx
+++ b/apps/web/src/analyses/components/Nuvs/__tests__/NuVsViewer.test.tsx
@@ -46,6 +46,18 @@ describe("<NuvsViewer />", () => {
 	afterEach(() => nock.cleanAll());
 
 	describe("<NuVsDetail />", () => {
+		it("should default to the first hit when no active hit is set", async () => {
+			renderWithAnalysisSearch(<NuvsViewer {...props} />);
+
+			expect(
+				await screen.findByText(
+					"This sequence has no BLAST information attached to it.",
+				),
+			).toBeInTheDocument();
+			expect(screen.getByText("Families")).toBeInTheDocument();
+			expect(screen.queryByText("No Hits")).not.toBeInTheDocument();
+		});
+
 		it("should render correctly", async () => {
 			renderWithAnalysisSearch(<NuvsViewer {...props} />, {
 				activeHit: String(firstHit.id),

--- a/apps/web/src/analyses/hooks.ts
+++ b/apps/web/src/analyses/hooks.ts
@@ -8,6 +8,7 @@ import type { SubtractionOption } from "@subtraction/types";
 import { groupBy, maxBy, sortBy } from "es-toolkit";
 import type {
 	FormattedNuvsAnalysis,
+	FormattedNuvsHit,
 	FormattedPathoscopeAnalysis,
 } from "./types";
 
@@ -70,16 +71,20 @@ export function useSortAndFilterNuVsHits(detail: FormattedNuvsAnalysis) {
 	return sortedHits;
 }
 
-export function useGetActiveHit(matches) {
+export function useActiveHit(matches: FormattedNuvsHit[]) {
 	const {
 		search: { activeHit },
 	} = useAnalysisSearch();
 
 	if (activeHit) {
-		return matches.find((match) => match.id === Number(activeHit)) || null;
+		return (
+			matches.find((match) => match.id === Number(activeHit)) ??
+			matches[0] ??
+			null
+		);
 	}
 
-	return null;
+	return matches[0] ?? null;
 }
 
 type UseCompatibleIndexesResult = {


### PR DESCRIPTION
## Summary
- The NuVs viewer showed "No Hits" until a user manually selected one; `useActiveHit` now falls back to the first hit in the sorted list instead of returning `null` when no `activeHit` search param is set.
- Consolidated the fallback logic into the `useActiveHit` hook so `NuvsList` and `NuvsDetail` share one source of truth, rather than `NuvsList` computing its own `firstHitId` fallback separately.
- Fixed `NuvsValues`'s `e` prop to stay a `number` instead of being stringified, and typed `useActiveHit`'s `matches` parameter.