### PR TITLE
fix: register reference selection when creating an analysis

### DIFF
--- a/apps/web/src/analyses/components/AnalysisItem.tsx
+++ b/apps/web/src/analyses/components/AnalysisItem.tsx
@@ -96,7 +96,7 @@ export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 						<li>
 							<Link
 								to="/refs/$refId/indexes/$indexId"
-								params={{ refId: reference.id, indexId: index.id }}
+								params={{ refId: reference.id, indexId: String(index.id) }}
 							>
 								Index {index.version}
 							</Link>

--- a/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
+++ b/apps/web/src/analyses/components/Create/CreateAnalysisForm.tsx
@@ -103,7 +103,7 @@ export default function CreateAnalysisForm({
 	async function onSubmit(values: CreateAnalysisFormValues) {
 		const { indexId, subtractionIds, workflow } = values;
 
-		const index = indexes.find((index) => index.id === indexId);
+		const index = indexes.find((index) => String(index.id) === indexId);
 		if (!index) {
 			return;
 		}

--- a/apps/web/src/analyses/components/Create/IndexSelector.tsx
+++ b/apps/web/src/analyses/components/Create/IndexSelector.tsx
@@ -14,7 +14,7 @@ import { Select as SelectPrimitive } from "radix-ui";
 import CreateAnalysisFieldTitle from "./CreateAnalysisFieldTitle";
 
 type IndexSelectorItemProps = {
-	id: string;
+	id: number;
 	name: string;
 	version: number | string;
 };
@@ -35,7 +35,10 @@ function IndexSelectorItem({ id, name, version }: IndexSelectorItemProps) {
 			)}
 			data-slot="select-item"
 			key={id}
-			value={id}
+			// A Radix Select only matches string values, but index ids are
+			// integers, so the value is stringified here and read back as a
+			// string in the form.
+			value={String(id)}
 		>
 			<SelectItemIndicator />
 			<SelectPrimitive.ItemText className="whitespace-nowrap">

--- a/apps/web/src/analyses/components/Create/__tests__/CreateAnalysisForm.test.tsx
+++ b/apps/web/src/analyses/components/Create/__tests__/CreateAnalysisForm.test.tsx
@@ -12,10 +12,11 @@ import { describe, expect, it, vi } from "vitest";
 import CreateAnalysisForm from "../CreateAnalysisForm";
 import { getCompatibleWorkflows } from "../workflows";
 
-async function renderForm() {
+async function renderForm(indexId?: number) {
 	const onClose = vi.fn();
 	const sample = createFakeSample({ subtractions: [] });
 	const index = createFakeIndexMinimal({
+		...(indexId === undefined ? {} : { id: indexId }),
 		ready: true,
 		reference: { id: "ref-1", name: "Plant Viruses", data_type: "genome" },
 	});
@@ -56,6 +57,29 @@ describe("<CreateAnalysisForm>", () => {
 		);
 
 		await selectReference();
+		await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+		await waitFor(() => expect(onClose).toHaveBeenCalled());
+		scope.done();
+	});
+
+	it("registers the selection when the server sends an integer index id", async () => {
+		// The API returns the index id as an integer, but a Radix Select only
+		// matches string values, so an unconverted numeric id silently fails to
+		// register the pick and the form submits nothing.
+		const { onClose, sample } = await renderForm(42);
+
+		const scope = mockApiCreateAnalysis(
+			createFakeAnalysisMinimal({ sample: { id: sample.id } }),
+		);
+
+		await selectReference();
+
+		const trigger = screen
+			.getAllByRole("combobox")
+			.find((element) => element.tagName === "BUTTON");
+		expect(trigger).toHaveTextContent("Plant Viruses");
+
 		await userEvent.click(screen.getByRole("button", { name: "Create" }));
 
 		await waitFor(() => expect(onClose).toHaveBeenCalled());

--- a/apps/web/src/indexes/__tests__/types.test.ts
+++ b/apps/web/src/indexes/__tests__/types.test.ts
@@ -1,0 +1,13 @@
+import { createFakeIndexMinimal } from "@tests/fake/indexes";
+import { describe, expect, it } from "vitest";
+import { indexMinimalSchema } from "../types";
+
+describe("indexMinimalSchema", () => {
+	it("accepts an index whose change_count is null", () => {
+		const index = { ...createFakeIndexMinimal(), change_count: null };
+
+		const parsed = indexMinimalSchema.parse(index);
+
+		expect(parsed.change_count).toBeNull();
+	});
+});

--- a/apps/web/src/indexes/components/Item/IndexItem.tsx
+++ b/apps/web/src/indexes/components/Item/IndexItem.tsx
@@ -6,7 +6,7 @@ import { IndexItemDescription } from "./IndexItemDescription";
 import { IndexItemIcon } from "./IndexItemIcon";
 
 type IndexItemProps = {
-	activeId?: string;
+	activeId?: number;
 	index: IndexMinimal;
 	refId: string;
 };
@@ -27,7 +27,7 @@ export function IndexItem({ activeId, index, refId }: IndexItemProps) {
 				<Link
 					className="font-medium"
 					to="/refs/$refId/indexes/$indexId"
-					params={{ refId, indexId: index.id }}
+					params={{ refId, indexId: String(index.id) }}
 				>
 					Version {index.version}
 				</Link>

--- a/apps/web/src/indexes/components/Item/IndexItemDescription.tsx
+++ b/apps/web/src/indexes/components/Item/IndexItemDescription.tsx
@@ -1,5 +1,5 @@
 type IndexItemDescriptionProps = {
-	changeCount: number;
+	changeCount: number | null;
 	modifiedCount: number;
 };
 

--- a/apps/web/src/indexes/components/Item/IndexItemIcon.tsx
+++ b/apps/web/src/indexes/components/Item/IndexItemIcon.tsx
@@ -3,8 +3,8 @@ import Loader from "@base/Loader";
 import { CircleCheck } from "lucide-react";
 
 type IndexItemIconProps = {
-	activeId?: string;
-	id: string;
+	activeId?: number;
+	id: number;
 	ready: boolean;
 };
 

--- a/apps/web/src/indexes/components/Item/__tests__/IndexItemIcon.test.tsx
+++ b/apps/web/src/indexes/components/Item/__tests__/IndexItemIcon.test.tsx
@@ -5,21 +5,21 @@ import { IndexItemIcon } from "../IndexItemIcon";
 
 describe("<IndexItemIcon />", () => {
 	it("renders the active status for the current ready index", () => {
-		renderWithProviders(<IndexItemIcon activeId="foo" id="foo" ready />);
+		renderWithProviders(<IndexItemIcon activeId={1} id={1} ready />);
 
 		expect(screen.getByText("Active")).toBeInTheDocument();
 	});
 
 	it("hides the status for ready indexes that are not active", () => {
 		const { container } = renderWithProviders(
-			<IndexItemIcon activeId="foo" id="bar" ready />,
+			<IndexItemIcon activeId={1} id={2} ready />,
 		);
 
 		expect(container).toBeEmptyDOMElement();
 	});
 
 	it("renders the building status for a not-ready index", () => {
-		renderWithProviders(<IndexItemIcon id="foo" ready={false} />);
+		renderWithProviders(<IndexItemIcon id={1} ready={false} />);
 
 		expect(screen.getByText("Building")).toBeInTheDocument();
 		expect(screen.getByRole("status", { name: "loading" })).toBeInTheDocument();

--- a/apps/web/src/indexes/queries.ts
+++ b/apps/web/src/indexes/queries.ts
@@ -7,12 +7,15 @@ import {
 	useQueryClient,
 	useSuspenseQuery,
 } from "@tanstack/react-query";
+import { z } from "zod";
 import type { ErrorResponse } from "@/types/api";
-import type {
-	Index,
-	IndexMinimal,
-	IndexSearchResult,
-	UnbuiltChangesSearchResults,
+import {
+	type Index,
+	type IndexMinimal,
+	type IndexSearchResult,
+	indexMinimalSchema,
+	indexSchema,
+	type UnbuiltChangesSearchResults,
 } from "./types";
 
 /**
@@ -37,7 +40,10 @@ export function indexesQueryOptions(
 				.query({ find: term, page, per_page })
 				.then((res) => {
 					const { documents, ...rest } = res.body;
-					return { ...rest, items: documents };
+					return {
+						...rest,
+						items: z.array(indexMinimalSchema).parse(documents),
+					};
 				}),
 	});
 }
@@ -104,7 +110,7 @@ export function useListIndexes({ ready, archived }: ListIndexesOptions) {
 			apiClient
 				.get("/indexes")
 				.query(params)
-				.then((res) => res.body),
+				.then((res) => z.array(indexMinimalSchema).parse(res.body)),
 	});
 }
 
@@ -118,7 +124,10 @@ export function useListIndexes({ ready, archived }: ListIndexesOptions) {
 export function useFetchIndex(indexId: string, enabled = true) {
 	return useQuery<Index, ErrorResponse>({
 		queryKey: indexQueryKeys.detail(indexId),
-		queryFn: () => apiClient.get(`/indexes/${indexId}`).then((res) => res.body),
+		queryFn: () =>
+			apiClient
+				.get(`/indexes/${indexId}`)
+				.then((res) => indexSchema.parse(res.body)),
 		enabled: enabled && Boolean(indexId),
 	});
 }

--- a/apps/web/src/indexes/types.ts
+++ b/apps/web/src/indexes/types.ts
@@ -24,7 +24,7 @@ export type IndexNested = z.infer<typeof indexNestedSchema>;
 
 /** Minimal index data for list views */
 export const indexMinimalSchema = indexNestedSchema.extend({
-	change_count: z.number(),
+	change_count: z.number().nullable(),
 	created_at: z.string(),
 	has_files: z.boolean(),
 	modified_otu_count: z.number(),

--- a/apps/web/src/indexes/types.ts
+++ b/apps/web/src/indexes/types.ts
@@ -1,84 +1,81 @@
 import type { HistoryNested, OtuNested } from "@otus/types";
 import type { ReferenceNested } from "@references/types";
-import type { UserNested } from "@users/types";
+import { z } from "zod";
 import type { SearchResult } from "@/types/api";
 
-/** Basic data for nested representations */
-export type IndexNested = {
-	/** The unique identifier */
-	id: string;
+const referenceNestedSchema = z.object({
+	id: z.string(),
+	data_type: z.string(),
+	name: z.string(),
+});
 
-	/** The build iteration */
-	version: number | string;
-};
+const userNestedSchema = z.object({
+	id: z.int(),
+	handle: z.string(),
+});
+
+const indexNestedSchema = z.object({
+	id: z.int(),
+	version: z.union([z.number(), z.string()]),
+});
+
+/** Basic data for nested representations */
+export type IndexNested = z.infer<typeof indexNestedSchema>;
 
 /** Minimal index data for list views */
-export type IndexMinimal = IndexNested & {
-	/** Total changes included in building the new index */
-	change_count: number;
+export const indexMinimalSchema = indexNestedSchema.extend({
+	change_count: z.number(),
+	created_at: z.string(),
+	has_files: z.boolean(),
+	modified_otu_count: z.number(),
+	reference: referenceNestedSchema,
+	user: userNestedSchema,
+	ready: z.boolean(),
+});
 
-	/** The iso formatted date of creation */
-	created_at: string;
+/** Minimal index data for list views */
+export type IndexMinimal = z.infer<typeof indexMinimalSchema>;
 
-	/** Whether there are downloadable uploads */
-	has_files: boolean;
+const indexContributorSchema = userNestedSchema.extend({
+	count: z.number(),
+});
 
-	/** A count of individual OTUs changed */
-	modified_otu_count: number;
+/** Index editor information */
+export type IndexContributor = z.infer<typeof indexContributorSchema>;
 
-	/** The reference the index is based on */
-	reference: ReferenceNested;
+const indexOTUSchema = z.object({
+	change_count: z.number(),
+	id: z.string(),
+	name: z.string(),
+});
 
-	/** Who initiated index creation */
-	user: UserNested;
+/** Index relevant minimal OTU data */
+export type IndexOTU = z.infer<typeof indexOTUSchema>;
 
-	/** Whether it is ready to view and be used */
-	ready: boolean;
-};
+const indexFileSchema = z.object({
+	download_url: z.string(),
+	id: z.int(),
+	index: z.int(),
+	name: z.string(),
+	size: z.number().optional(),
+	type: z.string(),
+});
 
-/**  Index editor information*/
-export type IndexContributor = UserNested & {
-	/** Total index changes made by the user */
-	count: number;
-};
-
-/** Index relevant minimal OTU data*/
-export type IndexOTU = {
-	/** The quantity of changes made to this otu since last index build */
-	change_count: number;
-	/** The unique identifier */
-	id: string;
-	/** The display name */
-	name: string;
-};
-
-export type IndexFile = {
-	/** The complete file location on API */
-	download_url: string;
-	/** The unique identifier */
-	id: number;
-	/** The unique identifier of the associated index */
-	index: string;
-	/** The display name */
-	name: string;
-	/** The file size in bytes */
-	size?: number;
-	/** The associated workflow */
-	type: string;
-};
+/** A downloadable file produced by an index build */
+export type IndexFile = z.infer<typeof indexFileSchema>;
 
 /** Reference index for use in workflows */
-export type Index = IndexMinimal & {
-	/** Users who contributed to the index*/
-	contributors: IndexContributor[];
-	/** Downloadable index uploads*/
-	files: IndexFile[];
-	/** The last index the OTU was included in */
-	manifest: object;
-	/** OTUs incorporated in the index*/
-	otus: IndexOTU[];
-};
+export const indexSchema = indexMinimalSchema.extend({
+	contributors: z.array(indexContributorSchema),
+	files: z.array(indexFileSchema),
+	manifest: z.record(z.string(), z.unknown()),
+	otus: z.array(indexOTUSchema),
+});
 
+/** Reference index for use in workflows */
+export type Index = z.infer<typeof indexSchema>;
+
+/** An unbuilt change awaiting the next index build */
 export type UnbuiltChanges = HistoryNested & {
 	index: IndexNested;
 	otu: OtuNested;
@@ -92,9 +89,9 @@ export type UnbuiltChangesSearchResults = SearchResult & {
 
 /** Index search results */
 export type IndexSearchResult = SearchResult & {
-	/** Indexes relevant to the query*/
-	items: Index[];
-	/** The number of individual OTUs changes since the last index build */
+	/** Indexes relevant to the query */
+	items: IndexMinimal[];
+	/** The number of individual OTUs changed since the last index build */
 	modified_otu_count: number;
 	/** The number of total OTUs in the reference */
 	total_otu_count: number;

--- a/apps/web/src/jobs/components/__tests__/JobDetail.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobDetail.test.tsx
@@ -1,6 +1,6 @@
 import type { ServerJob } from "@jobs/types";
 import { screen } from "@testing-library/react";
-import { createFakeIndexMinimal } from "@tests/fake/indexes";
+import { createFakeIndex } from "@tests/fake/indexes";
 import { createFakeReferenceNested } from "@tests/fake/references";
 import { mockGetJob } from "@tests/server-fn/jobs";
 import { renderRoute } from "@tests/setup";
@@ -34,8 +34,7 @@ describe("<JobDetail /> build_index links", () => {
 			.get(`/api/indexes/${indexId}`)
 			.reply(
 				200,
-				createFakeIndexMinimal({
-					id: indexId,
+				createFakeIndex({
 					reference: createFakeReferenceNested({ id: refId }),
 				}),
 			);

--- a/apps/web/src/tests/fake/indexes.ts
+++ b/apps/web/src/tests/fake/indexes.ts
@@ -1,5 +1,10 @@
 import { faker } from "@faker-js/faker";
-import type { IndexFile, IndexMinimal, IndexNested } from "@indexes/types";
+import type {
+	Index,
+	IndexFile,
+	IndexMinimal,
+	IndexNested,
+} from "@indexes/types";
 import { createFakeReferenceNested } from "./references";
 import { createFakeUserNested } from "./user";
 
@@ -7,7 +12,7 @@ export function createFakeIndexNested(
 	overrides?: Partial<IndexNested>,
 ): IndexNested {
 	const defaultIndexNested = {
-		id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
+		id: faker.number.int(),
 		version: faker.number.int({ max: 10 }),
 	};
 
@@ -31,11 +36,34 @@ export function createFakeIndexMinimal(
 	return { ...defaultIndexMinimal, ...overrides };
 }
 
+export function createFakeIndex(overrides?: Partial<Index>): Index {
+	const defaultIndex = {
+		...createFakeIndexMinimal(),
+		contributors: [
+			{
+				...createFakeUserNested(),
+				count: faker.number.int({ min: 1, max: 10 }),
+			},
+		],
+		files: [createFakeIndexFile()],
+		manifest: {},
+		otus: [
+			{
+				change_count: faker.number.int({ min: 1, max: 10 }),
+				id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
+				name: faker.word.noun({ strategy: "any-length" }),
+			},
+		],
+	};
+
+	return { ...defaultIndex, ...overrides };
+}
+
 export function createFakeIndexFile(overrides?: Partial<IndexFile>): IndexFile {
 	const defaultIndexFile = {
 		download_url: `/testUrl/${faker.word.noun({ strategy: "any-length" })}`,
 		id: faker.number.int(),
-		index: faker.string.alphanumeric({ casing: "lower", length: 8 }),
+		index: faker.number.int(),
 		name: faker.word.noun({ strategy: "any-length" }),
 		size: faker.number.int({ min: 20000 }),
 		type: "fasta",


### PR DESCRIPTION
## Summary
- Fixed a silent failure where picking a reference in the create-analysis dialog didn't register: the API returns integer index ids, but Radix Select only matches string values, so the selection never matched and the form submitted nothing.
- Stringified the id at the Select boundary and compared as strings on submit, and made index types honest by typing ids as integers throughout.
- Added a zod parse boundary on index API responses so a future server-side type drift fails loudly instead of silently breaking the selector again.