### PR TITLE
test: add axe-core accessibility checks to the test harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -742,7 +742,12 @@ and make commits easier to find later.
   `fireEvent`.
 - **Queries:** Prefer accessible queries (`getByRole`,
   `getByLabelText`) over `getByTestId`; don't disambiguate by index.
+- **Accessibility:** `expectNoViolations(container)` from
+  `src/tests/axe.ts` runs axe-core over a rendered subtree. Opt-in per
+  test, not auto-run in `renderWithProviders`; the `color-contrast` rule
+  is disabled under jsdom.
 
 See [docs/testing.md](docs/testing.md) for the unit / integration
 layer split, where to mock depending on migration state, snapshot
-guidance, and the shared-fixtures rule.
+guidance, the axe-core accessibility helper, and the shared-fixtures
+rule.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -72,6 +72,7 @@
 		"@types/react-dom": "^19.2.3",
 		"@types/superagent": "^8.1.9",
 		"@vitejs/plugin-react": "^6.0.3",
+		"axe-core": "^4.12.1",
 		"babel-plugin-react-compiler": "^1.0.0",
 		"drizzle-kit": "^0.31.10",
 		"jsdom": "^29.1.0",

--- a/apps/web/src/tests/__tests__/axe.test.tsx
+++ b/apps/web/src/tests/__tests__/axe.test.tsx
@@ -1,0 +1,38 @@
+import { renderWithProviders } from "@tests/setup";
+import { describe, expect, it } from "vitest";
+import { expectNoViolations } from "../axe";
+
+describe("expectNoViolations", () => {
+	it("passes an accessible tree", async () => {
+		const { container } = renderWithProviders(
+			<main>
+				<h1>Samples</h1>
+				<button type="button">Create</button>
+				<label>
+					Name
+					<input type="text" />
+				</label>
+			</main>,
+		);
+
+		await expectNoViolations(container);
+	});
+
+	it("reports a violation with the rule id and offending node", async () => {
+		// An input with no associated label is a well-known axe barrier.
+		const { container } = renderWithProviders(<input type="text" />);
+
+		await expect(expectNoViolations(container)).rejects.toThrow(/label/);
+	});
+
+	it("does not flag colour contrast, which jsdom cannot compute", async () => {
+		const { container } = renderWithProviders(
+			<main>
+				<h1>Low contrast heading</h1>
+				<p style={{ color: "#eee", background: "#fff" }}>Barely visible</p>
+			</main>,
+		);
+
+		await expectNoViolations(container);
+	});
+});

--- a/apps/web/src/tests/__tests__/axe.test.tsx
+++ b/apps/web/src/tests/__tests__/axe.test.tsx
@@ -1,6 +1,7 @@
 import { renderWithProviders } from "@tests/setup";
+import type { Result } from "axe-core";
 import { describe, expect, it } from "vitest";
-import { expectNoViolations } from "../axe";
+import { expectNoViolations, formatViolations } from "../axe";
 
 describe("expectNoViolations", () => {
 	it("passes an accessible tree", async () => {
@@ -18,11 +19,13 @@ describe("expectNoViolations", () => {
 		await expectNoViolations(container);
 	});
 
-	it("reports a violation with the rule id and offending node", async () => {
+	it("rejects when a barrier is present", async () => {
 		// An input with no associated label is a well-known axe barrier.
 		const { container } = renderWithProviders(<input type="text" />);
 
-		await expect(expectNoViolations(container)).rejects.toThrow(/label/);
+		await expect(expectNoViolations(container)).rejects.toThrow(
+			/expected no accessibility violations, found \d+/,
+		);
 	});
 
 	it("does not flag colour contrast, which jsdom cannot compute", async () => {
@@ -34,5 +37,35 @@ describe("expectNoViolations", () => {
 		);
 
 		await expectNoViolations(container);
+	});
+
+	it("formats multiple nodes, unknown impact, and multi-line summaries", () => {
+		const violations = [
+			{
+				id: "image-alt",
+				impact: null,
+				help: "Images must have alternate text",
+				helpUrl: "https://example.com/image-alt",
+				nodes: [
+					{
+						html: "<img src=first>",
+						failureSummary: "Fix any of the following:\n  Element has no alt",
+					},
+					{ html: "<img src=second>" },
+				],
+			},
+		] as unknown as Result[];
+
+		const output = formatViolations(violations);
+
+		// Unknown impact falls back to "unknown".
+		expect(output).toContain("image-alt (unknown):");
+		// Every offending node appears.
+		expect(output).toContain("<img src=first>");
+		expect(output).toContain("<img src=second>");
+		// The multi-line failure summary is indented under its node.
+		expect(output).toContain(
+			"    Fix any of the following:\n      Element has no alt",
+		);
 	});
 });

--- a/apps/web/src/tests/axe.ts
+++ b/apps/web/src/tests/axe.ts
@@ -1,0 +1,48 @@
+import axe, { type Result, type RunOptions } from "axe-core";
+
+// `color-contrast` needs a layout engine to compute rendered colours, and jsdom
+// has none — the rule either throws or reports noise. It is checked in a real
+// browser instead (VIR-2693 / VIR-2746), so disable it here.
+const defaultOptions: RunOptions = {
+	rules: {
+		"color-contrast": { enabled: false },
+	},
+};
+
+function formatViolations(violations: Result[]): string {
+	return violations
+		.map((violation) => {
+			const nodes = violation.nodes
+				.map((node) => {
+					const summary = node.failureSummary
+						? `\n    ${node.failureSummary.replace(/\n/g, "\n    ")}`
+						: "";
+					return `  - ${node.html}${summary}`;
+				})
+				.join("\n");
+
+			return `${violation.id} (${violation.impact ?? "unknown"}): ${violation.help}\n  ${violation.helpUrl}\n${nodes}`;
+		})
+		.join("\n\n");
+}
+
+/**
+ * Assert that `container` has no axe-core accessibility violations.
+ *
+ * Opt-in per test rather than run automatically inside `renderWithProviders`,
+ * so adding the harness does not fail every existing test at once and each
+ * barrier can be fixed incrementally. Pass the element returned by a render
+ * helper — usually `container` — or any subtree to scope the check.
+ */
+export async function expectNoViolations(
+	container: Element,
+	options: RunOptions = defaultOptions,
+): Promise<void> {
+	const { violations } = await axe.run(container, options);
+
+	if (violations.length > 0) {
+		throw new Error(
+			`expected no accessibility violations, found ${violations.length}:\n\n${formatViolations(violations)}`,
+		);
+	}
+}

--- a/apps/web/src/tests/axe.ts
+++ b/apps/web/src/tests/axe.ts
@@ -1,15 +1,7 @@
 import axe, { type Result, type RunOptions } from "axe-core";
 
-// `color-contrast` needs a layout engine to compute rendered colours, and jsdom
-// has none — the rule either throws or reports noise. It is checked in a real
-// browser instead (VIR-2693 / VIR-2746), so disable it here.
-const defaultOptions: RunOptions = {
-	rules: {
-		"color-contrast": { enabled: false },
-	},
-};
-
-function formatViolations(violations: Result[]): string {
+/** Render axe violations into a readable, indented block for the failure message. */
+export function formatViolations(violations: Result[]): string {
 	return violations
 		.map((violation) => {
 			const nodes = violation.nodes
@@ -32,13 +24,22 @@ function formatViolations(violations: Result[]): string {
  * Opt-in per test rather than run automatically inside `renderWithProviders`,
  * so adding the harness does not fail every existing test at once and each
  * barrier can be fixed incrementally. Pass the element returned by a render
- * helper — usually `container` — or any subtree to scope the check.
+ * helper — usually `baseElement` — or any subtree to scope the check.
+ *
+ * `color-contrast` needs a layout engine to compute rendered colours, and
+ * jsdom has none — the rule either throws or reports noise, so it is checked
+ * in a real browser instead (VIR-2693 / VIR-2746). It stays disabled unless a
+ * caller re-enables it explicitly through `options.rules`; other options merge
+ * over the defaults.
  */
 export async function expectNoViolations(
 	container: Element,
-	options: RunOptions = defaultOptions,
+	options: RunOptions = {},
 ): Promise<void> {
-	const { violations } = await axe.run(container, options);
+	const { violations } = await axe.run(container, {
+		...options,
+		rules: { "color-contrast": { enabled: false }, ...options.rules },
+	});
 
 	if (violations.length > 0) {
 		throw new Error(

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -158,6 +158,31 @@ one. Add an accessible name instead. Indexing into a list of
 intrinsically ordered, equivalent items (rows in a table, cards in a
 list) is fine.
 
+## Accessibility
+
+`expectNoViolations(container)` from `apps/web/src/tests/axe.ts` runs
+axe-core over a rendered subtree and fails the test if it finds any
+violation, reporting the rule, the offending node, and axe's fix
+summary. Render as usual, then assert:
+
+```ts
+const { container } = renderWithProviders(<CreateSample />);
+await expectNoViolations(container);
+```
+
+It is **opt-in per test**, not baked into `renderWithProviders`. Wiring
+it into every render would fail the whole suite on the first barrier and
+force an all-or-nothing fix; instead each test adopts it as its
+component is made accessible. Prefer it over Biome's static JSX lint for
+anything rendered at runtime — component-wrapped elements, d3 SVG,
+label/input splits, and ARIA props that a component drops all slip past a
+source-level check.
+
+The `color-contrast` rule is disabled: jsdom has no layout engine to
+compute rendered colours, so contrast is checked in a real browser
+instead (VIR-2746). Pass a second `RunOptions` argument to override the
+default rule set for a single call.
+
 ## Shared test fixtures
 
 When two or more test files share the same bootstrap, seed data, or

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -160,15 +160,22 @@ list) is fine.
 
 ## Accessibility
 
-`expectNoViolations(container)` from `apps/web/src/tests/axe.ts` runs
+`expectNoViolations(element)` from `apps/web/src/tests/axe.ts` runs
 axe-core over a rendered subtree and fails the test if it finds any
 violation, reporting the rule, the offending node, and axe's fix
 summary. Render as usual, then assert:
 
 ```ts
-const { container } = renderWithProviders(<CreateSample />);
-await expectNoViolations(container);
+const { baseElement } = renderWithProviders(<CreateSample />);
+await expectNoViolations(baseElement);
 ```
+
+Scan `baseElement` (the render's `document.body`) for a full-component
+check, not `container`. Radix-portalled UI — dialogs, selects,
+dropdowns, popovers, tooltips — renders outside `container` under
+`document.body`, so a `container`-scoped scan silently skips the open
+overlay and can pass while its content has violations. Reserve
+`container` for a deliberately scoped subtree check.
 
 It is **opt-in per test**, not baked into `renderWithProviders`. Wiring
 it into every render would fail the whole suite on the first barrier and
@@ -180,8 +187,9 @@ source-level check.
 
 The `color-contrast` rule is disabled: jsdom has no layout engine to
 compute rendered colours, so contrast is checked in a real browser
-instead (VIR-2746). Pass a second `RunOptions` argument to override the
-default rule set for a single call.
+instead (VIR-2746). Pass a second `RunOptions` argument to add or
+override rules for a single call; it merges over the defaults, so
+`color-contrast` stays off unless you re-enable it explicitly.
 
 ## Shared test fixtures
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      axe-core:
+        specifier: ^4.12.1
+        version: 4.12.1
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -3583,6 +3586,10 @@ packages:
 
   attr-accept@2.2.5:
     resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
+    engines: {node: '>=4'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
 
   b4a@1.8.1:
@@ -10220,6 +10227,8 @@ snapshots:
   atomic-sleep@1.0.0: {}
 
   attr-accept@2.2.5: {}
+
+  axe-core@4.12.1: {}
 
   b4a@1.8.1: {}
 


### PR DESCRIPTION
## Summary
- Add `expectNoViolations(container)` in `apps/web/src/tests/axe.ts`, running axe-core over a rendered subtree and reporting the rule, offending node, and fix summary on failure
- Opt-in per test rather than wired into `renderWithProviders`, so adopting the harness doesn't fail the whole suite at once; `color-contrast` is disabled since jsdom has no layout engine to compute it
- Document the helper in `docs/testing.md` and `AGENTS.md`