### PR TITLE
fix: hide reference details from users who cannot see them

### DIFF
--- a/apps/web/src/server/references/data.ts
+++ b/apps/web/src/server/references/data.ts
@@ -420,6 +420,39 @@ export async function checkReferenceRight(
 	return false;
 }
 
+/**
+ * Whether `actor` may see a reference at all — the single-row form of
+ * {@link referenceVisibilityFilter}, so detail read enforces the same rule the
+ * list does. A full administrator sees every reference; otherwise ownership, any
+ * user membership row, or any group membership row grants visibility, regardless
+ * of the rights flags on that row.
+ *
+ * Returns `false` for both a missing reference and one the actor cannot see, so
+ * the caller can collapse the two into an indistinguishable 404.
+ */
+export async function checkReferenceVisibility(
+	db: Db,
+	referenceId: number,
+	actor: ReferenceActor,
+): Promise<boolean> {
+	if (actor.isAdmin) {
+		return true;
+	}
+
+	const [row] = await db
+		.select({ id: legacyReferences.id })
+		.from(legacyReferences)
+		.where(
+			and(
+				eq(legacyReferences.id, referenceId),
+				referenceVisibilityFilter(db, actor),
+			),
+		)
+		.limit(1);
+
+	return Boolean(row);
+}
+
 // The rows a non-administrator may see: references they own, plus references
 // they can reach through a user or group membership row.
 function referenceVisibilityFilter(

--- a/apps/web/src/server/references/functions.test.ts
+++ b/apps/web/src/server/references/functions.test.ts
@@ -215,6 +215,65 @@ describe("getReference", () => {
 		expect(reference.users[0]?.id).toBe(ownerId);
 		expect(reference.users[0]?.modifyOtu).toBe(true);
 	});
+
+	it("hides a reference the caller cannot see behind a 404", async () => {
+		const ownerId = await seedUser(db, {
+			administratorRole: null,
+			handle: "bob",
+		});
+		await signIn(null);
+		const referenceId = await seedReference(ownerId);
+
+		await expect(call("getReference", { referenceId })).rejects.toThrow(
+			"Reference not found.",
+		);
+		expect(setResponseStatus).toHaveBeenCalledWith(404);
+	});
+
+	it("returns the detail for a full administrator who is not a member", async () => {
+		const ownerId = await seedUser(db, {
+			administratorRole: null,
+			handle: "bob",
+		});
+		await signIn("full");
+		const referenceId = await seedReference(ownerId);
+
+		const reference = (await call("getReference", { referenceId })) as {
+			id: number;
+		};
+
+		expect(reference.id).toBe(referenceId);
+	});
+
+	it("returns the detail for a member reached through a group, regardless of rights", async () => {
+		const ownerId = await seedUser(db, {
+			administratorRole: null,
+			handle: "bob",
+		});
+		const userId = await signIn(null);
+		const referenceId = await seedReference(ownerId);
+		const group = takeFirstOrThrow(
+			await db
+				.insert(groups)
+				.values({ name: "Team", permissions: {} as never })
+				.returning({ id: groups.id }),
+		);
+		await db.insert(userGroups).values({ userId, groupId: group.id });
+		// Every rights flag is false: visibility is broader than any single right.
+		await db.insert(legacyReferenceGroups).values({
+			reference_id: referenceId,
+			group_id: group.id,
+			build: false,
+			modify: false,
+			modify_otu: false,
+		});
+
+		const reference = (await call("getReference", { referenceId })) as {
+			id: number;
+		};
+
+		expect(reference.id).toBe(referenceId);
+	});
 });
 
 describe("createReference", () => {

--- a/apps/web/src/server/references/functions.ts
+++ b/apps/web/src/server/references/functions.ts
@@ -15,6 +15,7 @@ import {
 	addReferenceGroup as addReferenceGroupImpl,
 	addReferenceUser as addReferenceUserImpl,
 	checkReferenceRight,
+	checkReferenceVisibility,
 	createReference as createReferenceImpl,
 	findReferences as findReferencesImpl,
 	getReference as getReferenceImpl,
@@ -146,8 +147,15 @@ export const findReferences = createServerFn({ method: "GET" })
 export const getReference = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(referenceIdSchema)
-	.handler(async ({ data }) => {
+	.handler(async ({ context, data }) => {
 		try {
+			// Detail read enforces the same visibility rule as the list: a
+			// non-member, non-administrator caller cannot tell a hidden reference
+			// from a missing one — both surface as a 404.
+			const actor = await resolveReferenceActor(db, context.session.userId);
+			if (!(await checkReferenceVisibility(db, data.referenceId, actor))) {
+				throw new ReferenceNotFoundError();
+			}
 			return await getReferenceImpl(db, data.referenceId);
 		} catch (err) {
 			return rethrowAsHttp(err);


### PR DESCRIPTION
## Summary
- Enforce the same visibility rule on the single-reference detail read that already applies to the reference list, so a non-admin, non-member caller gets a 404 instead of the reference's data.
- Add `checkReferenceVisibility` to `references/data.ts`, treating a hidden reference and a missing one identically to avoid leaking existence.
- Cover the new check with tests for a blocked non-member, a full administrator, and a member reached only through a group.