### PR TITLE
test: cover users, groups, and auth core against a real database

### DIFF
--- a/apps/web/src/server/auth/core.test.ts
+++ b/apps/web/src/server/auth/core.test.ts
@@ -15,7 +15,12 @@ import { users } from "../db/schema/users";
 import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
 import type { CookieAdapter } from "./cookies";
 import {
+	createFirstUser,
+	FirstUserExistsError,
+	InvalidCredentialsError,
 	InvalidResetSessionError,
+	login,
+	logout,
 	PasswordReuseError,
 	resetPassword,
 } from "./core";
@@ -284,5 +289,192 @@ describe("resetPassword", () => {
 				ip: "127.0.0.1",
 			}),
 		).rejects.toThrow(InvalidResetSessionError);
+	});
+});
+
+describe("createFirstUser", () => {
+	it("creates a full-administrator user and signs them in", async () => {
+		const cookies = fakeCookies();
+
+		const user = await createFirstUser(db, cookies, {
+			handle: "root",
+			password: "a-real-password",
+			ip: "127.0.0.1",
+		});
+
+		expect(user.handle).toBe("root");
+		expect(user.administrator_role).toBe("full");
+
+		// The caller lands in the app: an authenticated session and both cookies.
+		const rows = await db
+			.select()
+			.from(sessions)
+			.where(eq(sessions.userId, user.id));
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.sessionType).toBe("authenticated");
+		expect(cookies.sessionId).toBe(rows[0]?.sessionId);
+		expect(cookies.token).toBeDefined();
+	});
+
+	it("refuses once any user exists", async () => {
+		await seedUser(db, { handle: "existing" });
+		const cookies = fakeCookies();
+
+		await expect(
+			createFirstUser(db, cookies, {
+				handle: "root",
+				password: "a-real-password",
+				ip: "127.0.0.1",
+			}),
+		).rejects.toBeInstanceOf(FirstUserExistsError);
+		expect(cookies.token).toBeUndefined();
+	});
+});
+
+describe("login", () => {
+	it("authenticates a valid credential and sets both cookies", async () => {
+		const userId = await seedUser(db, {
+			handle: "alice",
+			password: await hashPassword(OLD_PASSWORD),
+		});
+		const cookies = fakeCookies();
+
+		const result = await login(db, cookies, {
+			handle: "alice",
+			password: OLD_PASSWORD,
+			remember: false,
+			ip: "127.0.0.1",
+		});
+
+		expect(result).toEqual({ status: "authenticated" });
+		const rows = await db
+			.select()
+			.from(sessions)
+			.where(eq(sessions.userId, userId));
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.sessionType).toBe("authenticated");
+		expect(cookies.sessionId).toBe(rows[0]?.sessionId);
+		expect(cookies.token).toBeDefined();
+	});
+
+	it("matches the handle case-insensitively", async () => {
+		await seedUser(db, {
+			handle: "alice",
+			password: await hashPassword(OLD_PASSWORD),
+		});
+		const cookies = fakeCookies();
+
+		const result = await login(db, cookies, {
+			handle: "ALICE",
+			password: OLD_PASSWORD,
+			remember: false,
+			ip: "127.0.0.1",
+		});
+
+		expect(result).toEqual({ status: "authenticated" });
+	});
+
+	it("rejects a wrong password without creating a session", async () => {
+		const userId = await seedUser(db, {
+			handle: "alice",
+			password: await hashPassword(OLD_PASSWORD),
+		});
+		const cookies = fakeCookies();
+
+		await expect(
+			login(db, cookies, {
+				handle: "alice",
+				password: "wrong-password",
+				remember: false,
+				ip: "127.0.0.1",
+			}),
+		).rejects.toBeInstanceOf(InvalidCredentialsError);
+
+		expect(
+			await db.select().from(sessions).where(eq(sessions.userId, userId)),
+		).toHaveLength(0);
+		expect(cookies.sessionId).toBeUndefined();
+	});
+
+	it("rejects an unknown handle", async () => {
+		const cookies = fakeCookies();
+
+		await expect(
+			login(db, cookies, {
+				handle: "nobody",
+				password: OLD_PASSWORD,
+				remember: false,
+				ip: "127.0.0.1",
+			}),
+		).rejects.toBeInstanceOf(InvalidCredentialsError);
+	});
+
+	it("rejects an inactive user", async () => {
+		await seedUser(db, {
+			handle: "alice",
+			active: false,
+			password: await hashPassword(OLD_PASSWORD),
+		});
+		const cookies = fakeCookies();
+
+		await expect(
+			login(db, cookies, {
+				handle: "alice",
+				password: OLD_PASSWORD,
+				remember: false,
+				ip: "127.0.0.1",
+			}),
+		).rejects.toBeInstanceOf(InvalidCredentialsError);
+	});
+
+	it("defers a force-reset user to /reset instead of authenticating", async () => {
+		const userId = await seedUser(db, {
+			handle: "alice",
+			forceReset: true,
+			password: await hashPassword(OLD_PASSWORD),
+		});
+		const cookies = fakeCookies();
+
+		const result = await login(db, cookies, {
+			handle: "alice",
+			password: OLD_PASSWORD,
+			remember: false,
+			ip: "127.0.0.1",
+		});
+
+		expect(result.status).toBe("reset_required");
+		// A reset session is set, but no token cookie — the reset is not yet a login.
+		const rows = await db
+			.select()
+			.from(sessions)
+			.where(eq(sessions.userId, userId));
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.sessionType).toBe("reset");
+		expect(cookies.sessionId).toBe(rows[0]?.sessionId);
+		expect(cookies.token).toBeUndefined();
+	});
+});
+
+describe("logout", () => {
+	it("invalidates the session and clears the cookies", async () => {
+		const userId = await seedUser(db);
+		const { sessionId } = await seedSession(db, userId);
+		const cookies = fakeCookies(sessionId);
+
+		await logout(db, cookies);
+
+		expect(
+			await db.select().from(sessions).where(eq(sessions.sessionId, sessionId)),
+		).toHaveLength(0);
+		expect(cookies.sessionId).toBeUndefined();
+		expect(cookies.token).toBeUndefined();
+	});
+
+	it("still clears the cookies when there is no session", async () => {
+		const cookies = fakeCookies();
+
+		await logout(db, cookies);
+
+		expect(cookies.sessionId).toBeUndefined();
 	});
 });

--- a/apps/web/src/server/groups/data.test.ts
+++ b/apps/web/src/server/groups/data.test.ts
@@ -1,0 +1,236 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { seedUser } from "../auth/test/fixtures";
+import type { Db } from "../db/pg";
+import { groups, userGroups } from "../db/schema/groups";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import {
+	createGroup,
+	deleteGroup,
+	findGroups,
+	GroupConflictError,
+	GroupNotFoundError,
+	getGroup,
+	listGroups,
+	updateGroup,
+} from "./data";
+import { addToGroup, NO_PERMISSIONS, seedGroup } from "./test/fixtures";
+
+let database: TestDatabase;
+let db: Db;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(users);
+	await db.delete(groups);
+});
+
+async function readGroup(groupId: number) {
+	const [row] = await db.select().from(groups).where(eq(groups.id, groupId));
+	return row;
+}
+
+describe("listGroups", () => {
+	it("returns every group, name-ascending", async () => {
+		await seedGroup(db, { name: "technicians" });
+		await seedGroup(db, { name: "admins" });
+		await seedGroup(db, { name: "guests" });
+
+		const result = await listGroups(db);
+
+		expect(result.map((group) => group.name)).toEqual([
+			"admins",
+			"guests",
+			"technicians",
+		]);
+	});
+
+	it("returns the minimal shape without permissions or users", async () => {
+		const groupId = await seedGroup(db, { name: "technicians" });
+
+		const [group] = await listGroups(db);
+
+		expect(group).toEqual({
+			id: groupId,
+			legacy_id: null,
+			name: "technicians",
+		});
+	});
+});
+
+describe("findGroups", () => {
+	it("matches names case-insensitively and reports found and total counts", async () => {
+		await seedGroup(db, { name: "Technicians" });
+		await seedGroup(db, { name: "Administrators" });
+
+		const result = await findGroups(db, "tech", 1, 25);
+
+		expect(result.items.map((group) => group.name)).toEqual(["Technicians"]);
+		expect(result.found_count).toBe(1);
+		expect(result.total_count).toBe(2);
+	});
+
+	it("paginates the matches", async () => {
+		for (const letter of ["a", "b", "c"]) {
+			await seedGroup(db, { name: `group-${letter}` });
+		}
+
+		const page1 = await findGroups(db, "", 1, 2);
+		const page2 = await findGroups(db, "", 2, 2);
+
+		expect(page1.items.map((group) => group.name)).toEqual([
+			"group-a",
+			"group-b",
+		]);
+		expect(page2.items.map((group) => group.name)).toEqual(["group-c"]);
+		expect(page1.page_count).toBe(2);
+		expect(page1.per_page).toBe(2);
+	});
+});
+
+describe("getGroup", () => {
+	it("returns the group with its permissions and member users", async () => {
+		const groupId = await seedGroup(db, {
+			name: "technicians",
+			permissions: { create_ref: true },
+		});
+		const bob = await seedUser(db, { handle: "bob" });
+		const alice = await seedUser(db, { handle: "alice" });
+		await addToGroup(db, bob, groupId);
+		await addToGroup(db, alice, groupId);
+
+		const group = await getGroup(db, groupId);
+
+		expect(group).toMatchObject({
+			id: groupId,
+			legacy_id: null,
+			name: "technicians",
+			permissions: { ...NO_PERMISSIONS, create_ref: true },
+		});
+		// Members come back handle-ascending.
+		expect(group.users).toEqual([
+			{ id: alice, handle: "alice" },
+			{ id: bob, handle: "bob" },
+		]);
+	});
+
+	it("throws when the group does not exist", async () => {
+		await expect(getGroup(db, 404)).rejects.toBeInstanceOf(GroupNotFoundError);
+	});
+});
+
+describe("createGroup", () => {
+	it("creates a group granting nothing", async () => {
+		const group = await createGroup(db, "technicians");
+
+		expect(group).toMatchObject({
+			name: "technicians",
+			legacy_id: null,
+			permissions: NO_PERMISSIONS,
+			users: [],
+		});
+		expect((await readGroup(group.id))?.name).toBe("technicians");
+	});
+
+	it("rejects a duplicate name", async () => {
+		await createGroup(db, "technicians");
+
+		await expect(createGroup(db, "technicians")).rejects.toBeInstanceOf(
+			GroupConflictError,
+		);
+	});
+});
+
+describe("updateGroup", () => {
+	it("renames the group", async () => {
+		const groupId = await seedGroup(db, { name: "technicians" });
+
+		const group = await updateGroup(db, groupId, { name: "renamed" });
+
+		expect(group.name).toBe("renamed");
+		expect((await readGroup(groupId))?.name).toBe("renamed");
+	});
+
+	// A group's permissions are unioned into every member's, so a partial update
+	// must leave the permissions it doesn't mention untouched. Overwriting the
+	// whole set would silently strip grants the members already relied on.
+	it("merges a partial permission update, preserving the others", async () => {
+		const groupId = await seedGroup(db, {
+			permissions: { create_ref: true, upload_file: true },
+		});
+
+		const group = await updateGroup(db, groupId, {
+			permissions: { create_sample: true, upload_file: false },
+		});
+
+		expect(group.permissions).toEqual({
+			...NO_PERMISSIONS,
+			create_ref: true,
+			create_sample: true,
+			upload_file: false,
+		});
+		expect((await readGroup(groupId))?.permissions).toEqual(group.permissions);
+	});
+
+	it("returns the current group unchanged when given nothing to change", async () => {
+		const groupId = await seedGroup(db, {
+			name: "technicians",
+			permissions: { create_ref: true },
+		});
+
+		const group = await updateGroup(db, groupId, {});
+
+		expect(group.name).toBe("technicians");
+		expect(group.permissions).toEqual({ ...NO_PERMISSIONS, create_ref: true });
+	});
+
+	it("rejects a rename that collides with another group", async () => {
+		await seedGroup(db, { name: "technicians" });
+		const groupId = await seedGroup(db, { name: "admins" });
+
+		await expect(
+			updateGroup(db, groupId, { name: "technicians" }),
+		).rejects.toBeInstanceOf(GroupConflictError);
+	});
+
+	it("throws when the group does not exist", async () => {
+		await expect(
+			updateGroup(db, 404, { name: "renamed" }),
+		).rejects.toBeInstanceOf(GroupNotFoundError);
+	});
+});
+
+describe("deleteGroup", () => {
+	it("deletes the group and its membership rows", async () => {
+		const groupId = await seedGroup(db);
+		const userId = await seedUser(db);
+		await addToGroup(db, userId, groupId);
+
+		await deleteGroup(db, groupId);
+
+		expect(await readGroup(groupId)).toBeUndefined();
+		expect(
+			await db.select().from(userGroups).where(eq(userGroups.groupId, groupId)),
+		).toHaveLength(0);
+		// The user itself survives; only the membership is gone.
+		expect(
+			await db.select().from(users).where(eq(users.id, userId)),
+		).toHaveLength(1);
+	});
+
+	it("throws when the group does not exist", async () => {
+		await expect(deleteGroup(db, 404)).rejects.toBeInstanceOf(
+			GroupNotFoundError,
+		);
+	});
+});

--- a/apps/web/src/server/users/data.test.ts
+++ b/apps/web/src/server/users/data.test.ts
@@ -4,12 +4,23 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { verifyPassword } from "../auth/password";
 import { seedSession, seedUser } from "../auth/test/fixtures";
 import type { Db } from "../db/pg";
+import { groups, userGroups } from "../db/schema/groups";
 import { sessions } from "../db/schema/sessions";
 import { users } from "../db/schema/users";
 import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { addToGroup, seedGroup } from "../groups/test/fixtures";
 import {
+	createUser,
+	findUsers,
 	GroupMembershipError,
 	getAccount,
+	getAdministratorRole,
+	getUser,
+	getUserCount,
+	listAdministratorRoles,
+	listUsers,
+	setAdministratorRole,
+	UserConflictError,
 	UserNotFoundError,
 	updateUser,
 } from "./data";
@@ -28,6 +39,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
 	await db.delete(users);
+	await db.delete(groups);
 });
 
 const settings = {
@@ -172,5 +184,271 @@ describe("updateUser", () => {
 
 		expect(await countSessions(userId)).toBe(1);
 		expect((await readUser(userId))?.active).toBe(true);
+	});
+
+	it("replaces group membership, keeping the primary flag on a group that stays", async () => {
+		const userId = await seedUser(db);
+		const keep = await seedGroup(db, { name: "keep" });
+		const drop = await seedGroup(db, { name: "drop" });
+		const add = await seedGroup(db, { name: "add" });
+		await updateUser(db, userId, { groups: [keep, drop], primary_group: keep });
+
+		await updateUser(db, userId, { groups: [keep, add] });
+
+		const memberships = await db
+			.select()
+			.from(userGroups)
+			.where(eq(userGroups.userId, userId));
+		expect(memberships.map((row) => row.groupId).sort()).toEqual(
+			[keep, add].sort(),
+		);
+		// The primary survives because its group is still a member.
+		const primary = memberships.find((row) => row.primary);
+		expect(primary?.groupId).toBe(keep);
+	});
+
+	it("promotes a group the user belongs to and demotes the previous primary", async () => {
+		const userId = await seedUser(db);
+		const first = await seedGroup(db, { name: "first" });
+		const second = await seedGroup(db, { name: "second" });
+		await addToGroup(db, userId, first);
+		await addToGroup(db, userId, second);
+
+		await updateUser(db, userId, { primary_group: first });
+		await updateUser(db, userId, { primary_group: second });
+
+		const memberships = await db
+			.select()
+			.from(userGroups)
+			.where(eq(userGroups.userId, userId));
+		expect(
+			memberships.filter((row) => row.primary).map((row) => row.groupId),
+		).toEqual([second]);
+	});
+
+	it("clears the primary group", async () => {
+		const userId = await seedUser(db);
+		const groupId = await seedGroup(db);
+		await addToGroup(db, userId, groupId);
+		await updateUser(db, userId, { primary_group: groupId });
+
+		await updateUser(db, userId, { primary_group: null });
+
+		const memberships = await db
+			.select()
+			.from(userGroups)
+			.where(eq(userGroups.userId, userId));
+		expect(memberships.every((row) => !row.primary)).toBe(true);
+	});
+
+	it("rejects a primary group the user does not belong to", async () => {
+		const userId = await seedUser(db);
+		const groupId = await seedGroup(db);
+
+		await expect(
+			updateUser(db, userId, { primary_group: groupId }),
+		).rejects.toBeInstanceOf(GroupMembershipError);
+	});
+
+	it("throws when the user does not exist", async () => {
+		await expect(
+			updateUser(db, 404, { handle: "ghost" }),
+		).rejects.toBeInstanceOf(UserNotFoundError);
+	});
+});
+
+describe("getUserCount", () => {
+	it("counts every user row", async () => {
+		expect(await getUserCount(db)).toBe(0);
+		await seedUser(db, { handle: "alice" });
+		await seedUser(db, { handle: "bob" });
+		expect(await getUserCount(db)).toBe(2);
+	});
+});
+
+describe("listUsers", () => {
+	it("returns only active users, handle-ascending and case-insensitively", async () => {
+		await seedUser(db, { handle: "Charlie" });
+		await seedUser(db, { handle: "alice" });
+		await seedUser(db, { handle: "bob", active: false });
+
+		const result = await listUsers(db);
+
+		expect(result.map((user) => user.handle)).toEqual(["alice", "Charlie"]);
+	});
+});
+
+describe("findUsers", () => {
+	it("filters by handle substring", async () => {
+		await seedUser(db, { handle: "alice" });
+		await seedUser(db, { handle: "malice" });
+		await seedUser(db, { handle: "bob" });
+
+		const result = await findUsers(db, { term: "lice" });
+
+		expect(result.items.map((user) => user.handle)).toEqual([
+			"alice",
+			"malice",
+		]);
+		expect(result.found_count).toBe(2);
+		expect(result.total_count).toBe(3);
+	});
+
+	it("filters to administrators and to non-administrators", async () => {
+		await seedUser(db, { handle: "admin", administratorRole: "full" });
+		await seedUser(db, { handle: "regular" });
+
+		const admins = await findUsers(db, { administrator: true });
+		const regulars = await findUsers(db, { administrator: false });
+
+		expect(admins.items.map((user) => user.handle)).toEqual(["admin"]);
+		expect(regulars.items.map((user) => user.handle)).toEqual(["regular"]);
+	});
+
+	it("excludes inactive users by default and includes them on request", async () => {
+		await seedUser(db, { handle: "alice" });
+		await seedUser(db, { handle: "bob", active: false });
+
+		const active = await findUsers(db, {});
+		const inactive = await findUsers(db, { active: false });
+
+		expect(active.items.map((user) => user.handle)).toEqual(["alice"]);
+		expect(inactive.items.map((user) => user.handle)).toEqual(["bob"]);
+	});
+
+	it("paginates and reports the page count", async () => {
+		for (const handle of ["a", "b", "c"]) {
+			await seedUser(db, { handle });
+		}
+
+		const page1 = await findUsers(db, { page: 1, perPage: 2 });
+		const page2 = await findUsers(db, { page: 2, perPage: 2 });
+
+		expect(page1.items.map((user) => user.handle)).toEqual(["a", "b"]);
+		expect(page2.items.map((user) => user.handle)).toEqual(["c"]);
+		expect(page1.page_count).toBe(2);
+	});
+});
+
+describe("getUser", () => {
+	it("merges permissions across the user's groups and names the primary", async () => {
+		const userId = await seedUser(db, { handle: "alice" });
+		const refs = await seedGroup(db, {
+			name: "refs",
+			permissions: { create_ref: true },
+		});
+		const samples = await seedGroup(db, {
+			name: "samples",
+			permissions: { create_sample: true },
+		});
+		await addToGroup(db, userId, refs);
+		await addToGroup(db, userId, samples);
+		await updateUser(db, userId, { primary_group: samples });
+
+		const user = await getUser(db, userId);
+
+		expect(user.permissions).toMatchObject({
+			create_ref: true,
+			create_sample: true,
+			upload_file: false,
+		});
+		expect(user.groups.map((group) => group.name)).toEqual(["refs", "samples"]);
+		expect(user.primary_group).toMatchObject({ id: samples, name: "samples" });
+	});
+
+	it("throws when the user does not exist", async () => {
+		await expect(getUser(db, 404)).rejects.toBeInstanceOf(UserNotFoundError);
+	});
+});
+
+describe("createUser", () => {
+	it("creates a user with the default settings and no administrator role", async () => {
+		const user = await createUser(db, {
+			handle: "alice",
+			password: "a-real-password",
+			forceReset: true,
+		});
+
+		expect(user).toMatchObject({
+			handle: "alice",
+			administrator_role: null,
+			active: true,
+			force_reset: true,
+			groups: [],
+			primary_group: null,
+		});
+
+		const [row] = await db.select().from(users).where(eq(users.id, user.id));
+		expect(row?.settings).toEqual({
+			skip_quick_analyze_dialog: true,
+			show_ids: true,
+			show_versions: true,
+			quick_analyze_workflow: "pathoscope",
+		});
+		// The password is hashed, not stored verbatim.
+		expect(
+			await verifyPassword("a-real-password", row?.password as Buffer),
+		).toBe(true);
+	});
+
+	it("rejects a duplicate handle", async () => {
+		await createUser(db, {
+			handle: "alice",
+			password: "a-real-password",
+			forceReset: false,
+		});
+
+		await expect(
+			createUser(db, {
+				handle: "alice",
+				password: "another-password",
+				forceReset: false,
+			}),
+		).rejects.toBeInstanceOf(UserConflictError);
+	});
+});
+
+describe("setAdministratorRole", () => {
+	it("assigns and clears the administrator role", async () => {
+		const userId = await seedUser(db);
+
+		const promoted = await setAdministratorRole(db, userId, "full");
+		expect(promoted.administrator_role).toBe("full");
+
+		const demoted = await setAdministratorRole(db, userId, null);
+		expect(demoted.administrator_role).toBeNull();
+	});
+
+	it("throws when the user does not exist", async () => {
+		await expect(setAdministratorRole(db, 404, "full")).rejects.toBeInstanceOf(
+			UserNotFoundError,
+		);
+	});
+});
+
+describe("getAdministratorRole", () => {
+	it("returns the role, or null when there is none", async () => {
+		const admin = await seedUser(db, {
+			handle: "admin",
+			administratorRole: "settings",
+		});
+		const regular = await seedUser(db, { handle: "regular" });
+
+		expect(await getAdministratorRole(db, admin)).toBe("settings");
+		expect(await getAdministratorRole(db, regular)).toBeNull();
+	});
+});
+
+describe("listAdministratorRoles", () => {
+	it("lists every assignable administrator role", async () => {
+		const roles = listAdministratorRoles();
+
+		expect(roles.map((role) => role.id)).toEqual([
+			"full",
+			"settings",
+			"spaces",
+			"users",
+			"base",
+		]);
 	});
 });


### PR DESCRIPTION
## Summary
- Add integration tests for `server/users/data.ts`, `server/groups/data.ts`, and `server/auth/core.ts` that exercise Postgres via `createTestDatabase()` instead of mocks
- `groups/data.ts` had no tests at all; `users/data.ts` and `auth/core.ts` had only narrow single-bug regression tests — this fills out the remaining coverage across all three modules
- Closes out coverage gaps on the auth-handoff data layer ahead of further migration work