### PR TITLE
feat: allow file uploads to authenticate with an api key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -483,6 +483,13 @@ middleware runs on a route, the handler enforces the floor itself:
 check. Don't fold it back into a server function — the RPC client uses `fetch`
 and would lose progress.
 
+Raw routes are also the only endpoints reachable with an **API key**.
+`requireAuthenticatedRequest` accepts either the session cookie pair or an HTTP
+Basic `Authorization` header carrying `handle:key`; server functions stay
+cookie-only. A key-authenticated session carries the key's permissions, and
+`hasPermission` intersects them with the user's own — the key caps
+administrators too.
+
 See [docs/auth.md](docs/auth.md) for the middleware composition, the
 session model, cookies, lifetimes, and the login / reset / logout
 flows.

--- a/apps/web/src/server/account/data.ts
+++ b/apps/web/src/server/account/data.ts
@@ -1,6 +1,7 @@
-import { createHash, randomBytes } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import { emptyPermissions, type Permissions } from "@virtool/contracts";
 import { and, asc, eq, sql } from "drizzle-orm";
+import { hashToken } from "../auth/tokens";
 import type { Db } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import { type ApiKeyRow, apiKeys as apiKeysTable } from "../db/schema/apiKeys";
@@ -40,7 +41,7 @@ function toApiKey(row: ApiKeyRow): ApiKey {
 
 function generateKey(): { raw: string; hashed: string } {
 	const raw = randomBytes(32).toString("hex");
-	return { raw, hashed: createHash("sha256").update(raw).digest("hex") };
+	return { raw, hashed: hashToken(raw) };
 }
 
 /** List the account's API keys with their stored permissions. */

--- a/apps/web/src/server/auth/middleware.test.ts
+++ b/apps/web/src/server/auth/middleware.test.ts
@@ -1,3 +1,4 @@
+import { emptyPermissions } from "@virtool/contracts";
 import {
 	afterAll,
 	beforeAll,
@@ -9,6 +10,7 @@ import {
 } from "vitest";
 
 import type { Db } from "../db/pg";
+import { apiKeys } from "../db/schema/apiKeys";
 import { sessions } from "../db/schema/sessions";
 import { users } from "../db/schema/users";
 import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
@@ -56,7 +58,9 @@ const { createFirstUserFn, loginFn, logoutFn, resetPasswordFn } = await import(
 const { getPasswordPolicyFn } = await import("../settings/functions");
 const { getRoot } = await import("../root/functions");
 const { SESSION_ID_COOKIE, SESSION_TOKEN_COOKIE } = await import("./cookies");
-const { seedSession, seedUser } = await import("./test/fixtures");
+const { basicAuthHeader, seedApiKey, seedSession, seedUser } = await import(
+	"./test/fixtures"
+);
 
 let database: TestDatabase;
 
@@ -71,6 +75,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
 	vi.clearAllMocks();
+	await db.delete(apiKeys);
 	await db.delete(sessions);
 	await db.delete(users);
 });
@@ -93,6 +98,12 @@ function cookieHeader(sessionId: string, token: string): string {
 function requestFor(url: string, cookie?: string) {
 	return new Request(new URL(url, "https://virtool.test"), {
 		headers: cookie ? { cookie } : undefined,
+	});
+}
+
+function authorizedRequestFor(url: string, authorization: string) {
+	return new Request(new URL(url, "https://virtool.test"), {
+		headers: { authorization },
 	});
 }
 
@@ -256,6 +267,48 @@ describe("requireAuthenticatedRequest", () => {
 
 		expect(result).toBeInstanceOf(Response);
 		expect((result as Response).status).toBe(401);
+	});
+
+	it("resolves an api key from the authorization header", async () => {
+		const userId = await seedUser(db);
+		const key = await seedApiKey(db, userId, { upload_file: true });
+
+		expect(
+			await requireAuthenticatedRequest(
+				authorizedRequestFor("/uploads", basicAuthHeader("alice", key)),
+			),
+		).toEqual({
+			userId,
+			keyPermissions: { ...emptyPermissions(), upload_file: true },
+		});
+	});
+
+	it("returns a 401 for an api key that does not resolve", async () => {
+		await seedUser(db);
+
+		const result = await requireAuthenticatedRequest(
+			authorizedRequestFor("/uploads", basicAuthHeader("alice", "wrong")),
+		);
+
+		expect((result as Response).status).toBe(401);
+	});
+
+	// Otherwise a script sending a broken header would silently fall through to
+	// whatever cookies its client happened to have attached.
+	it("does not fall back to cookies when the authorization header is malformed", async () => {
+		const userId = await seedUser(db);
+		const { sessionId, token } = await seedSession(db, userId);
+
+		const request = new Request("https://virtool.test/uploads", {
+			headers: {
+				authorization: "Bearer nonsense",
+				cookie: cookieHeader(sessionId, token),
+			},
+		});
+
+		expect(
+			((await requireAuthenticatedRequest(request)) as Response).status,
+		).toBe(401);
 	});
 });
 

--- a/apps/web/src/server/auth/middleware.ts
+++ b/apps/web/src/server/auth/middleware.ts
@@ -11,7 +11,12 @@ import { eq } from "drizzle-orm";
 
 import { db } from "../db/pg";
 import { users } from "../db/schema/users";
-import { type AuthenticatedSession, verifyRequest } from "./verify";
+import {
+	type AuthenticatedSession,
+	parseBasicAuthHeader,
+	verifyApiKey,
+	verifyRequest,
+} from "./verify";
 
 /** Thrown by the auth middleware when a request has no valid session. */
 export class UnauthorizedError extends Error {
@@ -76,13 +81,34 @@ export const requireSession = createServerOnlyFn(
 );
 
 /**
- * Resolve the session for a raw `Request` (used by `createFileRoute` handlers
- * outside the server-function async-local context). Returns a 401 `Response`
- * on failure so the caller can `return` it directly.
+ * Resolve the identity behind a raw `Request` (used by `createFileRoute`
+ * handlers outside the server-function async-local context). Returns a 401
+ * `Response` on failure so the caller can `return` it directly.
+ *
+ * Either credential works: an HTTP Basic `Authorization` header carrying a user
+ * handle and API key, or the session cookie pair. Raw routes are the only
+ * endpoints a script can reach without the generated RPC client, so they are
+ * where key authentication has to live; server functions stay cookie-only.
+ *
+ * An `Authorization` header commits the request to the key path — a malformed
+ * one is a 401 rather than a silent fall back to whatever cookies happen to be
+ * attached. Python's `authentication_middleware` branches the same way.
  */
 export const requireAuthenticatedRequest = createServerOnlyFn(
 	async (request: Request): Promise<AuthenticatedSession | Response> => {
-		const session = await verifyRequest(db, request);
+		const header = request.headers.get("authorization");
+
+		let session: AuthenticatedSession | null;
+
+		if (header) {
+			const credentials = parseBasicAuthHeader(header);
+			session = credentials
+				? await verifyApiKey(db, credentials.handle, credentials.key)
+				: null;
+		} else {
+			session = await verifyRequest(db, request);
+		}
+
 		if (!session) {
 			return new Response("Unauthorized", { status: 401 });
 		}

--- a/apps/web/src/server/auth/policy.test.ts
+++ b/apps/web/src/server/auth/policy.test.ts
@@ -1,4 +1,4 @@
-import type { Permissions } from "@virtool/contracts";
+import { emptyPermissions, type Permissions } from "@virtool/contracts";
 import {
 	afterAll,
 	beforeAll,
@@ -126,5 +126,68 @@ describe("hasPermission", () => {
 
 	it("denies a session whose user no longer exists", async () => {
 		expect(await hasPermission({ userId: 404 }, "create_sample")).toBe(false);
+	});
+
+	describe("with an api key", () => {
+		function keyPermissions(overrides: Partial<Permissions>): Permissions {
+			return { ...emptyPermissions(), ...overrides };
+		}
+
+		it("grants a permission both the user and the key hold", async () => {
+			const userId = await seedUser(db);
+			const groupId = await seedGroup("uploaders", { upload_file: true });
+			await addToGroup(userId, groupId);
+
+			expect(
+				await hasPermission(
+					{ userId, keyPermissions: keyPermissions({ upload_file: true }) },
+					"upload_file",
+				),
+			).toBe(true);
+		});
+
+		it("denies a permission the user holds but the key does not", async () => {
+			const userId = await seedUser(db);
+			const groupId = await seedGroup("uploaders", { upload_file: true });
+			await addToGroup(userId, groupId);
+
+			expect(
+				await hasPermission(
+					{ userId, keyPermissions: keyPermissions({ create_sample: true }) },
+					"upload_file",
+				),
+			).toBe(false);
+		});
+
+		it("denies a permission the key holds but the user does not", async () => {
+			const userId = await seedUser(db);
+
+			expect(
+				await hasPermission(
+					{ userId, keyPermissions: keyPermissions({ upload_file: true }) },
+					"upload_file",
+				),
+			).toBe(false);
+		});
+
+		// Python's PermissionRoutePolicy lets any administrator role through
+		// regardless of the key. We cap them, because the account UI offers an
+		// administrator a checkbox per permission and promises it means something.
+		it("caps a full administrator to the key's permissions", async () => {
+			const userId = await seedUser(db, { administratorRole: "full" });
+
+			expect(
+				await hasPermission(
+					{ userId, keyPermissions: keyPermissions({ create_sample: true }) },
+					"upload_file",
+				),
+			).toBe(false);
+			expect(
+				await hasPermission(
+					{ userId, keyPermissions: keyPermissions({ upload_file: true }) },
+					"upload_file",
+				),
+			).toBe(true);
+		});
 	});
 });

--- a/apps/web/src/server/auth/policy.ts
+++ b/apps/web/src/server/auth/policy.ts
@@ -45,9 +45,22 @@ const forbid = createServerOnlyFn((): never => {
  *
  * Mirrors `checkAdminRoleOrPermissionsFromAccount` on the client: the two must
  * agree, or the UI offers an action the server then refuses.
+ *
+ * A session authenticated with an API key carries that key's permissions, and
+ * they cap the answer: the effective set is the intersection of what the user
+ * may do and what the key was granted. The cap applies to administrators too.
+ * Python's `PermissionRoutePolicy` lets any administrator role through
+ * regardless of the key, but the account UI tells the user the opposite — it
+ * offers an administrator a checkbox per permission and promises the key
+ * reverts to a smaller set if their role shrinks — so a key that ignored its own
+ * checkboxes would be a lie.
  */
 export const hasPermission = createServerOnlyFn(
 	async (session: AuthenticatedSession, name: Permission): Promise<boolean> => {
+		if (session.keyPermissions && !session.keyPermissions[name]) {
+			return false;
+		}
+
 		const [row] = await db
 			.select({ administratorRole: users.administratorRole })
 			.from(users)

--- a/apps/web/src/server/auth/test/fixtures.ts
+++ b/apps/web/src/server/auth/test/fixtures.ts
@@ -1,6 +1,13 @@
-import type { AdministratorRoleName } from "@virtool/contracts";
+import { randomBytes } from "node:crypto";
+
+import {
+	type AdministratorRoleName,
+	emptyPermissions,
+	type Permissions,
+} from "@virtool/contracts";
 
 import type { Db } from "../../db/pg";
+import { apiKeys } from "../../db/schema/apiKeys";
 import { sessions } from "../../db/schema/sessions";
 import { users } from "../../db/schema/users";
 import { hashToken, newSessionId, newSessionToken } from "../tokens";
@@ -96,4 +103,35 @@ export async function seedSession(
 	});
 
 	return { sessionId, token, userId };
+}
+
+/**
+ * Insert an API key for `userId` and return the raw secret. Only its hash is
+ * stored, so the plaintext is the only way a caller can authenticate with it
+ * afterwards.
+ *
+ * `permissions` is merged over an all-`false` set, so a test names only the
+ * permissions the key grants.
+ */
+export async function seedApiKey(
+	db: Db,
+	userId: number,
+	permissions: Partial<Permissions> = {},
+): Promise<string> {
+	const key = randomBytes(32).toString("hex");
+
+	await db.insert(apiKeys).values({
+		createdAt: new Date(),
+		hashed: hashToken(key),
+		name: "test",
+		permissions: { ...emptyPermissions(), ...permissions },
+		userId,
+	});
+
+	return key;
+}
+
+/** Encode `handle` and `key` as an HTTP Basic `Authorization` header value. */
+export function basicAuthHeader(handle: string, key: string): string {
+	return `Basic ${Buffer.from(`${handle}:${key}`, "utf8").toString("base64")}`;
 }

--- a/apps/web/src/server/auth/verify.test.ts
+++ b/apps/web/src/server/auth/verify.test.ts
@@ -192,12 +192,31 @@ describe("parseBasicAuthHeader", () => {
 		});
 	});
 
+	// RFC 7235 allows more than one space between the scheme and the credentials.
+	it.each([
+		["extra spaces between the scheme and credentials", "   "],
+		["a tab", "\t"],
+	])("accepts %s", (_label, separator) => {
+		expect(
+			parseBasicAuthHeader(encode("alice:secret").replace(" ", separator)),
+		).toEqual({ handle: "alice", key: "secret" });
+	});
+
+	it("accepts a header padded with surrounding whitespace", () => {
+		expect(parseBasicAuthHeader(`  ${encode("alice:secret")}  `)).toEqual({
+			handle: "alice",
+			key: "secret",
+		});
+	});
+
 	it.each([
 		["a bearer token", "Bearer abcdef"],
 		["no encoded credentials", "Basic"],
+		["trailing junk", `${encode("alice:secret")} extra`],
 		["no colon", encode("alice")],
 		["an empty handle", encode(":secret")],
 		["an empty string", ""],
+		["only whitespace", "   "],
 	])("rejects %s", (_label, header) => {
 		expect(parseBasicAuthHeader(header)).toBeNull();
 	});
@@ -270,6 +289,16 @@ describe("verifyApiKey", () => {
 		const key = await seedApiKey(db, userId);
 
 		expect(await verifyApiKey(db, "jobs", key)).toBeNull();
+	});
+
+	// The handle lookup is case-insensitive, so a guard that was not would let
+	// `JOBS` through to the row that `jobs` is refused.
+	it("rejects a job-prefixed login whatever its case", async () => {
+		const userId = await seedUser(db, { handle: "jobs" });
+		const key = await seedApiKey(db, userId);
+
+		expect(await verifyApiKey(db, "JOBS", key)).toBeNull();
+		expect(await verifyApiKey(db, "JoBs", key)).toBeNull();
 	});
 });
 

--- a/apps/web/src/server/auth/verify.test.ts
+++ b/apps/web/src/server/auth/verify.test.ts
@@ -1,14 +1,18 @@
+import { emptyPermissions, type Permissions } from "@virtool/contracts";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import type { Db } from "../db/pg";
+import { apiKeys } from "../db/schema/apiKeys";
 import { sessions } from "../db/schema/sessions";
 import { users } from "../db/schema/users";
 import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
 import { SESSION_ID_COOKIE, SESSION_TOKEN_COOKIE } from "./cookies";
-import { seedSession, seedUser } from "./test/fixtures";
+import { seedApiKey, seedSession, seedUser } from "./test/fixtures";
 import { newSessionToken } from "./tokens";
 import {
+	parseBasicAuthHeader,
 	parseCookieHeader,
+	verifyApiKey,
 	verifyAuthenticatedSession,
 	verifyRequest,
 } from "./verify";
@@ -26,6 +30,7 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
+	await db.delete(apiKeys);
 	await db.delete(sessions);
 	await db.delete(users);
 });
@@ -158,6 +163,113 @@ describe("parseCookieHeader", () => {
 
 	it("keeps a cookie with an empty value", () => {
 		expect(parseCookieHeader("session_id=")).toEqual({ session_id: "" });
+	});
+});
+
+describe("parseBasicAuthHeader", () => {
+	function encode(value: string): string {
+		return `Basic ${Buffer.from(value, "utf8").toString("base64")}`;
+	}
+
+	it("parses a handle and key", () => {
+		expect(parseBasicAuthHeader(encode("alice:secret"))).toEqual({
+			handle: "alice",
+			key: "secret",
+		});
+	});
+
+	it("accepts the scheme in any case", () => {
+		expect(
+			parseBasicAuthHeader(encode("alice:secret").replace("Basic", "bAsIc")),
+		).toEqual({ handle: "alice", key: "secret" });
+	});
+
+	// A key is hex today, but nothing stops a colon appearing in one later.
+	it("splits on the first colon only", () => {
+		expect(parseBasicAuthHeader(encode("alice:a:b"))).toEqual({
+			handle: "alice",
+			key: "a:b",
+		});
+	});
+
+	it.each([
+		["a bearer token", "Bearer abcdef"],
+		["no encoded credentials", "Basic"],
+		["no colon", encode("alice")],
+		["an empty handle", encode(":secret")],
+		["an empty string", ""],
+	])("rejects %s", (_label, header) => {
+		expect(parseBasicAuthHeader(header)).toBeNull();
+	});
+});
+
+describe("verifyApiKey", () => {
+	it("resolves the key owner and the key's permissions", async () => {
+		const userId = await seedUser(db);
+		const key = await seedApiKey(db, userId, { upload_file: true });
+
+		expect(await verifyApiKey(db, "alice", key)).toEqual({
+			userId,
+			keyPermissions: { ...emptyPermissions(), upload_file: true },
+		});
+	});
+
+	it("matches the handle case-insensitively", async () => {
+		const userId = await seedUser(db, { handle: "Alice" });
+		const key = await seedApiKey(db, userId);
+
+		expect(await verifyApiKey(db, "aLiCe", key)).toMatchObject({ userId });
+	});
+
+	it("expands a partially stored permission set", async () => {
+		const userId = await seedUser(db);
+		const key = await seedApiKey(db, userId);
+		await db.update(apiKeys).set({
+			// Keys written by the legacy Python path stored only granted names.
+			permissions: { upload_file: true } as unknown as Permissions,
+		});
+
+		expect(await verifyApiKey(db, "alice", key)).toEqual({
+			userId,
+			keyPermissions: { ...emptyPermissions(), upload_file: true },
+		});
+	});
+
+	it("rejects an unknown handle", async () => {
+		const userId = await seedUser(db);
+		const key = await seedApiKey(db, userId);
+
+		expect(await verifyApiKey(db, "nobody", key)).toBeNull();
+	});
+
+	it("rejects a deactivated user", async () => {
+		const userId = await seedUser(db, { active: false });
+		const key = await seedApiKey(db, userId);
+
+		expect(await verifyApiKey(db, "alice", key)).toBeNull();
+	});
+
+	it("rejects a key that is not the named user's", async () => {
+		const other = await seedUser(db, { handle: "bob" });
+		await seedUser(db, { handle: "alice" });
+		const key = await seedApiKey(db, other);
+
+		expect(await verifyApiKey(db, "alice", key)).toBeNull();
+	});
+
+	it("rejects an unknown key", async () => {
+		await seedUser(db);
+
+		expect(await verifyApiKey(db, "alice", "not-a-key")).toBeNull();
+	});
+
+	// Job keys authenticate against a separate service, and Python refuses them
+	// here rather than resolving `job-{id}` as a user handle.
+	it("rejects a job-prefixed login without touching the database", async () => {
+		const userId = await seedUser(db, { handle: "jobs" });
+		const key = await seedApiKey(db, userId);
+
+		expect(await verifyApiKey(db, "jobs", key)).toBeNull();
 	});
 });
 

--- a/apps/web/src/server/auth/verify.ts
+++ b/apps/web/src/server/auth/verify.ts
@@ -1,16 +1,23 @@
 import { timingSafeEqual } from "node:crypto";
 
-import { eq } from "drizzle-orm";
+import { emptyPermissions, type Permissions } from "@virtool/contracts";
+import { and, eq, sql } from "drizzle-orm";
 
 import type { Db } from "../db/pg";
+import { apiKeys } from "../db/schema/apiKeys";
 import { sessions } from "../db/schema/sessions";
 import { users } from "../db/schema/users";
 import { SESSION_ID_COOKIE, SESSION_TOKEN_COOKIE } from "./cookies";
 import { hashToken } from "./tokens";
 
-/** Authenticated identity resolved from a session cookie pair. */
+/** Authenticated identity resolved from a session cookie pair or an API key. */
 export type AuthenticatedSession = {
 	userId: number;
+	/**
+	 * Set only when the caller authenticated with an API key. The key's
+	 * permissions cap the user's own, so `hasPermission` must intersect the two.
+	 */
+	keyPermissions?: Permissions;
 };
 
 /**
@@ -96,6 +103,87 @@ export function parseCookieHeader(
 		out[key] = decodeURIComponent(value);
 	}
 	return out;
+}
+
+/** The login and password carried by an HTTP Basic `Authorization` header. */
+export type BasicCredentials = {
+	handle: string;
+	key: string;
+};
+
+/**
+ * Parse an HTTP Basic `Authorization` header into its login and password.
+ * Returns `null` for anything malformed — a non-Basic scheme, undecodable
+ * base64, a missing separator, or an empty login — which callers treat as a
+ * failed authentication rather than falling back to cookies.
+ */
+export function parseBasicAuthHeader(header: string): BasicCredentials | null {
+	const [scheme, encoded] = header.split(" ");
+
+	if (scheme?.toLowerCase() !== "basic" || !encoded) {
+		return null;
+	}
+
+	const decoded = Buffer.from(encoded, "base64").toString("utf8");
+	const idx = decoded.indexOf(":");
+
+	if (idx < 1) {
+		return null;
+	}
+
+	return { handle: decoded.slice(0, idx), key: decoded.slice(idx + 1) };
+}
+
+/**
+ * Resolve an identity from a user handle and a raw API key. Returns `null` for
+ * any failure — unknown handle, deactivated user, or a key that is not that
+ * user's — so callers answer a single 401 without saying which check failed.
+ *
+ * Handles are matched case-insensitively, as they are at login and in Python's
+ * `get_by_handle`. Only the key's SHA-256 is stored, so the lookup hashes the
+ * supplied secret and matches on that; the digest is indexed and unique, and
+ * scoping it to the user keeps one account's key from authenticating another's
+ * handle.
+ */
+export async function verifyApiKey(
+	db: Db,
+	handle: string,
+	key: string,
+): Promise<AuthenticatedSession | null> {
+	// Job keys use this same header format against the separate jobs API. Python
+	// refuses them here rather than resolving `job-{id}` as a user handle, and a
+	// handle that reaches Postgres either way must not authenticate differently
+	// depending on which backend served it.
+	if (!handle || handle.startsWith("job")) {
+		return null;
+	}
+
+	const [row] = await db
+		.select({
+			userId: users.id,
+			active: users.active,
+			permissions: apiKeys.permissions,
+		})
+		.from(users)
+		.innerJoin(apiKeys, eq(apiKeys.userId, users.id))
+		.where(
+			and(
+				sql`lower(${users.handle}) = ${handle.toLowerCase()}`,
+				eq(apiKeys.hashed, hashToken(key)),
+			),
+		)
+		.limit(1);
+
+	if (!row?.active) {
+		return null;
+	}
+
+	// Keys written by the legacy Python path stored only the permissions that
+	// were granted, so expand against the full set before it becomes a cap.
+	return {
+		userId: row.userId,
+		keyPermissions: { ...emptyPermissions(), ...row.permissions },
+	};
 }
 
 /** Resolve an authenticated session directly from a `Request`. */

--- a/apps/web/src/server/auth/verify.ts
+++ b/apps/web/src/server/auth/verify.ts
@@ -118,7 +118,17 @@ export type BasicCredentials = {
  * failed authentication rather than falling back to cookies.
  */
 export function parseBasicAuthHeader(header: string): BasicCredentials | null {
-	const [scheme, encoded] = header.split(" ");
+	// RFC 7235 allows one *or more* spaces between the scheme and the
+	// credentials, so split on runs of whitespace rather than a single space.
+	// Requiring exactly two parts still rejects a header with trailing junk —
+	// base64 contains no whitespace, so a third part means the header is broken.
+	const parts = header.trim().split(/\s+/);
+
+	if (parts.length !== 2) {
+		return null;
+	}
+
+	const [scheme, encoded] = parts;
 
 	if (scheme?.toLowerCase() !== "basic" || !encoded) {
 		return null;
@@ -150,11 +160,16 @@ export async function verifyApiKey(
 	handle: string,
 	key: string,
 ): Promise<AuthenticatedSession | null> {
+	// The lookup below matches the handle case-insensitively, so the prefix check
+	// has to as well — otherwise `JOB-1` would slip past a guard that `job-1`
+	// trips and then resolve to the very same row.
+	const normalized = handle.toLowerCase();
+
 	// Job keys use this same header format against the separate jobs API. Python
 	// refuses them here rather than resolving `job-{id}` as a user handle, and a
 	// handle that reaches Postgres either way must not authenticate differently
 	// depending on which backend served it.
-	if (!handle || handle.startsWith("job")) {
+	if (!normalized || normalized.startsWith("job")) {
 		return null;
 	}
 
@@ -168,7 +183,7 @@ export async function verifyApiKey(
 		.innerJoin(apiKeys, eq(apiKeys.userId, users.id))
 		.where(
 			and(
-				sql`lower(${users.handle}) = ${handle.toLowerCase()}`,
+				sql`lower(${users.handle}) = ${normalized}`,
 				eq(apiKeys.hashed, hashToken(key)),
 			),
 		)

--- a/apps/web/src/server/uploads/upload.test.ts
+++ b/apps/web/src/server/uploads/upload.test.ts
@@ -9,6 +9,7 @@ import {
 } from "vitest";
 
 import type { Db } from "../db/pg";
+import { apiKeys } from "../db/schema/apiKeys";
 import { sessions } from "../db/schema/sessions";
 import { uploads as uploadsTable } from "../db/schema/uploads";
 import { users } from "../db/schema/users";
@@ -48,7 +49,9 @@ const { handleUpload } = await import("./upload");
 const { SESSION_ID_COOKIE, SESSION_TOKEN_COOKIE } = await import(
 	"../auth/cookies"
 );
-const { seedSession, seedUser } = await import("../auth/test/fixtures");
+const { basicAuthHeader, seedApiKey, seedSession, seedUser } = await import(
+	"../auth/test/fixtures"
+);
 
 let database: TestDatabase;
 
@@ -64,6 +67,7 @@ afterAll(async () => {
 beforeEach(async () => {
 	vi.clearAllMocks();
 	await db.delete(uploadsTable);
+	await db.delete(apiKeys);
 	await db.delete(sessions);
 	await db.delete(users);
 });
@@ -138,5 +142,86 @@ describe("handleUpload", () => {
 		);
 
 		expect(response.status).toBe(400);
+	});
+});
+
+describe("handleUpload with an api key", () => {
+	/** Build a `POST /uploads` request authenticated with an Authorization header. */
+	function keyRequest(authorization: string): Request {
+		return new Request(
+			"https://virtool.test/uploads?name=external.fa.gz&type=reference",
+			{ method: "POST", body: "hello", headers: { authorization } },
+		);
+	}
+
+	it("accepts a key granted upload_file", async () => {
+		const userId = await seedUser(db, { administratorRole: "full" });
+		const key = await seedApiKey(db, userId, { upload_file: true });
+
+		const response = await handleUpload(
+			keyRequest(basicAuthHeader("alice", key)),
+		);
+
+		expect(response.status).toBe(201);
+		const [row] = await db.select().from(uploadsTable);
+		expect(row?.userId).toBe(userId);
+	});
+
+	it("rejects a key without upload_file with a 403", async () => {
+		const userId = await seedUser(db, { administratorRole: "full" });
+		const key = await seedApiKey(db, userId, { create_sample: true });
+
+		const response = await handleUpload(
+			keyRequest(basicAuthHeader("alice", key)),
+		);
+
+		expect(response.status).toBe(403);
+		expect(await db.select().from(uploadsTable)).toHaveLength(0);
+	});
+
+	// The key permits it, but the user themself does not, so neither does the
+	// intersection.
+	it("rejects a key whose owner lacks upload_file with a 403", async () => {
+		const userId = await seedUser(db);
+		const key = await seedApiKey(db, userId, { upload_file: true });
+
+		const response = await handleUpload(
+			keyRequest(basicAuthHeader("alice", key)),
+		);
+
+		expect(response.status).toBe(403);
+	});
+
+	it("rejects an unknown key with a 401", async () => {
+		await seedUser(db, { administratorRole: "full" });
+
+		const response = await handleUpload(
+			keyRequest(basicAuthHeader("alice", "not-a-key")),
+		);
+
+		expect(response.status).toBe(401);
+	});
+
+	it("rejects a key belonging to a deactivated user with a 401", async () => {
+		const userId = await seedUser(db, {
+			active: false,
+			administratorRole: "full",
+		});
+		const key = await seedApiKey(db, userId, { upload_file: true });
+
+		const response = await handleUpload(
+			keyRequest(basicAuthHeader("alice", key)),
+		);
+
+		expect(response.status).toBe(401);
+	});
+
+	it("rejects a malformed authorization header with a 401", async () => {
+		const userId = await seedUser(db, { administratorRole: "full" });
+		await seedApiKey(db, userId, { upload_file: true });
+
+		const response = await handleUpload(keyRequest("Bearer nonsense"));
+
+		expect(response.status).toBe(401);
 	});
 });

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -21,8 +21,8 @@ The pure layer is split by primitive rather than collapsed into one
   and deliberately free of bcrypt, the db, and the TanStack shell, so
   the browser can import it (see "Minimum password length" below)
 - `cookies.ts` — `CookieAdapter` type (framework-agnostic cookie I/O)
-- `verify.ts` — request verification (pure, given a cookie adapter and
-  db handle)
+- `verify.ts` — request verification, by session cookie pair or API key
+  (pure, given a cookie adapter and db handle)
 
 The wired layer is split too:
 
@@ -96,9 +96,11 @@ helpers:
   been resolved.
 - **`requireAuthenticatedRequest(request)`** — for raw `Request`
   handlers in `createFileRoute` (e.g. SSE / streaming routes like
-  `routes/events.ts`). These run outside the server-function
-  async-local context, so the middleware can't reach them. Returns a
-  401 `Response` on failure for the caller to `return` directly.
+  `routes/events.ts`, and `POST /uploads`). These run outside the
+  server-function async-local context, so the middleware can't reach
+  them. Accepts a session cookie pair *or* an API key (see "API key
+  authentication" below). Returns a 401 `Response` on failure for the
+  caller to `return` directly.
 - **`requireAdminRole(session, role)`** — throws `ForbiddenError` and
   sets a 403 when the session user does not hold at least `role`. Roles
   are ranked `full` (strongest) through `base` (weakest), so `"base"`
@@ -118,6 +120,55 @@ server function, and forgetting is silent — the fn would just be
 publicly callable. Default-on with an explicit opt-out flips the
 failure mode: forgetting to list a fn in `exceptions` produces a 401
 the moment you test it, not a security hole.
+
+## API key authentication
+
+A script has no browser and no session cookie. It authenticates with
+an HTTP Basic header carrying a user handle and a raw API key:
+
+```
+Authorization: Basic base64(handle:key)
+```
+
+`verify.ts` exports the two pieces: `parseBasicAuthHeader(header)`,
+which returns `null` for a non-Basic scheme, a missing `:`, or an empty
+handle; and `verifyApiKey(db, handle, key)`, which resolves the caller
+in one query — `users` joined to `api_keys`, matching the handle
+case-insensitively (as login and Python's `get_by_handle` both do) and
+the key by its SHA-256, which is all that is stored. Every failure
+returns `null`: unknown handle, deactivated user, a key that belongs
+to someone else. The caller answers one 401 without saying which check
+failed.
+
+A login starting with `job` is refused outright. Job keys use the same
+header format against the separate jobs API, and Python refuses them
+here rather than resolving `job-{id}` as a user handle.
+
+`requireAuthenticatedRequest` picks the path off the request: an
+`Authorization` header commits it to the key, cookies are read only
+when there is no header. A malformed header is therefore a 401, not a
+silent fall back to whatever cookies the client happened to attach —
+Python's `authentication_middleware` branches the same way.
+
+**Only raw routes accept a key.** Server functions stay cookie-only:
+they are the app's own RPC transport, not a public API, and the
+generated client always sends cookies. The raw routes — `POST
+/uploads` and `/events` — are what a script can actually reach.
+
+### The key's permissions are a cap
+
+A session resolved from a key carries `keyPermissions`, and
+`hasPermission` intersects it with the user's own permissions: a
+permission has to be granted by *both* the user (through a group or an
+administrator role) and the key.
+
+The cap applies to administrators. Python's `PermissionRoutePolicy`
+lets any administrator role through regardless of the key
+(`client.administrator_role or client.permissions[...]`); we do not,
+because the account UI tells the user the opposite. It offers an
+administrator a checkbox per permission and promises the key "will
+revert to your new limited set of permissions" if their role shrinks.
+A key that ignored its own checkboxes would make that a lie.
 
 ## Authorization: every server function declares a policy
 


### PR DESCRIPTION
## Summary

- File uploads — and other raw routes like `/events` — now accept an HTTP Basic `Authorization` header carrying a user handle and API key, not just a session cookie, so a script with no browser can upload a file. Server functions stay cookie-only.
- A key-authenticated session's permissions cap the user's own: `hasPermission` returns the intersection of what the user may do and what the key was granted. The cap applies to administrators too, unlike Python's `PermissionRoutePolicy`, because the account UI already offers an administrator a checkbox per permission and promises the key reverts to a smaller set when their role shrinks.
- A malformed `Authorization` header is a 401 rather than a silent fall back to whatever cookies were attached, and `job`-prefixed logins are refused outright — both matching Python's `authentication_middleware`.