### PR TITLE
fix: upload Sentry source maps by passing auth token into the build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,8 +32,6 @@ jobs:
               uses: docker/build-push-action@v7
               with:
                   target: dist
-                  secrets: |
-                      sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
     check-biome:
         name: Biome
         runs-on: ubuntu-24.04
@@ -155,3 +153,5 @@ jobs:
                   tags: ${{ steps.meta.outputs.tags }}
                   target: dist
                   labels: ${{ steps.meta.outputs.labels }}
+                  secrets: |
+                      sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,8 +32,8 @@ jobs:
               uses: docker/build-push-action@v7
               with:
                   target: dist
-              env:
-                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                  secrets: |
+                      sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
     check-biome:
         name: Biome
         runs-on: ubuntu-24.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,13 @@ COPY apps/web ./apps/web
 FROM base AS dev
 
 FROM base AS build
-RUN pnpm --filter @virtool/web build
+# The Sentry Vite plugin uploads source maps only when SENTRY_AUTH_TOKEN is set
+# at build time. Mount it as a BuildKit secret so it is available for this RUN
+# only and never persists in an image layer. Absent (e.g. local builds, forked
+# PRs) the upload gracefully no-ops and the build still succeeds.
+RUN --mount=type=secret,id=sentry_auth_token \
+    SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token 2>/dev/null || true)" \
+    pnpm --filter @virtool/web build
 
 FROM node:24-alpine AS dist
 WORKDIR /ui


### PR DESCRIPTION
## Summary

- Pass `SENTRY_AUTH_TOKEN` into the Docker build as a BuildKit secret so the Sentry Vite plugin can actually upload source maps during CI builds. Previously it was set as a plain `env` var on the `docker/build-push-action` step, which never reached `pnpm build` inside the container, so maps were generated but discarded (errors surfaced with minified symbols like `Ys`).
- Read the secret inside the `pnpm --filter @virtool/web build` `RUN` step so it's available only for that step and never persisted in an image layer.
- Builds still succeed with no token present (local builds, forked PRs), since the upload no-ops when it's absent.