### PR TITLE
ci: parallelize test suite across jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
                   node-version: ${{ env.NODE_VERSION }}
                   pnpm-version: ${{ env.PNPM_VERSION }}
             - name: Test
-              run: pnpm --filter @virtool/bio --filter @virtool/logger test
+              run: pnpm --filter @virtool/bio --filter @virtool/logger --filter @virtool/site test
     test-web:
         name: Test / Web
         runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,10 +74,58 @@ jobs:
                   pnpm-version: ${{ env.PNPM_VERSION }}
             - name: tsc
               run: pnpm typecheck
-    test:
-        name: Test
+    test-packages:
+        name: Test / Packages
+        runs-on: ubuntu-24.04
+        timeout-minutes: 10
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+            - name: Setup
+              uses: ./.github/actions/setup
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  pnpm-version: ${{ env.PNPM_VERSION }}
+            - name: Test
+              run: pnpm --filter @virtool/bio --filter @virtool/logger test
+    test-web:
+        name: Test / Web
+        runs-on: ubuntu-24.04
+        timeout-minutes: 10
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+            - name: Setup
+              uses: ./.github/actions/setup
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  pnpm-version: ${{ env.PNPM_VERSION }}
+            - name: Test
+              run: VT_TEST_WORKERS=$(nproc) pnpm --filter @virtool/web exec vitest run --project web
+              env:
+                  TZ: UTC
+                  VT_TEST_REACT_COMPILER: "1"
+    test-server:
+        name: Test / Server
         runs-on: ubuntu-24.04
         timeout-minutes: 15
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+            - name: Setup
+              uses: ./.github/actions/setup
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  pnpm-version: ${{ env.PNPM_VERSION }}
+            - name: Test
+              run: VT_TEST_WORKERS=$(nproc) pnpm --filter @virtool/web exec vitest run --project server --project storage
+              env:
+                  TZ: UTC
+                  VT_TEST_REACT_COMPILER: "1"
+    test-a11y:
+        name: Test / Accessibility
+        runs-on: ubuntu-24.04
+        timeout-minutes: 10
         steps:
             - name: Checkout
               uses: actions/checkout@v7
@@ -89,9 +137,9 @@ jobs:
             - name: Install Playwright Chromium
               run: pnpm --filter @virtool/web exec playwright install --with-deps chromium
             - name: Test
-              run: pnpm test
+              run: VT_TEST_WORKERS=$(nproc) pnpm --filter @virtool/web exec vitest run --project a11y
               env:
-                  VT_TEST_REACT_COMPILER: "1"
+                  TZ: UTC
     build-site:
         name: Build Site
         runs-on: ubuntu-24.04
@@ -112,7 +160,18 @@ jobs:
         name: Publish / Release
         runs-on: ubuntu-24.04
         timeout-minutes: 15
-        needs: [build, build-site, check-biome, check-knip, check-typescript, test]
+        needs:
+            [
+                build,
+                build-site,
+                check-biome,
+                check-knip,
+                check-typescript,
+                test-packages,
+                test-web,
+                test-server,
+                test-a11y,
+            ]
         if: github.event_name == 'push'
         outputs:
             git-tag: ${{ steps.semantic.outputs.git-tag }}

--- a/apps/web/vitest.config.js
+++ b/apps/web/vitest.config.js
@@ -28,6 +28,12 @@ export default defineConfig({
 					// Postgres. Component tests must not need Docker.
 					name: "web",
 					environment: "jsdom",
+					// A full-route `renderRoute` test (router load + the whole route
+					// tree + the React Compiler Babel pass) is the heaviest thing the
+					// suite does. When CI runs a worker per core, the shared CPU pushes
+					// these past the 5s default and they time out — masquerading as a
+					// flake. Give them headroom while still failing a genuine hang fast.
+					testTimeout: 15_000,
 					setupFiles: ["./src/tests/setup.tsx"],
 					include: ["src/**/*.test.{ts,tsx}"],
 					// `*.a11y.test.tsx` files run in the browser `a11y` project below,


### PR DESCRIPTION
## Summary
- Splits the single sequential `test` job (web, server, storage, a11y projects) into four concurrent jobs — `test-packages`, `test-web`, `test-server`, `test-a11y` — each on its own runner.
- Removes the vitest worker cap that halved parallelism for local multi-worktree runs; each CI job now sets `VT_TEST_WORKERS=$(nproc)` to use every core on its own runner.
- Drops the Playwright Chromium install from jobs that don't need it, keeping it only on `test-a11y`.