### PR TITLE
fix: align data model shapes with the api

### DIFF
--- a/apps/web/src/analyses/__tests__/queries.test.tsx
+++ b/apps/web/src/analyses/__tests__/queries.test.tsx
@@ -31,7 +31,7 @@ describe("useCreateAnalysis()", () => {
 		result.current.mutate({
 			sampleId: 1,
 			workflow: "pathoscope_bowtie",
-			refId: "ref-1",
+			refId: 1,
 			subtractionIds: [],
 		});
 

--- a/apps/web/src/analyses/components/AnalysisItem.tsx
+++ b/apps/web/src/analyses/components/AnalysisItem.tsx
@@ -89,14 +89,17 @@ export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 					<Equal size={18} />
 					<SlashList className="m-0">
 						<li>
-							<Link to="/refs/$refId" params={{ refId: reference.id }}>
+							<Link to="/refs/$refId" params={{ refId: String(reference.id) }}>
 								{reference.name}
 							</Link>
 						</li>
 						<li>
 							<Link
 								to="/refs/$refId/indexes/$indexId"
-								params={{ refId: reference.id, indexId: String(index.id) }}
+								params={{
+									refId: String(reference.id),
+									indexId: String(index.id),
+								}}
 							>
 								Index {index.version}
 							</Link>

--- a/apps/web/src/analyses/components/Create/__tests__/CreateAnalysisForm.test.tsx
+++ b/apps/web/src/analyses/components/Create/__tests__/CreateAnalysisForm.test.tsx
@@ -18,7 +18,7 @@ async function renderForm(indexId?: number) {
 	const index = createFakeIndexMinimal({
 		...(indexId === undefined ? {} : { id: indexId }),
 		ready: true,
-		reference: { id: "ref-1", name: "Plant Viruses", data_type: "genome" },
+		reference: { id: 1, name: "Plant Viruses", data_type: "genome" },
 	});
 
 	mockApiListIndexes([index]);

--- a/apps/web/src/analyses/components/Create/__tests__/IndexSelector.test.tsx
+++ b/apps/web/src/analyses/components/Create/__tests__/IndexSelector.test.tsx
@@ -35,7 +35,7 @@ describe("<IndexSelector>", () => {
 
 	it("renders a selectable reference when indexes are available", async () => {
 		const index = createFakeIndexMinimal({
-			reference: { id: "ref-1", name: "Plant Viruses", data_type: "genome" },
+			reference: { id: 1, name: "Plant Viruses", data_type: "genome" },
 			version: 3,
 		});
 

--- a/apps/web/src/analyses/components/Pathoscope/PathoscopeMapping.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/PathoscopeMapping.tsx
@@ -25,7 +25,7 @@ export function AnalysisMappingReferenceTitle({
 }: AnalysisMappingReferenceTitleProps) {
 	return (
 		<div className="flex items-center [&_a]:mr-1">
-			<Link to="/refs/$refId" params={{ refId: reference.id }}>
+			<Link to="/refs/$refId" params={{ refId: String(reference.id) }}>
 				{reference.name}
 			</Link>
 			<Label>{index.version}</Label>

--- a/apps/web/src/analyses/queries.ts
+++ b/apps/web/src/analyses/queries.ts
@@ -82,7 +82,7 @@ export function useGetAnalysis(analysisId: number) {
 }
 
 export type CreateAnalysisParams = {
-	refId?: string;
+	refId?: number;
 	sampleId: number;
 	subtractionIds?: string[];
 	workflow: string;

--- a/apps/web/src/indexes/components/Indexes.tsx
+++ b/apps/web/src/indexes/components/Indexes.tsx
@@ -53,9 +53,7 @@ export default function Indexes({ page, setSearch }: IndexesProps) {
 								key={item.id}
 								index={item}
 								refId={refId}
-								activeId={
-									items.find((index) => index.ready && index.has_files)?.id
-								}
+								activeId={items.find((index) => index.ready)?.id}
 							/>
 						))}
 					</BoxGroup>

--- a/apps/web/src/indexes/types.ts
+++ b/apps/web/src/indexes/types.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import type { SearchResult } from "@/types/api";
 
 const referenceNestedSchema = z.object({
-	id: z.string(),
+	id: z.int(),
 	data_type: z.string(),
 	name: z.string(),
 });
@@ -26,7 +26,6 @@ export type IndexNested = z.infer<typeof indexNestedSchema>;
 export const indexMinimalSchema = indexNestedSchema.extend({
 	change_count: z.number().nullable(),
 	created_at: z.string(),
-	has_files: z.boolean(),
 	modified_otu_count: z.number(),
 	reference: referenceNestedSchema,
 	user: userNestedSchema,

--- a/apps/web/src/jobs/components/__tests__/JobDetail.test.tsx
+++ b/apps/web/src/jobs/components/__tests__/JobDetail.test.tsx
@@ -26,7 +26,7 @@ describe("<JobDetail /> build_index links", () => {
 	afterEach(() => nock.cleanAll());
 
 	it("derives the reference id from the index so both links resolve", async () => {
-		const refId = "reference-1";
+		const refId = 55;
 		const indexId = 41;
 
 		const getJob = mockGetJob(123, createBuildIndexJob(indexId));
@@ -41,7 +41,9 @@ describe("<JobDetail /> build_index links", () => {
 
 		await renderRoute("/jobs/123");
 
-		const referenceLink = await screen.findByRole("link", { name: refId });
+		const referenceLink = await screen.findByRole("link", {
+			name: String(refId),
+		});
 		expect(referenceLink).toHaveAttribute("href", `/refs/${refId}`);
 
 		const indexLink = screen.getByRole("link", { name: String(indexId) });

--- a/apps/web/src/otus/components/Detail/Isolates/IsolateDetail.tsx
+++ b/apps/web/src/otus/components/Detail/Isolates/IsolateDetail.tsx
@@ -31,10 +31,10 @@ export default function IsolateDetail() {
 	const [openCreateSequence, setOpenCreateSequence] = useState(false);
 	const mutation = useSetIsolateAsDefault();
 	const { hasPermission: canModify } = useCheckReferenceRight(
-		reference.id,
+		String(reference.id),
 		"modify_otu",
 	);
-	const archived = useReferenceIsArchived(reference.id);
+	const archived = useReferenceIsArchived(String(reference.id));
 	const canModifyIsolates = canModify && !archived;
 
 	const activeIsolate = otu.isolates.find(
@@ -114,7 +114,7 @@ export default function IsolateDetail() {
 					</DownloadLink>
 					<CreateSequenceButton
 						onCreate={() => setOpenCreateSequence(true)}
-						refId={reference.id}
+						refId={String(reference.id)}
 					/>
 				</div>
 			</div>

--- a/apps/web/src/otus/components/Detail/Isolates/IsolateList.tsx
+++ b/apps/web/src/otus/components/Detail/Isolates/IsolateList.tsx
@@ -48,10 +48,10 @@ export default function IsolateList() {
 	);
 
 	const { hasPermission: canModify } = useCheckReferenceRight(
-		reference.id,
+		String(reference.id),
 		"modify_otu",
 	);
-	const archived = useReferenceIsArchived(reference.id);
+	const archived = useReferenceIsArchived(String(reference.id));
 	const canModifyIsolates = canModify && !archived;
 
 	const [results, term, setTerm] = useFuse<OtuIsolate>(

--- a/apps/web/src/otus/components/__tests__/CreateOTU.test.tsx
+++ b/apps/web/src/otus/components/__tests__/CreateOTU.test.tsx
@@ -20,7 +20,7 @@ describe("<OtuCreate />", () => {
 
 	it("should render", () => {
 		renderWithProviders(
-			<OtuCreate open refId={reference.id} setOpen={vi.fn()} />,
+			<OtuCreate open refId={String(reference.id)} setOpen={vi.fn()} />,
 		);
 
 		expect(screen.getByText("Create OTU")).toBeInTheDocument();
@@ -31,7 +31,7 @@ describe("<OtuCreate />", () => {
 
 	it("should render error once submitted with no name", async () => {
 		renderWithProviders(
-			<OtuCreate open refId={reference.id} setOpen={vi.fn()} />,
+			<OtuCreate open refId={String(reference.id)} setOpen={vi.fn()} />,
 		);
 
 		await userEvent.click(screen.getByRole("button", { name: "Save" }));
@@ -39,9 +39,9 @@ describe("<OtuCreate />", () => {
 	});
 
 	it("should create OTU without abbreviation", async () => {
-		const scope = mockApiCreateOtu(reference.id, "TestName", "");
+		const scope = mockApiCreateOtu(String(reference.id), "TestName", "");
 		renderWithProviders(
-			<OtuCreate open refId={reference.id} setOpen={vi.fn()} />,
+			<OtuCreate open refId={String(reference.id)} setOpen={vi.fn()} />,
 		);
 
 		await userEvent.type(screen.getByLabelText("Name"), "TestName");
@@ -52,12 +52,12 @@ describe("<OtuCreate />", () => {
 
 	it("should create OTU with abbreviation", async () => {
 		const scope = mockApiCreateOtu(
-			reference.id,
+			String(reference.id),
 			"TestName",
 			"TestAbbreviation",
 		);
 		renderWithProviders(
-			<OtuCreate open refId={reference.id} setOpen={vi.fn()} />,
+			<OtuCreate open refId={String(reference.id)} setOpen={vi.fn()} />,
 		);
 
 		await userEvent.type(screen.getByLabelText("Name"), "TestName");

--- a/apps/web/src/otus/components/__tests__/OtuToolbar.test.tsx
+++ b/apps/web/src/otus/components/__tests__/OtuToolbar.test.tsx
@@ -26,7 +26,7 @@ describe("<OtuToolbar />", () => {
 				term=""
 				setTerm={vi.fn()}
 				onCreate={vi.fn()}
-				refId={reference.id}
+				refId={String(reference.id)}
 				remotesFrom={null}
 			/>,
 		);
@@ -44,7 +44,7 @@ describe("<OtuToolbar />", () => {
 				term=""
 				setTerm={vi.fn()}
 				onCreate={vi.fn()}
-				refId={reference.id}
+				refId={String(reference.id)}
 				remotesFrom={null}
 			/>,
 		);

--- a/apps/web/src/references/components/CloneReference.tsx
+++ b/apps/web/src/references/components/CloneReference.tsx
@@ -31,7 +31,7 @@ export default function CloneReference({
 	unsetCloneReferenceId,
 }: CloneReferenceProps) {
 	const reference = references.find(
-		(reference) => reference.id === cloneReferenceId,
+		(reference) => String(reference.id) === cloneReferenceId,
 	);
 
 	const {

--- a/apps/web/src/references/components/Detail/ArchiveReference.tsx
+++ b/apps/web/src/references/components/Detail/ArchiveReference.tsx
@@ -24,8 +24,8 @@ type ArchiveReferenceProps = {
  */
 export default function ArchiveReference({ detail }: ArchiveReferenceProps) {
 	const [open, setOpen] = useState(false);
-	const archiveMutation = useArchiveReference(detail.id);
-	const unarchiveMutation = useUnarchiveReference(detail.id);
+	const archiveMutation = useArchiveReference(String(detail.id));
+	const unarchiveMutation = useUnarchiveReference(String(detail.id));
 
 	const mutation = detail.archived ? unarchiveMutation : archiveMutation;
 	const verb = detail.archived ? "Unarchive" : "Archive";

--- a/apps/web/src/references/components/Detail/Clone.tsx
+++ b/apps/web/src/references/components/Detail/Clone.tsx
@@ -4,7 +4,7 @@ import BoxGroupSection from "@base/BoxGroupSection";
 import { Link } from "@tanstack/react-router";
 
 type CloneProps = {
-	source: { id: string; name: string };
+	source: { id: number; name: string };
 };
 
 export function Clone({ source }: CloneProps) {
@@ -18,7 +18,7 @@ export function Clone({ source }: CloneProps) {
 				<strong>Source Reference</strong>
 				<span>
 					{" / "}
-					<Link to="/refs/$refId" params={{ refId: source.id }}>
+					<Link to="/refs/$refId" params={{ refId: String(source.id) }}>
 						{source.name}
 					</Link>
 				</span>

--- a/apps/web/src/references/components/Detail/EditReference.tsx
+++ b/apps/web/src/references/components/Detail/EditReference.tsx
@@ -35,7 +35,7 @@ export default function EditReference({ detail }: EditReferenceProps) {
 			organism: detail.organism,
 		},
 	});
-	const { mutation } = useUpdateReference(detail.id);
+	const { mutation } = useUpdateReference(String(detail.id));
 
 	function handleEdit({ name, description, organism }: FormValues) {
 		mutation.mutate(

--- a/apps/web/src/references/components/Detail/__tests__/ArchiveReference.test.tsx
+++ b/apps/web/src/references/components/Detail/__tests__/ArchiveReference.test.tsx
@@ -22,7 +22,7 @@ describe("<ArchiveReference />", () => {
 	it("should archive an active reference and close the dialog on success", async () => {
 		const detail = createFakeReference({ archived: false });
 		const archived = { ...detail, archived: true };
-		const scope = mockApiArchiveReference(detail.id, archived);
+		const scope = mockApiArchiveReference(String(detail.id), archived);
 
 		await renderWithRouter(<ArchiveReference detail={detail} />);
 
@@ -41,7 +41,7 @@ describe("<ArchiveReference />", () => {
 	it("should unarchive an archived reference", async () => {
 		const detail = createFakeReference({ archived: true });
 		const unarchived = { ...detail, archived: false };
-		const scope = mockApiUnarchiveReference(detail.id, unarchived);
+		const scope = mockApiUnarchiveReference(String(detail.id), unarchived);
 
 		await renderWithRouter(<ArchiveReference detail={detail} />);
 
@@ -96,7 +96,7 @@ describe("<ArchiveReference />", () => {
 
 	it("should surface a generic message when the server returns no message", async () => {
 		const detail = createFakeReference({ archived: false });
-		const scope = mockApiArchiveReference(detail.id, detail, 500);
+		const scope = mockApiArchiveReference(String(detail.id), detail, 500);
 
 		await renderWithRouter(<ArchiveReference detail={detail} />);
 
@@ -112,7 +112,7 @@ describe("<ArchiveReference />", () => {
 
 	it("should close without mutating when the Cancel button is clicked", async () => {
 		const detail = createFakeReference({ archived: false });
-		const scope = mockApiArchiveReference(detail.id, detail);
+		const scope = mockApiArchiveReference(String(detail.id), detail);
 
 		await renderWithRouter(<ArchiveReference detail={detail} />);
 

--- a/apps/web/src/references/components/Detail/__tests__/ReferenceDetailHeader.test.tsx
+++ b/apps/web/src/references/components/Detail/__tests__/ReferenceDetailHeader.test.tsx
@@ -27,7 +27,7 @@ describe("<ReferenceDetailHeaderIcon />", () => {
 			isRemote: false,
 			name: reference.name,
 			userHandle: reference.user.handle,
-			refId: reference.id,
+			refId: String(reference.id),
 		};
 		path = `/refs/${reference.id}/manage`;
 	});
@@ -120,7 +120,7 @@ describe("<ReferenceDetailHeaderIcon />", () => {
 				isRemote: false,
 				name: reference.name,
 				userHandle: reference.user.handle,
-				refId: reference.id,
+				refId: String(reference.id),
 			};
 			path = `/refs/${reference.id}/manage`;
 		});

--- a/apps/web/src/references/components/Detail/__tests__/ReferenceManager.test.tsx
+++ b/apps/web/src/references/components/Detail/__tests__/ReferenceManager.test.tsx
@@ -11,7 +11,7 @@ describe("<ReferenceManager />", () => {
 
 	beforeEach(() => {
 		reference = createFakeReference({
-			cloned_from: { id: "source-ref", name: "Source Reference Name" },
+			cloned_from: { id: 62, name: "Source Reference Name" },
 		});
 		path = `/refs/${reference.id}/manage`;
 		mockApiGetReferenceDetail(reference);

--- a/apps/web/src/references/components/ReferenceItem.tsx
+++ b/apps/web/src/references/components/ReferenceItem.tsx
@@ -48,7 +48,7 @@ export function ReferenceItem({ onClone, reference }: ReferenceItemProps) {
 				IconComponent={Copy}
 				tip="clone"
 				color="blue"
-				onClick={() => onClone(id)}
+				onClick={() => onClone(String(id))}
 			/>
 		);
 	}
@@ -58,7 +58,7 @@ export function ReferenceItem({ onClone, reference }: ReferenceItemProps) {
 			<Link
 				className="font-medium text-lg"
 				to="/refs/$refId"
-				params={{ refId: id }}
+				params={{ refId: String(id) }}
 			>
 				{name}
 			</Link>

--- a/apps/web/src/references/queries.ts
+++ b/apps/web/src/references/queries.ts
@@ -141,7 +141,7 @@ export function useCloneReference() {
 	return useMutation<
 		ReferenceMinimal,
 		unknown,
-		{ name: string; description: string; refId: string }
+		{ name: string; description: string; refId: number }
 	>({
 		mutationFn: ({ name, description, refId }) =>
 			apiClient

--- a/apps/web/src/references/types.ts
+++ b/apps/web/src/references/types.ts
@@ -2,7 +2,7 @@ import type { UserNested } from "@users/types";
 import type { SearchResult, Task } from "@/types/api";
 
 export type ReferenceClonedFrom = {
-	id: string;
+	id: number;
 	name: string;
 };
 
@@ -52,7 +52,7 @@ export type ReferenceRelease = {
 /** Basic reference data for nested representation */
 export type ReferenceNested = {
 	/** The unique identifier */
-	id: string;
+	id: number;
 
 	/** The build style dictating workflow compatibility */
 	data_type: string;

--- a/apps/web/src/sequences/components/SequenceButtons.tsx
+++ b/apps/web/src/sequences/components/SequenceButtons.tsx
@@ -25,10 +25,10 @@ export default function SequenceButtons({
 	const { otu, reference } = useCurrentOtuContext();
 
 	const { hasPermission: canModify } = useCheckReferenceRight(
-		reference.id,
+		String(reference.id),
 		"modify_otu",
 	);
-	const archived = useReferenceIsArchived(reference.id);
+	const archived = useReferenceIsArchived(String(reference.id));
 	const isolateId = useGetActiveIsolateId(otu);
 
 	const href = `/api/otus/${otu.id}/isolates/${isolateId}/sequences/${id}.fa`;

--- a/apps/web/src/sequences/components/Sequences.tsx
+++ b/apps/web/src/sequences/components/Sequences.tsx
@@ -53,7 +53,7 @@ export default function Sequences({
 	setOpenCreate,
 }: IsolateSequencesProps) {
 	const { otu, reference } = useCurrentOtuContext();
-	const archived = useReferenceIsArchived(reference.id);
+	const archived = useReferenceIsArchived(String(reference.id));
 	const [sequenceToEdit, setSequenceToEdit] = useState<
 		OtuSequence | undefined
 	>();
@@ -109,7 +109,7 @@ export default function Sequences({
 				isolateId={activeIsolate.id}
 				open={openCreate && !archived}
 				otuId={otuId}
-				refId={reference.id}
+				refId={String(reference.id)}
 				schema={otu.schema}
 				sequences={sequences}
 				setOpen={setOpenCreate}
@@ -120,7 +120,7 @@ export default function Sequences({
 				isolateId={activeIsolate.id}
 				open={Boolean(sequenceToEdit) && !archived}
 				otuId={otuId}
-				refId={reference.id}
+				refId={String(reference.id)}
 				schema={otu.schema}
 				sequences={sequences}
 				setOpen={(open) => {

--- a/apps/web/src/sequences/components/__tests__/Accession.test.tsx
+++ b/apps/web/src/sequences/components/__tests__/Accession.test.tsx
@@ -19,7 +19,7 @@ describe("<Accession> auto fill", () => {
 				isolateId={isolate.id}
 				open
 				otuId={otu.id}
-				refId={reference.id}
+				refId={String(reference.id)}
 				schema={otu.schema}
 				sequences={isolate.sequences}
 				setOpen={vi.fn()}

--- a/apps/web/src/sequences/components/__tests__/CreateSequence.test.tsx
+++ b/apps/web/src/sequences/components/__tests__/CreateSequence.test.tsx
@@ -19,7 +19,7 @@ describe("<CreateSequence>", () => {
 				isolateId={isolate.id}
 				open
 				otuId={otu.id}
-				refId={reference.id}
+				refId={String(reference.id)}
 				schema={otu.schema}
 				sequences={isolate.sequences}
 				setOpen={setOpen}

--- a/apps/web/src/tests/fake/indexes.ts
+++ b/apps/web/src/tests/fake/indexes.ts
@@ -26,7 +26,6 @@ export function createFakeIndexMinimal(
 		...createFakeIndexNested(),
 		change_count: faker.number.int({ min: 2, max: 10 }),
 		created_at: faker.date.past().toISOString(),
-		has_files: faker.datatype.boolean(),
 		modified_otu_count: faker.number.int({ min: 2, max: 10 }),
 		reference: createFakeReferenceNested(),
 		user: createFakeUserNested(),

--- a/apps/web/src/tests/fake/references.ts
+++ b/apps/web/src/tests/fake/references.ts
@@ -13,7 +13,7 @@ export function createFakeReferenceNested(
 	overrides?: Partial<ReferenceNested>,
 ): ReferenceNested {
 	return {
-		id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
+		id: faker.number.int(),
 		data_type: "genome",
 		name: faker.word.noun({ strategy: "any-length" }),
 		...overrides,
@@ -30,7 +30,7 @@ export function createFakeReferenceMinimal(
 		...createFakeReferenceNested(overrides),
 		archived: false,
 		cloned_from: {
-			id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
+			id: faker.number.int(),
 			name: faker.word.noun({ strategy: "any-length" }),
 		},
 		created_at: faker.date.past().toISOString(),

--- a/packages/contracts/src/analyses.ts
+++ b/packages/contracts/src/analyses.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 /** Analysis metadata returned by `GET /analyses/{id}`. Provisional shape. */
 export const Analysis = z.object({
-	id: z.string(),
+	id: z.int(),
 });
 
 export type Analysis = z.infer<typeof Analysis>;

--- a/packages/contracts/src/indexes.ts
+++ b/packages/contracts/src/indexes.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 /** Index metadata returned by `GET /indexes/{id}`. Provisional shape. */
 export const Index = z.object({
-	id: z.string(),
+	id: z.int(),
 });
 
 export type Index = z.infer<typeof Index>;

--- a/packages/contracts/src/jobs.ts
+++ b/packages/contracts/src/jobs.ts
@@ -3,7 +3,7 @@ import { WorkflowName } from "./workflowName";
 
 /** Job row returned by the lifecycle endpoints. Provisional shape. */
 export const Job = z.object({
-	id: z.string(),
+	id: z.int(),
 	workflow: WorkflowName,
 	analysisId: z.string(),
 	sampleId: z.string(),

--- a/packages/contracts/src/samples.ts
+++ b/packages/contracts/src/samples.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 
 /** Library type used by sample-trimming heuristics; mirrors the Python `LibraryType` enum. */
-export const LibraryType = z.enum(["normal", "amplicon", "srna"]);
+export const LibraryType = z.enum(["normal", "srna"]);
 
 export type LibraryType = z.infer<typeof LibraryType>;
 
 /** Sample metadata returned by `GET /samples/{id}`. Provisional shape — fields land as the runner needs them. */
 export const Sample = z.object({
-	id: z.string(),
+	id: z.int(),
 	name: z.string(),
 	paired: z.boolean(),
 	library_type: LibraryType,

--- a/packages/contracts/src/subtractions.ts
+++ b/packages/contracts/src/subtractions.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 /** Subtraction metadata returned by `GET /subtractions/{id}`. Provisional shape. */
 export const Subtraction = z.object({
-	id: z.string(),
+	id: z.int(),
 });
 
 export type Subtraction = z.infer<typeof Subtraction>;


### PR DESCRIPTION
## Summary
- IDs on analyses, indexes, jobs, samples, and subtractions are integers, not strings — the contracts and index types now validate against what the API actually returns.
- Drop the `amplicon` library type and the index `has_files` field, neither of which the API returns.