### PR TITLE
fix: keep sample updates from being dropped after integer sample IDs

### DIFF
--- a/apps/web/src/analyses/__tests__/queries.test.tsx
+++ b/apps/web/src/analyses/__tests__/queries.test.tsx
@@ -15,7 +15,7 @@ describe("useCreateAnalysis()", () => {
 		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
 
 		const scope = nock("http://localhost")
-			.post("/api/samples/sample-1/analyses")
+			.post("/api/samples/1/analyses")
 			.reply(201, { id: "analysis-1" });
 
 		function wrapper({ children }: { children: ReactNode }) {
@@ -29,7 +29,7 @@ describe("useCreateAnalysis()", () => {
 		const { result } = renderHook(() => useCreateAnalysis(), { wrapper });
 
 		result.current.mutate({
-			sampleId: "sample-1",
+			sampleId: 1,
 			workflow: "pathoscope_bowtie",
 			refId: "ref-1",
 			subtractionIds: [],
@@ -38,7 +38,7 @@ describe("useCreateAnalysis()", () => {
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
 		expect(invalidateQueries).toHaveBeenCalledWith({
-			queryKey: [...analysesQueryKeys.lists(), "sample-1"],
+			queryKey: [...analysesQueryKeys.lists(), 1],
 		});
 		expect(invalidateQueries).not.toHaveBeenCalledWith({
 			queryKey: analysesQueryKeys.lists(),
@@ -50,7 +50,7 @@ describe("useCreateAnalysis()", () => {
 			queryKey: samplesQueryKeys.lists(),
 		});
 		expect(invalidateQueries).not.toHaveBeenCalledWith({
-			queryKey: samplesQueryKeys.detail("sample-1"),
+			queryKey: samplesQueryKeys.detail(1),
 		});
 
 		scope.done();

--- a/apps/web/src/analyses/components/AnalysisDetail.tsx
+++ b/apps/web/src/analyses/components/AnalysisDetail.tsx
@@ -30,7 +30,7 @@ export default function AnalysisDetail() {
 		data: sample,
 		isPending: isPendingSample,
 		isError: isSampleError,
-	} = useFetchSample(sampleId);
+	} = useFetchSample(Number(sampleId));
 
 	if ((isError && !analysis) || (isSampleError && !sample)) {
 		return <QueryError noun="analysis" />;

--- a/apps/web/src/analyses/components/AnalysisItem.tsx
+++ b/apps/web/src/analyses/components/AnalysisItem.tsx
@@ -37,7 +37,7 @@ export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 	const title = checkSupportedWorkflow(workflow) ? (
 		<Link
 			to="/samples/$sampleId/analyses/$analysisId"
-			params={{ sampleId: analysis.sample.id, analysisId: id }}
+			params={{ sampleId: String(analysis.sample.id), analysisId: id }}
 		>
 			{getWorkflowDisplayName(workflow)}
 		</Link>

--- a/apps/web/src/analyses/components/AnalysisList.tsx
+++ b/apps/web/src/analyses/components/AnalysisList.tsx
@@ -18,7 +18,7 @@ import AnalysisHMMAlert from "./HMMAlert";
 type AnalysesListProps = {
 	onPageChange: (page: number) => void;
 	page: number;
-	sampleId: string;
+	sampleId: number;
 };
 
 /**

--- a/apps/web/src/analyses/components/Create/CreateAnalysis.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysis.tsx
@@ -14,7 +14,7 @@ type CreateAnalysisProps = {
 	setOpen: (open: boolean) => void;
 
 	/** The id of the sample being used */
-	sampleId: string;
+	sampleId: number;
 };
 
 /**

--- a/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
@@ -45,7 +45,7 @@ type CreateAnalysisFormProps = {
 	sampleCount: number;
 
 	/** The ids of the samples being analyzed */
-	sampleIds: string[];
+	sampleIds: number[];
 };
 
 /**

--- a/apps/web/src/analyses/hooks.ts
+++ b/apps/web/src/analyses/hooks.ts
@@ -127,7 +127,7 @@ type UseSubtractionOptionsResult = {
  * @param sampleIds
  */
 export function useSubtractionOptions(
-	sampleIds: string[],
+	sampleIds: number[],
 ): UseSubtractionOptionsResult {
 	const {
 		data: subtractionShortlist,
@@ -135,7 +135,7 @@ export function useSubtractionOptions(
 		isError: isErrorSubtractionShortlist,
 	} = useFetchSubtractionsShortlist(true);
 
-	const sampleId = sampleIds[0] ?? "";
+	const sampleId = sampleIds[0] ?? Number.NaN;
 
 	const {
 		data: sample,

--- a/apps/web/src/analyses/queries.ts
+++ b/apps/web/src/analyses/queries.ts
@@ -22,7 +22,7 @@ import { formatData } from "./utils";
  * @returns A page of analyses search results
  */
 export function useListAnalyses(
-	sampleId: string,
+	sampleId: number,
 	page: number,
 	per_page: number,
 	term?: string,
@@ -83,7 +83,7 @@ export function useGetAnalysis(analysisId: string) {
 
 export type CreateAnalysisParams = {
 	refId?: string;
-	sampleId: string;
+	sampleId: number;
 	subtractionIds?: string[];
 	workflow: string;
 };

--- a/apps/web/src/analyses/types.ts
+++ b/apps/web/src/analyses/types.ts
@@ -7,7 +7,7 @@ import type { SearchResult } from "@/types/api";
 
 /** The sample associated with the analysis */
 export type AnalysisSample = {
-	id: string;
+	id: number;
 };
 
 /** Minimal Analysis used for resource listings */

--- a/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
+++ b/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
@@ -60,11 +60,11 @@ describe("reactQueryHandler", () => {
 				queryKey: referenceQueryKeys.lists(),
 			},
 			{
-				message: { domain: "samples", operation: "update", id: "abc" },
-				queryKey: samplesQueryKeys.detail("abc"),
+				message: { domain: "samples", operation: "update", id: 4184 },
+				queryKey: samplesQueryKeys.detail(4184),
 			},
 			{
-				message: { domain: "samples", operation: "insert", id: "abc" },
+				message: { domain: "samples", operation: "insert", id: 4184 },
 				queryKey: samplesQueryKeys.lists(),
 			},
 			{

--- a/apps/web/src/app/sse/__tests__/schema.test.ts
+++ b/apps/web/src/app/sse/__tests__/schema.test.ts
@@ -18,7 +18,7 @@ describe("SseMessageSchema", () => {
 
 	it("accepts a frame for a string-id domain", () => {
 		const result = SseMessageSchema.safeParse({
-			domain: "samples",
+			domain: "indexes",
 			operation: "insert",
 			id: "abc123",
 		});
@@ -27,9 +27,7 @@ describe("SseMessageSchema", () => {
 
 	it("accepts a frame for every domain in the enum", () => {
 		for (const domain of SseDomainSchema.options) {
-			const stringId = ["indexes", "references", "roles", "samples"].includes(
-				domain,
-			);
+			const stringId = ["indexes", "references", "roles"].includes(domain);
 			const result = SseMessageSchema.safeParse({
 				domain,
 				operation: "update",
@@ -56,7 +54,7 @@ describe("SseMessageSchema", () => {
 
 	it("rejects a number id for a string-id domain", () => {
 		const result = SseMessageSchema.safeParse({
-			domain: "samples",
+			domain: "indexes",
 			operation: "update",
 			id: 7,
 		});
@@ -76,7 +74,7 @@ describe("SseMessageSchema", () => {
 		const result = SseMessageSchema.safeParse({
 			domain: "samples",
 			operation: "patch",
-			id: "1",
+			id: 1,
 		});
 		expect(result.success).toBe(false);
 	});

--- a/apps/web/src/routes/_authenticated/samples/$sampleId.tsx
+++ b/apps/web/src/routes/_authenticated/samples/$sampleId.tsx
@@ -25,7 +25,7 @@ export const Route = createFileRoute("/_authenticated/samples/$sampleId")({
 		const { sampleQueryOptions } = await import("@samples/queries");
 
 		try {
-			await queryClient.ensureQueryData(sampleQueryOptions(sampleId));
+			await queryClient.ensureQueryData(sampleQueryOptions(Number(sampleId)));
 		} catch (error) {
 			if (
 				error != null &&
@@ -43,9 +43,10 @@ export const Route = createFileRoute("/_authenticated/samples/$sampleId")({
 
 function SampleDetailLayout() {
 	const { sampleId } = Route.useParams();
+	const numericSampleId = Number(sampleId);
 	const location = useLocation();
-	const { data } = useSuspenseSample(sampleId);
-	const { hasPermission: canModify } = useCheckCanEditSample(sampleId);
+	const { data } = useSuspenseSample(numericSampleId);
+	const { hasPermission: canModify } = useCheckCanEditSample(numericSampleId);
 	const [editOpen, setEditOpen] = useState(false);
 
 	const { created_at, name, user } = data;
@@ -66,7 +67,7 @@ function SampleDetailLayout() {
 									onClick={() => setEditOpen(true)}
 								/>
 								<DeleteSample
-									id={sampleId}
+									id={numericSampleId}
 									name={data.name}
 									ready={data.ready}
 									job={job}

--- a/apps/web/src/routes/_authenticated/samples/$sampleId.tsx
+++ b/apps/web/src/routes/_authenticated/samples/$sampleId.tsx
@@ -22,10 +22,19 @@ import { useState } from "react";
 
 export const Route = createFileRoute("/_authenticated/samples/$sampleId")({
 	loader: async ({ context: { queryClient }, params: { sampleId } }) => {
+		// Sample ids are integers. A nonnumeric param — e.g. a stale link from a
+		// pre-migration job that recorded a legacy string sample id — can no
+		// longer resolve, so treat it as not-found rather than requesting
+		// `/api/samples/NaN`.
+		const numericSampleId = Number(sampleId);
+		if (!Number.isInteger(numericSampleId)) {
+			throw notFound();
+		}
+
 		const { sampleQueryOptions } = await import("@samples/queries");
 
 		try {
-			await queryClient.ensureQueryData(sampleQueryOptions(Number(sampleId)));
+			await queryClient.ensureQueryData(sampleQueryOptions(numericSampleId));
 		} catch (error) {
 			if (
 				error != null &&

--- a/apps/web/src/routes/_authenticated/samples/$sampleId/analyses/index.tsx
+++ b/apps/web/src/routes/_authenticated/samples/$sampleId/analyses/index.tsx
@@ -25,7 +25,7 @@ function AnalysesRoute() {
 		<AnalysesList
 			onPageChange={(page) => navigate({ search: { page } })}
 			page={page}
-			sampleId={sampleId}
+			sampleId={Number(sampleId)}
 		/>
 	);
 }

--- a/apps/web/src/routes/_authenticated/samples/$sampleId/rights.tsx
+++ b/apps/web/src/routes/_authenticated/samples/$sampleId/rights.tsx
@@ -9,5 +9,5 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
 	const { sampleId } = Route.useParams();
-	return <SampleRights sampleId={sampleId} />;
+	return <SampleRights sampleId={Number(sampleId)} />;
 }

--- a/apps/web/src/samples/components/Detail/DeleteSample.tsx
+++ b/apps/web/src/samples/components/Detail/DeleteSample.tsx
@@ -7,7 +7,7 @@ import { Trash } from "lucide-react";
 
 type DeleteSampleProps = {
 	/** The id of the sample being deleted */
-	id: string;
+	id: number;
 
 	/** The sample's job if it exists */
 	job?: JobNested;

--- a/apps/web/src/samples/components/Detail/SampleDetailGeneral.tsx
+++ b/apps/web/src/samples/components/Detail/SampleDetailGeneral.tsx
@@ -32,7 +32,7 @@ type SampleDetailGeneralProps = {
 export default function SampleDetailGeneral({
 	labels,
 }: SampleDetailGeneralProps) {
-	const { sampleId } = routeApi.useParams();
+	const sampleId = Number(routeApi.useParams().sampleId);
 	const { data } = useSuspenseSample(sampleId);
 	const { data: job } = useFetchJob(data.job?.id ?? Number.NaN, data.job);
 

--- a/apps/web/src/samples/components/Detail/SampleFileSizeWarning.tsx
+++ b/apps/web/src/samples/components/Detail/SampleFileSizeWarning.tsx
@@ -6,7 +6,7 @@ import { AlertTriangle } from "lucide-react";
 
 type SampleFileSizeWarningProps = {
 	reads: Read[];
-	sampleId: string;
+	sampleId: number;
 };
 
 /**
@@ -23,7 +23,10 @@ export default function SampleFileSizeWarning({
 		const showLink = !location.endsWith("/uploads");
 
 		const link = showLink ? (
-			<Link to="/samples/$sampleId/files" params={{ sampleId }}>
+			<Link
+				to="/samples/$sampleId/files"
+				params={{ sampleId: String(sampleId) }}
+			>
 				Check the file sizes
 			</Link>
 		) : (

--- a/apps/web/src/samples/components/Detail/SampleRights.tsx
+++ b/apps/web/src/samples/components/Detail/SampleRights.tsx
@@ -27,7 +27,7 @@ import { ChevronDown } from "lucide-react";
 const noGroup = "none";
 
 type SampleRightsProps = {
-	sampleId: string;
+	sampleId: number;
 };
 
 /**

--- a/apps/web/src/samples/components/Detail/Sidebar.tsx
+++ b/apps/web/src/samples/components/Detail/Sidebar.tsx
@@ -6,7 +6,7 @@ import SampleLabels from "../Sidebar/SampleLabels";
 
 type SidebarProps = {
 	labels: Label[];
-	sampleId: string;
+	sampleId: number;
 	sampleLabels: Array<LabelNested>;
 	defaultSubtractions: Array<SubtractionNested>;
 };

--- a/apps/web/src/samples/components/Detail/__tests__/DeleteSample.test.tsx
+++ b/apps/web/src/samples/components/Detail/__tests__/DeleteSample.test.tsx
@@ -12,7 +12,7 @@ describe("<DeleteSample />", () => {
 
 	beforeEach(() => {
 		props = {
-			id: "foo",
+			id: 1,
 			name: "test",
 			ready: true,
 		};

--- a/apps/web/src/samples/components/Detail/__tests__/SampleFileSizeWarning.test.tsx
+++ b/apps/web/src/samples/components/Detail/__tests__/SampleFileSizeWarning.test.tsx
@@ -10,7 +10,7 @@ describe("<SampleFileSizeWarning />", () => {
 
 	beforeEach(() => {
 		props = {
-			sampleId: "test",
+			sampleId: 1,
 			reads: [],
 		};
 	});

--- a/apps/web/src/samples/components/Files/SampleDetailFiles.tsx
+++ b/apps/web/src/samples/components/Files/SampleDetailFiles.tsx
@@ -12,7 +12,7 @@ const routeApi = getRouteApi("/_authenticated/samples/$sampleId");
  */
 export default function SampleDetailFiles() {
 	const { sampleId } = routeApi.useParams();
-	const { data } = useSuspenseSample(sampleId);
+	const { data } = useSuspenseSample(Number(sampleId));
 
 	return (
 		<ContainerNarrow>

--- a/apps/web/src/samples/components/Item/SampleItem.tsx
+++ b/apps/web/src/samples/components/Item/SampleItem.tsx
@@ -49,7 +49,7 @@ export default function SampleItem({
 			<Link
 				className="text-lg font-medium overflow-hidden text-ellipsis whitespace-nowrap"
 				to="/samples/$sampleId"
-				params={{ sampleId: sample.id }}
+				params={{ sampleId: String(sample.id) }}
 			>
 				{sample.name}
 			</Link>

--- a/apps/web/src/samples/components/SampleQuality.tsx
+++ b/apps/web/src/samples/components/SampleQuality.tsx
@@ -10,7 +10,7 @@ const routeApi = getRouteApi("/_authenticated/samples/$sampleId");
  */
 export default function SampleQuality() {
 	const { sampleId } = routeApi.useParams();
-	const { data } = useSuspenseSample(sampleId);
+	const { data } = useSuspenseSample(Number(sampleId));
 
 	return (
 		<div className="flex flex-col">

--- a/apps/web/src/samples/components/Tag/WorkflowTags.tsx
+++ b/apps/web/src/samples/components/Tag/WorkflowTags.tsx
@@ -5,7 +5,7 @@ import { BaseWorkflowTag } from "./BaseWorkflowTag";
 import WorkflowTag from "./WorkflowTag";
 
 type WorkflowTagsProps = {
-	id: string;
+	id: number;
 	workflows: SampleWorkflows;
 };
 

--- a/apps/web/src/samples/components/__tests__/SampleLabelsSelector.test.tsx
+++ b/apps/web/src/samples/components/__tests__/SampleLabelsSelector.test.tsx
@@ -11,7 +11,7 @@ import SampleLabelsSelector from "../SampleLabelsSelector";
  * Mocks the sample-update endpoint and captures the request body so tests can
  * assert which labels were sent for each selected sample.
  */
-function mockApiUpdateSampleLabels(sampleId: string) {
+function mockApiUpdateSampleLabels(sampleId: number) {
 	const captured: { body?: { labels: number[] } } = {};
 
 	nock("http://localhost")
@@ -93,7 +93,7 @@ describe("<SampleLabelsSelector>", () => {
 			props.selectedSamples = [
 				createFakeSampleMinimal({
 					name: "Foo Sample",
-					id: "foo_sample",
+					id: 1,
 					labels: [
 						{ color: "#C4B5FD", description: "", id: 1, name: "test" },
 						{ color: "#FCA5A5", description: "", id: 2, name: "label" },
@@ -101,7 +101,7 @@ describe("<SampleLabelsSelector>", () => {
 				}),
 				createFakeSampleMinimal({
 					name: "Bar Sample",
-					id: "bar_sample",
+					id: 2,
 					labels: [{ color: "#C4B5FD", description: "", id: 1, name: "test" }],
 				}),
 			];
@@ -137,8 +137,8 @@ describe("<SampleLabelsSelector>", () => {
 		});
 
 		it("removes a fully-applied label from every sample", async () => {
-			const foo = mockApiUpdateSampleLabels("foo_sample");
-			const bar = mockApiUpdateSampleLabels("bar_sample");
+			const foo = mockApiUpdateSampleLabels(1);
+			const bar = mockApiUpdateSampleLabels(2);
 
 			await openSelectorAndClick("test");
 
@@ -149,8 +149,8 @@ describe("<SampleLabelsSelector>", () => {
 		});
 
 		it("adds a partially-applied label to every sample", async () => {
-			const foo = mockApiUpdateSampleLabels("foo_sample");
-			const bar = mockApiUpdateSampleLabels("bar_sample");
+			const foo = mockApiUpdateSampleLabels(1);
+			const bar = mockApiUpdateSampleLabels(2);
 
 			await openSelectorAndClick("label");
 
@@ -161,8 +161,8 @@ describe("<SampleLabelsSelector>", () => {
 		});
 
 		it("adds an unapplied label to every sample", async () => {
-			const foo = mockApiUpdateSampleLabels("foo_sample");
-			const bar = mockApiUpdateSampleLabels("bar_sample");
+			const foo = mockApiUpdateSampleLabels(1);
+			const bar = mockApiUpdateSampleLabels(2);
 
 			await openSelectorAndClick("bar");
 

--- a/apps/web/src/samples/hooks.ts
+++ b/apps/web/src/samples/hooks.ts
@@ -8,7 +8,7 @@ import { useFetchSample } from "./queries";
  * @param sampleId - The unique identifier of the sample to check permissions for
  * @returns whether the current user has permission to edit the sample
  */
-export function useCheckCanEditSample(sampleId: string) {
+export function useCheckCanEditSample(sampleId: number) {
 	const {
 		data: account,
 		isPending: isPendingAccount,

--- a/apps/web/src/samples/queries.ts
+++ b/apps/web/src/samples/queries.ts
@@ -33,7 +33,7 @@ export type SampleLabel = LabelNested & {
  *
  * Shared by the single-sample update hook and the bulk label-update hook.
  */
-function updateSample(sampleId: string, update: SampleUpdate): Promise<Sample> {
+function updateSample(sampleId: number, update: SampleUpdate): Promise<Sample> {
 	return apiClient
 		.patch(`/samples/${sampleId}`)
 		.send(update)
@@ -86,7 +86,7 @@ export function useListSamples(
 	});
 }
 
-export function sampleQueryOptions(sampleId: string) {
+export function sampleQueryOptions(sampleId: number) {
 	return queryOptions<Sample, ErrorResponse>({
 		queryKey: samplesQueryKeys.detail(sampleId),
 		queryFn: () =>
@@ -94,8 +94,11 @@ export function sampleQueryOptions(sampleId: string) {
 	});
 }
 
-export function useFetchSample(sampleId: string) {
-	return useQuery(sampleQueryOptions(sampleId));
+export function useFetchSample(sampleId: number) {
+	return useQuery({
+		...sampleQueryOptions(sampleId),
+		enabled: Number.isInteger(sampleId),
+	});
 }
 
 /**
@@ -107,7 +110,7 @@ export function useFetchSample(sampleId: string) {
  * `$sampleId` detail layout and its children) — loading and errors are handled
  * by the route's Suspense and `errorComponent` rather than inline.
  */
-export function useSuspenseSample(sampleId: string) {
+export function useSuspenseSample(sampleId: number) {
 	return useSuspenseQuery(sampleQueryOptions(sampleId));
 }
 
@@ -169,7 +172,7 @@ export function useCreateSample() {
  *
  * @returns A mutator for updating a sample
  */
-export function useUpdateSample(sampleId: string) {
+export function useUpdateSample(sampleId: number) {
 	const queryClient = useQueryClient();
 
 	return useMutation<Sample, ErrorResponse, { update: SampleUpdate }>({
@@ -188,7 +191,7 @@ export function useUpdateSample(sampleId: string) {
  * @returns A mutator for removing a sample
  */
 export function useRemoveSample() {
-	return useMutation<null, unknown, { sampleId: string }>({
+	return useMutation<null, unknown, { sampleId: number }>({
 		mutationFn: ({ sampleId }) =>
 			apiClient
 				.delete(`/samples/${sampleId}`)
@@ -201,7 +204,7 @@ export function useRemoveSample() {
  *
  * @returns A mutator for updating a samples rights
  */
-export function useUpdateSampleRights(sampleId: string) {
+export function useUpdateSampleRights(sampleId: number) {
 	return useMutation<
 		SampleRightsUpdateReturn,
 		unknown,

--- a/apps/web/src/samples/types.ts
+++ b/apps/web/src/samples/types.ts
@@ -37,7 +37,7 @@ export type SampleArtifact = {
 
 /* A Sample ID */
 export type SampleID = {
-	id: string;
+	id: number;
 };
 
 /* A Sample with essential information */
@@ -87,7 +87,7 @@ export type Read = {
 	id: number;
 	name: string;
 	name_on_disk: string;
-	sample: string;
+	sample: number;
 	size: number;
 	upload?: File;
 	uploaded_at: string;

--- a/apps/web/src/server/events/broadcast.test.ts
+++ b/apps/web/src/server/events/broadcast.test.ts
@@ -47,12 +47,12 @@ describe("eventToSseMessage", () => {
 	it("preserves string resource ids", () => {
 		expect(
 			eventToSseMessage({
-				domain: "samples",
+				domain: "references",
 				resource_id: "abc",
 				operation: "create",
 			}),
 		).toEqual({
-			domain: "samples",
+			domain: "references",
 			operation: "insert",
 			id: "abc",
 		});

--- a/apps/web/src/server/events/channel.ts
+++ b/apps/web/src/server/events/channel.ts
@@ -11,7 +11,6 @@ export type ResourceId<D extends SseDomain> = D extends
 	| "indexes"
 	| "references"
 	| "roles"
-	| "samples"
 	? string
 	: number;
 

--- a/apps/web/src/server/events/emit.test.ts
+++ b/apps/web/src/server/events/emit.test.ts
@@ -46,13 +46,13 @@ describe("emit", () => {
 	});
 
 	it("accepts string resource ids", async () => {
-		await emit("samples", "abc123", "update");
+		await emit("references", "ref123", "update");
 
 		expect(notify).toHaveBeenCalledWith(
 			"client_events",
 			JSON.stringify({
-				domain: "samples",
-				resource_id: "abc123",
+				domain: "references",
+				resource_id: "ref123",
 				operation: "update",
 			}),
 		);

--- a/apps/web/src/tests/api/samples.ts
+++ b/apps/web/src/tests/api/samples.ts
@@ -159,6 +159,6 @@ export function mockApiCreateSample(
  * @param sampleId - The id of the sample being removed
  * @returns The nock scope for the mocked API call
  */
-export function mockApiRemoveSample(sampleId: string) {
+export function mockApiRemoveSample(sampleId: number) {
 	return nock("http://localhost").delete(`/api/samples/${sampleId}`).reply(200);
 }

--- a/apps/web/src/tests/fake/analyses.ts
+++ b/apps/web/src/tests/fake/analyses.ts
@@ -26,7 +26,7 @@ export function createFakeAnalysisMinimal(
 		ready: true,
 		reference: createFakeReferenceNested(),
 		sample: {
-			id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
+			id: faker.number.int(),
 		},
 		subtractions: [createFakeSubtractionNested()],
 		updated_at: faker.date.past().toISOString(),

--- a/apps/web/src/tests/fake/samples.ts
+++ b/apps/web/src/tests/fake/samples.ts
@@ -14,7 +14,7 @@ export function createFakeSampleMinimal(
 	overrides?: Partial<SampleMinimal>,
 ): SampleMinimal {
 	const defaultSampleMinimal: SampleMinimal = {
-		id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
+		id: faker.number.int(),
 		name: `${faker.word.noun({ strategy: "any-length" })} ${faker.number.int()}`,
 		created_at: faker.date.past().toISOString(),
 		host: faker.word.noun({ strategy: "any-length" }),
@@ -45,7 +45,7 @@ export function createFakeSampleRead(overrides?: Partial<Read>): Read {
 		id: faker.number.int(),
 		name: faker.word.noun({ strategy: "any-length" }),
 		name_on_disk: faker.word.noun({ strategy: "any-length" }),
-		sample: faker.word.noun({ strategy: "any-length" }),
+		sample: faker.number.int(),
 		size: faker.number.int(),
 		uploaded_at: faker.date.past().toISOString(),
 	};

--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -56,8 +56,8 @@ The SSE handler emits one `data:` frame per event:
 - `operation` — `"insert"`, `"update"`, or `"delete"`. `create` events
   map to `insert`; the other two pass through.
 - `id` — per-domain primary key type. Domains not yet migrated off
-  Mongo on the Python side (`indexes`, `references`, `roles`,
-  `samples`) use string ids; the others use number ids. A frame whose
+  Mongo on the Python side (`indexes`, `references`, `roles`) use
+  string ids; the others use number ids. A frame whose
   `id` type doesn't match its `domain` is rejected at the parse
   boundary.
 

--- a/packages/contracts/src/sse.ts
+++ b/packages/contracts/src/sse.ts
@@ -43,7 +43,7 @@ export const SseMessageSchema = z.discriminatedUnion("domain", [
 	frame("messages", NumberId),
 	frame("references", StringId),
 	frame("roles", StringId),
-	frame("samples", StringId),
+	frame("samples", NumberId),
 	frame("tasks", NumberId),
 	frame("uploads", NumberId),
 	frame("users", NumberId),


### PR DESCRIPTION
## Summary

- The `samples` SSE schema still typed `id` as a string, so frames carrying the new numeric sample IDs threw a ZodError and dropped the update (Sentry VIRTOOL-3, VIR-2794).
- The sample detail query was keyed on the string route param while SSE invalidated by number, so cache invalidation would have silently missed the query even after the schema was fixed.
- Threads sample IDs through the client as numbers (`Number()` at route boundaries for query keys, `String()` at router `Link` params), matching the existing `jobs` pattern.