### PR TITLE
chore: type HMM ids as integers

### DIFF
--- a/apps/web/src/analyses/components/Nuvs/NuvsOrfLabel.tsx
+++ b/apps/web/src/analyses/components/Nuvs/NuvsOrfLabel.tsx
@@ -11,7 +11,7 @@ export default function NuvsOrfLabel({ hmm }: NuvsOrfLabelProps) {
 			<Link
 				className="capitalize"
 				to="/hmms/$hmmId"
-				params={{ hmmId: hmm.hit }}
+				params={{ hmmId: String(hmm.hit) }}
 			>
 				{hmm.names[0]}
 			</Link>

--- a/apps/web/src/analyses/types.ts
+++ b/apps/web/src/analyses/types.ts
@@ -271,7 +271,7 @@ export type NuvsOrfHit = {
 	full_bias: number;
 	full_e: number;
 	full_score: number;
-	hit: string;
+	hit: number;
 	names: string[];
 };
 

--- a/apps/web/src/hmm/components/HmmDetail.tsx
+++ b/apps/web/src/hmm/components/HmmDetail.tsx
@@ -20,7 +20,7 @@ const routeApi = getRouteApi("/_authenticated/hmms/$hmmId");
  */
 export default function HmmDetail() {
 	const { hmmId } = routeApi.useParams();
-	const { data, isPending, isError } = useFetchHmm(hmmId);
+	const { data, isPending, isError } = useFetchHmm(Number(hmmId));
 
 	if (isError) {
 		return <NotFound />;

--- a/apps/web/src/hmm/components/HmmItem.tsx
+++ b/apps/web/src/hmm/components/HmmItem.tsx
@@ -28,7 +28,7 @@ export default function HmmItem({ hmm }: HmmItemProps) {
 			<Link
 				className="flex-1 shrink-0"
 				to="/hmms/$hmmId"
-				params={{ hmmId: hmm.id }}
+				params={{ hmmId: String(hmm.id) }}
 			>
 				{hmm.names[0]}
 			</Link>

--- a/apps/web/src/hmm/queries.ts
+++ b/apps/web/src/hmm/queries.ts
@@ -69,7 +69,7 @@ export function useSuspenseHmms(page: number, per_page: number, term?: string) {
  * @param hmmId - The id of the hmm to fetch
  * @returns A single HMM
  */
-export function useFetchHmm(hmmId: string) {
+export function useFetchHmm(hmmId: number) {
 	return useQuery<Hmm, ErrorResponse>({
 		queryKey: hmmQueryKeys.detail(hmmId),
 		queryFn: () => apiClient.get(`/hmms/${hmmId}`).then((res) => res.body),

--- a/apps/web/src/hmm/types.ts
+++ b/apps/web/src/hmm/types.ts
@@ -6,7 +6,7 @@ import type { SearchResult } from "@/types/api";
 /** Minimal HMM used for resource listings */
 export type HMMMinimal = {
 	/** The unique identifier */
-	id: string;
+	id: number;
 	cluster: number;
 	count: number;
 	families: { [key: string]: number };

--- a/apps/web/src/tests/fake/analyses.ts
+++ b/apps/web/src/tests/fake/analyses.ts
@@ -87,7 +87,7 @@ export function createFakeFormattedNuVsHit(overrides?: FakeFormattedNuVsHit) {
 						full_bias: faker.number.float(),
 						full_e: faker.number.float(),
 						full_score: faker.number.float(),
-						hit: faker.word.noun({ strategy: "any-length" }),
+						hit: faker.number.int(),
 						names: [faker.word.noun({ strategy: "any-length" })],
 					},
 				],

--- a/apps/web/src/tests/fake/analyses.ts
+++ b/apps/web/src/tests/fake/analyses.ts
@@ -87,7 +87,7 @@ export function createFakeFormattedNuVsHit(overrides?: FakeFormattedNuVsHit) {
 						full_bias: faker.number.float(),
 						full_e: faker.number.float(),
 						full_score: faker.number.float(),
-						hit: faker.number.int(),
+						hit: faker.number.int({ min: 1 }),
 						names: [faker.word.noun({ strategy: "any-length" })],
 					},
 				],

--- a/apps/web/src/tests/fake/hmm.ts
+++ b/apps/web/src/tests/fake/hmm.ts
@@ -13,7 +13,7 @@ export function createFakeHmmMinimal() {
 			None: faker.number.int(),
 			Papillomaviridae: faker.number.int(),
 		},
-		id: faker.number.int(),
+		id: faker.number.int({ min: 1 }),
 		names: [faker.person.lastName()],
 	};
 }

--- a/apps/web/src/tests/fake/hmm.ts
+++ b/apps/web/src/tests/fake/hmm.ts
@@ -13,7 +13,7 @@ export function createFakeHmmMinimal() {
 			None: faker.number.int(),
 			Papillomaviridae: faker.number.int(),
 		},
-		id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
+		id: faker.number.int(),
 		names: [faker.person.lastName()],
 	};
 }

--- a/packages/contracts/src/hmms.ts
+++ b/packages/contracts/src/hmms.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 /** HMM profile metadata returned by `GET /hmms` (nuvs only). Provisional shape. */
 export const Hmms = z.array(
 	z.object({
-		id: z.string(),
+		id: z.number().int().nonnegative(),
 		cluster: z.number().int().nonnegative(),
 	}),
 );


### PR DESCRIPTION
## Summary
- Change `HMMMinimal.id` and `NuvsOrfHit.hit` from `string` to `number` to match the backend's integer HMM ids.
- Update `useFetchHmm` and its call sites accordingly, coercing to `String()` where the value feeds a route `Link` param.
- Update HMM and NuVs fake data generators to produce numeric ids.