### PR TITLE
fix: resolve job resources without missing junction tables

### DIFF
--- a/apps/web/src/server/db/schema/index.ts
+++ b/apps/web/src/server/db/schema/index.ts
@@ -5,9 +5,11 @@
 // the `export *` list as it lands.
 export * from "./analyses";
 export * from "./groups";
+export * from "./indexes";
 export * from "./jobs";
 export * from "./labels";
 export * from "./messages";
+export * from "./samples";
 export * from "./sessions";
 export * from "./settings";
 export * from "./subtractions";

--- a/apps/web/src/server/db/schema/indexes.ts
+++ b/apps/web/src/server/db/schema/indexes.ts
@@ -1,0 +1,12 @@
+// Partial read-only mirror of the `indexes` table managed by the upstream
+// Python service via Alembic. Only the columns needed to reconstruct a job's
+// `args` are declared here — the indexes domain is not otherwise served from
+// this side yet. Keep in sync with
+// `../../../../../../virtool/virtool/indexes/sql.py`.
+
+import { bigint, integer, pgTable } from "drizzle-orm/pg-core";
+
+export const indexes = pgTable("indexes", {
+	id: bigint("id", { mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
+	job_id: integer("job_id"),
+});

--- a/apps/web/src/server/db/schema/jobs.ts
+++ b/apps/web/src/server/db/schema/jobs.ts
@@ -1,13 +1,13 @@
-// Read-only mirror of the `jobs` table and its resource junction tables,
-// managed by the upstream Python service via Alembic. Do not generate or push
-// migrations from this side. Keep the columns in sync with
-// `../../../../../../virtool/virtool/jobs/pg.py`.
+// Read-only mirror of the `jobs` table, managed by the upstream Python service
+// via Alembic. Do not generate or push migrations from this side. Keep the
+// columns in sync with `../../../../../../virtool/virtool/jobs/pg.py`.
 //
-// The legacy Mongo `args` field is not a column. A job's sample and index
-// resources live in the `job_samples` / `job_indexes` junction tables, while
-// its subtraction and analysis resources are found on the owning rows
-// (`subtractions.job_id`, `analyses.job_id`). All are recombined into `args`
-// when a job is read.
+// The legacy Mongo `args` field is not a column. A job's resources are all
+// found on the owning rows via a reverse `job_id` foreign key —
+// `legacy_samples.job_id`, `indexes.job_id`, `subtractions.job_id`, and
+// `analyses.job_id` — and recombined into `args` when a job is read. There are
+// no `job_samples` / `job_indexes` junction tables: the sample and index are
+// resolved through those reverse foreign keys, not link rows.
 
 import {
 	boolean,
@@ -54,13 +54,3 @@ export const jobs = pgTable("jobs", {
 
 /** A row from the `jobs` table. */
 export type JobRow = typeof jobs.$inferSelect;
-
-export const jobSamples = pgTable("job_samples", {
-	job_id: integer("job_id").primaryKey(),
-	sample_id: text("sample_id").notNull(),
-});
-
-export const jobIndexes = pgTable("job_indexes", {
-	job_id: integer("job_id").primaryKey(),
-	index_id: text("index_id").notNull(),
-});

--- a/apps/web/src/server/db/schema/samples.ts
+++ b/apps/web/src/server/db/schema/samples.ts
@@ -1,0 +1,12 @@
+// Partial read-only mirror of the `legacy_samples` table managed by the
+// upstream Python service via Alembic. Only the columns needed to reconstruct a
+// job's `args` are declared here — the samples domain is not otherwise served
+// from this side yet. Keep in sync with
+// `../../../../../../virtool/virtool/samples/sql.py`.
+
+import { bigint, integer, pgTable } from "drizzle-orm/pg-core";
+
+export const legacySamples = pgTable("legacy_samples", {
+	id: bigint("id", { mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
+	job_id: integer("job_id").unique(),
+});

--- a/apps/web/src/server/jobs/data.test.ts
+++ b/apps/web/src/server/jobs/data.test.ts
@@ -3,7 +3,9 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { seedUser } from "../auth/test/fixtures";
 import type { Db } from "../db/pg";
 import { analyses } from "../db/schema/analyses";
+import { indexes } from "../db/schema/indexes";
 import { jobs } from "../db/schema/jobs";
+import { legacySamples } from "../db/schema/samples";
 import { users } from "../db/schema/users";
 import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
 import { getJob, getJobs, JobNotFoundError } from "./data";
@@ -116,6 +118,44 @@ describe("getJob", () => {
 		const job = await getJob(db, jobId);
 
 		expect(job.args.analysis_id).toBe(String(analysis.id));
+	});
+
+	// A create_sample job's sample is resolved through the reverse
+	// `legacy_samples.job_id` foreign key — there is no `job_samples` link table
+	// — and its integer id is exposed as the `sample_id` arg.
+	it("exposes a linked sample's id as a string arg", async () => {
+		const jobId = await seedJob("succeeded", { started: 0, of: 1 });
+
+		const [sample] = await db
+			.insert(legacySamples)
+			.values({ job_id: jobId })
+			.returning({ id: legacySamples.id });
+		if (!sample) {
+			throw new Error("failed to seed sample");
+		}
+
+		const job = await getJob(db, jobId);
+
+		expect(job.args.sample_id).toBe(String(sample.id));
+	});
+
+	// A build_index job's index is resolved through the reverse `indexes.job_id`
+	// foreign key — there is no `job_indexes` link table — and its integer id is
+	// exposed as the `index_id` arg.
+	it("exposes a linked index's id as a string arg", async () => {
+		const jobId = await seedJob("succeeded", { started: 0, of: 1 });
+
+		const [index] = await db
+			.insert(indexes)
+			.values({ job_id: jobId })
+			.returning({ id: indexes.id });
+		if (!index) {
+			throw new Error("failed to seed index");
+		}
+
+		const job = await getJob(db, jobId);
+
+		expect(job.args.index_id).toBe(String(index.id));
 	});
 });
 

--- a/apps/web/src/server/jobs/data.ts
+++ b/apps/web/src/server/jobs/data.ts
@@ -2,13 +2,9 @@ import { count, desc, eq, inArray } from "drizzle-orm";
 import type { Db } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import { analyses } from "../db/schema/analyses";
-import {
-	type JobClaim,
-	type JobStep,
-	jobIndexes,
-	jobSamples,
-	jobs,
-} from "../db/schema/jobs";
+import { indexes } from "../db/schema/indexes";
+import { type JobClaim, type JobStep, jobs } from "../db/schema/jobs";
+import { legacySamples } from "../db/schema/samples";
 import { subtractions } from "../db/schema/subtractions";
 import { users } from "../db/schema/users";
 import { AppError } from "../errors";
@@ -178,15 +174,16 @@ type JobRowWithResources = Awaited<
 
 function toJob(row: JobRowWithResources): Job {
 	// `args` is reconstructed from the related resources — the legacy Mongo
-	// `args` field is not stored as a column. Samples and indexes come from the
-	// `job_*` junction tables; the subtraction and analysis are found on the
-	// owning rows.
+	// `args` field is not stored as a column. Every resource is found on its
+	// owning row via a reverse `job_id` foreign key, and its integer primary key
+	// is the public identifier the client links to; `args` is a string map, so
+	// each id is stringified.
 	const args: Record<string, string> = {};
 	if (row.sample_id != null) {
-		args.sample_id = row.sample_id;
+		args.sample_id = String(row.sample_id);
 	}
 	if (row.index_id != null) {
-		args.index_id = row.index_id;
+		args.index_id = String(row.index_id);
 	}
 	if (row.subtraction_id != null) {
 		args.subtraction_id = String(row.subtraction_id);
@@ -223,15 +220,15 @@ function selectJobsWithResources(db: Db) {
 			workflow: jobs.workflow,
 			userId: users.id,
 			handle: users.handle,
-			sample_id: jobSamples.sample_id,
-			index_id: jobIndexes.index_id,
+			sample_id: legacySamples.id,
+			index_id: indexes.id,
 			subtraction_id: subtractions.id,
 			analysis_id: analyses.id,
 		})
 		.from(jobs)
 		.innerJoin(users, eq(jobs.user_id, users.id))
-		.leftJoin(jobSamples, eq(jobs.id, jobSamples.job_id))
-		.leftJoin(jobIndexes, eq(jobs.id, jobIndexes.job_id))
+		.leftJoin(legacySamples, eq(jobs.id, legacySamples.job_id))
+		.leftJoin(indexes, eq(jobs.id, indexes.job_id))
 		.leftJoin(subtractions, eq(jobs.id, subtractions.job_id))
 		.leftJoin(analyses, eq(jobs.id, analyses.job_id));
 }


### PR DESCRIPTION
## Summary

- Job listing/detail queries failed with `relation "job_samples" does not exist` because they joined against `job_samples` and `job_indexes` — junction tables that don't exist in the Python-owned Postgres schema. Samples and indexes are actually linked back to a job via their own `job_id` column.
- Replace those joins with reverse `job_id` foreign key lookups against new partial mirrors of the `legacy_samples` and `indexes` tables, matching how `subtraction_id`/`analysis_id` were already resolved and mirroring Python's `JobsData.get`.
- Add coverage in `data.test.ts` asserting a job's `sample_id`/`index_id` args are populated from the linked rows.