### PR TITLE
feat: serve user search and root document from the typescript server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,7 +279,7 @@ at all:
 - `@administration/passwordPolicy` — `passwordPolicyQueryOptions`, backed by
   `getPasswordPolicyFn`.
 - `@nav/queries` — `rootQueryOptions` / `useRootQuery`, backed by the `getRoot`
-  server function. The guard reads `first_user` from it before a session
+  server function. The guard reads `firstUser` from it before a session
   exists; the whole module is `@app/api`-free.
 
 All three are server-function-backed and need no HTTP client. Don't fold them

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,10 +278,14 @@ at all:
   `getAccount` server function.
 - `@administration/passwordPolicy` — `passwordPolicyQueryOptions`, backed by
   `getPasswordPolicyFn`.
+- `@nav/queries` — `rootQueryOptions` / `useRootQuery`, backed by the `getRoot`
+  server function. The guard reads `first_user` from it before a session
+  exists; the whole module is `@app/api`-free.
 
-Both are server-function-backed and need no HTTP client. Don't fold them back
-into their feature's `queries.ts`, and don't add an `apiClient` call to either.
-Prefer a server function over a Python REST call for anything a guard reads.
+All three are server-function-backed and need no HTTP client. Don't fold them
+back into a feature's `queries.ts` that also imports `@app/api`, and don't add
+an `apiClient` call to any of them. Prefer a server function over a Python REST
+call for anything a guard reads.
 
 ### Heavy dependencies get their own module
 

--- a/apps/web/src/app/types.ts
+++ b/apps/web/src/app/types.ts
@@ -1,5 +1,0 @@
-export type Root = {
-	first_user: boolean;
-	endpoints: { [key: string]: object };
-	version: string;
-};

--- a/apps/web/src/nav/components/__tests__/AboutDialog.test.tsx
+++ b/apps/web/src/nav/components/__tests__/AboutDialog.test.tsx
@@ -6,7 +6,7 @@ import AboutDialog from "../AboutDialog";
 
 describe("<AboutDialog />", () => {
 	it("shows the server and web app versions", async () => {
-		mockGetRoot({ first_user: false, version: "5.4.3" });
+		mockGetRoot({ firstUser: false, version: "5.4.3" });
 
 		renderWithProviders(<AboutDialog open setOpen={() => undefined} />);
 

--- a/apps/web/src/nav/components/__tests__/AboutDialog.test.tsx
+++ b/apps/web/src/nav/components/__tests__/AboutDialog.test.tsx
@@ -1,13 +1,18 @@
 import { screen, within } from "@testing-library/react";
+import { mockGetRoot } from "@tests/server-fn/root";
 import { renderWithProviders } from "@tests/setup";
 import { describe, expect, it } from "vitest";
 import AboutDialog from "../AboutDialog";
 
 describe("<AboutDialog />", () => {
-	it("shows the server and web app versions", () => {
+	it("shows the server and web app versions", async () => {
+		mockGetRoot({ first_user: false, version: "5.4.3" });
+
 		renderWithProviders(<AboutDialog open setOpen={() => undefined} />);
 
-		expect(screen.getByText("Server")).toBeInTheDocument();
+		const serverVersion = await screen.findByText("5.4.3");
+		const server = screen.getByText("Server").closest("div");
+		expect(server).toContainElement(serverVersion);
 
 		const webApp = screen.getByText("Web app").closest("div");
 		expect(

--- a/apps/web/src/nav/queries.ts
+++ b/apps/web/src/nav/queries.ts
@@ -1,24 +1,32 @@
-import { apiClient } from "@app/api";
-import type { Root } from "@app/types";
-import { useQuery } from "@tanstack/react-query";
+import { getRoot } from "@server/root/functions";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import { rootQueryKeys } from "@wall/keys";
 
-import type { ErrorResponse } from "@/types/api";
+/**
+ * Query options for the instance root document.
+ *
+ * Backed by the `getRoot` server function, so this module imports no
+ * `@app/api`. The `_authenticated` guard reads it before any session exists to
+ * decide first-user setup, and the whole module must stay HTTP-client-free to
+ * keep superagent off the login wall.
+ */
+export function rootQueryOptions() {
+	return queryOptions({
+		queryKey: rootQueryKeys.all(),
+		queryFn: () => getRoot(),
+	});
+}
 
 /**
  * Initializes a query for fetching the root document.
  *
  * Lives here rather than in `@wall/queries` because the wall never reads the
- * root document — the About dialog does. Keeping it there made `LoginWall`,
- * which imports that module for its login and reset mutations, drag `@app/api`
- * and superagent onto the unauthenticated `/login` first paint for a hook
- * `/login` never calls.
+ * root document — the About dialog does. `LoginWall` imports `@wall/queries`
+ * for its login and reset mutations, so keeping the root query out of that
+ * module avoids loading it on the unauthenticated `/login` first paint.
  *
  * @returns A query for fetching the root document
  */
 export function useRootQuery() {
-	return useQuery<Root, ErrorResponse>({
-		queryKey: rootQueryKeys.all(),
-		queryFn: () => apiClient.get("/").then((res) => res.body),
-	});
+	return useQuery(rootQueryOptions());
 }

--- a/apps/web/src/references/components/Detail/AddReferenceUser.tsx
+++ b/apps/web/src/references/components/Detail/AddReferenceUser.tsx
@@ -58,7 +58,7 @@ export default function AddReferenceUser({
 	}
 
 	const userIds = users.map((u) => u.id);
-	const items = data.pages.flatMap((page) => page.documents);
+	const items = data.pages.flatMap((page) => page.items);
 	const filteredItems = items.filter((item) => !userIds.includes(item.id));
 
 	// CompactScrollList types its rows as `unknown`; the items are users.

--- a/apps/web/src/references/components/Detail/__tests__/AddReferenceUser.test.tsx
+++ b/apps/web/src/references/components/Detail/__tests__/AddReferenceUser.test.tsx
@@ -1,0 +1,54 @@
+import { screen } from "@testing-library/react";
+import { createFakeUser } from "@tests/fake/user";
+import { mockSearchUsers } from "@tests/server-fn/users";
+import { renderWithProviders } from "@tests/setup";
+import { describe, expect, it } from "vitest";
+import AddReferenceUser from "../AddReferenceUser";
+
+describe("<AddReferenceUser />", () => {
+	it("lists users returned by the search", async () => {
+		const alice = createFakeUser({ handle: "alice" });
+		const bob = createFakeUser({ handle: "bob" });
+		mockSearchUsers([alice, bob]);
+
+		renderWithProviders(
+			<AddReferenceUser
+				users={[]}
+				onHide={() => undefined}
+				refId="ref-1"
+				show
+			/>,
+		);
+
+		expect(await screen.findByText("alice")).toBeInTheDocument();
+		expect(screen.getByText("bob")).toBeInTheDocument();
+	});
+
+	it("omits users already members of the reference", async () => {
+		const alice = createFakeUser({ handle: "alice" });
+		const bob = createFakeUser({ handle: "bob" });
+		mockSearchUsers([alice, bob]);
+
+		renderWithProviders(
+			<AddReferenceUser
+				users={[
+					{
+						id: alice.id,
+						handle: alice.handle,
+						build: false,
+						modify: false,
+						modify_otu: false,
+						remove: false,
+						created_at: "",
+					},
+				]}
+				onHide={() => undefined}
+				refId="ref-1"
+				show
+			/>,
+		);
+
+		expect(await screen.findByText("bob")).toBeInTheDocument();
+		expect(screen.queryByText("alice")).not.toBeInTheDocument();
+	});
+});

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -40,7 +40,7 @@ export const Route = createFileRoute("/_authenticated")({
 
 		const rootData = await queryClient.ensureQueryData(rootQueryOptions());
 
-		if (rootData.first_user) {
+		if (rootData.firstUser) {
 			throw redirect({ to: "/setup" });
 		}
 

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -2,7 +2,6 @@ import { useFetchAccount } from "@account/account";
 import { CONTENT_SCROLL_ID } from "@app/scroll";
 import { armSessionEnd } from "@app/session";
 import * as Sse from "@app/sse/SseConnection";
-import type { Root } from "@app/types";
 import Banner from "@banner/components/Banner";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import SkipLink from "@base/SkipLink";
@@ -19,7 +18,6 @@ import {
 	redirect,
 	useLocation,
 } from "@tanstack/react-router";
-import { rootQueryKeys } from "@wall/keys";
 import { lazy, Suspense, useEffect } from "react";
 
 const UploadOverlay = lazy(() => import("@uploads/components/UploadOverlay"));
@@ -35,15 +33,12 @@ export const Route = createFileRoute("/_authenticated")({
 	beforeLoad: async ({ context, location }) => {
 		const { queryClient } = context;
 
-		const [{ apiClient }, { accountQueryOptions }] = await Promise.all([
-			import("@app/api"),
+		const [{ rootQueryOptions }, { accountQueryOptions }] = await Promise.all([
+			import("@nav/queries"),
 			import("@account/account"),
 		]);
 
-		const rootData = await queryClient.ensureQueryData<Root>({
-			queryKey: rootQueryKeys.all(),
-			queryFn: () => apiClient.get("/").then((res) => res.body),
-		});
+		const rootData = await queryClient.ensureQueryData(rootQueryOptions());
 
 		if (rootData.first_user) {
 			throw redirect({ to: "/setup" });

--- a/apps/web/src/server/__tests__/authorization.test.ts
+++ b/apps/web/src/server/__tests__/authorization.test.ts
@@ -100,6 +100,13 @@ const MODULES = [
 		)) as SplitServerFnModule,
 	},
 	{
+		path: "../root/functions.ts",
+		fns: await import("../root/functions"),
+		handlers: (await import(
+			"../root/functions.ts?tss-serverfn-split"
+		)) as SplitServerFnModule,
+	},
+	{
 		path: "../settings/functions.ts",
 		fns: await import("../settings/functions"),
 		handlers: (await import(
@@ -217,6 +224,7 @@ describe("the open endpoints are reachable without a session", () => {
 		expect(open.map((endpoint) => endpoint.name).sort()).toEqual([
 			"createFirstUserFn",
 			"getPasswordPolicyFn",
+			"getRoot",
 			"loginFn",
 			"logoutFn",
 			"resetPasswordFn",

--- a/apps/web/src/server/appVersion.d.ts
+++ b/apps/web/src/server/appVersion.d.ts
@@ -1,0 +1,5 @@
+// `__APP_VERSION__` is injected by Vite's `define` (see vite.config.js) and is
+// substituted in server-transformed modules too. Declared here because the
+// server tsconfig does not include the app's vite-env.d.ts, where the browser
+// program picks up the same global.
+declare const __APP_VERSION__: string;

--- a/apps/web/src/server/auth/exceptions.ts
+++ b/apps/web/src/server/auth/exceptions.ts
@@ -1,3 +1,4 @@
+import { getRoot } from "../root/functions";
 import { getPasswordPolicyFn } from "../settings/functions";
 import {
 	createFirstUserFn,
@@ -13,6 +14,8 @@ import {
  * createFirstUserFn runs before any user or session exists.
  * getPasswordPolicyFn serves the first-user and forced-reset forms, which set a
  * password before there is a session to authenticate.
+ * getRoot reports whether first-user setup is needed, read by the
+ * `_authenticated` guard before a session exists.
  */
 // Annotated rather than inferred: an inferred type would reference TanStack's
 // server-fn types transitively, breaking declaration emit for `@server/*`
@@ -20,6 +23,7 @@ import {
 export const authenticationExceptions: ReadonlyArray<{ url: string }> = [
 	createFirstUserFn,
 	getPasswordPolicyFn,
+	getRoot,
 	loginFn,
 	logoutFn,
 	resetPasswordFn,

--- a/apps/web/src/server/auth/middleware.test.ts
+++ b/apps/web/src/server/auth/middleware.test.ts
@@ -54,6 +54,7 @@ const { createFirstUserFn, loginFn, logoutFn, resetPasswordFn } = await import(
 	"./functions"
 );
 const { getPasswordPolicyFn } = await import("../settings/functions");
+const { getRoot } = await import("../root/functions");
 const { SESSION_ID_COOKIE, SESSION_TOKEN_COOKIE } = await import("./cookies");
 const { seedSession, seedUser } = await import("./test/fixtures");
 
@@ -99,12 +100,13 @@ describe("authenticationExceptions", () => {
 	// The list is the whole security boundary: anything on it is publicly
 	// callable. A fn added here by mistake is a silent hole, so pin the contents
 	// rather than just the middleware's handling of them.
-	it("exempts exactly the five unauthenticated endpoints", () => {
-		expect(authenticationExceptions).toHaveLength(5);
+	it("exempts exactly the six unauthenticated endpoints", () => {
+		expect(authenticationExceptions).toHaveLength(6);
 		expect(authenticationExceptions.map((fn) => fn.url).sort()).toEqual(
 			[
 				createFirstUserFn,
 				getPasswordPolicyFn,
+				getRoot,
 				loginFn,
 				logoutFn,
 				resetPasswordFn,
@@ -119,6 +121,7 @@ describe("createAuthenticationMiddleware", () => {
 	it.each([
 		["createFirstUserFn", () => createFirstUserFn],
 		["getPasswordPolicyFn", () => getPasswordPolicyFn],
+		["getRoot", () => getRoot],
 		["loginFn", () => loginFn],
 		["logoutFn", () => logoutFn],
 		["resetPasswordFn", () => resetPasswordFn],

--- a/apps/web/src/server/root/functions.test.ts
+++ b/apps/web/src/server/root/functions.test.ts
@@ -61,23 +61,23 @@ beforeEach(() => {
 });
 
 describe("getRoot", () => {
-	it("reports first_user when the instance has no users", async () => {
+	it("reports firstUser when the instance has no users", async () => {
 		const root = (await callServerFn(handlers, "getRoot", undefined)) as {
-			first_user: boolean;
+			firstUser: boolean;
 			version: string;
 		};
 
-		expect(root.first_user).toBe(true);
+		expect(root.firstUser).toBe(true);
 		expect(root.version).toBe(__APP_VERSION__);
 	});
 
-	it("reports no first_user once a user exists", async () => {
+	it("reports no firstUser once a user exists", async () => {
 		await seedUser(db);
 
 		const root = (await callServerFn(handlers, "getRoot", undefined)) as {
-			first_user: boolean;
+			firstUser: boolean;
 		};
 
-		expect(root.first_user).toBe(false);
+		expect(root.firstUser).toBe(false);
 	});
 });

--- a/apps/web/src/server/root/functions.test.ts
+++ b/apps/web/src/server/root/functions.test.ts
@@ -1,0 +1,83 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import type { Db } from "../db/pg";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { callServerFn, type SplitServerFnModule } from "../test/serverFn";
+
+const getRequest = vi.fn();
+
+vi.mock("@tanstack/react-start/server", () => ({
+	deleteCookie: vi.fn(),
+	getCookie: vi.fn(),
+	getRequest,
+	setCookie: vi.fn(),
+	setResponseStatus: vi.fn(),
+}));
+
+vi.mock("@sentry/tanstackstart-react", () => ({
+	captureException: vi.fn(),
+	setUser: vi.fn(),
+}));
+
+let db: Db;
+vi.mock("../db/pg", () => ({
+	client: {},
+	get db() {
+		return db;
+	},
+}));
+
+vi.mock("../events/emit", () => ({ emit: vi.fn() }));
+
+const handlers = (await import(
+	"./functions.ts?tss-serverfn-split"
+)) as SplitServerFnModule;
+const { seedUser } = await import("../auth/test/fixtures");
+
+let database: TestDatabase;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	// No cookies: the root document is reachable without a session.
+	getRequest.mockReturnValue(
+		new Request("https://virtool.test/_serverFn/test"),
+	);
+});
+
+describe("getRoot", () => {
+	it("reports first_user when the instance has no users", async () => {
+		const root = (await callServerFn(handlers, "getRoot", undefined)) as {
+			first_user: boolean;
+			version: string;
+		};
+
+		expect(root.first_user).toBe(true);
+		expect(root.version).toBe(__APP_VERSION__);
+	});
+
+	it("reports no first_user once a user exists", async () => {
+		await seedUser(db);
+
+		const root = (await callServerFn(handlers, "getRoot", undefined)) as {
+			first_user: boolean;
+		};
+
+		expect(root.first_user).toBe(false);
+	});
+});

--- a/apps/web/src/server/root/functions.ts
+++ b/apps/web/src/server/root/functions.ts
@@ -3,13 +3,13 @@ import { open } from "../auth/policy";
 import { db } from "../db/pg";
 import { getUserCount } from "../users/data";
 
-// Public, like Python's `GET /`: the `_authenticated` guard reads `first_user`
+// Public, like Python's `GET /`: the `_authenticated` guard reads `firstUser`
 // before any session exists to decide whether to redirect to first-user setup,
 // so this cannot require a session. `version` is the running deployment's build
 // version, injected by Vite's `define` (see appVersion.d.ts).
 export const getRoot = createServerFn({ method: "GET" })
 	.middleware([open()])
 	.handler(async () => ({
-		first_user: (await getUserCount(db)) === 0,
+		firstUser: (await getUserCount(db)) === 0,
 		version: __APP_VERSION__,
 	}));

--- a/apps/web/src/server/root/functions.ts
+++ b/apps/web/src/server/root/functions.ts
@@ -1,0 +1,15 @@
+import { createServerFn } from "@tanstack/react-start";
+import { open } from "../auth/policy";
+import { db } from "../db/pg";
+import { getUserCount } from "../users/data";
+
+// Public, like Python's `GET /`: the `_authenticated` guard reads `first_user`
+// before any session exists to decide whether to redirect to first-user setup,
+// so this cannot require a session. `version` is the running deployment's build
+// version, injected by Vite's `define` (see appVersion.d.ts).
+export const getRoot = createServerFn({ method: "GET" })
+	.middleware([open()])
+	.handler(async () => ({
+		first_user: (await getUserCount(db)) === 0,
+		version: __APP_VERSION__,
+	}));

--- a/apps/web/src/server/users/data.test.ts
+++ b/apps/web/src/server/users/data.test.ts
@@ -290,8 +290,8 @@ describe("findUsers", () => {
 			"alice",
 			"malice",
 		]);
-		expect(result.found_count).toBe(2);
-		expect(result.total_count).toBe(3);
+		expect(result.foundCount).toBe(2);
+		expect(result.totalCount).toBe(3);
 	});
 
 	it("filters to administrators and to non-administrators", async () => {
@@ -326,7 +326,7 @@ describe("findUsers", () => {
 
 		expect(page1.items.map((user) => user.handle)).toEqual(["a", "b"]);
 		expect(page2.items.map((user) => user.handle)).toEqual(["c"]);
-		expect(page1.page_count).toBe(2);
+		expect(page1.pageCount).toBe(2);
 	});
 });
 

--- a/apps/web/src/server/users/data.ts
+++ b/apps/web/src/server/users/data.ts
@@ -77,11 +77,11 @@ export type UserOption = {
 /** A page of user search results. */
 export type UserSearchResults = {
 	items: User[];
-	found_count: number;
-	total_count: number;
+	foundCount: number;
+	totalCount: number;
 	page: number;
-	page_count: number;
-	per_page: number;
+	pageCount: number;
+	perPage: number;
 };
 
 /** Filters accepted when searching users. */
@@ -329,11 +329,11 @@ export async function findUsers(
 
 	return {
 		items: await assembleUsers(db, rows),
-		found_count: foundCount,
-		total_count: totalRow?.value ?? 0,
+		foundCount,
+		totalCount: totalRow?.value ?? 0,
 		page,
-		page_count: perPage > 0 ? Math.ceil(foundCount / perPage) : 0,
-		per_page: perPage,
+		pageCount: perPage > 0 ? Math.ceil(foundCount / perPage) : 0,
+		perPage,
 	};
 }
 

--- a/apps/web/src/server/users/functions.ts
+++ b/apps/web/src/server/users/functions.ts
@@ -44,6 +44,14 @@ const findUsersSchema = z
 	})
 	.optional();
 
+const searchUsersSchema = z
+	.object({
+		term: z.string().default(""),
+		page: z.number().int().positive().default(1),
+		per_page: z.number().int().positive().max(100).default(25),
+	})
+	.optional();
+
 // Password length is enforced by checkConfiguredPasswordLength in the handlers
 // below, not here — see that function for why the validator is the wrong place
 // for it.
@@ -129,6 +137,22 @@ export const findUsers = createServerFn({ method: "GET" })
 			active: data?.active ?? true,
 		});
 	});
+
+// A paginated user search any signed-in user may run, mirroring Python's
+// `GET /users` (authenticated, no administrator filter). Backs the reference
+// member picker, where a non-admin who holds `modify` on a reference searches
+// users to add. `findUsers` above is the stricter administrator-only variant
+// used by the user administration views.
+export const searchUsers = createServerFn({ method: "GET" })
+	.middleware([authenticated()])
+	.validator(searchUsersSchema)
+	.handler(async ({ data }) =>
+		findUsersImpl(db, {
+			term: data?.term ?? "",
+			page: data?.page ?? 1,
+			perPage: data?.per_page ?? 25,
+		}),
+	);
 
 // Not on the authentication exception list, so an anonymous call gets a 401.
 // The login wall and the authenticated route guard both rely on that: a

--- a/apps/web/src/server/users/functions.ts
+++ b/apps/web/src/server/users/functions.ts
@@ -38,7 +38,7 @@ const findUsersSchema = z
 	.object({
 		term: z.string().default(""),
 		page: z.number().int().positive().default(1),
-		per_page: z.number().int().positive().max(100).default(25),
+		perPage: z.number().int().positive().max(100).default(25),
 		administrator: z.boolean().optional(),
 		active: z.boolean().default(true),
 	})
@@ -48,7 +48,7 @@ const searchUsersSchema = z
 	.object({
 		term: z.string().default(""),
 		page: z.number().int().positive().default(1),
-		per_page: z.number().int().positive().max(100).default(25),
+		perPage: z.number().int().positive().max(100).default(25),
 	})
 	.optional();
 
@@ -132,7 +132,7 @@ export const findUsers = createServerFn({ method: "GET" })
 		return findUsersImpl(db, {
 			term: data?.term ?? "",
 			page: data?.page ?? 1,
-			perPage: data?.per_page ?? 25,
+			perPage: data?.perPage ?? 25,
 			administrator: data?.administrator,
 			active: data?.active ?? true,
 		});
@@ -150,7 +150,7 @@ export const searchUsers = createServerFn({ method: "GET" })
 		findUsersImpl(db, {
 			term: data?.term ?? "",
 			page: data?.page ?? 1,
-			perPage: data?.per_page ?? 25,
+			perPage: data?.perPage ?? 25,
 		}),
 	);
 

--- a/apps/web/src/tests/server-fn/root.ts
+++ b/apps/web/src/tests/server-fn/root.ts
@@ -1,0 +1,25 @@
+import { type Mock, vi } from "vitest";
+
+/**
+ * Mock handles for the `@server/root/functions` server-fn module. Wired in
+ * globally from `tests/setup.tsx` so route-level tests can stub the
+ * unauthenticated root document without per-file `vi.mock` boilerplate.
+ */
+export const rootServerFnMocks = {
+	getRoot: vi.fn(),
+};
+
+/**
+ * Sets up getRoot to resolve with the given root document. `version` defaults to
+ * the build version so callers that only care about `first_user` can omit it.
+ */
+export function mockGetRoot(root: {
+	first_user: boolean;
+	version?: string;
+}): Mock {
+	rootServerFnMocks.getRoot.mockResolvedValue({
+		version: __APP_VERSION__,
+		...root,
+	});
+	return rootServerFnMocks.getRoot;
+}

--- a/apps/web/src/tests/server-fn/root.ts
+++ b/apps/web/src/tests/server-fn/root.ts
@@ -11,10 +11,10 @@ export const rootServerFnMocks = {
 
 /**
  * Sets up getRoot to resolve with the given root document. `version` defaults to
- * the build version so callers that only care about `first_user` can omit it.
+ * the build version so callers that only care about `firstUser` can omit it.
  */
 export function mockGetRoot(root: {
-	first_user: boolean;
+	firstUser: boolean;
 	version?: string;
 }): Mock {
 	rootServerFnMocks.getRoot.mockResolvedValue({

--- a/apps/web/src/tests/server-fn/users.ts
+++ b/apps/web/src/tests/server-fn/users.ts
@@ -10,6 +10,7 @@ import { expect, type Mock, vi } from "vitest";
  */
 export const userServerFnMocks = {
 	findUsers: vi.fn(),
+	searchUsers: vi.fn(),
 	listUsers: vi.fn(),
 	getAccount: vi.fn(),
 	getUser: vi.fn(),
@@ -31,6 +32,19 @@ export function mockFindUsers(users: User[]): Mock {
 		total_count: users.length,
 	});
 	return userServerFnMocks.findUsers;
+}
+
+/** Sets up searchUsers to resolve with a single page containing the given users. */
+export function mockSearchUsers(users: User[]): Mock {
+	userServerFnMocks.searchUsers.mockResolvedValue({
+		items: users,
+		found_count: users.length,
+		page: 1,
+		page_count: 1,
+		per_page: 25,
+		total_count: users.length,
+	});
+	return userServerFnMocks.searchUsers;
 }
 
 /** Sets up listUsers to resolve with the given users, reduced to id and handle. */

--- a/apps/web/src/tests/server-fn/users.ts
+++ b/apps/web/src/tests/server-fn/users.ts
@@ -25,11 +25,11 @@ export const userServerFnMocks = {
 export function mockFindUsers(users: User[]): Mock {
 	userServerFnMocks.findUsers.mockResolvedValue({
 		items: users,
-		found_count: users.length,
+		foundCount: users.length,
 		page: 1,
-		page_count: 1,
-		per_page: 25,
-		total_count: users.length,
+		pageCount: 1,
+		perPage: 25,
+		totalCount: users.length,
 	});
 	return userServerFnMocks.findUsers;
 }
@@ -38,11 +38,11 @@ export function mockFindUsers(users: User[]): Mock {
 export function mockSearchUsers(users: User[]): Mock {
 	userServerFnMocks.searchUsers.mockResolvedValue({
 		items: users,
-		found_count: users.length,
+		foundCount: users.length,
 		page: 1,
-		page_count: 1,
-		per_page: 25,
-		total_count: users.length,
+		pageCount: 1,
+		perPage: 25,
+		totalCount: users.length,
 	});
 	return userServerFnMocks.searchUsers;
 }

--- a/apps/web/src/tests/setup.tsx
+++ b/apps/web/src/tests/setup.tsx
@@ -292,7 +292,7 @@ export async function renderRoute(path: string, opts?: RenderRouteOptions) {
 	const history: string[] = [];
 	const queryClient = createTestQueryClient();
 
-	queryClient.setQueryData(rootQueryKeys.all(), { first_user: false });
+	queryClient.setQueryData(rootQueryKeys.all(), { firstUser: false });
 	queryClient.setQueryData(
 		accountQueryKeys.all(),
 		opts?.account ?? createFakeAccount(),

--- a/apps/web/src/tests/setup.tsx
+++ b/apps/web/src/tests/setup.tsx
@@ -28,6 +28,7 @@ import { groupServerFnMocks } from "./server-fn/groups";
 import { hmmServerFnMocks } from "./server-fn/hmm";
 import { jobServerFnMocks } from "./server-fn/jobs";
 import { labelServerFnMocks } from "./server-fn/labels";
+import { rootServerFnMocks } from "./server-fn/root";
 import {
 	mockGetPasswordPolicy,
 	settingsServerFnMocks,
@@ -52,6 +53,10 @@ vi.mock("@server/auth/functions", async () => {
 vi.mock("@server/users/functions", async () => {
 	const { userServerFnMocks } = await import("./server-fn/users");
 	return userServerFnMocks;
+});
+vi.mock("@server/root/functions", async () => {
+	const { rootServerFnMocks } = await import("./server-fn/root");
+	return rootServerFnMocks;
 });
 vi.mock("@server/hmm/functions", async () => {
 	const { hmmServerFnMocks } = await import("./server-fn/hmm");
@@ -89,6 +94,7 @@ beforeEach(() => {
 		...Object.values(hmmServerFnMocks),
 		...Object.values(authServerFnMocks),
 		...Object.values(labelServerFnMocks),
+		...Object.values(rootServerFnMocks),
 		uploadServerFnMocks.findUploads,
 		uploadServerFnMocks.deleteUpload,
 		subtractionServerFnMocks.findSubtractions,

--- a/apps/web/src/users/components/UsersList.tsx
+++ b/apps/web/src/users/components/UsersList.tsx
@@ -31,13 +31,13 @@ export default function UsersList({
 		status === "active",
 	);
 
-	const { items, page, page_count } = data;
+	const { items, page, pageCount } = data;
 
 	return items.length ? (
 		<Pagination
 			storedPage={page}
 			currentPage={urlPage}
-			pageCount={page_count}
+			pageCount={pageCount}
 			onPageChange={setPage}
 		>
 			<BoxGroup as="ul">

--- a/apps/web/src/users/queries.ts
+++ b/apps/web/src/users/queries.ts
@@ -1,10 +1,10 @@
 import type { AdministratorRoleName } from "@administration/types";
-import { apiClient } from "@app/api";
 import {
 	createUser,
 	findUsers,
 	getUser,
 	listUsers,
+	searchUsers,
 	setAdministratorRole,
 	updateUser,
 } from "@server/users/functions";
@@ -18,7 +18,7 @@ import {
 	useSuspenseQuery,
 } from "@tanstack/react-query";
 import { userQueryKeys } from "@users/keys";
-import type { UserNested, UserResponse } from "./types";
+import type { UserNested } from "./types";
 
 /**
  * Fetch every active user, for populating selectors and filters
@@ -40,13 +40,10 @@ export function useListUsers() {
  * @returns An UseInfiniteQueryResult object containing the user search results
  */
 export function useInfiniteFindUsers(per_page: number, term: string) {
-	return useInfiniteQuery<UserResponse>({
+	return useInfiniteQuery({
 		queryKey: userQueryKeys.infiniteList([per_page, term]),
 		queryFn: ({ pageParam }) =>
-			apiClient
-				.get("/users")
-				.query({ page: pageParam as number, per_page, term })
-				.then((res) => res.body),
+			searchUsers({ data: { page: pageParam as number, per_page, term } }),
 		initialPageParam: 1,
 		getNextPageParam: (lastPage) => {
 			if (lastPage.page >= lastPage.page_count) {

--- a/apps/web/src/users/queries.ts
+++ b/apps/web/src/users/queries.ts
@@ -35,18 +35,18 @@ export function useListUsers() {
 /**
  * Setup query for fetching user search results for infinite scrolling view
  *
- * @param per_page - The number of users to fetch per page
+ * @param perPage - The number of users to fetch per page
  * @param term - The search term to filter users by
  * @returns An UseInfiniteQueryResult object containing the user search results
  */
-export function useInfiniteFindUsers(per_page: number, term: string) {
+export function useInfiniteFindUsers(perPage: number, term: string) {
 	return useInfiniteQuery({
-		queryKey: userQueryKeys.infiniteList([per_page, term]),
+		queryKey: userQueryKeys.infiniteList([perPage, term]),
 		queryFn: ({ pageParam }) =>
-			searchUsers({ data: { page: pageParam as number, per_page, term } }),
+			searchUsers({ data: { page: pageParam as number, perPage, term } }),
 		initialPageParam: 1,
 		getNextPageParam: (lastPage) => {
-			if (lastPage.page >= lastPage.page_count) {
+			if (lastPage.page >= lastPage.pageCount) {
 				return undefined;
 			}
 			return (lastPage.page || 1) + 1;
@@ -59,23 +59,23 @@ export function useInfiniteFindUsers(per_page: number, term: string) {
  * Query options for a page of user search results.
  *
  * @param page - The page to fetch
- * @param per_page - The number of users to fetch per page
+ * @param perPage - The number of users to fetch per page
  * @param term - The search term to filter users by
  * @param administrator - Filter the users by administrator status
  * @param active - Filter the users by whether they are active
  */
 export function usersQueryOptions(
 	page: number,
-	per_page: number,
+	perPage: number,
 	term: string,
 	administrator?: boolean,
 	active?: boolean,
 ) {
 	return queryOptions({
-		queryKey: userQueryKeys.list([page, per_page, term, administrator, active]),
+		queryKey: userQueryKeys.list([page, perPage, term, administrator, active]),
 		queryFn: () =>
 			findUsers({
-				data: { page, per_page, term, administrator, active },
+				data: { page, perPage, term, administrator, active },
 			}),
 	});
 }
@@ -91,13 +91,13 @@ export function usersQueryOptions(
  */
 export function useSuspenseUsers(
 	page: number,
-	per_page: number,
+	perPage: number,
 	term: string,
 	administrator?: boolean,
 	active?: boolean,
 ) {
 	return useSuspenseQuery(
-		usersQueryOptions(page, per_page, term, administrator, active),
+		usersQueryOptions(page, perPage, term, administrator, active),
 	);
 }
 

--- a/apps/web/src/users/types.ts
+++ b/apps/web/src/users/types.ts
@@ -1,6 +1,5 @@
 import type { AdministratorRoleName } from "@administration/types";
 import type { GroupMinimal, Permissions } from "@groups/types";
-import type { SearchResult } from "@/types/api";
 
 /** Business to consumer provided user details */
 type UserB2c = {
@@ -63,10 +62,4 @@ export type User = UserNested & {
 
 	/** Their primary group */
 	primary_group: GroupMinimal | null;
-};
-
-/** User search results from the API */
-export type UserResponse = SearchResult & {
-	/** The page of users */
-	documents: Array<User>;
 };

--- a/apps/web/src/users/types.ts
+++ b/apps/web/src/users/types.ts
@@ -1,21 +1,6 @@
 import type { AdministratorRoleName } from "@administration/types";
 import type { GroupMinimal, Permissions } from "@groups/types";
 
-/** Business to consumer provided user details */
-type UserB2c = {
-	/** The display name */
-	display_name?: string;
-
-	/** The family name */
-	family_name?: string;
-
-	/** The given name */
-	given_name?: string;
-
-	/** The object ID */
-	oid: string;
-};
-
 /** A user with the essential information */
 export type UserNested = {
 	/** The unique identifier */
@@ -32,21 +17,6 @@ export type User = UserNested & {
 
 	/** Indicates if user is active */
 	active: boolean;
-
-	/** Their B2C specific information */
-	b2c?: UserB2c;
-
-	/** Their display name */
-	b2c_display_name?: string;
-
-	/** Their family name */
-	b2c_family_name?: string;
-
-	/** Their given name */
-	b2c_given_name?: string;
-
-	/** Their B2C object ID */
-	b2c_oid?: string;
 
 	/** Whether the user will be forced to reset their password on next login */
 	force_reset: boolean;

--- a/apps/web/src/wall/components/__tests__/FirstUser.test.tsx
+++ b/apps/web/src/wall/components/__tests__/FirstUser.test.tsx
@@ -3,14 +3,12 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeAccount } from "@tests/fake/account";
 import { mockCreateFirstUser } from "@tests/server-fn/auth";
+import { mockGetRoot } from "@tests/server-fn/root";
 import { mockGetAccount } from "@tests/server-fn/users";
 import { renderRoute } from "@tests/setup";
-import nock from "nock";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 describe("<FirstUser />", () => {
-	afterEach(() => nock.cleanAll());
-
 	async function renderSetup() {
 		return renderRoute("/setup", {
 			seed: (queryClient) => {
@@ -32,7 +30,7 @@ describe("<FirstUser />", () => {
 		// After setup the root reports no first user, and the session created by
 		// the server function authenticates the account fetch, so the guard
 		// admits the user instead of bouncing back to /setup.
-		nock("http://localhost").get("/api/").reply(200, { first_user: false });
+		mockGetRoot({ first_user: false });
 		mockGetAccount(account);
 
 		const { router } = await renderSetup();

--- a/apps/web/src/wall/components/__tests__/FirstUser.test.tsx
+++ b/apps/web/src/wall/components/__tests__/FirstUser.test.tsx
@@ -14,7 +14,7 @@ describe("<FirstUser />", () => {
 			seed: (queryClient) => {
 				// A fresh instance: the root reports the setup is needed and no
 				// account has been fetched yet.
-				queryClient.setQueryData(["root"], { first_user: true });
+				queryClient.setQueryData(["root"], { firstUser: true });
 				queryClient.removeQueries({ queryKey: accountQueryKeys.all() });
 			},
 		});
@@ -30,7 +30,7 @@ describe("<FirstUser />", () => {
 		// After setup the root reports no first user, and the session created by
 		// the server function authenticates the account fetch, so the guard
 		// admits the user instead of bouncing back to /setup.
-		mockGetRoot({ first_user: false });
+		mockGetRoot({ firstUser: false });
 		mockGetAccount(account);
 
 		const { router } = await renderSetup();

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -282,7 +282,7 @@ client can hold it in JS for the duration of the reset flow.
 ## First-user setup
 
 A fresh instance has no users; the root document reports
-`first_user: true` and the `_authenticated` guard redirects to
+`firstUser: true` and the `_authenticated` guard redirects to
 `/setup`. `createFirstUserFn` (`server/auth/functions.ts`) is the
 public server function that bootstraps the instance. It is unauthenticated
 by necessity — it runs before any user or session exists — and delegates


### PR DESCRIPTION
## Summary
- Convert the reference member picker's user search (`useInfiniteFindUsers`) and the root document (`useRootQuery`) from Python REST calls to TanStack Start server functions.
- Add an authenticated `searchUsers` server function for the reference member picker, gated by a per-reference modify right rather than admin; the existing `findUsers` stays administrator-only.
- Add a public `getRoot` server function returning `first_user` and `version`, read by the `_authenticated` guard before a session exists, letting the guard drop its `@app/api` import.