### PR TITLE
feat: serve account API keys from the typescript server

### DIFF
--- a/apps/web/src/account/components/ApiKeyCreate.tsx
+++ b/apps/web/src/account/components/ApiKeyCreate.tsx
@@ -15,6 +15,7 @@ import InputLabel from "@base/InputLabel";
 import InputSimple from "@base/InputSimple";
 import SaveButton from "@base/SaveButton";
 import type { Permissions } from "@groups/types";
+import { emptyPermissions } from "@virtool/contracts";
 import { useId, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useCreateAPIKey } from "../queries";
@@ -44,16 +45,7 @@ export default function ApiKeyCreate() {
 	} = useForm<FormValues>({
 		defaultValues: {
 			name: "",
-			permissions: {
-				cancel_job: false,
-				create_ref: false,
-				create_sample: false,
-				modify_hmm: false,
-				modify_subtraction: false,
-				remove_file: false,
-				remove_job: false,
-				upload_file: false,
-			},
+			permissions: emptyPermissions(),
 		},
 	});
 

--- a/apps/web/src/account/components/ApiKeyCreate.tsx
+++ b/apps/web/src/account/components/ApiKeyCreate.tsx
@@ -19,7 +19,7 @@ import { emptyPermissions } from "@virtool/contracts";
 import { useId, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useCreateApiKey } from "../queries";
-import CreateApiKeyInfo from "./ApiKeyAdministratorInfo";
+import ApiKeyAdministratorInfo from "./ApiKeyAdministratorInfo";
 import ApiKeyPermissions from "./ApiKeyPermissions";
 
 type FormValues = {
@@ -110,7 +110,7 @@ export default function ApiKeyCreate() {
 					</div>
 				) : (
 					<form onSubmit={handleSubmit(onSubmit)}>
-						<CreateApiKeyInfo />
+						<ApiKeyAdministratorInfo />
 						<InputGroup>
 							<InputLabel htmlFor="name">Name</InputLabel>
 							<InputSimple

--- a/apps/web/src/account/components/ApiKeyCreate.tsx
+++ b/apps/web/src/account/components/ApiKeyCreate.tsx
@@ -18,8 +18,8 @@ import type { Permissions } from "@groups/types";
 import { emptyPermissions } from "@virtool/contracts";
 import { useId, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { useCreateAPIKey } from "../queries";
-import CreateAPIKeyInfo from "./ApiKeyAdministratorInfo";
+import { useCreateApiKey } from "../queries";
+import CreateApiKeyInfo from "./ApiKeyAdministratorInfo";
 import ApiKeyPermissions from "./ApiKeyPermissions";
 
 type FormValues = {
@@ -33,7 +33,7 @@ type FormValues = {
 export default function ApiKeyCreate() {
 	const [copied, setCopied] = useState(false);
 	const [newKey, setNewKey] = useState("");
-	const mutation = useCreateAPIKey();
+	const mutation = useCreateApiKey();
 	const permissionsLabelId = useId();
 
 	const {
@@ -110,7 +110,7 @@ export default function ApiKeyCreate() {
 					</div>
 				) : (
 					<form onSubmit={handleSubmit(onSubmit)}>
-						<CreateAPIKeyInfo />
+						<CreateApiKeyInfo />
 						<InputGroup>
 							<InputLabel htmlFor="name">Name</InputLabel>
 							<InputSimple

--- a/apps/web/src/account/components/ApiKeyEdit.tsx
+++ b/apps/web/src/account/components/ApiKeyEdit.tsx
@@ -19,7 +19,7 @@ type FormValues = {
 };
 
 type ApiKeyEditProps = {
-	id: string;
+	id: number;
 	permissions: Permissions;
 };
 

--- a/apps/web/src/account/components/ApiKeyItem.tsx
+++ b/apps/web/src/account/components/ApiKeyItem.tsx
@@ -3,17 +3,17 @@ import BoxGroupSection from "@base/BoxGroupSection";
 import IconButton from "@base/IconButton";
 import { Trash } from "lucide-react";
 import { useRemoveAPIKey } from "../queries";
-import type { APIKeyMinimal } from "../types";
+import type { ApiKey } from "../types";
 import ApiKeyEdit from "./ApiKeyEdit";
 
-type ApiKeyProps = {
-	apiKey: APIKeyMinimal;
+type ApiKeyItemProps = {
+	apiKey: ApiKey;
 };
 
 /**
  * Display a condensed API key for use in a list of API keys
  */
-export default function ApiKey({ apiKey }: ApiKeyProps) {
+export default function ApiKeyItem({ apiKey }: ApiKeyItemProps) {
 	const permissionCount = Object.values(apiKey.permissions).reduce(
 		(result, value) => result + (value ? 1 : 0),
 		0,
@@ -25,7 +25,7 @@ export default function ApiKey({ apiKey }: ApiKeyProps) {
 		<BoxGroupSection>
 			<h4 className="grid items-center grid-cols-4">
 				<span className="font-medium text-lg">{apiKey.name}</span>
-				<Attribution time={apiKey.created_at} />
+				<Attribution time={apiKey.createdAt} />
 				<div className="text-right">
 					{permissionCount} permission
 					{permissionCount === 1 ? null : "s"}

--- a/apps/web/src/account/components/ApiKeyItem.tsx
+++ b/apps/web/src/account/components/ApiKeyItem.tsx
@@ -2,7 +2,7 @@ import Attribution from "@base/Attribution";
 import BoxGroupSection from "@base/BoxGroupSection";
 import IconButton from "@base/IconButton";
 import { Trash } from "lucide-react";
-import { useRemoveAPIKey } from "../queries";
+import { useRemoveApiKey } from "../queries";
 import type { ApiKey } from "../types";
 import ApiKeyEdit from "./ApiKeyEdit";
 
@@ -19,7 +19,7 @@ export default function ApiKeyItem({ apiKey }: ApiKeyItemProps) {
 		0,
 	);
 
-	const removeMutation = useRemoveAPIKey();
+	const removeMutation = useRemoveApiKey();
 
 	return (
 		<BoxGroupSection>

--- a/apps/web/src/account/components/ApiKeyPermissions.tsx
+++ b/apps/web/src/account/components/ApiKeyPermissions.tsx
@@ -11,7 +11,7 @@ import QueryError from "@base/QueryError";
 import type { Permission, Permissions } from "@groups/types";
 import { sortBy } from "es-toolkit";
 
-type APIPermissionsProps = {
+type ApiPermissionsProps = {
 	"aria-labelledby"?: string;
 	className?: string;
 	keyPermissions: Permissions;
@@ -27,7 +27,7 @@ export default function ApiKeyPermissions({
 	className,
 	keyPermissions,
 	onChange,
-}: APIPermissionsProps) {
+}: ApiPermissionsProps) {
 	const { data: account, isPending, isError } = useFetchAccount();
 
 	if (isError && !account) {

--- a/apps/web/src/account/components/ApiKeys.tsx
+++ b/apps/web/src/account/components/ApiKeys.tsx
@@ -7,8 +7,8 @@ import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
 import { KeyRound } from "lucide-react";
 import { useFetchAPIKeys } from "../queries";
-import ApiKey from "./ApiKey";
 import ApiKeyCreate from "./ApiKeyCreate";
+import ApiKeyItem from "./ApiKeyItem";
 
 /**
  * A component to manage and display API keys
@@ -24,7 +24,9 @@ export default function ApiKeys() {
 		return <LoadingPlaceholder className="mt-36" />;
 	}
 
-	const keyComponents = data.map((key) => <ApiKey key={key.id} apiKey={key} />);
+	const keyComponents = data.map((key) => (
+		<ApiKeyItem key={key.id} apiKey={key} />
+	));
 
 	return (
 		<div>

--- a/apps/web/src/account/components/ApiKeys.tsx
+++ b/apps/web/src/account/components/ApiKeys.tsx
@@ -6,7 +6,7 @@ import ExternalLink from "@base/ExternalLink";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
 import { KeyRound } from "lucide-react";
-import { useFetchAPIKeys } from "../queries";
+import { useFetchApiKeys } from "../queries";
 import ApiKeyCreate from "./ApiKeyCreate";
 import ApiKeyItem from "./ApiKeyItem";
 
@@ -14,7 +14,7 @@ import ApiKeyItem from "./ApiKeyItem";
  * A component to manage and display API keys
  */
 export default function ApiKeys() {
-	const { data, isPending, isError } = useFetchAPIKeys();
+	const { data, isPending, isError } = useFetchApiKeys();
 
 	if (isError && !data) {
 		return <QueryError noun="API keys" />;

--- a/apps/web/src/account/components/__tests__/ApiKeys.test.tsx
+++ b/apps/web/src/account/components/__tests__/ApiKeys.test.tsx
@@ -1,18 +1,15 @@
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { mockApiCreateApiKey, mockApiGetApiKeys } from "@tests/api/account";
 import { createFakeAccount, createFakeApiKey } from "@tests/fake/account";
 import { createFakePermissions } from "@tests/fake/permissions";
+import { mockCreateApiKey, mockFindApiKeys } from "@tests/server-fn/account";
 import { mockGetAccount } from "@tests/server-fn/users";
 import { renderWithRouter } from "@tests/setup";
-import nock from "nock";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import ApiKeys from "../ApiKeys";
 
 describe("<ApiKeys />", () => {
 	const basePath = "/account/api";
-
-	afterEach(() => nock.cleanAll());
 
 	it("should render correctly when keys === null", async () => {
 		await renderWithRouter(<ApiKeys />, basePath);
@@ -31,12 +28,9 @@ describe("<ApiKeys />", () => {
 				administrator_role: "full",
 			}),
 		);
-		mockApiGetApiKeys([]);
+		mockFindApiKeys([]);
 
-		const scope = mockApiCreateApiKey(
-			"test",
-			createFakePermissions({ remove_job: true }),
-		);
+		mockCreateApiKey("testKey", createFakePermissions({ remove_job: true }));
 
 		await renderWithRouter(<ApiKeys />, "/account/api");
 
@@ -66,14 +60,16 @@ describe("<ApiKeys />", () => {
 		await user.click(checkbox);
 		expect(checkbox).toBeChecked();
 
-		await user.click(screen.getByRole("button", { name: "Save" }));
-
-		mockApiGetApiKeys([
+		// The list refetches when the create mutation invalidates the account
+		// cache, so the new key must be resolvable before the save is submitted.
+		mockFindApiKeys([
 			createFakeApiKey({
 				name: "Key A",
 				permissions: createFakePermissions({ remove_job: true }),
 			}),
 		]);
+
+		await user.click(screen.getByRole("button", { name: "Save" }));
 
 		// Test that the secret key is displayed in the dialog after creation.
 		expect(await screen.findByText("Here is your key.")).toBeInTheDocument();
@@ -86,8 +82,6 @@ describe("<ApiKeys />", () => {
 		expect(screen.getByText("Key A")).toBeInTheDocument();
 		expect(screen.getByText(/Created/)).toBeInTheDocument();
 		expect(screen.getByText("1 permission")).toBeInTheDocument();
-
-		scope.done();
 	});
 
 	it("should show administrator notice when appropriate", async () => {
@@ -96,7 +90,7 @@ describe("<ApiKeys />", () => {
 				administrator_role: "full",
 			}),
 		);
-		mockApiGetApiKeys([]);
+		mockFindApiKeys([]);
 
 		await renderWithRouter(<ApiKeys />, basePath);
 
@@ -131,7 +125,7 @@ describe("<ApiKeys />", () => {
 				},
 			}),
 		);
-		mockApiGetApiKeys([key]);
+		mockFindApiKeys([key]);
 
 		await renderWithRouter(<ApiKeys />, "/account/api");
 

--- a/apps/web/src/account/components/__tests__/ApiKeys.test.tsx
+++ b/apps/web/src/account/components/__tests__/ApiKeys.test.tsx
@@ -113,16 +113,11 @@ describe("<ApiKeys />", () => {
 
 		mockGetAccount(
 			createFakeAccount({
-				permissions: {
+				permissions: createFakePermissions({
 					cancel_job: true,
 					create_ref: true,
-					create_sample: false,
-					modify_hmm: false,
-					modify_subtraction: false,
-					remove_file: false,
-					remove_job: false,
 					upload_file: true,
-				},
+				}),
 			}),
 		);
 		mockFindApiKeys([key]);

--- a/apps/web/src/account/queries.ts
+++ b/apps/web/src/account/queries.ts
@@ -113,7 +113,7 @@ export function useCreateAPIKey() {
 		mutationFn: ({ name, permissions }) =>
 			createApiKey({ data: { name, permissions } }),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: accountQueryKeys.all() });
+			queryClient.invalidateQueries({ queryKey: accountQueryKeys.apiKeys() });
 		},
 	});
 }
@@ -134,7 +134,7 @@ export function useUpdateApiKey() {
 		mutationFn: ({ keyId, permissions }) =>
 			updateApiKey({ data: { keyId, permissions } }),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: accountQueryKeys.all() });
+			queryClient.invalidateQueries({ queryKey: accountQueryKeys.apiKeys() });
 		},
 	});
 }
@@ -150,7 +150,7 @@ export function useRemoveAPIKey() {
 	return useMutation<null, Error, { keyId: number }>({
 		mutationFn: ({ keyId }) => deleteApiKey({ data: { keyId } }),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: accountQueryKeys.all() });
+			queryClient.invalidateQueries({ queryKey: accountQueryKeys.apiKeys() });
 		},
 	});
 }

--- a/apps/web/src/account/queries.ts
+++ b/apps/web/src/account/queries.ts
@@ -4,6 +4,12 @@ import { apiClient } from "@app/api";
 import { resetClient } from "@app/utils";
 import type { Permissions } from "@groups/types";
 import * as Sentry from "@sentry/tanstackstart-react";
+import {
+	createApiKey,
+	deleteApiKey,
+	findApiKeys,
+	updateApiKey,
+} from "@server/account/functions";
 import { logoutFn } from "@server/auth/functions";
 import { updateAccountHandle } from "@server/users/functions";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -87,7 +93,7 @@ export function useChangePassword() {
 export function useFetchAPIKeys() {
 	return useQuery<APIKeyMinimal[]>({
 		queryKey: accountQueryKeys.apiKeys(),
-		queryFn: () => apiClient.get("/account/keys").then((res) => res.body),
+		queryFn: () => findApiKeys(),
 	});
 }
 
@@ -100,15 +106,12 @@ export function useCreateAPIKey() {
 	const queryClient = useQueryClient();
 
 	return useMutation<
-		APIKeyMinimal,
-		ErrorResponse,
+		Awaited<ReturnType<typeof createApiKey>>,
+		Error,
 		{ name: string; permissions: Permissions }
 	>({
 		mutationFn: ({ name, permissions }) =>
-			apiClient
-				.post("/account/keys")
-				.send({ name, permissions })
-				.then((res) => res.body),
+			createApiKey({ data: { name, permissions } }),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: accountQueryKeys.all() });
 		},
@@ -124,15 +127,12 @@ export function useUpdateApiKey() {
 	const queryClient = useQueryClient();
 
 	return useMutation<
-		APIKeyMinimal,
-		ErrorResponse,
-		{ keyId: string; permissions: Permissions }
+		Awaited<ReturnType<typeof updateApiKey>>,
+		Error,
+		{ keyId: number; permissions: Permissions }
 	>({
 		mutationFn: ({ keyId, permissions }) =>
-			apiClient
-				.patch(`/account/keys/${keyId}`)
-				.send({ permissions })
-				.then((res) => res.body),
+			updateApiKey({ data: { keyId, permissions } }),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: accountQueryKeys.all() });
 		},
@@ -147,9 +147,8 @@ export function useUpdateApiKey() {
 export function useRemoveAPIKey() {
 	const queryClient = useQueryClient();
 
-	return useMutation<null, ErrorResponse, { keyId: string }>({
-		mutationFn: ({ keyId }) =>
-			apiClient.delete(`/account/keys/${keyId}`).then((res) => res.body),
+	return useMutation<null, Error, { keyId: number }>({
+		mutationFn: ({ keyId }) => deleteApiKey({ data: { keyId } }),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: accountQueryKeys.all() });
 		},

--- a/apps/web/src/account/queries.ts
+++ b/apps/web/src/account/queries.ts
@@ -90,7 +90,7 @@ export function useChangePassword() {
  *
  * @returns A list of API keys for the current user
  */
-export function useFetchAPIKeys() {
+export function useFetchApiKeys() {
 	return useQuery<ApiKey[]>({
 		queryKey: accountQueryKeys.apiKeys(),
 		queryFn: () => findApiKeys(),
@@ -102,7 +102,7 @@ export function useFetchAPIKeys() {
  *
  * @returns A mutator for creating a new API key
  */
-export function useCreateAPIKey() {
+export function useCreateApiKey() {
 	const queryClient = useQueryClient();
 
 	return useMutation<
@@ -144,7 +144,7 @@ export function useUpdateApiKey() {
  *
  * @returns A mutator for removing an API key
  */
-export function useRemoveAPIKey() {
+export function useRemoveApiKey() {
 	const queryClient = useQueryClient();
 
 	return useMutation<null, Error, { keyId: number }>({

--- a/apps/web/src/account/queries.ts
+++ b/apps/web/src/account/queries.ts
@@ -1,5 +1,5 @@
 import { accountQueryKeys } from "@account/keys";
-import type { APIKeyMinimal } from "@account/types";
+import type { ApiKey } from "@account/types";
 import { apiClient } from "@app/api";
 import { resetClient } from "@app/utils";
 import type { Permissions } from "@groups/types";
@@ -91,7 +91,7 @@ export function useChangePassword() {
  * @returns A list of API keys for the current user
  */
 export function useFetchAPIKeys() {
-	return useQuery<APIKeyMinimal[]>({
+	return useQuery<ApiKey[]>({
 		queryKey: accountQueryKeys.apiKeys(),
 		queryFn: () => findApiKeys(),
 	});

--- a/apps/web/src/account/types.ts
+++ b/apps/web/src/account/types.ts
@@ -1,15 +1,8 @@
-import type { Permissions } from "@groups/types";
 import type { User } from "@users/types";
 
-export type QuickAnalyzeWorkflow = "nuvs" | "pathoscope";
+export type { ApiKey } from "@server/account/data";
 
-export type APIKeyMinimal = {
-	created_at: string;
-	id: number;
-	key?: string;
-	name: string;
-	permissions: Permissions;
-};
+export type QuickAnalyzeWorkflow = "nuvs" | "pathoscope";
 
 export type AccountSettings = {
 	quick_analyze_workflow: QuickAnalyzeWorkflow;

--- a/apps/web/src/account/types.ts
+++ b/apps/web/src/account/types.ts
@@ -1,12 +1,11 @@
-import type { GroupMinimal, Permissions } from "@groups/types";
+import type { Permissions } from "@groups/types";
 import type { User } from "@users/types";
 
 export type QuickAnalyzeWorkflow = "nuvs" | "pathoscope";
 
 export type APIKeyMinimal = {
 	created_at: string;
-	groups: Array<GroupMinimal>;
-	id: string;
+	id: number;
 	key?: string;
 	name: string;
 	permissions: Permissions;

--- a/apps/web/src/groups/types.ts
+++ b/apps/web/src/groups/types.ts
@@ -1,8 +1,8 @@
 import type { UserNested } from "@users/types";
-import type { Permission } from "@virtool/contracts";
+import type { Permission, Permissions } from "@virtool/contracts";
 import type { SearchResult } from "@/types/api";
 
-export type { Permission };
+export type { Permission, Permissions };
 
 export type GroupMinimal = {
 	id: number;
@@ -15,27 +15,8 @@ export type Group = GroupMinimal & {
 	users: UserNested[];
 };
 
-export type Permissions = {
-	cancel_job: boolean;
-	create_ref: boolean;
-	create_sample: boolean;
-	modify_hmm: boolean;
-	modify_subtraction: boolean;
-	remove_file: boolean;
-	remove_job: boolean;
-	upload_file: boolean;
-};
-
-export type PermissionsUpdate = {
-	cancel_job?: boolean;
-	create_ref?: boolean;
-	create_sample?: boolean;
-	modify_hmm?: boolean;
-	modify_subtraction?: boolean;
-	remove_file?: boolean;
-	remove_job?: boolean;
-	upload_file?: boolean;
-};
+/** Partial permission flags accepted when updating a group or key. */
+export type PermissionsUpdate = Partial<Permissions>;
 
 /** Group search results from the API */
 export type GroupSearchResults = SearchResult & {

--- a/apps/web/src/server/__tests__/authorization.test.ts
+++ b/apps/web/src/server/__tests__/authorization.test.ts
@@ -51,6 +51,13 @@ const { authenticationExceptions } = await import("../auth/exceptions");
  */
 const MODULES = [
 	{
+		path: "../account/functions.ts",
+		fns: await import("../account/functions"),
+		handlers: (await import(
+			"../account/functions.ts?tss-serverfn-split"
+		)) as SplitServerFnModule,
+	},
+	{
 		path: "../auth/functions.ts",
 		fns: await import("../auth/functions"),
 		handlers: (await import(

--- a/apps/web/src/server/account/data.test.ts
+++ b/apps/web/src/server/account/data.test.ts
@@ -1,9 +1,8 @@
+import type { Permissions } from "@virtool/contracts";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-
 import { seedUser } from "../auth/test/fixtures";
 import type { Db } from "../db/pg";
 import { apiKeys } from "../db/schema/apiKeys";
-import type { GroupPermissions } from "../db/schema/groups";
 import { groups, userGroups } from "../db/schema/groups";
 import { users } from "../db/schema/users";
 import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
@@ -35,7 +34,7 @@ beforeEach(async () => {
 	await db.delete(groups);
 });
 
-function perms(overrides: Partial<GroupPermissions> = {}): GroupPermissions {
+function perms(overrides: Partial<Permissions> = {}): Permissions {
 	return { ...NO_PERMISSIONS, ...overrides };
 }
 
@@ -93,7 +92,7 @@ describe("findApiKeys", () => {
 			name: "Legacy",
 			createdAt: new Date(),
 			userId,
-			permissions: { create_ref: true } as GroupPermissions,
+			permissions: { create_ref: true } as Permissions,
 		});
 
 		const keys = await findApiKeys(db, userId);

--- a/apps/web/src/server/account/data.test.ts
+++ b/apps/web/src/server/account/data.test.ts
@@ -1,0 +1,195 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { seedUser } from "../auth/test/fixtures";
+import type { Db } from "../db/pg";
+import { apiKeys } from "../db/schema/apiKeys";
+import type { GroupPermissions } from "../db/schema/groups";
+import { groups, userGroups } from "../db/schema/groups";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { addToGroup, NO_PERMISSIONS, seedGroup } from "../groups/test/fixtures";
+import {
+	ApiKeyNotFoundError,
+	createApiKey,
+	deleteApiKey,
+	findApiKeys,
+	getApiKey,
+	updateApiKey,
+} from "./data";
+
+let database: TestDatabase;
+let db: Db;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(apiKeys);
+	await db.delete(userGroups);
+	await db.delete(users);
+	await db.delete(groups);
+});
+
+function perms(overrides: Partial<GroupPermissions> = {}): GroupPermissions {
+	return { ...NO_PERMISSIONS, ...overrides };
+}
+
+/** Seed a non-administrator user granted a single permission through a group. */
+async function seedLimitedUser(): Promise<number> {
+	const userId = await seedUser(db);
+	const groupId = await seedGroup(db, { permissions: { create_sample: true } });
+	await addToGroup(db, userId, groupId);
+	return userId;
+}
+
+describe("createApiKey", () => {
+	it("stores the requested permissions and returns the raw secret once", async () => {
+		const userId = await seedUser(db, { administratorRole: "full" });
+
+		const { key, apiKey } = await createApiKey(db, userId, {
+			name: "Robot",
+			permissions: perms({ create_ref: true }),
+		});
+
+		expect(key).toMatch(/^[0-9a-f]{64}$/);
+		expect(apiKey.name).toBe("Robot");
+		expect(apiKey.permissions).toEqual(perms({ create_ref: true }));
+
+		const [row] = await db.select().from(apiKeys);
+		expect(row?.permissions).toEqual(perms({ create_ref: true }));
+		// The raw secret is never persisted — only its hash.
+		expect(row?.hashed).not.toBe(key);
+	});
+
+	it("clamps the returned permissions to a non-admin owner's permissions", async () => {
+		const userId = await seedLimitedUser();
+
+		const { apiKey } = await createApiKey(db, userId, {
+			name: "Robot",
+			permissions: perms({ create_ref: true, create_sample: true }),
+		});
+
+		// create_ref is dropped — the owner does not hold it — but create_sample
+		// survives.
+		expect(apiKey.permissions).toEqual(perms({ create_sample: true }));
+	});
+});
+
+describe("findApiKeys", () => {
+	it("lists the owner's keys with their stored, unclamped permissions", async () => {
+		const userId = await seedLimitedUser();
+		await createApiKey(db, userId, {
+			name: "Robot",
+			permissions: perms({ create_ref: true, create_sample: true }),
+		});
+
+		const keys = await findApiKeys(db, userId);
+
+		expect(keys).toHaveLength(1);
+		// Unlike the single-key read, the list is not clamped.
+		expect(keys[0]?.permissions).toEqual(
+			perms({ create_ref: true, create_sample: true }),
+		);
+	});
+
+	it("does not return another user's keys", async () => {
+		const owner = await seedUser(db, { handle: "owner" });
+		const other = await seedUser(db, { handle: "other" });
+		await createApiKey(db, owner, { name: "Robot", permissions: perms() });
+
+		expect(await findApiKeys(db, other)).toHaveLength(0);
+	});
+});
+
+describe("getApiKey", () => {
+	it("clamps a non-admin owner's permissions", async () => {
+		const userId = await seedLimitedUser();
+		const { apiKey } = await createApiKey(db, userId, {
+			name: "Robot",
+			permissions: perms({ create_ref: true, create_sample: true }),
+		});
+
+		const read = await getApiKey(db, userId, apiKey.id);
+
+		expect(read.permissions).toEqual(perms({ create_sample: true }));
+	});
+
+	it("does not clamp an administrator owner's permissions", async () => {
+		const userId = await seedUser(db, { administratorRole: "full" });
+		const { apiKey } = await createApiKey(db, userId, {
+			name: "Robot",
+			permissions: perms({ create_ref: true }),
+		});
+
+		const read = await getApiKey(db, userId, apiKey.id);
+
+		expect(read.permissions).toEqual(perms({ create_ref: true }));
+	});
+
+	it("throws when the key belongs to another user", async () => {
+		const owner = await seedUser(db, { handle: "owner" });
+		const other = await seedUser(db, { handle: "other" });
+		const { apiKey } = await createApiKey(db, owner, {
+			name: "Robot",
+			permissions: perms(),
+		});
+
+		await expect(getApiKey(db, other, apiKey.id)).rejects.toBeInstanceOf(
+			ApiKeyNotFoundError,
+		);
+	});
+});
+
+describe("updateApiKey", () => {
+	it("merges the update into the stored permissions", async () => {
+		const userId = await seedUser(db, { administratorRole: "full" });
+		const { apiKey } = await createApiKey(db, userId, {
+			name: "Robot",
+			permissions: perms({ create_ref: true }),
+		});
+
+		const updated = await updateApiKey(db, userId, apiKey.id, {
+			create_sample: true,
+		});
+
+		expect(updated.permissions).toEqual(
+			perms({ create_ref: true, create_sample: true }),
+		);
+	});
+
+	it("throws when the key does not exist", async () => {
+		const userId = await seedUser(db);
+
+		await expect(
+			updateApiKey(db, userId, 404, { create_ref: true }),
+		).rejects.toBeInstanceOf(ApiKeyNotFoundError);
+	});
+});
+
+describe("deleteApiKey", () => {
+	it("removes the key", async () => {
+		const userId = await seedUser(db);
+		const { apiKey } = await createApiKey(db, userId, {
+			name: "Robot",
+			permissions: perms(),
+		});
+
+		await deleteApiKey(db, userId, apiKey.id);
+
+		expect(await findApiKeys(db, userId)).toHaveLength(0);
+	});
+
+	it("throws when the key does not exist", async () => {
+		const userId = await seedUser(db);
+
+		await expect(deleteApiKey(db, userId, 404)).rejects.toBeInstanceOf(
+			ApiKeyNotFoundError,
+		);
+	});
+});

--- a/apps/web/src/server/account/data.test.ts
+++ b/apps/web/src/server/account/data.test.ts
@@ -13,7 +13,6 @@ import {
 	createApiKey,
 	deleteApiKey,
 	findApiKeys,
-	getApiKey,
 	updateApiKey,
 } from "./data";
 
@@ -66,23 +65,10 @@ describe("createApiKey", () => {
 		// The raw secret is never persisted — only its hash.
 		expect(row?.hashed).not.toBe(key);
 	});
-
-	it("clamps the returned permissions to a non-admin owner's permissions", async () => {
-		const userId = await seedLimitedUser();
-
-		const { apiKey } = await createApiKey(db, userId, {
-			name: "Robot",
-			permissions: perms({ create_ref: true, create_sample: true }),
-		});
-
-		// create_ref is dropped — the owner does not hold it — but create_sample
-		// survives.
-		expect(apiKey.permissions).toEqual(perms({ create_sample: true }));
-	});
 });
 
 describe("findApiKeys", () => {
-	it("lists the owner's keys with their stored, unclamped permissions", async () => {
+	it("lists the owner's keys with their stored permissions", async () => {
 		const userId = await seedLimitedUser();
 		await createApiKey(db, userId, {
 			name: "Robot",
@@ -92,7 +78,8 @@ describe("findApiKeys", () => {
 		const keys = await findApiKeys(db, userId);
 
 		expect(keys).toHaveLength(1);
-		// Unlike the single-key read, the list is not clamped.
+		// Permissions are reported as stored — never clamped to what the owner
+		// currently holds, so create_ref survives even though this owner lacks it.
 		expect(keys[0]?.permissions).toEqual(
 			perms({ create_ref: true, create_sample: true }),
 		);
@@ -123,45 +110,6 @@ describe("findApiKeys", () => {
 	});
 });
 
-describe("getApiKey", () => {
-	it("clamps a non-admin owner's permissions", async () => {
-		const userId = await seedLimitedUser();
-		const { apiKey } = await createApiKey(db, userId, {
-			name: "Robot",
-			permissions: perms({ create_ref: true, create_sample: true }),
-		});
-
-		const read = await getApiKey(db, userId, apiKey.id);
-
-		expect(read.permissions).toEqual(perms({ create_sample: true }));
-	});
-
-	it("does not clamp an administrator owner's permissions", async () => {
-		const userId = await seedUser(db, { administratorRole: "full" });
-		const { apiKey } = await createApiKey(db, userId, {
-			name: "Robot",
-			permissions: perms({ create_ref: true }),
-		});
-
-		const read = await getApiKey(db, userId, apiKey.id);
-
-		expect(read.permissions).toEqual(perms({ create_ref: true }));
-	});
-
-	it("throws when the key belongs to another user", async () => {
-		const owner = await seedUser(db, { handle: "owner" });
-		const other = await seedUser(db, { handle: "other" });
-		const { apiKey } = await createApiKey(db, owner, {
-			name: "Robot",
-			permissions: perms(),
-		});
-
-		await expect(getApiKey(db, other, apiKey.id)).rejects.toBeInstanceOf(
-			ApiKeyNotFoundError,
-		);
-	});
-});
-
 describe("updateApiKey", () => {
 	it("merges the update into the stored permissions", async () => {
 		const userId = await seedUser(db, { administratorRole: "full" });
@@ -185,6 +133,23 @@ describe("updateApiKey", () => {
 		await expect(
 			updateApiKey(db, userId, 404, { create_ref: true }),
 		).rejects.toBeInstanceOf(ApiKeyNotFoundError);
+	});
+
+	it("throws when the key belongs to another user", async () => {
+		const owner = await seedUser(db, { handle: "owner" });
+		const other = await seedUser(db, { handle: "other" });
+		const { apiKey } = await createApiKey(db, owner, {
+			name: "Robot",
+			permissions: perms({ create_ref: true }),
+		});
+
+		await expect(
+			updateApiKey(db, other, apiKey.id, { create_sample: true }),
+		).rejects.toBeInstanceOf(ApiKeyNotFoundError);
+
+		// The owner's key is untouched by the rejected cross-user update.
+		const [row] = await findApiKeys(db, owner);
+		expect(row?.permissions).toEqual(perms({ create_ref: true }));
 	});
 });
 

--- a/apps/web/src/server/account/data.test.ts
+++ b/apps/web/src/server/account/data.test.ts
@@ -98,6 +98,22 @@ describe("findApiKeys", () => {
 		);
 	});
 
+	it("expands sparse legacy permissions to the full checklist", async () => {
+		const userId = await seedUser(db, { administratorRole: "full" });
+		// The legacy Python path stored only the provided permission keys.
+		await db.insert(apiKeys).values({
+			hashed: "legacy",
+			name: "Legacy",
+			createdAt: new Date(),
+			userId,
+			permissions: { create_ref: true } as GroupPermissions,
+		});
+
+		const keys = await findApiKeys(db, userId);
+
+		expect(keys[0]?.permissions).toEqual(perms({ create_ref: true }));
+	});
+
 	it("does not return another user's keys", async () => {
 		const owner = await seedUser(db, { handle: "owner" });
 		const other = await seedUser(db, { handle: "other" });

--- a/apps/web/src/server/account/data.ts
+++ b/apps/web/src/server/account/data.ts
@@ -9,7 +9,7 @@ import { AppError } from "../errors";
 /** An account API key as returned to the API-key management UI. */
 export type ApiKey = {
 	id: number;
-	created_at: string;
+	createdAt: string;
 	name: string;
 	permissions: Permissions;
 };
@@ -32,7 +32,7 @@ export class ApiKeyNotFoundError extends AppError {}
 function toApiKey(row: ApiKeyRow): ApiKey {
 	return {
 		id: row.id,
-		created_at: row.createdAt.toISOString(),
+		createdAt: row.createdAt.toISOString(),
 		name: row.name,
 		permissions: { ...emptyPermissions(), ...row.permissions },
 	};

--- a/apps/web/src/server/account/data.ts
+++ b/apps/web/src/server/account/data.ts
@@ -1,0 +1,175 @@
+import { createHash, randomBytes } from "node:crypto";
+import { and, asc, eq } from "drizzle-orm";
+import type { Db } from "../db/pg";
+import { takeFirstOrThrow } from "../db/rows";
+import { type ApiKeyRow, apiKeys as apiKeysTable } from "../db/schema/apiKeys";
+import type { GroupPermissions } from "../db/schema/groups";
+import { AppError } from "../errors";
+import { getUser } from "../users/data";
+
+/** An account API key as returned to the API-key management UI. */
+export type ApiKey = {
+	id: number;
+	created_at: string;
+	name: string;
+	permissions: GroupPermissions;
+};
+
+/** An API key paired with its raw secret, returned only once at creation. */
+export type CreatedApiKey = {
+	key: string;
+	apiKey: ApiKey;
+};
+
+/** Thrown when a requested API key does not exist on the user's account. */
+export class ApiKeyNotFoundError extends AppError {}
+
+function basePermissions(): GroupPermissions {
+	return {
+		cancel_job: false,
+		create_ref: false,
+		create_sample: false,
+		modify_hmm: false,
+		modify_subtraction: false,
+		remove_file: false,
+		remove_job: false,
+		upload_file: false,
+	};
+}
+
+/**
+ * Clamp `permissions` so no value exceeds the matching one in `limit`. Mirrors
+ * `limit_permissions` in the Python service: a key can never report a
+ * permission its owner no longer holds.
+ */
+function limitPermissions(
+	permissions: GroupPermissions,
+	limit: GroupPermissions,
+): GroupPermissions {
+	const result = basePermissions();
+	for (const key of Object.keys(result) as (keyof GroupPermissions)[]) {
+		result[key] = permissions[key] && limit[key];
+	}
+	return result;
+}
+
+function toApiKey(row: ApiKeyRow, permissions: GroupPermissions): ApiKey {
+	return {
+		id: row.id,
+		created_at: row.createdAt.toISOString(),
+		name: row.name,
+		permissions,
+	};
+}
+
+function generateKey(): { raw: string; hashed: string } {
+	const raw = randomBytes(32).toString("hex");
+	return { raw, hashed: createHash("sha256").update(raw).digest("hex") };
+}
+
+/**
+ * List the account's API keys with their stored permissions.
+ *
+ * The list is deliberately not clamped, mirroring the Python service: only the
+ * single-key read (and the representation returned from create/update) clamps
+ * to the owner's current permissions.
+ */
+export async function findApiKeys(db: Db, userId: number): Promise<ApiKey[]> {
+	const rows = await db
+		.select()
+		.from(apiKeysTable)
+		.where(eq(apiKeysTable.userId, userId))
+		.orderBy(asc(apiKeysTable.id));
+
+	return rows.map((row) => toApiKey(row, row.permissions));
+}
+
+/**
+ * Read a single API key, clamping its permissions to the owner's current
+ * permissions unless the owner is an administrator.
+ */
+export async function getApiKey(
+	db: Db,
+	userId: number,
+	keyId: number,
+): Promise<ApiKey> {
+	const user = await getUser(db, userId);
+
+	const [row] = await db
+		.select()
+		.from(apiKeysTable)
+		.where(and(eq(apiKeysTable.id, keyId), eq(apiKeysTable.userId, userId)))
+		.limit(1);
+
+	if (!row) {
+		throw new ApiKeyNotFoundError();
+	}
+
+	const permissions = user.administrator_role
+		? row.permissions
+		: limitPermissions(row.permissions, user.permissions);
+
+	return toApiKey(row, permissions);
+}
+
+export async function createApiKey(
+	db: Db,
+	userId: number,
+	values: { name: string; permissions: Partial<GroupPermissions> },
+): Promise<CreatedApiKey> {
+	const { raw, hashed } = generateKey();
+
+	const row = takeFirstOrThrow(
+		await db
+			.insert(apiKeysTable)
+			.values({
+				hashed,
+				name: values.name,
+				createdAt: new Date(),
+				userId,
+				permissions: { ...basePermissions(), ...values.permissions },
+			})
+			.returning(),
+	);
+
+	return { key: raw, apiKey: await getApiKey(db, userId, row.id) };
+}
+
+export async function updateApiKey(
+	db: Db,
+	userId: number,
+	keyId: number,
+	permissions: Partial<GroupPermissions>,
+): Promise<ApiKey> {
+	const [existing] = await db
+		.select({ permissions: apiKeysTable.permissions })
+		.from(apiKeysTable)
+		.where(and(eq(apiKeysTable.id, keyId), eq(apiKeysTable.userId, userId)))
+		.limit(1);
+
+	if (!existing) {
+		throw new ApiKeyNotFoundError();
+	}
+
+	await db
+		.update(apiKeysTable)
+		.set({ permissions: { ...existing.permissions, ...permissions } })
+		.where(and(eq(apiKeysTable.id, keyId), eq(apiKeysTable.userId, userId)));
+
+	return getApiKey(db, userId, keyId);
+}
+
+export async function deleteApiKey(
+	db: Db,
+	userId: number,
+	keyId: number,
+): Promise<void> {
+	const [row] = await db
+		.delete(apiKeysTable)
+		.where(and(eq(apiKeysTable.id, keyId), eq(apiKeysTable.userId, userId)))
+		.returning({ id: apiKeysTable.id });
+
+	if (!row) {
+		throw new ApiKeyNotFoundError();
+	}
+}

--- a/apps/web/src/server/account/data.ts
+++ b/apps/web/src/server/account/data.ts
@@ -1,11 +1,10 @@
 import { createHash, randomBytes } from "node:crypto";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 import type { Db } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import { type ApiKeyRow, apiKeys as apiKeysTable } from "../db/schema/apiKeys";
 import type { GroupPermissions } from "../db/schema/groups";
 import { AppError } from "../errors";
-import { getUser } from "../users/data";
 
 /** An account API key as returned to the API-key management UI. */
 export type ApiKey = {
@@ -38,27 +37,17 @@ function basePermissions(): GroupPermissions {
 }
 
 /**
- * Clamp `permissions` so no value exceeds the matching one in `limit`. Mirrors
- * `limit_permissions` in the Python service: a key can never report a
- * permission its owner no longer holds.
+ * Build the API-key representation from a stored row. Permissions are expanded
+ * against `basePermissions()` so keys written by the legacy Python path — which
+ * stored only the provided keys — still report every permission as an explicit
+ * boolean, and the edit UI can offer the full checklist.
  */
-function limitPermissions(
-	permissions: GroupPermissions,
-	limit: GroupPermissions,
-): GroupPermissions {
-	const result = basePermissions();
-	for (const key of Object.keys(result) as (keyof GroupPermissions)[]) {
-		result[key] = permissions[key] && limit[key];
-	}
-	return result;
-}
-
-function toApiKey(row: ApiKeyRow, permissions: GroupPermissions): ApiKey {
+function toApiKey(row: ApiKeyRow): ApiKey {
 	return {
 		id: row.id,
 		created_at: row.createdAt.toISOString(),
 		name: row.name,
-		permissions,
+		permissions: { ...basePermissions(), ...row.permissions },
 	};
 }
 
@@ -67,16 +56,7 @@ function generateKey(): { raw: string; hashed: string } {
 	return { raw, hashed: createHash("sha256").update(raw).digest("hex") };
 }
 
-/**
- * List the account's API keys with their stored permissions.
- *
- * The list is deliberately not clamped, mirroring the Python service: only the
- * single-key read (and the representation returned from create/update) clamps
- * to the owner's current permissions. Stored permissions are expanded against
- * `basePermissions()` so keys written by the legacy Python path — which stored
- * only the provided keys — still report every permission as an explicit
- * boolean, and the edit UI can offer the full checklist.
- */
+/** List the account's API keys with their stored permissions. */
 export async function findApiKeys(db: Db, userId: number): Promise<ApiKey[]> {
 	const rows = await db
 		.select()
@@ -84,37 +64,7 @@ export async function findApiKeys(db: Db, userId: number): Promise<ApiKey[]> {
 		.where(eq(apiKeysTable.userId, userId))
 		.orderBy(asc(apiKeysTable.id));
 
-	return rows.map((row) =>
-		toApiKey(row, { ...basePermissions(), ...row.permissions }),
-	);
-}
-
-/**
- * Read a single API key, clamping its permissions to the owner's current
- * permissions unless the owner is an administrator.
- */
-export async function getApiKey(
-	db: Db,
-	userId: number,
-	keyId: number,
-): Promise<ApiKey> {
-	const user = await getUser(db, userId);
-
-	const [row] = await db
-		.select()
-		.from(apiKeysTable)
-		.where(and(eq(apiKeysTable.id, keyId), eq(apiKeysTable.userId, userId)))
-		.limit(1);
-
-	if (!row) {
-		throw new ApiKeyNotFoundError();
-	}
-
-	const permissions = user.administrator_role
-		? row.permissions
-		: limitPermissions(row.permissions, user.permissions);
-
-	return toApiKey(row, permissions);
+	return rows.map(toApiKey);
 }
 
 export async function createApiKey(
@@ -137,7 +87,7 @@ export async function createApiKey(
 			.returning(),
 	);
 
-	return { key: raw, apiKey: await getApiKey(db, userId, row.id) };
+	return { key: raw, apiKey: toApiKey(row) };
 }
 
 export async function updateApiKey(
@@ -146,22 +96,21 @@ export async function updateApiKey(
 	keyId: number,
 	permissions: Partial<GroupPermissions>,
 ): Promise<ApiKey> {
-	const [existing] = await db
-		.select({ permissions: apiKeysTable.permissions })
-		.from(apiKeysTable)
+	// Merge the partial into the stored jsonb in a single statement; Postgres
+	// does the merge server-side, so no prior read of the existing value.
+	const [row] = await db
+		.update(apiKeysTable)
+		.set({
+			permissions: sql`${apiKeysTable.permissions} || ${JSON.stringify(permissions)}::jsonb`,
+		})
 		.where(and(eq(apiKeysTable.id, keyId), eq(apiKeysTable.userId, userId)))
-		.limit(1);
+		.returning();
 
-	if (!existing) {
+	if (!row) {
 		throw new ApiKeyNotFoundError();
 	}
 
-	await db
-		.update(apiKeysTable)
-		.set({ permissions: { ...existing.permissions, ...permissions } })
-		.where(and(eq(apiKeysTable.id, keyId), eq(apiKeysTable.userId, userId)));
-
-	return getApiKey(db, userId, keyId);
+	return toApiKey(row);
 }
 
 export async function deleteApiKey(

--- a/apps/web/src/server/account/data.ts
+++ b/apps/web/src/server/account/data.ts
@@ -1,9 +1,9 @@
 import { createHash, randomBytes } from "node:crypto";
+import { emptyPermissions, type Permissions } from "@virtool/contracts";
 import { and, asc, eq, sql } from "drizzle-orm";
 import type { Db } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import { type ApiKeyRow, apiKeys as apiKeysTable } from "../db/schema/apiKeys";
-import type { GroupPermissions } from "../db/schema/groups";
 import { AppError } from "../errors";
 
 /** An account API key as returned to the API-key management UI. */
@@ -11,7 +11,7 @@ export type ApiKey = {
 	id: number;
 	created_at: string;
 	name: string;
-	permissions: GroupPermissions;
+	permissions: Permissions;
 };
 
 /** An API key paired with its raw secret, returned only once at creation. */
@@ -23,31 +23,18 @@ export type CreatedApiKey = {
 /** Thrown when a requested API key does not exist on the user's account. */
 export class ApiKeyNotFoundError extends AppError {}
 
-function basePermissions(): GroupPermissions {
-	return {
-		cancel_job: false,
-		create_ref: false,
-		create_sample: false,
-		modify_hmm: false,
-		modify_subtraction: false,
-		remove_file: false,
-		remove_job: false,
-		upload_file: false,
-	};
-}
-
 /**
  * Build the API-key representation from a stored row. Permissions are expanded
- * against `basePermissions()` so keys written by the legacy Python path — which
- * stored only the provided keys — still report every permission as an explicit
- * boolean, and the edit UI can offer the full checklist.
+ * against `emptyPermissions()` so keys written by the legacy Python path —
+ * which stored only the provided keys — still report every permission as an
+ * explicit boolean, and the edit UI can offer the full checklist.
  */
 function toApiKey(row: ApiKeyRow): ApiKey {
 	return {
 		id: row.id,
 		created_at: row.createdAt.toISOString(),
 		name: row.name,
-		permissions: { ...basePermissions(), ...row.permissions },
+		permissions: { ...emptyPermissions(), ...row.permissions },
 	};
 }
 
@@ -70,7 +57,7 @@ export async function findApiKeys(db: Db, userId: number): Promise<ApiKey[]> {
 export async function createApiKey(
 	db: Db,
 	userId: number,
-	values: { name: string; permissions: Partial<GroupPermissions> },
+	values: { name: string; permissions: Partial<Permissions> },
 ): Promise<CreatedApiKey> {
 	const { raw, hashed } = generateKey();
 
@@ -82,7 +69,7 @@ export async function createApiKey(
 				name: values.name,
 				createdAt: new Date(),
 				userId,
-				permissions: { ...basePermissions(), ...values.permissions },
+				permissions: { ...emptyPermissions(), ...values.permissions },
 			})
 			.returning(),
 	);
@@ -94,7 +81,7 @@ export async function updateApiKey(
 	db: Db,
 	userId: number,
 	keyId: number,
-	permissions: Partial<GroupPermissions>,
+	permissions: Partial<Permissions>,
 ): Promise<ApiKey> {
 	// Merge the partial into the stored jsonb in a single statement; Postgres
 	// does the merge server-side, so no prior read of the existing value.

--- a/apps/web/src/server/account/data.ts
+++ b/apps/web/src/server/account/data.ts
@@ -9,7 +9,7 @@ import { AppError } from "../errors";
 /** An account API key as returned to the API-key management UI. */
 export type ApiKey = {
 	id: number;
-	createdAt: string;
+	createdAt: Date;
 	name: string;
 	permissions: Permissions;
 };
@@ -32,7 +32,7 @@ export class ApiKeyNotFoundError extends AppError {}
 function toApiKey(row: ApiKeyRow): ApiKey {
 	return {
 		id: row.id,
-		createdAt: row.createdAt.toISOString(),
+		createdAt: row.createdAt,
 		name: row.name,
 		permissions: { ...emptyPermissions(), ...row.permissions },
 	};

--- a/apps/web/src/server/account/data.ts
+++ b/apps/web/src/server/account/data.ts
@@ -72,7 +72,10 @@ function generateKey(): { raw: string; hashed: string } {
  *
  * The list is deliberately not clamped, mirroring the Python service: only the
  * single-key read (and the representation returned from create/update) clamps
- * to the owner's current permissions.
+ * to the owner's current permissions. Stored permissions are expanded against
+ * `basePermissions()` so keys written by the legacy Python path — which stored
+ * only the provided keys — still report every permission as an explicit
+ * boolean, and the edit UI can offer the full checklist.
  */
 export async function findApiKeys(db: Db, userId: number): Promise<ApiKey[]> {
 	const rows = await db
@@ -81,7 +84,9 @@ export async function findApiKeys(db: Db, userId: number): Promise<ApiKey[]> {
 		.where(eq(apiKeysTable.userId, userId))
 		.orderBy(asc(apiKeysTable.id));
 
-	return rows.map((row) => toApiKey(row, row.permissions));
+	return rows.map((row) =>
+		toApiKey(row, { ...basePermissions(), ...row.permissions }),
+	);
 }
 
 /**

--- a/apps/web/src/server/account/functions.test.ts
+++ b/apps/web/src/server/account/functions.test.ts
@@ -1,0 +1,172 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+
+import type { Db } from "../db/pg";
+import { apiKeys } from "../db/schema/apiKeys";
+import { sessions } from "../db/schema/sessions";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { callServerFn, type SplitServerFnModule } from "../test/serverFn";
+
+const getRequest = vi.fn();
+const setResponseStatus = vi.fn();
+
+vi.mock("@tanstack/react-start/server", () => ({
+	deleteCookie: vi.fn(),
+	getCookie: vi.fn(),
+	getRequest,
+	setCookie: vi.fn(),
+	setResponseStatus,
+}));
+
+vi.mock("@sentry/tanstackstart-react", () => ({
+	captureException: vi.fn(),
+	setUser: vi.fn(),
+}));
+
+// The handlers read the `db` singleton at module scope. A getter defers the
+// read until a handler actually runs, by which point beforeAll has pointed it
+// at this file's isolated database.
+let db: Db;
+vi.mock("../db/pg", () => ({
+	client: {},
+	get db() {
+		return db;
+	},
+}));
+
+const handlers = (await import(
+	"./functions.ts?tss-serverfn-split"
+)) as SplitServerFnModule;
+const { UnauthorizedError } = await import("../auth/middleware");
+const { SESSION_ID_COOKIE, SESSION_TOKEN_COOKIE } = await import(
+	"../auth/cookies"
+);
+const { seedSession, seedUser } = await import("../auth/test/fixtures");
+
+let database: TestDatabase;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	await db.delete(apiKeys);
+	await db.delete(sessions);
+	await db.delete(users);
+	getRequest.mockReturnValue(
+		new Request("https://virtool.test/_serverFn/test"),
+	);
+});
+
+/** Authenticate the next call as a freshly seeded user and return its id. */
+async function signIn(handle = "alice"): Promise<number> {
+	const userId = await seedUser(db, { handle });
+	const { sessionId, token } = await seedSession(db, userId);
+
+	getRequest.mockReturnValue(
+		new Request("https://virtool.test/_serverFn/test", {
+			headers: {
+				cookie: `${SESSION_ID_COOKIE}=${sessionId}; ${SESSION_TOKEN_COOKIE}=${token}`,
+			},
+		}),
+	);
+
+	return userId;
+}
+
+function call(name: string, data?: unknown) {
+	return callServerFn(handlers, name, data);
+}
+
+describe("findApiKeys", () => {
+	it("refuses an unauthenticated caller", async () => {
+		await expect(call("findApiKeys")).rejects.toBeInstanceOf(UnauthorizedError);
+	});
+
+	it("returns only the signed-in user's keys", async () => {
+		await signIn();
+		await call("createApiKey", { name: "Robot", permissions: {} });
+
+		const keys = (await call("findApiKeys")) as { name: string }[];
+
+		expect(keys).toHaveLength(1);
+		expect(keys[0]?.name).toBe("Robot");
+	});
+});
+
+describe("createApiKey", () => {
+	it("returns the raw secret and a 201", async () => {
+		await signIn();
+
+		const created = (await call("createApiKey", {
+			name: "Robot",
+			permissions: { create_ref: true },
+		})) as { key: string; name: string };
+
+		expect(created.key).toMatch(/^[0-9a-f]{64}$/);
+		expect(created.name).toBe("Robot");
+		expect(setResponseStatus).toHaveBeenCalledWith(201);
+	});
+});
+
+describe("updateApiKey", () => {
+	it("responds with 404 for a key the user does not own", async () => {
+		const owner = await signIn("owner");
+		const created = (await call("createApiKey", {
+			name: "Robot",
+			permissions: {},
+		})) as { id: number };
+
+		await signIn("intruder");
+
+		await expect(
+			call("updateApiKey", {
+				keyId: created.id,
+				permissions: { create_ref: true },
+			}),
+		).rejects.toThrow("API key not found.");
+		expect(setResponseStatus).toHaveBeenCalledWith(404);
+		// The owner's key is untouched.
+		const [row] = await db.select().from(apiKeys);
+		expect(row?.userId).toBe(owner);
+		expect(row?.permissions.create_ref).toBe(false);
+	});
+});
+
+describe("deleteApiKey", () => {
+	it("removes the signed-in user's key with a 204", async () => {
+		await signIn();
+		const created = (await call("createApiKey", {
+			name: "Robot",
+			permissions: {},
+		})) as { id: number };
+
+		await call("deleteApiKey", { keyId: created.id });
+
+		expect(setResponseStatus).toHaveBeenCalledWith(204);
+		expect(await db.select().from(apiKeys)).toHaveLength(0);
+	});
+
+	it("responds with 404 when the key does not exist", async () => {
+		await signIn();
+
+		await expect(call("deleteApiKey", { keyId: 404 })).rejects.toThrow(
+			"API key not found.",
+		);
+		expect(setResponseStatus).toHaveBeenCalledWith(404);
+	});
+});

--- a/apps/web/src/server/account/functions.ts
+++ b/apps/web/src/server/account/functions.ts
@@ -1,5 +1,6 @@
 import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
+import { permissionsSchema } from "@virtool/contracts";
 import { z } from "zod";
 import { authenticated } from "../auth/policy";
 import { db } from "../db/pg";
@@ -10,17 +11,6 @@ import {
 	findApiKeys as findApiKeysImpl,
 	updateApiKey as updateApiKeyImpl,
 } from "./data";
-
-const permissionsSchema = z.object({
-	cancel_job: z.boolean(),
-	create_ref: z.boolean(),
-	create_sample: z.boolean(),
-	modify_hmm: z.boolean(),
-	modify_subtraction: z.boolean(),
-	remove_file: z.boolean(),
-	remove_job: z.boolean(),
-	upload_file: z.boolean(),
-});
 
 const createApiKeySchema = z.object({
 	name: z.string().trim().min(1),

--- a/apps/web/src/server/account/functions.ts
+++ b/apps/web/src/server/account/functions.ts
@@ -1,0 +1,94 @@
+import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
+import { setResponseStatus } from "@tanstack/react-start/server";
+import { z } from "zod";
+import { authenticated } from "../auth/policy";
+import { db } from "../db/pg";
+import {
+	ApiKeyNotFoundError,
+	createApiKey as createApiKeyImpl,
+	deleteApiKey as deleteApiKeyImpl,
+	findApiKeys as findApiKeysImpl,
+	updateApiKey as updateApiKeyImpl,
+} from "./data";
+
+const permissionsSchema = z.object({
+	cancel_job: z.boolean(),
+	create_ref: z.boolean(),
+	create_sample: z.boolean(),
+	modify_hmm: z.boolean(),
+	modify_subtraction: z.boolean(),
+	remove_file: z.boolean(),
+	remove_job: z.boolean(),
+	upload_file: z.boolean(),
+});
+
+const createApiKeySchema = z.object({
+	name: z.string().trim().min(1),
+	permissions: permissionsSchema.partial().default({}),
+});
+
+const updateApiKeySchema = z.object({
+	keyId: z.number().int().positive(),
+	permissions: permissionsSchema.partial().default({}),
+});
+
+const keyIdSchema = z.object({
+	keyId: z.number().int().positive(),
+});
+
+// Wrapped in createServerOnlyFn so the compiler can strip this body — and the
+// ApiKeyNotFoundError import it references — from the client bundle. A plain
+// top-level helper would pin ./data and its postgres transitive dependency in
+// the client graph.
+const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
+	if (err instanceof ApiKeyNotFoundError) {
+		setResponseStatus(404);
+		throw new Error("API key not found.");
+	}
+	throw err;
+});
+
+export const findApiKeys = createServerFn({ method: "GET" })
+	.middleware([authenticated()])
+	.handler(async ({ context }) => findApiKeysImpl(db, context.session.userId));
+
+export const createApiKey = createServerFn({ method: "POST" })
+	.middleware([authenticated()])
+	.validator(createApiKeySchema)
+	.handler(async ({ context, data }) => {
+		const { key, apiKey } = await createApiKeyImpl(db, context.session.userId, {
+			name: data.name,
+			permissions: data.permissions,
+		});
+		setResponseStatus(201);
+		return { ...apiKey, key };
+	});
+
+export const updateApiKey = createServerFn({ method: "POST" })
+	.middleware([authenticated()])
+	.validator(updateApiKeySchema)
+	.handler(async ({ context, data }) => {
+		try {
+			return await updateApiKeyImpl(
+				db,
+				context.session.userId,
+				data.keyId,
+				data.permissions,
+			);
+		} catch (err) {
+			return rethrowAsHttp(err);
+		}
+	});
+
+export const deleteApiKey = createServerFn({ method: "POST" })
+	.middleware([authenticated()])
+	.validator(keyIdSchema)
+	.handler(async ({ context, data }) => {
+		try {
+			await deleteApiKeyImpl(db, context.session.userId, data.keyId);
+			setResponseStatus(204);
+			return null;
+		} catch (err) {
+			return rethrowAsHttp(err);
+		}
+	});

--- a/apps/web/src/server/auth/policy.test.ts
+++ b/apps/web/src/server/auth/policy.test.ts
@@ -1,3 +1,4 @@
+import type { Permissions } from "@virtool/contracts";
 import {
 	afterAll,
 	beforeAll,
@@ -7,9 +8,8 @@ import {
 	it,
 	vi,
 } from "vitest";
-
 import type { Db } from "../db/pg";
-import { type GroupPermissions, groups, userGroups } from "../db/schema/groups";
+import { groups, userGroups } from "../db/schema/groups";
 import { sessions } from "../db/schema/sessions";
 import { users } from "../db/schema/users";
 import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
@@ -57,7 +57,7 @@ beforeEach(async () => {
 
 function seedGroup(
 	name: string,
-	permissions: Partial<GroupPermissions>,
+	permissions: Partial<Permissions>,
 ): Promise<number> {
 	return seedGroupImpl(db, { name, permissions });
 }

--- a/apps/web/src/server/db/schema/apiKeys.ts
+++ b/apps/web/src/server/db/schema/apiKeys.ts
@@ -1,0 +1,21 @@
+// Read-only mirror of the `api_keys` table managed by the upstream Python
+// service via Alembic. Do not generate or push migrations from this side. Keep
+// the columns in sync with `../../../../../../virtool/virtool/account/sql.py`.
+
+import { integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import type { GroupPermissions } from "./groups";
+import { users } from "./users";
+
+export const apiKeys = pgTable("api_keys", {
+	id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+	hashed: text("hashed").notNull().unique(),
+	name: text("name").notNull(),
+	createdAt: timestamp("created_at").notNull(),
+	userId: integer("user_id")
+		.notNull()
+		.references(() => users.id, { onDelete: "cascade" }),
+	permissions: jsonb("permissions").$type<GroupPermissions>().notNull(),
+});
+
+/** A row from the `api_keys` table. */
+export type ApiKeyRow = typeof apiKeys.$inferSelect;

--- a/apps/web/src/server/db/schema/apiKeys.ts
+++ b/apps/web/src/server/db/schema/apiKeys.ts
@@ -2,8 +2,8 @@
 // service via Alembic. Do not generate or push migrations from this side. Keep
 // the columns in sync with `../../../../../../virtool/virtool/account/sql.py`.
 
+import type { Permissions } from "@virtool/contracts";
 import { integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
-import type { GroupPermissions } from "./groups";
 import { users } from "./users";
 
 export const apiKeys = pgTable("api_keys", {
@@ -14,7 +14,7 @@ export const apiKeys = pgTable("api_keys", {
 	userId: integer("user_id")
 		.notNull()
 		.references(() => users.id, { onDelete: "cascade" }),
-	permissions: jsonb("permissions").$type<GroupPermissions>().notNull(),
+	permissions: jsonb("permissions").$type<Permissions>().notNull(),
 });
 
 /** A row from the `api_keys` table. */

--- a/apps/web/src/server/db/schema/groups.ts
+++ b/apps/web/src/server/db/schema/groups.ts
@@ -4,6 +4,7 @@
 // `../../../../../../virtool/virtool/groups/pg.py` and
 // `../../../../../../virtool/virtool/users/pg.py`.
 
+import type { Permissions } from "@virtool/contracts";
 import {
 	boolean,
 	integer,
@@ -14,23 +15,11 @@ import {
 } from "drizzle-orm/pg-core";
 import { users } from "./users";
 
-/** Permission flags stored on every group row. */
-export type GroupPermissions = {
-	cancel_job: boolean;
-	create_ref: boolean;
-	create_sample: boolean;
-	modify_hmm: boolean;
-	modify_subtraction: boolean;
-	remove_file: boolean;
-	remove_job: boolean;
-	upload_file: boolean;
-};
-
 export const groups = pgTable("groups", {
 	id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
 	legacyId: text("legacy_id").unique(),
 	name: text("name").unique().notNull(),
-	permissions: jsonb("permissions").$type<GroupPermissions>().notNull(),
+	permissions: jsonb("permissions").$type<Permissions>().notNull(),
 });
 
 /** A row from the `groups` table. */

--- a/apps/web/src/server/db/schema/index.ts
+++ b/apps/web/src/server/db/schema/index.ts
@@ -4,6 +4,7 @@
 // here. Each feature owns a sibling file (e.g. `labels.ts`) and is added to
 // the `export *` list as it lands.
 export * from "./analyses";
+export * from "./apiKeys";
 export * from "./groups";
 export * from "./indexes";
 export * from "./jobs";

--- a/apps/web/src/server/groups/data.ts
+++ b/apps/web/src/server/groups/data.ts
@@ -1,9 +1,9 @@
+import { emptyPermissions, type Permissions } from "@virtool/contracts";
 import { asc, count, eq, ilike } from "drizzle-orm";
 import type { PostgresError } from "postgres";
 import type { Db } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import {
-	type GroupPermissions,
 	type GroupRow,
 	groups as groupsTable,
 	userGroups as userGroupsTable,
@@ -27,7 +27,7 @@ export type GroupMinimal = {
 
 /** A full group record including permissions and member users. */
 export type Group = GroupMinimal & {
-	permissions: GroupPermissions;
+	permissions: Permissions;
 	users: GroupUserNested[];
 };
 
@@ -44,7 +44,7 @@ export type GroupSearchResults = {
 /** Partial values accepted when updating a group. */
 export type GroupUpdateValues = {
 	name?: string;
-	permissions?: Partial<GroupPermissions>;
+	permissions?: Partial<Permissions>;
 };
 
 /** Thrown when a requested group does not exist. */
@@ -64,19 +64,6 @@ function isUniqueViolation(error: unknown): boolean {
 			typeof cause === "object" &&
 			(cause as Partial<PostgresError>).code === "23505")
 	);
-}
-
-function generateBasePermissions(): GroupPermissions {
-	return {
-		cancel_job: false,
-		create_ref: false,
-		create_sample: false,
-		modify_hmm: false,
-		modify_subtraction: false,
-		remove_file: false,
-		remove_job: false,
-		upload_file: false,
-	};
 }
 
 function toGroupMinimal(row: GroupRow): GroupMinimal {
@@ -170,7 +157,7 @@ export async function createGroup(db: Db, name: string): Promise<Group> {
 				.values({
 					name,
 					legacyId: null,
-					permissions: generateBasePermissions(),
+					permissions: emptyPermissions(),
 				})
 				.returning(),
 		);

--- a/apps/web/src/server/groups/functions.test.ts
+++ b/apps/web/src/server/groups/functions.test.ts
@@ -1,3 +1,4 @@
+import type { Permissions } from "@virtool/contracts";
 import { eq } from "drizzle-orm";
 import {
 	afterAll,
@@ -8,10 +9,9 @@ import {
 	it,
 	vi,
 } from "vitest";
-
 import type { Db } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
-import { type GroupPermissions, groups } from "../db/schema/groups";
+import { groups } from "../db/schema/groups";
 import { sessions } from "../db/schema/sessions";
 import { users } from "../db/schema/users";
 import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
@@ -172,7 +172,7 @@ describe("updateGroup", () => {
 		const group = (await call("updateGroup", {
 			groupId,
 			permissions: { create_ref: true },
-		})) as { permissions: GroupPermissions };
+		})) as { permissions: Permissions };
 
 		expect(group.permissions).toEqual({ ...NO_PERMISSIONS, create_ref: true });
 	});

--- a/apps/web/src/server/groups/functions.ts
+++ b/apps/web/src/server/groups/functions.ts
@@ -1,5 +1,6 @@
 import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
+import { permissionsSchema } from "@virtool/contracts";
 import { z } from "zod";
 import { adminRole, authenticated } from "../auth/policy";
 import { db } from "../db/pg";
@@ -30,23 +31,10 @@ const createGroupSchema = z.object({
 	name: z.string().min(1),
 });
 
-const permissionsPatchSchema = z
-	.object({
-		cancel_job: z.boolean(),
-		create_ref: z.boolean(),
-		create_sample: z.boolean(),
-		modify_hmm: z.boolean(),
-		modify_subtraction: z.boolean(),
-		remove_file: z.boolean(),
-		remove_job: z.boolean(),
-		upload_file: z.boolean(),
-	})
-	.partial();
-
 const updateGroupSchema = z.object({
 	groupId: z.number().int().positive(),
 	name: z.string().min(1).optional(),
-	permissions: permissionsPatchSchema.optional(),
+	permissions: permissionsSchema.partial().optional(),
 });
 
 // Wrapped in createServerOnlyFn so the compiler can strip this body — and the

--- a/apps/web/src/server/groups/test/fixtures.ts
+++ b/apps/web/src/server/groups/test/fixtures.ts
@@ -1,25 +1,13 @@
+import { emptyPermissions, type Permissions } from "@virtool/contracts";
 import type { Db } from "../../db/pg";
 import { takeFirstOrThrow } from "../../db/rows";
-import {
-	type GroupPermissions,
-	groups,
-	userGroups,
-} from "../../db/schema/groups";
+import { groups, userGroups } from "../../db/schema/groups";
 
 /**
  * A group granting nothing. Spread it to build a group that grants one thing,
  * and assert against it to prove a group still grants nothing.
  */
-export const NO_PERMISSIONS: GroupPermissions = {
-	cancel_job: false,
-	create_ref: false,
-	create_sample: false,
-	modify_hmm: false,
-	modify_subtraction: false,
-	remove_file: false,
-	remove_job: false,
-	upload_file: false,
-};
+export const NO_PERMISSIONS: Permissions = emptyPermissions();
 
 /**
  * Insert a group granting no permissions unless told otherwise, and return its
@@ -32,7 +20,7 @@ export async function seedGroup(
 	{
 		name = "technicians",
 		permissions = {},
-	}: { name?: string; permissions?: Partial<GroupPermissions> } = {},
+	}: { name?: string; permissions?: Partial<Permissions> } = {},
 ): Promise<number> {
 	const row = takeFirstOrThrow(
 		await db

--- a/apps/web/src/server/users/data.ts
+++ b/apps/web/src/server/users/data.ts
@@ -1,4 +1,9 @@
-import type { AdministratorRoleName } from "@virtool/contracts";
+import {
+	type AdministratorRoleName,
+	emptyPermissions,
+	PERMISSION_NAMES,
+	type Permissions,
+} from "@virtool/contracts";
 import {
 	and,
 	asc,
@@ -17,7 +22,6 @@ import { invalidateUserSessions } from "../auth/session";
 import type { Db } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import {
-	type GroupPermissions,
 	groups as groupsTable,
 	userGroups as userGroupsTable,
 } from "../db/schema/groups";
@@ -41,7 +45,7 @@ export type User = {
 	force_reset: boolean;
 	groups: UserGroupReference[];
 	last_password_change: string;
-	permissions: GroupPermissions;
+	permissions: Permissions;
 	primary_group: UserGroupReference | null;
 };
 
@@ -164,34 +168,10 @@ const ADMINISTRATOR_ROLES: AdministratorRole[] = [
 	},
 ];
 
-const PERMISSION_KEYS: ReadonlyArray<keyof GroupPermissions> = [
-	"cancel_job",
-	"create_ref",
-	"create_sample",
-	"modify_hmm",
-	"modify_subtraction",
-	"remove_file",
-	"remove_job",
-	"upload_file",
-];
-
-function generateBasePermissions(): GroupPermissions {
-	return {
-		cancel_job: false,
-		create_ref: false,
-		create_sample: false,
-		modify_hmm: false,
-		modify_subtraction: false,
-		remove_file: false,
-		remove_job: false,
-		upload_file: false,
-	};
-}
-
 /** Merge the permissions granted by membership in a list of groups. */
-function mergePermissions(memberships: GroupPermissions[]): GroupPermissions {
-	const merged = generateBasePermissions();
-	for (const key of PERMISSION_KEYS) {
+function mergePermissions(memberships: Permissions[]): Permissions {
+	const merged = emptyPermissions();
+	for (const key of PERMISSION_NAMES) {
 		for (const permissions of memberships) {
 			if (permissions[key]) {
 				merged[key] = true;
@@ -221,7 +201,7 @@ type GroupMembershipRow = {
 	id: number;
 	legacyId: string | null;
 	name: string;
-	permissions: GroupPermissions;
+	permissions: Permissions;
 };
 
 async function fetchGroupMemberships(

--- a/apps/web/src/tests/api/account.ts
+++ b/apps/web/src/tests/api/account.ts
@@ -1,39 +1,5 @@
-import type { Account, APIKeyMinimal } from "@account/types";
-import { faker } from "@faker-js/faker";
-import type { Permissions } from "@groups/types";
+import type { Account } from "@account/types";
 import nock from "nock";
-
-/**
- * Mocks an API call for getting the API keys
- *
- * @param apiKeys - The array of API keys to return
- * @returns A nock scope for the mocked API call
- */
-export function mockApiGetApiKeys(apiKeys: APIKeyMinimal[]) {
-	return nock("http://localhost").get("/api/account/keys").reply(200, apiKeys);
-}
-
-/**
- * Mocks an API call for creating an API key
- *
- * @param name - The name of the API key
- * @param permissions - The permissions for the API key
- * @returns A nock scope for the mocked API call
- */
-export function mockApiCreateApiKey(name: string, permissions: Permissions) {
-	const createApiKeyResponse = {
-		groups: [],
-		id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
-		key: "testKey",
-		name,
-		permissions,
-	};
-
-	return nock("http://localhost")
-		.post("/api/account/keys")
-		.query(true)
-		.reply(201, createApiKeyResponse);
-}
 
 /**
  * Mocks a successful API call for changing the account password

--- a/apps/web/src/tests/fake/account.ts
+++ b/apps/web/src/tests/fake/account.ts
@@ -1,4 +1,4 @@
-import type { Account, AccountSettings, APIKeyMinimal } from "@account/types";
+import type { Account, AccountSettings, ApiKey } from "@account/types";
 import { faker } from "@faker-js/faker";
 import { createFakePermissions } from "./permissions";
 import { createFakeUser } from "./user";
@@ -25,11 +25,9 @@ export function createFakeAccount(overrides?: Partial<Account>): Account {
  *
  * @param overrides - optional properties for creating a fake API key with specific values
  */
-export function createFakeApiKey(
-	overrides?: Partial<APIKeyMinimal>,
-): APIKeyMinimal {
+export function createFakeApiKey(overrides?: Partial<ApiKey>): ApiKey {
 	return {
-		created_at: faker.date.past().toISOString(),
+		createdAt: faker.date.past().toISOString(),
 		id: faker.number.int({ min: 1, max: 100000 }),
 		name: faker.word.noun({ strategy: "any-length" }),
 		permissions: createFakePermissions({

--- a/apps/web/src/tests/fake/account.ts
+++ b/apps/web/src/tests/fake/account.ts
@@ -1,6 +1,5 @@
 import type { Account, AccountSettings, APIKeyMinimal } from "@account/types";
 import { faker } from "@faker-js/faker";
-import { createFakeGroupMinimal } from "./groups";
 import { createFakePermissions } from "./permissions";
 import { createFakeUser } from "./user";
 
@@ -31,8 +30,7 @@ export function createFakeApiKey(
 ): APIKeyMinimal {
 	return {
 		created_at: faker.date.past().toISOString(),
-		groups: [createFakeGroupMinimal()],
-		id: faker.string.alphanumeric({ casing: "lower", length: 8 }),
+		id: faker.number.int({ min: 1, max: 100000 }),
 		name: faker.word.noun({ strategy: "any-length" }),
 		permissions: createFakePermissions({
 			cancel_job: true,

--- a/apps/web/src/tests/fake/account.ts
+++ b/apps/web/src/tests/fake/account.ts
@@ -27,7 +27,7 @@ export function createFakeAccount(overrides?: Partial<Account>): Account {
  */
 export function createFakeApiKey(overrides?: Partial<ApiKey>): ApiKey {
 	return {
-		createdAt: faker.date.past().toISOString(),
+		createdAt: faker.date.past(),
 		id: faker.number.int({ min: 1, max: 100000 }),
 		name: faker.word.noun({ strategy: "any-length" }),
 		permissions: createFakePermissions({

--- a/apps/web/src/tests/fake/permissions.ts
+++ b/apps/web/src/tests/fake/permissions.ts
@@ -1,15 +1,4 @@
-import type { Permissions } from "@groups/types";
-
-const defaultPermissions = {
-	cancel_job: false,
-	create_ref: false,
-	create_sample: false,
-	modify_hmm: false,
-	modify_subtraction: false,
-	remove_file: false,
-	remove_job: false,
-	upload_file: false,
-};
+import { emptyPermissions, type Permissions } from "@virtool/contracts";
 
 /**
  * Create permissions object with default false values
@@ -21,7 +10,7 @@ export function createFakePermissions(
 	permissions?: Partial<Permissions>,
 ): Permissions {
 	return {
-		...defaultPermissions,
+		...emptyPermissions(),
 		...permissions,
 	};
 }

--- a/apps/web/src/tests/server-fn/account.ts
+++ b/apps/web/src/tests/server-fn/account.ts
@@ -1,4 +1,4 @@
-import type { APIKeyMinimal } from "@account/types";
+import type { ApiKey } from "@account/types";
 import type { Permissions } from "@groups/types";
 import { type Mock, vi } from "vitest";
 import { createFakeApiKey } from "../fake/account";
@@ -16,7 +16,7 @@ export const accountServerFnMocks = {
 };
 
 /** Sets up findApiKeys to resolve with the given API keys. */
-export function mockFindApiKeys(apiKeys: APIKeyMinimal[]): Mock {
+export function mockFindApiKeys(apiKeys: ApiKey[]): Mock {
 	accountServerFnMocks.findApiKeys.mockResolvedValue(apiKeys);
 	return accountServerFnMocks.findApiKeys;
 }
@@ -28,7 +28,7 @@ export function mockFindApiKeys(apiKeys: APIKeyMinimal[]): Mock {
 export function mockCreateApiKey(
 	key: string,
 	permissions: Permissions,
-	overrides?: Partial<APIKeyMinimal>,
+	overrides?: Partial<ApiKey>,
 ): Mock {
 	accountServerFnMocks.createApiKey.mockResolvedValue({
 		...createFakeApiKey({ permissions, ...overrides }),

--- a/apps/web/src/tests/server-fn/account.ts
+++ b/apps/web/src/tests/server-fn/account.ts
@@ -1,0 +1,38 @@
+import type { APIKeyMinimal } from "@account/types";
+import type { Permissions } from "@groups/types";
+import { type Mock, vi } from "vitest";
+import { createFakeApiKey } from "../fake/account";
+
+/**
+ * Mock handles for the `@server/account/functions` server-fn module. Wired in
+ * globally from `tests/setup.tsx` so any test rendering the API-key management
+ * view can stub them without per-file `vi.mock` boilerplate.
+ */
+export const accountServerFnMocks = {
+	findApiKeys: vi.fn(),
+	createApiKey: vi.fn(),
+	updateApiKey: vi.fn(),
+	deleteApiKey: vi.fn(),
+};
+
+/** Sets up findApiKeys to resolve with the given API keys. */
+export function mockFindApiKeys(apiKeys: APIKeyMinimal[]): Mock {
+	accountServerFnMocks.findApiKeys.mockResolvedValue(apiKeys);
+	return accountServerFnMocks.findApiKeys;
+}
+
+/**
+ * Sets up createApiKey to resolve with a created key carrying the given raw
+ * secret and permissions.
+ */
+export function mockCreateApiKey(
+	key: string,
+	permissions: Permissions,
+	overrides?: Partial<APIKeyMinimal>,
+): Mock {
+	accountServerFnMocks.createApiKey.mockResolvedValue({
+		...createFakeApiKey({ permissions, ...overrides }),
+		key,
+	});
+	return accountServerFnMocks.createApiKey;
+}

--- a/apps/web/src/tests/setup.tsx
+++ b/apps/web/src/tests/setup.tsx
@@ -22,6 +22,7 @@ import nock from "nock";
 import { createContext, type ReactNode, useContext, useState } from "react";
 import { beforeEach, vi } from "vitest";
 import { createFakeAccount } from "./fake/account";
+import { accountServerFnMocks } from "./server-fn/account";
 import { authServerFnMocks } from "./server-fn/auth";
 import { groupServerFnMocks } from "./server-fn/groups";
 import { jobServerFnMocks } from "./server-fn/jobs";
@@ -34,6 +35,10 @@ import { uploadServerFnMocks } from "./server-fn/uploads";
 import { userServerFnMocks } from "./server-fn/users";
 
 vi.mock("@server/groups/functions", () => groupServerFnMocks);
+vi.mock("@server/account/functions", async () => {
+	const { accountServerFnMocks } = await import("./server-fn/account");
+	return accountServerFnMocks;
+});
 // See the users mock below for why this resolves the mock via dynamic import.
 vi.mock("@server/auth/functions", async () => {
 	const { authServerFnMocks } = await import("./server-fn/auth");
@@ -69,6 +74,7 @@ beforeEach(() => {
 	}
 	for (const fn of [
 		...Object.values(userServerFnMocks),
+		...Object.values(accountServerFnMocks),
 		...Object.values(jobServerFnMocks),
 		...Object.values(authServerFnMocks),
 		...Object.values(labelServerFnMocks),

--- a/docs/database.md
+++ b/docs/database.md
@@ -74,6 +74,7 @@ states:
 | Labels       | `labels`                                             | Built          |
 | Jobs         | `jobs`                                               | Built          |
 | Settings     | `settings`                                           | Built          |
+| API keys     | `api_keys`                                           | Built          |
 | Analyses     | `analyses`                                           | Partial mirror |
 | Indexes      | `indexes`                                            | Partial mirror |
 | Samples      | `legacy_samples`                                     | Partial mirror |
@@ -84,7 +85,6 @@ states:
 | References   | `legacy_references`, `legacy_reference_*`            | Not started    |
 | HMMs         | `hmms`, `legacy_hmm_status`                          | Not started    |
 | History      | `legacy_history`, `legacy_history_diff`, `revisions` | Not started    |
-| API keys     | `api_keys`                                           | Not started    |
 
 The Postgres table(s) column lists the single mirrored table for the
 **partial mirror** rows and the principal Python-defined table(s) for

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -7,6 +7,7 @@ export * from "./hmms";
 export * from "./indexes";
 export * from "./jobs";
 export * from "./permissions";
+export * from "./permissionsSchema";
 export * from "./samples";
 export * from "./sse";
 export * from "./subtractions";

--- a/packages/contracts/src/permissions.ts
+++ b/packages/contracts/src/permissions.ts
@@ -1,10 +1,24 @@
+/** The names of every legacy group permission, in a stable order. */
+export const PERMISSION_NAMES = [
+	"cancel_job",
+	"create_ref",
+	"create_sample",
+	"modify_hmm",
+	"modify_subtraction",
+	"remove_file",
+	"remove_job",
+	"upload_file",
+] as const;
+
 /** A legacy group permission that gates a specific action. */
-export type Permission =
-	| "cancel_job"
-	| "create_ref"
-	| "create_sample"
-	| "modify_hmm"
-	| "modify_subtraction"
-	| "remove_file"
-	| "remove_job"
-	| "upload_file";
+export type Permission = (typeof PERMISSION_NAMES)[number];
+
+/** A full set of permission flags, one boolean per permission. */
+export type Permissions = Record<Permission, boolean>;
+
+/** Build a permission set with every flag set to `false`. */
+export function emptyPermissions(): Permissions {
+	return Object.fromEntries(
+		PERMISSION_NAMES.map((name) => [name, false]),
+	) as Permissions;
+}

--- a/packages/contracts/src/permissionsSchema.ts
+++ b/packages/contracts/src/permissionsSchema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+import { PERMISSION_NAMES, type Permission } from "./permissions";
+
+/**
+ * Zod schema validating a full set of permission flags. Kept in its own module
+ * so importing the runtime `PERMISSION_NAMES` tuple never pulls zod into a
+ * bundle that only needs the permission names or types.
+ */
+export const permissionsSchema = z.object(
+	Object.fromEntries(PERMISSION_NAMES.map((name) => [name, z.boolean()])),
+) as z.ZodObject<Record<Permission, z.ZodBoolean>>;


### PR DESCRIPTION
## Summary
- Move account API key list/create/update/delete calls off the Python REST API onto TanStack Start server functions backed by Postgres.
- Add the `api_keys` Drizzle schema mirror and an account `data.ts`/`functions.ts` layer, with permission clamping and authorization-policy coverage.
- Update account queries, tests, and fakes to the server-function-backed shape (API key `id` is now numeric; the unused `groups` field is dropped).