### PR TITLE
fix: surface API contract drift instead of crashing or retrying silently

### DIFF
--- a/apps/web/src/app/__tests__/queryErrors.test.ts
+++ b/apps/web/src/app/__tests__/queryErrors.test.ts
@@ -1,5 +1,5 @@
 import {
-	handleAuthenticationError,
+	handleQueryError,
 	type QueryError,
 	shouldRetryQuery,
 } from "@app/queryErrors";
@@ -15,6 +15,19 @@ vi.mock("@app/session", () => ({
 	armSessionEnd: vi.fn(),
 	endSession,
 }));
+
+const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }));
+
+vi.mock("@sentry/tanstackstart-react", () => ({ captureException }));
+
+// A rejected `.parse()` reaches these functions as a `ZodError`, recognized by
+// its `name` so the guard need not import zod. A plain Error with the name set
+// is exactly that shape.
+function validationError(): Error {
+	const error = new Error("index.id: expected string, received number");
+	error.name = "ZodError";
+	return error;
+}
 
 // The auth errors arrive rebuilt by `authErrorSerializationAdapter`, which
 // carries `name` but nothing else — so a plain Error with the name set is
@@ -63,15 +76,20 @@ describe("shouldRetryQuery", () => {
 		expect(shouldRetryQuery(3, error)).toBe(true);
 		expect(shouldRetryQuery(4, error)).toBe(false);
 	});
+
+	it("gives up immediately on a validation failure that cannot recover", () => {
+		expect(shouldRetryQuery(0, validationError())).toBe(false);
+	});
 });
 
-describe("handleAuthenticationError", () => {
+describe("handleQueryError", () => {
 	afterEach(() => {
 		endSession.mockClear();
+		captureException.mockClear();
 	});
 
 	it("ends the session when a server function rejects the session", () => {
-		handleAuthenticationError(
+		handleQueryError(
 			serializedAuthError(UNAUTHORIZED_ERROR_NAME, "Unauthorized"),
 		);
 
@@ -79,16 +97,35 @@ describe("handleAuthenticationError", () => {
 	});
 
 	it("leaves the session alone when the user merely lacks the role", () => {
-		handleAuthenticationError(
-			serializedAuthError(FORBIDDEN_ERROR_NAME, "Forbidden"),
-		);
+		handleQueryError(serializedAuthError(FORBIDDEN_ERROR_NAME, "Forbidden"));
 
 		expect(endSession).not.toHaveBeenCalled();
 	});
 
 	it("leaves the session alone when a query fails for any other reason", () => {
-		handleAuthenticationError(new Error("network down"));
+		handleQueryError(new Error("network down"));
 
 		expect(endSession).not.toHaveBeenCalled();
+	});
+
+	it("reports a drifted contract to Sentry so it fails loudly", () => {
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		const error = validationError();
+
+		handleQueryError(error);
+
+		expect(captureException).toHaveBeenCalledWith(error, {
+			tags: { contract: "drift" },
+		});
+
+		consoleError.mockRestore();
+	});
+
+	it("does not report an ordinary failure as contract drift", () => {
+		handleQueryError(new Error("network down"));
+
+		expect(captureException).not.toHaveBeenCalled();
 	});
 });

--- a/apps/web/src/app/authErrors.ts
+++ b/apps/web/src/app/authErrors.ts
@@ -21,7 +21,7 @@ type SerializedAuthError = {
  * TanStack Router's built-in `ShallowErrorPlugin` matches every `Error` and
  * serializes only its `message`, so a server function's `UnauthorizedError`
  * reaches the client as a plain `Error` named `"Error"`. That erases the one
- * field the query retry guard and `handleAuthenticationError` use to recognize
+ * field the query retry guard and `handleQueryError` use to recognize
  * a 401/403 — without it, an auth failure is retried ~4× with backoff before
  * the guard can bounce to the login wall. Registered adapters run before the
  * default plugins, so this one re-serializes the auth errors with their `name`

--- a/apps/web/src/app/queryErrors.ts
+++ b/apps/web/src/app/queryErrors.ts
@@ -1,4 +1,5 @@
 import { endSession } from "@app/session";
+import * as Sentry from "@sentry/tanstackstart-react";
 import {
 	FORBIDDEN_ERROR_NAME,
 	UNAUTHORIZED_ERROR_NAME,
@@ -10,9 +11,39 @@ export type QueryError = Error & { response?: { status?: number } };
 const NON_RETRYABLE_STATUSES = new Set([401, 403, 404]);
 
 /**
- * End the session when a query fails because the session is gone.
+ * Whether an error is a zod validation failure — the API returned a payload a
+ * response schema rejected, i.e. the client/server contract has drifted.
  *
- * Wired into the query and mutation caches' `onError`.
+ * Matched by `name` rather than `instanceof ZodError` so this module, which is
+ * reached eagerly from `router.tsx`, does not pull zod into the login-wall
+ * bundle.
+ */
+function isValidationError(error: Error): boolean {
+	return error.name === "ZodError";
+}
+
+/**
+ * Surface a contract-drift validation error to the console and Sentry.
+ *
+ * React Query swallows a rejected `.parse()` into query state, so without this
+ * it reaches neither place and the drift fails silently — which is how the
+ * index integer-id cutover broke the analysis dialog in production unseen
+ * (VIR-2804). The dev console is the only place a developer sees it locally,
+ * where Sentry has no DSN; Sentry carries it in production.
+ */
+function reportContractDrift(error: Error): void {
+	if (import.meta.env.DEV) {
+		// biome-ignore lint/suspicious/noConsole: contract drift is otherwise invisible in local dev, where Sentry has no DSN
+		console.error(error);
+	}
+	Sentry.captureException(error, { tags: { contract: "drift" } });
+}
+
+/**
+ * Handle a settled query or mutation error at the cache boundary.
+ *
+ * Wired into the query and mutation caches' `onError`. Ends the session when it
+ * is gone, and reports a drifted contract so it fails loudly.
  */
 // Server-function errors reach the client with their `name` preserved only
 // because `authErrorSerializationAdapter` (start.ts) carries it past Router's
@@ -21,9 +52,13 @@ const NON_RETRYABLE_STATUSES = new Set([401, 403, 404]);
 //
 // A 403 is deliberately not handled: the session is valid, the user just lacks
 // the role, so bouncing them to the login wall would be wrong.
-export function handleAuthenticationError(error: Error): void {
+export function handleQueryError(error: Error): void {
 	if (error.name === UNAUTHORIZED_ERROR_NAME) {
 		endSession();
+	}
+
+	if (isValidationError(error)) {
+		reportContractDrift(error);
 	}
 }
 
@@ -49,6 +84,12 @@ export function shouldRetryQuery(
 		error.name === UNAUTHORIZED_ERROR_NAME ||
 		error.name === FORBIDDEN_ERROR_NAME
 	) {
+		return false;
+	}
+	// A schema validation failure means the response shape is wrong; the same
+	// request will fail identically, so surface it now instead of after ~4
+	// retries.
+	if (isValidationError(error)) {
 		return false;
 	}
 	return failureCount <= 3;

--- a/apps/web/src/indexes/types.ts
+++ b/apps/web/src/indexes/types.ts
@@ -77,7 +77,7 @@ export type Index = z.infer<typeof indexSchema>;
 
 /** An unbuilt change awaiting the next index build */
 export type UnbuiltChanges = HistoryNested & {
-	index: IndexNested;
+	index: IndexNested | null;
 	otu: OtuNested;
 	reference: ReferenceNested;
 };

--- a/apps/web/src/jobs/components/JobArgs.tsx
+++ b/apps/web/src/jobs/components/JobArgs.tsx
@@ -56,7 +56,7 @@ function AnalysisRows({ sample_id, analysis_id }: AnalysisRowsProps) {
 
 type BuildIndexRowsProps = {
 	/** The unique identifier of the index being built */
-	index_id: string;
+	index_id: number;
 
 	/** The unique identifier of the reference the index is based on */
 	ref_id: string;
@@ -74,7 +74,7 @@ function BuildIndexRows({ index_id, ref_id }: BuildIndexRowsProps) {
 			<JobArgsRow title="Index">
 				<Link
 					to="/refs/$refId/indexes/$indexId"
-					params={{ refId: ref_id, indexId: index_id }}
+					params={{ refId: ref_id, indexId: String(index_id) }}
 				>
 					{index_id}
 				</Link>

--- a/apps/web/src/jobs/components/JobDetail.tsx
+++ b/apps/web/src/jobs/components/JobDetail.tsx
@@ -59,11 +59,11 @@ export default function JobDetail() {
 	// fetches under the same loading gate.
 	const indexId =
 		data?.workflow === "build_index"
-			? (data.args.index_id as string)
+			? (data.args.index_id as number)
 			: undefined;
 	const { data: index, isPending: isIndexPending } = useFetchIndex(
-		indexId ?? "",
-		Boolean(indexId),
+		indexId === undefined ? "" : String(indexId),
+		indexId !== undefined,
 	);
 
 	if (!Number.isInteger(numericJobId)) {
@@ -77,7 +77,7 @@ export default function JobDetail() {
 		throw error;
 	}
 
-	if (isPending || (indexId && isIndexPending)) {
+	if (isPending || (indexId !== undefined && isIndexPending)) {
 		return <LoadingPlaceholder />;
 	}
 

--- a/apps/web/src/jobs/components/__tests__/JobArgs.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobArgs.test.tsx
@@ -6,9 +6,9 @@ import JobArgs from "../JobArgs";
 const workflows = [
 	{
 		workflow: "build_index",
-		args: { index_id: "idx1", ref_id: "ref1" },
+		args: { index_id: 41, ref_id: "ref1" },
 		links: [
-			{ name: "idx1", href: "/refs/ref1/indexes/idx1" },
+			{ name: "41", href: "/refs/ref1/indexes/41" },
 			{ name: "ref1", href: "/refs/ref1" },
 		],
 	},

--- a/apps/web/src/jobs/components/__tests__/JobDetail.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobDetail.test.tsx
@@ -7,7 +7,7 @@ import { renderRoute } from "@tests/setup";
 import nock from "nock";
 import { afterEach, describe, expect, it } from "vitest";
 
-function createBuildIndexJob(indexId: string): ServerJob {
+function createBuildIndexJob(indexId: number): ServerJob {
 	return {
 		args: { index_id: indexId },
 		id: 123,
@@ -27,7 +27,7 @@ describe("<JobDetail /> build_index links", () => {
 
 	it("derives the reference id from the index so both links resolve", async () => {
 		const refId = "reference-1";
-		const indexId = "index-1";
+		const indexId = 41;
 
 		const getJob = mockGetJob(123, createBuildIndexJob(indexId));
 		nock("http://localhost")
@@ -44,7 +44,7 @@ describe("<JobDetail /> build_index links", () => {
 		const referenceLink = await screen.findByRole("link", { name: refId });
 		expect(referenceLink).toHaveAttribute("href", `/refs/${refId}`);
 
-		const indexLink = screen.getByRole("link", { name: indexId });
+		const indexLink = screen.getByRole("link", { name: String(indexId) });
 		expect(indexLink).toHaveAttribute(
 			"href",
 			`/refs/${refId}/indexes/${indexId}`,

--- a/apps/web/src/otus/components/Detail/History/OtuHistory.tsx
+++ b/apps/web/src/otus/components/Detail/History/OtuHistory.tsx
@@ -13,7 +13,7 @@ export default function OtuHistory() {
 	const { data } = useSuspenseOtuHistory(otuId);
 
 	const changes = groupBy(data, (change) =>
-		change.index.version === "unbuilt" ? "unbuilt" : "built",
+		change.index === null ? "unbuilt" : "built",
 	);
 
 	return (

--- a/apps/web/src/otus/types.ts
+++ b/apps/web/src/otus/types.ts
@@ -57,7 +57,8 @@ export type HistoryNested = {
 };
 
 export type OtuHistory = HistoryNested & {
-	index: IndexNested;
+	/** The index the change was built into, or `null` while it is unbuilt */
+	index: IndexNested | null;
 	otu: OtuNested;
 	reference: ReferenceNested;
 };

--- a/apps/web/src/references/components/Detail/LatestBuild.tsx
+++ b/apps/web/src/references/components/Detail/LatestBuild.tsx
@@ -22,7 +22,7 @@ export function LatestBuild({ id, latestBuild }: LatestBuildProps) {
 					<strong>
 						<Link
 							to="/refs/$refId/indexes/$indexId"
-							params={{ refId: id, indexId: latestBuild.id }}
+							params={{ refId: id, indexId: String(latestBuild.id) }}
 						>
 							Index {latestBuild.version}
 						</Link>

--- a/apps/web/src/references/types.ts
+++ b/apps/web/src/references/types.ts
@@ -77,7 +77,7 @@ export type ReferenceInstalled = {
 
 export type ReferenceBuild = {
 	created_at: string;
-	id: string;
+	id: number;
 	user: UserNested;
 	version: number;
 	has_json: boolean;

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,4 +1,4 @@
-import { handleAuthenticationError, shouldRetryQuery } from "@app/queryErrors";
+import { handleQueryError, shouldRetryQuery } from "@app/queryErrors";
 import { readSentryDsn } from "@app/sentryDsn";
 import RouteError from "@base/RouteError";
 import * as Sentry from "@sentry/tanstackstart-react";
@@ -11,8 +11,8 @@ import { routeTree } from "./routeTree.gen";
 
 export function getRouter() {
 	const queryClient = new QueryClient({
-		queryCache: new QueryCache({ onError: handleAuthenticationError }),
-		mutationCache: new MutationCache({ onError: handleAuthenticationError }),
+		queryCache: new QueryCache({ onError: handleQueryError }),
+		mutationCache: new MutationCache({ onError: handleQueryError }),
 		defaultOptions: {
 			queries: {
 				retry: shouldRetryQuery,


### PR DESCRIPTION
## Summary

- Fix the OTU history page crashing for references with unbuilt changes — the backend's index integer-id cutover changed the unbuilt sentinel from `{"id":"unbuilt",...}` to `null`, which the history grouping didn't handle; also reconciles `ReferenceBuild.id` and the `build_index` job's `index_id` to the same integer type so the type system catches future drift.
- Stop retrying and silently swallowing zod validation failures: `shouldRetryQuery` now gives up immediately on a schema mismatch, and the shared `onError` handler (renamed `handleQueryError`) reports it via `console.error` in dev and `Sentry.captureException` (tagged `contract: "drift"`) everywhere else, so a client/server contract drift like this one is caught loudly instead of surfacing only as a generic "couldn't load" spinner.