### PR TITLE
fix: announce form validation errors to screen readers

### DIFF
--- a/apps/web/src/account/components/AccountEmail.tsx
+++ b/apps/web/src/account/components/AccountEmail.tsx
@@ -44,6 +44,8 @@ export default function AccountEmail({ email }: EmailProps) {
 						<InputLabel htmlFor="email">Email Address</InputLabel>
 						<InputSimple
 							id="email"
+							aria-invalid={Boolean(errors.email) || undefined}
+							aria-describedby={errors.email ? "email-error" : undefined}
 							{...register("email", {
 								pattern: {
 									value: /^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/,
@@ -51,7 +53,7 @@ export default function AccountEmail({ email }: EmailProps) {
 								},
 							})}
 						/>
-						<InputError>{errors.email?.message}</InputError>
+						<InputError id="email-error">{errors.email?.message}</InputError>
 					</InputGroup>
 					<footer className="flex items-center justify-end mb-4">
 						<SaveButton altText="Change" />

--- a/apps/web/src/account/components/AccountHandle.tsx
+++ b/apps/web/src/account/components/AccountHandle.tsx
@@ -48,11 +48,18 @@ export default function AccountHandle({ handle }: HandleProps) {
 						<InputSimple
 							id="handle"
 							autoComplete="off"
+							aria-required
+							aria-invalid={
+								Boolean(errors.handle) || mutation.isError || undefined
+							}
+							aria-describedby={
+								errors.handle || mutation.isError ? "handle-error" : undefined
+							}
 							{...register("handle", {
 								required: "Please specify a username",
 							})}
 						/>
-						<InputError>
+						<InputError id="handle-error">
 							{errors.handle?.message ||
 								(mutation.isError ? mutation.error.message : "")}
 						</InputError>

--- a/apps/web/src/account/components/AccountPassword.tsx
+++ b/apps/web/src/account/components/AccountPassword.tsx
@@ -69,6 +69,15 @@ export default function AccountPassword({
 							<InputPassword
 								id="oldPassword"
 								autoComplete="current-password"
+								aria-required
+								aria-invalid={
+									Boolean(errors.oldPassword) || mutation.isError || undefined
+								}
+								aria-describedby={
+									errors.oldPassword || mutation.isError
+										? "oldPassword-error"
+										: undefined
+								}
 								{...register("oldPassword", {
 									// No length rule. This authenticates the password the user
 									// already has, and if the minimum were raised, checking it
@@ -77,7 +86,7 @@ export default function AccountPassword({
 									required: "Please provide your old password",
 								})}
 							/>
-							<InputError>
+							<InputError id="oldPassword-error">
 								{errors.oldPassword?.message ||
 									(mutation.isError && mutation.error.response.body?.message)}
 							</InputError>
@@ -89,9 +98,16 @@ export default function AccountPassword({
 							<InputPassword
 								id="newPassword"
 								autoComplete="new-password"
+								aria-required
+								aria-invalid={Boolean(errors.newPassword) || undefined}
+								aria-describedby={
+									errors.newPassword ? "newPassword-error" : undefined
+								}
 								{...register("newPassword", passwordRules)}
 							/>
-							<InputError>{errors.newPassword?.message}</InputError>
+							<InputError id="newPassword-error">
+								{errors.newPassword?.message}
+							</InputError>
 						</InputContainer>
 					</InputGroup>
 					{mutation.isSuccess && (

--- a/apps/web/src/account/components/ApiKeyCreate.tsx
+++ b/apps/web/src/account/components/ApiKeyCreate.tsx
@@ -123,12 +123,14 @@ export default function ApiKeyCreate() {
 							<InputLabel htmlFor="name">Name</InputLabel>
 							<InputSimple
 								id="name"
-								aria-invalid={errors.name ? "true" : "false"}
+								aria-required
+								aria-invalid={Boolean(errors.name) || undefined}
+								aria-describedby={errors.name ? "name-error" : undefined}
 								{...register("name", {
 									required: "Provide a name for the key",
 								})}
 							/>
-							<InputError>{errors.name?.message}</InputError>
+							<InputError id="name-error">{errors.name?.message}</InputError>
 						</InputGroup>
 
 						<InputLabel id={permissionsLabelId}>Permissions</InputLabel>

--- a/apps/web/src/administration/components/BannerForm.tsx
+++ b/apps/web/src/administration/components/BannerForm.tsx
@@ -48,10 +48,16 @@ export default function BannerForm({
 				<InputLabel htmlFor="message">Message</InputLabel>
 				<InputSimple
 					id="message"
-					aria-invalid={errors.message ? "true" : "false"}
+					aria-required
+					aria-invalid={Boolean(errors.message) || Boolean(error) || undefined}
+					aria-describedby={
+						errors.message || error ? "message-error" : undefined
+					}
 					{...register("message", { required: "Message is required." })}
 				/>
-				<InputError>{errors.message?.message || error}</InputError>
+				<InputError id="message-error">
+					{errors.message?.message || error}
+				</InputError>
 			</InputGroup>
 			<InputGroup>
 				<InputLabel id="color-label">Color</InputLabel>

--- a/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
@@ -177,12 +177,13 @@ export default function CreateAnalysisForm({
 						selected={value}
 						onChange={onChange}
 						invalid={Boolean(errors.indexId)}
+						describedById={errors.indexId ? "indexId-error" : undefined}
 					/>
 				)}
 				rules={{ required: true }}
 			/>
 
-			<InputError className="mb-0">
+			<InputError id="indexId-error" className="mb-0">
 				{errors.indexId && "A reference must be selected"}
 			</InputError>
 

--- a/apps/web/src/analyses/components/Create/IndexSelector.tsx
+++ b/apps/web/src/analyses/components/Create/IndexSelector.tsx
@@ -85,7 +85,7 @@ export default function IndexSelector({
 			{indexes.length ? (
 				<Select value={selected} onValueChange={onChange}>
 					<SelectButton
-						aria-invalid={invalid}
+						aria-invalid={invalid || undefined}
 						aria-describedby={describedById}
 						className={cn("flex", "w-full")}
 						placeholder="Select a reference"

--- a/apps/web/src/analyses/components/Create/IndexSelector.tsx
+++ b/apps/web/src/analyses/components/Create/IndexSelector.tsx
@@ -54,6 +54,8 @@ type IndexSelectorProps = {
 	onChange: (value: string) => void;
 	/** Whether the field is in an invalid state (e.g. required but empty) */
 	invalid?: boolean;
+	/** `id` of the error message describing this field, when invalid. */
+	describedById?: string;
 };
 
 /**
@@ -64,6 +66,7 @@ export default function IndexSelector({
 	selected,
 	onChange,
 	invalid,
+	describedById,
 }: IndexSelectorProps) {
 	const sortedIndexes = sortBy(indexes, [(index) => index.reference.name]);
 
@@ -83,6 +86,7 @@ export default function IndexSelector({
 				<Select value={selected} onValueChange={onChange}>
 					<SelectButton
 						aria-invalid={invalid}
+						aria-describedby={describedById}
 						className={cn("flex", "w-full")}
 						placeholder="Select a reference"
 						icon={ChevronDown}

--- a/apps/web/src/base/InputError.tsx
+++ b/apps/web/src/base/InputError.tsx
@@ -1,19 +1,35 @@
 import { cn } from "@app/cn";
+import { CircleAlert } from "lucide-react";
 import type { ReactNode } from "react";
 
 type InputErrorProps = {
 	children: ReactNode;
 	className?: string;
+
+	/** Links the message to its input via `aria-describedby`. */
+	id?: string;
 };
 
-function InputError({ children, className }: InputErrorProps) {
+/**
+ * A validation error message for a form control.
+ *
+ * Rendered as an assertive live region (`role="alert"`) so a screen reader
+ * announces the message the moment it appears on a failed submit, and paired
+ * with a non-color icon so the error never relies on the red text alone.
+ */
+function InputError({ children, className, id }: InputErrorProps) {
 	return (
 		<p
+			id={id}
+			role="alert"
 			className={cn(
-				"text-red-600 text-sm font-medium mt-1 -mb-2.5 min-h-5 text-right",
+				"flex items-center justify-end gap-1 text-red-600 text-sm font-medium mt-1 -mb-2.5 min-h-5 text-right",
 				className,
 			)}
 		>
+			{children ? (
+				<CircleAlert aria-hidden className="shrink-0" size={14} />
+			) : null}
 			{children}
 		</p>
 	);

--- a/apps/web/src/base/SelectButton.tsx
+++ b/apps/web/src/base/SelectButton.tsx
@@ -17,6 +17,8 @@ type SelectButtonProps = {
 	"aria-label"?: string;
 	/** Marks the trigger invalid, turning its border and focus ring red */
 	"aria-invalid"?: AriaAttributes["aria-invalid"];
+	/** `id` of the element describing the trigger, e.g. an error message. */
+	"aria-describedby"?: string;
 };
 
 export default function SelectButton({
@@ -26,11 +28,13 @@ export default function SelectButton({
 	id,
 	"aria-label": ariaLabel,
 	"aria-invalid": ariaInvalid,
+	"aria-describedby": ariaDescribedby,
 }: SelectButtonProps) {
 	return (
 		<SelectPrimitive.Trigger
 			aria-invalid={ariaInvalid}
 			aria-label={ariaLabel}
+			aria-describedby={ariaDescribedby}
 			className={cn(
 				"flex justify-between items-center px-2.5 bg-white border rounded font-medium capitalize [&_svg]:ml-1",
 				inputHeightClass,

--- a/apps/web/src/base/__tests__/InputError.test.tsx
+++ b/apps/web/src/base/__tests__/InputError.test.tsx
@@ -1,0 +1,32 @@
+import { renderWithProviders } from "@tests/setup";
+import { describe, expect, it } from "vitest";
+import InputError from "../InputError";
+
+describe("<InputError />", () => {
+	it("should announce its message as an assertive live region", () => {
+		const { getByRole } = renderWithProviders(
+			<InputError id="handle-error">Handle is required</InputError>,
+		);
+
+		const alert = getByRole("alert");
+
+		expect(alert).toHaveTextContent("Handle is required");
+		expect(alert).toHaveAttribute("id", "handle-error");
+	});
+
+	it("should show a non-color icon alongside the message", () => {
+		const { getByRole } = renderWithProviders(
+			<InputError>Handle is required</InputError>,
+		);
+
+		expect(getByRole("alert").querySelector("svg")).not.toBeNull();
+	});
+
+	it("should not show an icon when there is no error", () => {
+		const { getByRole } = renderWithProviders(<InputError>{""}</InputError>);
+
+		const alert = getByRole("alert");
+
+		expect(alert).toBeEmptyDOMElement();
+	});
+});

--- a/apps/web/src/base/__tests__/InputError.test.tsx
+++ b/apps/web/src/base/__tests__/InputError.test.tsx
@@ -25,8 +25,6 @@ describe("<InputError />", () => {
 	it("should not show an icon when there is no error", () => {
 		const { getByRole } = renderWithProviders(<InputError>{""}</InputError>);
 
-		const alert = getByRole("alert");
-
-		expect(alert).toBeEmptyDOMElement();
+		expect(getByRole("alert").querySelector("svg")).toBeNull();
 	});
 });

--- a/apps/web/src/groups/components/CreateGroup.tsx
+++ b/apps/web/src/groups/components/CreateGroup.tsx
@@ -47,14 +47,17 @@ export default function CreateGroup({
 				<DialogTitle>Create Group</DialogTitle>
 				<form onSubmit={handleSubmit(onSubmit)}>
 					<InputGroup>
-						<InputLabel>Name</InputLabel>
+						<InputLabel htmlFor="name">Name</InputLabel>
 						<InputSimple
 							id="name"
+							aria-required
+							aria-invalid={Boolean(errors.name) || undefined}
+							aria-describedby={errors.name ? "name-error" : undefined}
 							{...register("name", {
 								required: "Provide a name for the group",
 							})}
 						/>
-						<InputError>{errors.name?.message}</InputError>
+						<InputError id="name-error">{errors.name?.message}</InputError>
 					</InputGroup>
 					<DialogFooter>
 						<SaveButton />

--- a/apps/web/src/groups/components/__tests__/Groups.test.tsx
+++ b/apps/web/src/groups/components/__tests__/Groups.test.tsx
@@ -58,7 +58,23 @@ describe("Groups", () => {
 		expect(screen.getByRole("dialog")).toBeInTheDocument();
 		expect(screen.getByText("Name")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
-		expect(screen.getByRole("textbox", { name: "" })).toBeInTheDocument();
+		expect(screen.getByRole("textbox", { name: "Name" })).toBeInTheDocument();
+	});
+
+	it("should announce a validation error and tie it to the input on failed submit", async () => {
+		mockListGroups([]);
+		await renderWithRouter(<Groups />);
+
+		await userEvent.click(await screen.findByText("Create"));
+		const input = screen.getByRole("textbox", { name: "Name" });
+		expect(input).not.toBeInvalid();
+
+		await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+		const alert = await screen.findByRole("alert");
+		expect(alert).toHaveTextContent("Provide a name for the group");
+		expect(input).toBeInvalid();
+		expect(input).toHaveAccessibleDescription("Provide a name for the group");
 	});
 
 	it("should render correctly when active group has a group member", async () => {

--- a/apps/web/src/labels/components/LabelForm.tsx
+++ b/apps/web/src/labels/components/LabelForm.tsx
@@ -52,16 +52,18 @@ export function LabelForm({
 				<InputLabel htmlFor="name">Name</InputLabel>
 				<InputSimple
 					id="name"
-					aria-invalid={errors.name ? "true" : "false"}
+					aria-required
+					aria-invalid={Boolean(errors.name) || Boolean(error) || undefined}
+					aria-describedby={errors.name || error ? "name-error" : undefined}
 					{...register("name", { required: "Name is required." })}
 				/>
-				<InputError>{errors.name?.message || error}</InputError>
+				<InputError id="name-error">{errors.name?.message || error}</InputError>
 			</InputGroup>
 			<InputGroup>
 				<InputLabel htmlFor="description">Description</InputLabel>
 				<InputSimple
 					id="description"
-					aria-invalid={errors.description ? "true" : "false"}
+					aria-invalid={Boolean(errors.description) || undefined}
 					{...register("description")}
 				/>
 			</InputGroup>

--- a/apps/web/src/otus/components/Detail/SegmentForm.tsx
+++ b/apps/web/src/otus/components/Detail/SegmentForm.tsx
@@ -69,6 +69,9 @@ export default function SegmentForm({
 					<InputLabel htmlFor="name">Name</InputLabel>
 					<InputSimple
 						id="name"
+						aria-required
+						aria-invalid={Boolean(errors.segmentName) || undefined}
+						aria-describedby={errors.segmentName ? "name-error" : undefined}
 						{...register("segmentName", {
 							required: "Name required",
 							validate: (value) =>
@@ -78,7 +81,7 @@ export default function SegmentForm({
 								"Segment names must be unique. This name is currently in use.",
 						})}
 					/>
-					<InputError>{errors.segmentName?.message}</InputError>
+					<InputError id="name-error">{errors.segmentName?.message}</InputError>
 				</InputGroup>
 
 				<InputGroup>

--- a/apps/web/src/otus/components/OtuForm.tsx
+++ b/apps/web/src/otus/components/OtuForm.tsx
@@ -44,9 +44,14 @@ export default function OtuForm({
 					<InputLabel htmlFor="name">Name</InputLabel>
 					<InputSimple
 						id="name"
+						aria-required
+						aria-invalid={Boolean(errors.name) || Boolean(error) || undefined}
+						aria-describedby={errors.name || error ? "name-error" : undefined}
 						{...register("name", { required: "Name required" })}
 					/>
-					<InputError>{errors.name?.message || error}</InputError>
+					<InputError id="name-error">
+						{errors.name?.message || error}
+					</InputError>
 				</InputGroup>
 
 				<InputGroup>

--- a/apps/web/src/references/components/CloneReference.tsx
+++ b/apps/web/src/references/components/CloneReference.tsx
@@ -91,11 +91,14 @@ export default function CloneReference({
 						<InputLabel htmlFor="name">Name</InputLabel>
 						<InputSimple
 							id="name"
+							aria-required
+							aria-invalid={Boolean(errors.name) || undefined}
+							aria-describedby={errors.name ? "name-error" : undefined}
 							{...register("name", {
 								required: "Required Field",
 							})}
 						/>
-						<InputError>{errors.name?.message}</InputError>
+						<InputError id="name-error">{errors.name?.message}</InputError>
 					</InputGroup>
 					<DialogFooter>
 						<SaveButton

--- a/apps/web/src/references/components/CreateReferenceForm.tsx
+++ b/apps/web/src/references/components/CreateReferenceForm.tsx
@@ -145,9 +145,12 @@ export function CreateReferenceForm({
 				<InputLabel htmlFor={nameId}>Name</InputLabel>
 				<InputSimple
 					id={nameId}
+					aria-required
+					aria-invalid={Boolean(errors.name) || undefined}
+					aria-describedby={errors.name ? `${nameId}-error` : undefined}
 					{...register("name", { required: "Required Field" })}
 				/>
-				<InputError>{errors.name?.message}</InputError>
+				<InputError id={`${nameId}-error`}>{errors.name?.message}</InputError>
 			</InputGroup>
 
 			{mode === "empty" && (

--- a/apps/web/src/references/components/ReferenceForm.tsx
+++ b/apps/web/src/references/components/ReferenceForm.tsx
@@ -45,9 +45,12 @@ export function ReferenceForm({ errors, mode, register }: ReferenceFormProps) {
 				<InputLabel htmlFor={nameId}>Name</InputLabel>
 				<InputSimple
 					id={nameId}
+					aria-required
+					aria-invalid={Boolean(errors.name) || undefined}
+					aria-describedby={errors.name ? `${nameId}-error` : undefined}
 					{...register("name", { required: "Required Field" })}
 				/>
-				<InputError>{errors.name?.message}</InputError>
+				<InputError id={`${nameId}-error`}>{errors.name?.message}</InputError>
 			</InputGroup>
 
 			{organismComponent}

--- a/apps/web/src/references/components/SourceTypes/GlobalSourceTypes.tsx
+++ b/apps/web/src/references/components/SourceTypes/GlobalSourceTypes.tsx
@@ -62,13 +62,18 @@ export function GlobalSourceTypes({ sourceTypes }: GlobalSourceTypesProps) {
 						<InputLabel htmlFor="SourceType">Add Source Type</InputLabel>
 						<Toolbar>
 							<div className="flex-grow">
-								<InputSimple id="SourceType" {...register("sourceType")} />
+								<InputSimple
+									id="SourceType"
+									aria-invalid={Boolean(error) || undefined}
+									aria-describedby={error ? "SourceType-error" : undefined}
+									{...register("sourceType")}
+								/>
 							</div>
 							<Button color="green" type="submit">
 								Add
 							</Button>
 						</Toolbar>
-						<InputError>{error}</InputError>
+						<InputError id="SourceType-error">{error}</InputError>
 					</form>
 				</BoxGroupSection>
 			</BoxGroup>

--- a/apps/web/src/references/components/SourceTypes/LocalSourceTypes.tsx
+++ b/apps/web/src/references/components/SourceTypes/LocalSourceTypes.tsx
@@ -95,8 +95,13 @@ export function LocalSourceTypes() {
 							</label>
 							<InputContainer className="flex mb-1.5">
 								<span className="flex flex-auto mr-2.5 flex-col">
-									<InputSimple id="sourceType" {...register("sourceType")} />
-									<InputError>{error}</InputError>
+									<InputSimple
+										id="sourceType"
+										aria-invalid={Boolean(error) || undefined}
+										aria-describedby={error ? "sourceType-error" : undefined}
+										{...register("sourceType")}
+									/>
+									<InputError id="sourceType-error">{error}</InputError>
 								</span>
 								<div
 									className="ml-auto mr-1"

--- a/apps/web/src/samples/components/Create/CreateSample.tsx
+++ b/apps/web/src/samples/components/Create/CreateSample.tsx
@@ -189,6 +189,9 @@ export default function CreateSample({ labels }: CreateSampleProps) {
 							<InputContainer align="right" className="flex">
 								<InputSimple
 									id="name"
+									aria-required
+									aria-invalid={Boolean(errors.name) || undefined}
+									aria-describedby={errors.name ? "name-error" : undefined}
 									{...register("name", {
 										required: "Required Field",
 									})}
@@ -202,7 +205,7 @@ export default function CreateSample({ labels }: CreateSampleProps) {
 									/>
 								)}
 							</InputContainer>
-							<InputError>{errors.name?.message}</InputError>
+							<InputError id="name-error">{errors.name?.message}</InputError>
 						</InputGroup>
 
 						<Controller

--- a/apps/web/src/samples/components/Create/CreateSampleFromFile.tsx
+++ b/apps/web/src/samples/components/Create/CreateSampleFromFile.tsx
@@ -160,9 +160,12 @@ function CreateSampleFromFileForm({
 						<InputLabel htmlFor="name">Name</InputLabel>
 						<InputSimple
 							id="name"
+							aria-required
+							aria-invalid={Boolean(errors.name) || undefined}
+							aria-describedby={errors.name ? "name-error" : undefined}
 							{...register("name", { required: "Required Field" })}
 						/>
-						<InputError>{errors.name?.message}</InputError>
+						<InputError id="name-error">{errors.name?.message}</InputError>
 					</InputGroup>
 
 					<Controller

--- a/apps/web/src/samples/components/Create/ReadSelector.tsx
+++ b/apps/web/src/samples/components/Create/ReadSelector.tsx
@@ -260,6 +260,7 @@ export default function ReadSelector({
 						<InputSearch
 							id="read-files-search"
 							aria-label="Search read files"
+							aria-describedby={error ? "read-files-error" : undefined}
 							placeholder="Filename"
 							value={term}
 							onChange={(e) => setTerm(e.target.value)}
@@ -300,7 +301,9 @@ export default function ReadSelector({
 							renderRow={renderRow}
 						/>
 
-						<InputError className="mb-2.5">{error}</InputError>
+						<InputError id="read-files-error" className="mb-2.5">
+							{error}
+						</InputError>
 					</>
 				)}
 			</Box>

--- a/apps/web/src/samples/components/EditSample.tsx
+++ b/apps/web/src/samples/components/EditSample.tsx
@@ -63,8 +63,14 @@ export default function EditSample({
 				>
 					<InputGroup>
 						<InputLabel htmlFor="name">Name</InputLabel>
-						<InputSimple id="name" {...register("name")} />
-						<InputError>
+						<InputSimple
+							id="name"
+							aria-required
+							aria-invalid={mutation.isError || undefined}
+							aria-describedby={mutation.isError ? "name-error" : undefined}
+							{...register("name")}
+						/>
+						<InputError id="name-error">
 							{mutation.isError &&
 								(mutation.error.response.body.message || "Required Field")}
 						</InputError>

--- a/apps/web/src/sequences/components/Accession.tsx
+++ b/apps/web/src/sequences/components/Accession.tsx
@@ -48,6 +48,11 @@ export default function Accession() {
 			<InputContainer align="right">
 				<InputSimple
 					id="accession"
+					aria-required
+					aria-invalid={notFound || Boolean(errors.accession) || undefined}
+					aria-describedby={
+						notFound || errors.accession ? "accession-error" : undefined
+					}
 					{...register("accession", {
 						required: "Required Field",
 						onChange: () => {
@@ -67,7 +72,7 @@ export default function Accession() {
 					/>
 				)}
 			</InputContainer>
-			<InputError>
+			<InputError id="accession-error">
 				{notFound ? "Accession not found" : errors.accession?.message}
 			</InputError>
 		</InputGroup>

--- a/apps/web/src/sequences/components/SequenceField.tsx
+++ b/apps/web/src/sequences/components/SequenceField.tsx
@@ -23,6 +23,9 @@ export default function SequenceField() {
 			<TextArea
 				className="font-mono uppercase"
 				id="sequence"
+				aria-required
+				aria-invalid={Boolean(errors.sequence) || undefined}
+				aria-describedby={errors.sequence ? "sequence-error" : undefined}
 				{...register("sequence", {
 					required: "Required Field",
 					pattern: {
@@ -31,7 +34,7 @@ export default function SequenceField() {
 					},
 				})}
 			/>
-			<InputError>{errors.sequence?.message}</InputError>
+			<InputError id="sequence-error">{errors.sequence?.message}</InputError>
 		</InputGroup>
 	);
 }

--- a/apps/web/src/sequences/components/SequenceForm.tsx
+++ b/apps/web/src/sequences/components/SequenceForm.tsx
@@ -92,11 +92,18 @@ export default function SequenceForm({
 					<InputLabel htmlFor="definition">Definition</InputLabel>
 					<InputSimple
 						id="definition"
+						aria-required
+						aria-invalid={Boolean(errors.definition) || undefined}
+						aria-describedby={
+							errors.definition ? "definition-error" : undefined
+						}
 						{...register("definition", {
 							required: "Required Field",
 						})}
 					/>
-					<InputError>{errors.definition?.message}</InputError>
+					<InputError id="definition-error">
+						{errors.definition?.message}
+					</InputError>
 				</InputGroup>
 
 				<SequenceField />

--- a/apps/web/src/subtraction/components/Detail/EditSubtraction.tsx
+++ b/apps/web/src/subtraction/components/Detail/EditSubtraction.tsx
@@ -56,11 +56,14 @@ export default function EditSubtraction({ subtraction }: EditSubtractionProps) {
 						<InputLabel htmlFor="name">Name</InputLabel>
 						<InputSimple
 							id="name"
+							aria-required
+							aria-invalid={Boolean(errors.name) || undefined}
+							aria-describedby={errors.name ? "name-error" : undefined}
 							{...register("name", {
 								required: "A name must be provided",
 							})}
 						/>
-						<InputError>{errors.name?.message}</InputError>
+						<InputError id="name-error">{errors.name?.message}</InputError>
 					</InputGroup>
 					<InputGroup>
 						<InputLabel htmlFor="nickname">Nickname</InputLabel>

--- a/apps/web/src/subtraction/components/SubtractionCreate.tsx
+++ b/apps/web/src/subtraction/components/SubtractionCreate.tsx
@@ -90,11 +90,14 @@ export default function SubtractionCreate() {
 							<InputLabel htmlFor="name">Name</InputLabel>
 							<InputSimple
 								id="name"
+								aria-required
+								aria-invalid={Boolean(errors.name) || undefined}
+								aria-describedby={errors.name ? "name-error" : undefined}
 								{...register("name", {
 									required: "A name is required",
 								})}
 							/>
-							<InputError>{errors.name?.message}</InputError>
+							<InputError id="name-error">{errors.name?.message}</InputError>
 						</InputGroup>
 
 						<InputGroup>

--- a/apps/web/src/users/components/CreateUserForm.tsx
+++ b/apps/web/src/users/components/CreateUserForm.tsx
@@ -46,11 +46,14 @@ export function CreateUserForm({
 				<InputSimple
 					id="handle"
 					autoComplete="off"
+					aria-required
+					aria-invalid={Boolean(errors.handle) || undefined}
+					aria-describedby={errors.handle ? "handle-error" : undefined}
 					{...register("handle", {
 						required: "Please specify a username",
 					})}
 				/>
-				<InputError>{errors.handle?.message}</InputError>
+				<InputError id="handle-error">{errors.handle?.message}</InputError>
 			</InputGroup>
 			<InputGroup>
 				<InputLabel htmlFor="password">Password</InputLabel>
@@ -58,9 +61,16 @@ export function CreateUserForm({
 					id="password"
 					type="password"
 					autoComplete="off"
+					aria-required
+					aria-invalid={Boolean(errors.password) || Boolean(error) || undefined}
+					aria-describedby={
+						errors.password || error ? "password-error" : undefined
+					}
 					{...register("password", passwordRules)}
 				/>
-				<InputError>{errors.password?.message || error}</InputError>
+				<InputError id="password-error">
+					{errors.password?.message || error}
+				</InputError>
 			</InputGroup>
 
 			<div className="flex justify-between items-center mb-2.5">

--- a/apps/web/src/users/components/Handle.tsx
+++ b/apps/web/src/users/components/Handle.tsx
@@ -60,11 +60,18 @@ export default function Handle({ id, handle }: HandleProps) {
 								aria-label="handle"
 								id="handle"
 								autoComplete="off"
+								aria-required
+								aria-invalid={
+									Boolean(errors.handle) || mutation.isError || undefined
+								}
+								aria-describedby={
+									errors.handle || mutation.isError ? "handle-error" : undefined
+								}
 								{...register("handle", {
 									required: "Please specify a username",
 								})}
 							/>
-							<InputError>
+							<InputError id="handle-error">
 								{errors.handle?.message ||
 									(mutation.isError ? mutation.error.message : "")}
 							</InputError>

--- a/apps/web/src/users/components/Password.tsx
+++ b/apps/web/src/users/components/Password.tsx
@@ -71,9 +71,18 @@ export default function Password({
 								id="password"
 								type="password"
 								autoComplete="new-password-for-other-user"
+								aria-required
+								aria-invalid={
+									Boolean(errors.password) || mutation.isError || undefined
+								}
+								aria-describedby={
+									errors.password || mutation.isError
+										? "password-error"
+										: undefined
+								}
 								{...register("password", passwordRules)}
 							/>
-							<InputError>
+							<InputError id="password-error">
 								{errors.password?.message ||
 									(mutation.isError && mutation.error.message)}
 							</InputError>

--- a/apps/web/src/wall/components/FirstUser.tsx
+++ b/apps/web/src/wall/components/FirstUser.tsx
@@ -50,8 +50,18 @@ export default function FirstUser() {
 						aria-label="username"
 						id="username"
 						autoComplete="username"
-						{...register("username", { required: true })}
+						aria-required
+						aria-invalid={Boolean(errors.username) || undefined}
+						aria-describedby={errors.username ? "username-error" : undefined}
+						{...register("username", {
+							required: "Please provide a username",
+						})}
 					/>
+					{errors.username?.message && (
+						<InputError id="username-error">
+							{errors.username.message}
+						</InputError>
+					)}
 				</InputGroup>
 				<InputGroup>
 					<InputLabel htmlFor="password">Password</InputLabel>
@@ -60,10 +70,15 @@ export default function FirstUser() {
 						id="password"
 						type="password"
 						autoComplete="new-password"
+						aria-required
+						aria-invalid={Boolean(errors.password) || undefined}
+						aria-describedby={errors.password ? "password-error" : undefined}
 						{...register("password", passwordRules)}
 					/>
 					{errors.password?.message && (
-						<InputError>{errors.password.message}</InputError>
+						<InputError id="password-error">
+							{errors.password.message}
+						</InputError>
 					)}
 				</InputGroup>
 

--- a/apps/web/src/wall/components/LoginForm.tsx
+++ b/apps/web/src/wall/components/LoginForm.tsx
@@ -4,6 +4,7 @@ import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import InputSimple from "@base/InputSimple";
 import { useNavigate } from "@tanstack/react-router";
+import { CircleAlert } from "lucide-react";
 import { Controller, useForm } from "react-hook-form";
 import { useLoginMutation } from "../queries";
 import { WallTitle } from "./WallTitle";
@@ -48,6 +49,9 @@ export default function LoginForm({ redirect, setResetCode }: LoginFormProps) {
 					<InputSimple
 						id="handle"
 						autoComplete="username"
+						aria-required
+						aria-invalid={isError || undefined}
+						aria-describedby={isError ? "login-error" : undefined}
 						{...register("handle", { required: true })}
 						autoFocus
 					/>
@@ -58,6 +62,9 @@ export default function LoginForm({ redirect, setResetCode }: LoginFormProps) {
 						id="password"
 						type="password"
 						autoComplete="current-password"
+						aria-required
+						aria-invalid={isError || undefined}
+						aria-describedby={isError ? "login-error" : undefined}
 						{...register("password", { required: true })}
 					/>
 				</InputGroup>
@@ -75,7 +82,12 @@ export default function LoginForm({ redirect, setResetCode }: LoginFormProps) {
 						)}
 					/>
 					{isError && (
-						<div className="flex text-red-500">
+						<div
+							id="login-error"
+							role="alert"
+							className="flex items-center gap-1 text-red-600 font-medium"
+						>
+							<CircleAlert aria-hidden className="shrink-0" size={14} />
 							{error?.message || "An error occurred during login"}
 						</div>
 					)}

--- a/apps/web/src/wall/components/ResetForm.tsx
+++ b/apps/web/src/wall/components/ResetForm.tsx
@@ -54,10 +54,15 @@ export default function ResetForm({ redirect, resetCode }: ResetFormProps) {
 						id="password"
 						type="password"
 						autoComplete="new-password"
+						aria-required
+						aria-invalid={Boolean(errors.password) || undefined}
+						aria-describedby={errors.password ? "password-error" : undefined}
 						{...register("password", passwordRules)}
 					/>
 					{errors.password?.message && (
-						<InputError>{errors.password.message}</InputError>
+						<InputError id="password-error">
+							{errors.password.message}
+						</InputError>
 					)}
 					{isError && (
 						<InputError>


### PR DESCRIPTION
## Summary
- `InputError` now renders as an assertive `role="alert"` live region and pairs each message with a non-color icon, so a failed submit is announced to assistive technology instead of silently showing red text (WCAG 3.3.1 / 1.4.1).
- Wires `aria-invalid`, `aria-describedby`, and `aria-required` from each input to its error across account, admin, analyses, groups, labels, otus, references, samples, sequences, subtraction, users, and wall forms — including the login and first-user flows, which previously announced nothing on failure.
- Threads `aria-describedby` through `SelectButton` and `IndexSelector` so the analysis reference selector's error is tied to its control.