### PR TITLE
chore: stop reporting expected auth rejections to Sentry

### DIFF
--- a/apps/web/src/instrument.server.ts
+++ b/apps/web/src/instrument.server.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/tanstackstart-react";
+import { dropExpectedAuthErrors } from "@server/sentryFilters";
 import { getCommonOptions } from "@virtool/sentry";
 
 // Server-side Sentry initialisation. Imported for its side effect at the top of
@@ -17,6 +18,7 @@ if (options.dsn) {
 	Sentry.init({
 		...options,
 		integrations: [nodeProfilingIntegration()],
+		beforeSend: dropExpectedAuthErrors,
 	});
 
 	// Import the logger lazily and only after `Sentry.init`. `@server/logger`

--- a/apps/web/src/server/__tests__/sentryFilters.test.ts
+++ b/apps/web/src/server/__tests__/sentryFilters.test.ts
@@ -1,0 +1,63 @@
+import type { ErrorEvent, EventHint } from "@sentry/tanstackstart-react";
+import {
+	FORBIDDEN_ERROR_NAME,
+	UNAUTHORIZED_ERROR_NAME,
+} from "@virtool/contracts";
+import { describe, expect, it } from "vitest";
+
+import { dropExpectedAuthErrors } from "../sentryFilters";
+
+function authError(name: string): Error {
+	const error = new Error(
+		name === UNAUTHORIZED_ERROR_NAME ? "Unauthorized" : "Forbidden",
+	);
+	error.name = name;
+	return error;
+}
+
+function eventWithType(type: string): ErrorEvent {
+	return { exception: { values: [{ type }] } } as ErrorEvent;
+}
+
+describe("dropExpectedAuthErrors", () => {
+	it("drops an event whose original exception is an UnauthorizedError", () => {
+		const result = dropExpectedAuthErrors(
+			{} as ErrorEvent,
+			{
+				originalException: authError(UNAUTHORIZED_ERROR_NAME),
+			} as EventHint,
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it("drops an event whose original exception is a ForbiddenError", () => {
+		const result = dropExpectedAuthErrors(
+			{} as ErrorEvent,
+			{
+				originalException: authError(FORBIDDEN_ERROR_NAME),
+			} as EventHint,
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it("drops an event that reports an auth error type when the original exception is absent", () => {
+		const event = eventWithType(UNAUTHORIZED_ERROR_NAME);
+
+		expect(dropExpectedAuthErrors(event, {} as EventHint)).toBeNull();
+	});
+
+	it("keeps an unrelated error event", () => {
+		const event = eventWithType("TypeError");
+		const hint = { originalException: new TypeError("boom") } as EventHint;
+
+		expect(dropExpectedAuthErrors(event, hint)).toBe(event);
+	});
+
+	it("keeps an event with no exception details", () => {
+		const event = {} as ErrorEvent;
+
+		expect(dropExpectedAuthErrors(event, {} as EventHint)).toBe(event);
+	});
+});

--- a/apps/web/src/server/sentryFilters.ts
+++ b/apps/web/src/server/sentryFilters.ts
@@ -1,0 +1,48 @@
+import type { ErrorEvent, EventHint } from "@sentry/tanstackstart-react";
+import {
+	FORBIDDEN_ERROR_NAME,
+	UNAUTHORIZED_ERROR_NAME,
+} from "@virtool/contracts";
+
+const EXPECTED_AUTH_ERROR_NAMES = new Set<string>([
+	UNAUTHORIZED_ERROR_NAME,
+	FORBIDDEN_ERROR_NAME,
+]);
+
+/**
+ * Sentry `beforeSend` hook that drops the auth middleware's expected 401/403
+ * rejections before they are reported.
+ *
+ * A server function called without a valid session throws `UnauthorizedError`
+ * (or `ForbiddenError` for an insufficient role) by design — the client's query
+ * retry guard reads the error name and bounces to the login wall. These are
+ * routine control flow, not incidents, so reporting them only buries real
+ * errors in noise.
+ */
+export function dropExpectedAuthErrors(
+	event: ErrorEvent,
+	hint: EventHint,
+): ErrorEvent | null {
+	if (
+		isExpectedAuthError(hint.originalException) ||
+		eventReportsAuthError(event)
+	) {
+		return null;
+	}
+	return event;
+}
+
+function isExpectedAuthError(exception: unknown): boolean {
+	return (
+		exception instanceof Error && EXPECTED_AUTH_ERROR_NAMES.has(exception.name)
+	);
+}
+
+function eventReportsAuthError(event: ErrorEvent): boolean {
+	return (
+		event.exception?.values?.some(
+			(value) =>
+				value.type !== undefined && EXPECTED_AUTH_ERROR_NAMES.has(value.type),
+		) ?? false
+	);
+}


### PR DESCRIPTION
## Summary

- Auth middleware throws `UnauthorizedError`/`ForbiddenError` by design on missing/insufficient sessions, but Sentry's server-function instrumentation was capturing these routine 401/403s as incidents (VIRTOOL-5).
- Add a `beforeSend` hook that drops events whose exception matches one of the expected auth error names, keyed on the shared name constants from `@virtool/contracts`.