### PR TITLE
fix: stop reporting expected login and 4xx errors to Sentry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,6 +375,14 @@ first.
 Legacy features that still call the Python API through their
 client-side `api.ts` are not subject to this layering.
 
+A handler maps an expected outcome to an HTTP status with
+`setResponseStatus`, then throws `ClientError` (`@server/errors`) — never
+a plain `Error` — for any deliberate 4xx (a bad login, a missing record,
+a name conflict). The Sentry `beforeSend` filter drops `ClientError`
+(and the auth middleware's 401/403) as routine control flow; a plain
+`Error` is reported as a false incident. A bare `throw` stays reserved
+for the genuinely unexpected.
+
 See [docs/architecture.md](docs/architecture.md) for the import-direction
 invariant in full, the labels (minimal) and auth (carve-out) shapes,
 the pure-policy-vs-framework-shell principle, and when to introduce

--- a/apps/web/src/instrument.server.ts
+++ b/apps/web/src/instrument.server.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/tanstackstart-react";
-import { dropExpectedAuthErrors } from "@server/sentryFilters";
+import { dropExpectedClientErrors } from "@server/sentryFilters";
 import { getCommonOptions } from "@virtool/sentry";
 
 // Server-side Sentry initialisation. Imported for its side effect at the top of
@@ -18,7 +18,7 @@ if (options.dsn) {
 	Sentry.init({
 		...options,
 		integrations: [nodeProfilingIntegration()],
-		beforeSend: dropExpectedAuthErrors,
+		beforeSend: dropExpectedClientErrors,
 	});
 
 	// Import the logger lazily and only after `Sentry.init`. `@server/logger`

--- a/apps/web/src/server/__tests__/sentryFilters.test.ts
+++ b/apps/web/src/server/__tests__/sentryFilters.test.ts
@@ -5,12 +5,11 @@ import {
 } from "@virtool/contracts";
 import { describe, expect, it } from "vitest";
 
-import { dropExpectedAuthErrors } from "../sentryFilters";
+import { CLIENT_ERROR_NAME, ClientError } from "../errors";
+import { dropExpectedClientErrors } from "../sentryFilters";
 
-function authError(name: string): Error {
-	const error = new Error(
-		name === UNAUTHORIZED_ERROR_NAME ? "Unauthorized" : "Forbidden",
-	);
+function namedError(name: string, message: string): Error {
+	const error = new Error(message);
 	error.name = name;
 	return error;
 }
@@ -19,12 +18,12 @@ function eventWithType(type: string): ErrorEvent {
 	return { exception: { values: [{ type }] } } as ErrorEvent;
 }
 
-describe("dropExpectedAuthErrors", () => {
+describe("dropExpectedClientErrors", () => {
 	it("drops an event whose original exception is an UnauthorizedError", () => {
-		const result = dropExpectedAuthErrors(
+		const result = dropExpectedClientErrors(
 			{} as ErrorEvent,
 			{
-				originalException: authError(UNAUTHORIZED_ERROR_NAME),
+				originalException: namedError(UNAUTHORIZED_ERROR_NAME, "Unauthorized"),
 			} as EventHint,
 		);
 
@@ -32,32 +31,49 @@ describe("dropExpectedAuthErrors", () => {
 	});
 
 	it("drops an event whose original exception is a ForbiddenError", () => {
-		const result = dropExpectedAuthErrors(
+		const result = dropExpectedClientErrors(
 			{} as ErrorEvent,
 			{
-				originalException: authError(FORBIDDEN_ERROR_NAME),
+				originalException: namedError(FORBIDDEN_ERROR_NAME, "Forbidden"),
 			} as EventHint,
 		);
 
 		expect(result).toBeNull();
 	});
 
-	it("drops an event that reports an auth error type when the original exception is absent", () => {
+	it("drops an event whose original exception is a ClientError", () => {
+		const result = dropExpectedClientErrors(
+			{} as ErrorEvent,
+			{
+				originalException: new ClientError("Invalid handle or password."),
+			} as EventHint,
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it("drops an event that reports an expected error type when the original exception is absent", () => {
 		const event = eventWithType(UNAUTHORIZED_ERROR_NAME);
 
-		expect(dropExpectedAuthErrors(event, {} as EventHint)).toBeNull();
+		expect(dropExpectedClientErrors(event, {} as EventHint)).toBeNull();
+	});
+
+	it("drops an event that reports a ClientError type when the original exception is absent", () => {
+		const event = eventWithType(CLIENT_ERROR_NAME);
+
+		expect(dropExpectedClientErrors(event, {} as EventHint)).toBeNull();
 	});
 
 	it("keeps an unrelated error event", () => {
 		const event = eventWithType("TypeError");
 		const hint = { originalException: new TypeError("boom") } as EventHint;
 
-		expect(dropExpectedAuthErrors(event, hint)).toBe(event);
+		expect(dropExpectedClientErrors(event, hint)).toBe(event);
 	});
 
 	it("keeps an event with no exception details", () => {
 		const event = {} as ErrorEvent;
 
-		expect(dropExpectedAuthErrors(event, {} as EventHint)).toBe(event);
+		expect(dropExpectedClientErrors(event, {} as EventHint)).toBe(event);
 	});
 });

--- a/apps/web/src/server/account/functions.ts
+++ b/apps/web/src/server/account/functions.ts
@@ -4,6 +4,7 @@ import { permissionsSchema } from "@virtool/contracts";
 import { z } from "zod";
 import { authenticated } from "../auth/policy";
 import { db } from "../db/pg";
+import { ClientError } from "../errors";
 import {
 	ApiKeyNotFoundError,
 	createApiKey as createApiKeyImpl,
@@ -33,7 +34,7 @@ const keyIdSchema = z.object({
 const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 	if (err instanceof ApiKeyNotFoundError) {
 		setResponseStatus(404);
-		throw new Error("API key not found.");
+		throw new ClientError("API key not found.");
 	}
 	throw err;
 });

--- a/apps/web/src/server/auth/functions.ts
+++ b/apps/web/src/server/auth/functions.ts
@@ -3,6 +3,7 @@ import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
 import { getRequest, setResponseStatus } from "@tanstack/react-start/server";
 import { z } from "zod";
 import { db } from "../db/pg";
+import { ClientError } from "../errors";
 import { realCookies } from "./cookies";
 import {
 	createFirstUser,
@@ -74,7 +75,7 @@ export const loginFn = createServerFn({ method: "POST" })
 		} catch (err) {
 			if (err instanceof InvalidCredentialsError) {
 				setResponseStatus(400);
-				throw new Error("Invalid handle or password.");
+				throw new ClientError("Invalid handle or password.");
 			}
 			throw err;
 		}
@@ -102,11 +103,11 @@ export const createFirstUserFn = createServerFn({ method: "POST" })
 		} catch (err) {
 			if (err instanceof PasswordTooShortError) {
 				setResponseStatus(400);
-				throw new Error(err.message);
+				throw new ClientError(err.message);
 			}
 			if (err instanceof FirstUserExistsError) {
 				setResponseStatus(409);
-				throw new Error("Virtool already has a user.");
+				throw new ClientError("Virtool already has a user.");
 			}
 			throw err;
 		}
@@ -149,15 +150,15 @@ export const resetPasswordFn = createServerFn({ method: "POST" })
 		} catch (err) {
 			if (err instanceof PasswordTooShortError) {
 				setResponseStatus(400);
-				throw new Error(err.message);
+				throw new ClientError(err.message);
 			}
 			if (err instanceof InvalidResetSessionError) {
 				setResponseStatus(400);
-				throw new Error("Invalid session");
+				throw new ClientError("Invalid session");
 			}
 			if (err instanceof PasswordReuseError) {
 				setResponseStatus(400);
-				throw new Error("Cannot reuse current password");
+				throw new ClientError("Cannot reuse current password");
 			}
 			throw err;
 		}

--- a/apps/web/src/server/errors.ts
+++ b/apps/web/src/server/errors.ts
@@ -5,3 +5,25 @@ export class AppError extends Error {
 		this.name = new.target.name;
 	}
 }
+
+/**
+ * The `.name` every `ClientError` carries. A string literal rather than the
+ * class name so it survives server minification — the same reason the auth
+ * error names are literals — because the Sentry filter matches on it.
+ */
+export const CLIENT_ERROR_NAME = "ClientError";
+
+/**
+ * An expected, client-facing failure a server-function handler surfaces as a
+ * 4xx: a bad login, a missing record, a name conflict. Thrown alongside
+ * `setResponseStatus`, it carries the message the client renders. It is routine
+ * control flow, not an incident, so `dropExpectedClientErrors` keeps it out of
+ * Sentry — throw this rather than a plain `Error` for any deliberate 4xx, or it
+ * is reported as an incident.
+ */
+export class ClientError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = CLIENT_ERROR_NAME;
+	}
+}

--- a/apps/web/src/server/groups/functions.ts
+++ b/apps/web/src/server/groups/functions.ts
@@ -4,6 +4,7 @@ import { permissionsSchema } from "@virtool/contracts";
 import { z } from "zod";
 import { adminRole, authenticated } from "../auth/policy";
 import { db } from "../db/pg";
+import { ClientError } from "../errors";
 import {
 	createGroup as createGroupImpl,
 	deleteGroup as deleteGroupImpl,
@@ -44,11 +45,11 @@ const updateGroupSchema = z.object({
 const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 	if (err instanceof GroupNotFoundError) {
 		setResponseStatus(404);
-		throw new Error("Group not found.");
+		throw new ClientError("Group not found.");
 	}
 	if (err instanceof GroupConflictError) {
 		setResponseStatus(409);
-		throw new Error("Group name already exists.");
+		throw new ClientError("Group name already exists.");
 	}
 	throw err;
 });

--- a/apps/web/src/server/jobs/functions.ts
+++ b/apps/web/src/server/jobs/functions.ts
@@ -3,6 +3,7 @@ import { setResponseStatus } from "@tanstack/react-start/server";
 import { z } from "zod";
 import { authenticated } from "../auth/policy";
 import { db } from "../db/pg";
+import { ClientError } from "../errors";
 import {
 	findJobs as findJobsImpl,
 	getJob as getJobImpl,
@@ -37,7 +38,7 @@ const jobIdsSchema = z.object({
 const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 	if (err instanceof JobNotFoundError) {
 		setResponseStatus(404);
-		throw new Error("Job not found.");
+		throw new ClientError("Job not found.");
 	}
 	throw err;
 });

--- a/apps/web/src/server/labels/functions.ts
+++ b/apps/web/src/server/labels/functions.ts
@@ -3,6 +3,7 @@ import { setResponseStatus } from "@tanstack/react-start/server";
 import { z } from "zod";
 import { authenticated } from "../auth/policy";
 import { db } from "../db/pg";
+import { ClientError } from "../errors";
 import {
 	createLabel as createLabelImpl,
 	deleteLabel as deleteLabelImpl,
@@ -47,11 +48,11 @@ const findLabelsSchema = z.object({ term: z.string().default("") }).optional();
 const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 	if (err instanceof LabelNotFoundError) {
 		setResponseStatus(404);
-		throw new Error("Label not found.");
+		throw new ClientError("Label not found.");
 	}
 	if (err instanceof LabelConflictError) {
 		setResponseStatus(409);
-		throw new Error("Label name already exists.");
+		throw new ClientError("Label name already exists.");
 	}
 	throw err;
 });

--- a/apps/web/src/server/messages/functions.ts
+++ b/apps/web/src/server/messages/functions.ts
@@ -4,6 +4,7 @@ import { bannerColors } from "@virtool/contracts";
 import { z } from "zod";
 import { adminRole, authenticated } from "../auth/policy";
 import { db } from "../db/pg";
+import { ClientError } from "../errors";
 import {
 	clearActiveMessage as clearActiveMessageImpl,
 	createMessage as createMessageImpl,
@@ -39,7 +40,7 @@ const updateMessageSchema = z
 const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 	if (err instanceof MessageNotFoundError) {
 		setResponseStatus(404);
-		throw new Error("Message not found.");
+		throw new ClientError("Message not found.");
 	}
 	throw err;
 });

--- a/apps/web/src/server/sentryFilters.ts
+++ b/apps/web/src/server/sentryFilters.ts
@@ -3,46 +3,50 @@ import {
 	FORBIDDEN_ERROR_NAME,
 	UNAUTHORIZED_ERROR_NAME,
 } from "@virtool/contracts";
+import { CLIENT_ERROR_NAME } from "./errors";
 
-const EXPECTED_AUTH_ERROR_NAMES = new Set<string>([
+const EXPECTED_CLIENT_ERROR_NAMES = new Set<string>([
 	UNAUTHORIZED_ERROR_NAME,
 	FORBIDDEN_ERROR_NAME,
+	CLIENT_ERROR_NAME,
 ]);
 
 /**
- * Sentry `beforeSend` hook that drops the auth middleware's expected 401/403
- * rejections before they are reported.
+ * Sentry `beforeSend` hook that drops a server function's expected client-facing
+ * errors before they are reported.
  *
- * A server function called without a valid session throws `UnauthorizedError`
- * (or `ForbiddenError` for an insufficient role) by design — the client's query
- * retry guard reads the error name and bounces to the login wall. These are
- * routine control flow, not incidents, so reporting them only buries real
- * errors in noise.
+ * Two kinds slip through here, both routine control flow rather than incidents:
+ * the auth middleware's 401/403 rejections (`UnauthorizedError` /
+ * `ForbiddenError`), whose name the client's retry guard reads to bounce to the
+ * login wall; and the handlers' deliberate 4xx `ClientError`s — a bad login, a
+ * missing record, a name conflict — which the client renders as a message.
+ * Reporting either only buries real errors in noise.
  */
-export function dropExpectedAuthErrors(
+export function dropExpectedClientErrors(
 	event: ErrorEvent,
 	hint: EventHint,
 ): ErrorEvent | null {
 	if (
-		isExpectedAuthError(hint.originalException) ||
-		eventReportsAuthError(event)
+		isExpectedClientError(hint.originalException) ||
+		eventReportsClientError(event)
 	) {
 		return null;
 	}
 	return event;
 }
 
-function isExpectedAuthError(exception: unknown): boolean {
+function isExpectedClientError(exception: unknown): boolean {
 	return (
-		exception instanceof Error && EXPECTED_AUTH_ERROR_NAMES.has(exception.name)
+		exception instanceof Error &&
+		EXPECTED_CLIENT_ERROR_NAMES.has(exception.name)
 	);
 }
 
-function eventReportsAuthError(event: ErrorEvent): boolean {
+function eventReportsClientError(event: ErrorEvent): boolean {
 	return (
 		event.exception?.values?.some(
 			(value) =>
-				value.type !== undefined && EXPECTED_AUTH_ERROR_NAMES.has(value.type),
+				value.type !== undefined && EXPECTED_CLIENT_ERROR_NAMES.has(value.type),
 		) ?? false
 	);
 }

--- a/apps/web/src/server/tasks/functions.ts
+++ b/apps/web/src/server/tasks/functions.ts
@@ -3,6 +3,7 @@ import { setResponseStatus } from "@tanstack/react-start/server";
 import { z } from "zod";
 import { authenticated } from "../auth/policy";
 import { db } from "../db/pg";
+import { ClientError } from "../errors";
 import { getTask as getTaskImpl, TaskNotFoundError } from "./data";
 
 const taskIdSchema = z.object({
@@ -16,7 +17,7 @@ const taskIdSchema = z.object({
 const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 	if (err instanceof TaskNotFoundError) {
 		setResponseStatus(404);
-		throw new Error("Task not found.");
+		throw new ClientError("Task not found.");
 	}
 	throw err;
 });

--- a/apps/web/src/server/uploads/functions.ts
+++ b/apps/web/src/server/uploads/functions.ts
@@ -3,6 +3,7 @@ import { setResponseStatus } from "@tanstack/react-start/server";
 import { z } from "zod";
 import { authenticated, permission } from "../auth/policy";
 import { db } from "../db/pg";
+import { ClientError } from "../errors";
 import { storage } from "../storage";
 import {
 	deleteUpload as deleteUploadImpl,
@@ -36,11 +37,11 @@ const uploadIdSchema = z.object({
 const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 	if (err instanceof UploadNotFoundError) {
 		setResponseStatus(404);
-		throw new Error("Upload not found.");
+		throw new ClientError("Upload not found.");
 	}
 	if (err instanceof UploadReservedError) {
 		setResponseStatus(409);
-		throw new Error("Upload is reserved and in use.");
+		throw new ClientError("Upload is reserved and in use.");
 	}
 	throw err;
 });

--- a/apps/web/src/server/users/functions.ts
+++ b/apps/web/src/server/users/functions.ts
@@ -6,6 +6,7 @@ import { PasswordTooShortError } from "../auth/passwordPolicy";
 import { adminRole, authenticated } from "../auth/policy";
 import { checkConfiguredPasswordLength } from "../auth/service";
 import { db } from "../db/pg";
+import { ClientError } from "../errors";
 import {
 	createUser as createUserImpl,
 	findUsers as findUsersImpl,
@@ -73,7 +74,7 @@ const accountHandleSchema = z.object({
 function checkReservedHandle(handle: string): void {
 	if (handle.trim().toLowerCase() === "virtool") {
 		setResponseStatus(400);
-		throw new Error("Reserved user name: virtool");
+		throw new ClientError("Reserved user name: virtool");
 	}
 }
 
@@ -89,19 +90,19 @@ const setAdministratorRoleSchema = z.object({
 const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 	if (err instanceof PasswordTooShortError) {
 		setResponseStatus(400);
-		throw new Error(err.message);
+		throw new ClientError(err.message);
 	}
 	if (err instanceof UserNotFoundError) {
 		setResponseStatus(404);
-		throw new Error("User not found.");
+		throw new ClientError("User not found.");
 	}
 	if (err instanceof UserConflictError) {
 		setResponseStatus(409);
-		throw new Error("User already exists.");
+		throw new ClientError("User already exists.");
 	}
 	if (err instanceof GroupMembershipError) {
 		setResponseStatus(400);
-		throw new Error("User is not a member of group.");
+		throw new ClientError("User is not a member of group.");
 	}
 	throw err;
 });
@@ -217,7 +218,7 @@ export const setAdministratorRole = createServerFn({ method: "POST" })
 	.handler(async ({ context, data }) => {
 		if (context.session.userId === data.userId) {
 			setResponseStatus(400);
-			throw new Error("Cannot change own role");
+			throw new ClientError("Cannot change own role");
 		}
 
 		try {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,7 +68,14 @@ import-direction invariant stays enforceable.
 - `functions.ts` — TanStack Start server function shell. Wraps
   `createServerFn` / `createServerOnlyFn`, validates input with zod,
   delegates to `data` / `service`, and maps `AppError` subclasses to
-  HTTP responses via `setResponseStatus`. Should contain no business
+  HTTP responses — `setResponseStatus(4xx)` paired with a `ClientError`
+  (`@server/errors`) carrying the message the client renders. Throw
+  `ClientError`, never a plain `Error`, for a deliberate 4xx: the Sentry
+  `beforeSend` filter (`dropExpectedClientErrors`) drops it — along with
+  the auth middleware's 401/403 `UnauthorizedError` / `ForbiddenError` —
+  as routine control flow, so a plain `Error` surfaces as a false
+  incident. Reserve a bare `throw`/`throw err` for the genuinely
+  unexpected, which _should_ reach Sentry. Should contain no business
   logic — if a handler grows a multi-step orchestration with rollbacks
   or branching, that is the signal to extract a `service.ts`.
 
@@ -153,8 +160,8 @@ from `@labels/constants`, the one remaining sanctioned sideways import.
 - `data.ts` — defines `Label`, `LabelValues`, `LabelNotFoundError`,
   `LabelConflictError`, and CRUD functions over the `labels` table.
 - `functions.ts` — wraps each CRUD function in a TanStack Start server
-  function, validates with zod, rethrows `LabelNotFoundError` as 404 and
-  `LabelConflictError` as 409.
+  function, validates with zod, rethrows `LabelNotFoundError` as a 404
+  `ClientError` and `LabelConflictError` as a 409 `ClientError`.
 
 No `service.ts` — the data layer is enough.
 


### PR DESCRIPTION
## Summary
- Add a `ClientError` type (`@server/errors`) for deliberate 4xx responses — bad login, missing record, name conflict — distinct from unexpected server failures.
- Replace plain `Error` throws with `ClientError` across account, auth, groups, jobs, labels, messages, tasks, uploads, and users server functions.
- Extend the Sentry `beforeSend` filter (`dropExpectedClientErrors`) to drop `ClientError` events alongside the existing 401/403 auth rejections, so routine client-facing failures like an invalid login no longer show up as Sentry incidents.