### PR TITLE
feat: serve subtraction file downloads from the typescript server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -524,6 +524,15 @@ produce. Its `$document` param is the `{id}.{extension}` segment. It too
 enforces its own floor — `requireAuthenticatedRequest`, then the **read** right
 on the analysis's parent sample.
 
+Subtraction file downloads
+(`routes/subtractions.$subtractionId.files.$filename.ts` →
+`@server/subtraction/download`) are a raw route for the same reason, and stream
+the bytes out of storage rather than buffering a multi-GB Bowtie2 index. Their
+floor is `requireAuthenticatedRequest` alone — subtractions carry no per-row
+rights. The filename is only ever composed into a storage key *after* it has
+matched a `subtraction_files` row, which is what keeps a URL param from
+traversing out of the prefix.
+
 Raw routes are also the only endpoints reachable with an **API key**.
 `requireAuthenticatedRequest` accepts either the session cookie pair or an HTTP
 Basic `Authorization` header carrying `handle:key`; server functions stay

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -59,6 +59,7 @@ import { Route as AuthenticatedSamplesSampleIdFilesRouteImport } from './routes/
 import { Route as AuthenticatedSamplesSampleIdGeneralRouteImport } from './routes/_authenticated/samples/$sampleId/general'
 import { Route as AuthenticatedSamplesSampleIdQualityRouteImport } from './routes/_authenticated/samples/$sampleId/quality'
 import { Route as AuthenticatedSamplesSampleIdRightsRouteImport } from './routes/_authenticated/samples/$sampleId/rights'
+import { Route as SubtractionsSubtractionIdFilesFilenameRouteImport } from './routes/subtractions.$subtractionId.files.$filename'
 import { Route as AuthenticatedRefsRefIdIndexesIndexRouteImport } from './routes/_authenticated/refs/$refId/indexes/index'
 import { Route as AuthenticatedRefsRefIdIndexesIndexIdRouteImport } from './routes/_authenticated/refs/$refId/indexes/$indexId'
 import { Route as AuthenticatedRefsRefIdOtusIndexRouteImport } from './routes/_authenticated/refs/$refId/otus/index'
@@ -351,6 +352,12 @@ const AuthenticatedSamplesSampleIdRightsRoute =
     path: '/rights',
     getParentRoute: () => AuthenticatedSamplesSampleIdRoute,
   } as any)
+const SubtractionsSubtractionIdFilesFilenameRoute =
+  SubtractionsSubtractionIdFilesFilenameRouteImport.update({
+    id: '/subtractions/$subtractionId/files/$filename',
+    path: '/subtractions/$subtractionId/files/$filename',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const AuthenticatedRefsRefIdIndexesIndexRoute =
   AuthenticatedRefsRefIdIndexesIndexRouteImport.update({
     id: '/indexes/',
@@ -471,6 +478,7 @@ export interface FileRoutesByFullPath {
   '/samples/$sampleId/general': typeof AuthenticatedSamplesSampleIdGeneralRoute
   '/samples/$sampleId/quality': typeof AuthenticatedSamplesSampleIdQualityRoute
   '/samples/$sampleId/rights': typeof AuthenticatedSamplesSampleIdRightsRoute
+  '/subtractions/$subtractionId/files/$filename': typeof SubtractionsSubtractionIdFilesFilenameRoute
   '/administration/users/': typeof AuthenticatedAdministrationUsersIndexRoute
   '/refs/$refId/': typeof AuthenticatedRefsRefIdIndexRoute
   '/samples/$sampleId/': typeof AuthenticatedSamplesSampleIdIndexRoute
@@ -524,6 +532,7 @@ export interface FileRoutesByTo {
   '/samples/$sampleId/general': typeof AuthenticatedSamplesSampleIdGeneralRoute
   '/samples/$sampleId/quality': typeof AuthenticatedSamplesSampleIdQualityRoute
   '/samples/$sampleId/rights': typeof AuthenticatedSamplesSampleIdRightsRoute
+  '/subtractions/$subtractionId/files/$filename': typeof SubtractionsSubtractionIdFilesFilenameRoute
   '/administration/users': typeof AuthenticatedAdministrationUsersIndexRoute
   '/refs/$refId': typeof AuthenticatedRefsRefIdIndexRoute
   '/samples/$sampleId': typeof AuthenticatedSamplesSampleIdIndexRoute
@@ -587,6 +596,7 @@ export interface FileRoutesById {
   '/_authenticated/samples/$sampleId/general': typeof AuthenticatedSamplesSampleIdGeneralRoute
   '/_authenticated/samples/$sampleId/quality': typeof AuthenticatedSamplesSampleIdQualityRoute
   '/_authenticated/samples/$sampleId/rights': typeof AuthenticatedSamplesSampleIdRightsRoute
+  '/subtractions/$subtractionId/files/$filename': typeof SubtractionsSubtractionIdFilesFilenameRoute
   '/_authenticated/administration/users/': typeof AuthenticatedAdministrationUsersIndexRoute
   '/_authenticated/refs/$refId/': typeof AuthenticatedRefsRefIdIndexRoute
   '/_authenticated/samples/$sampleId/': typeof AuthenticatedSamplesSampleIdIndexRoute
@@ -652,6 +662,7 @@ export interface FileRouteTypes {
     | '/samples/$sampleId/general'
     | '/samples/$sampleId/quality'
     | '/samples/$sampleId/rights'
+    | '/subtractions/$subtractionId/files/$filename'
     | '/administration/users/'
     | '/refs/$refId/'
     | '/samples/$sampleId/'
@@ -705,6 +716,7 @@ export interface FileRouteTypes {
     | '/samples/$sampleId/general'
     | '/samples/$sampleId/quality'
     | '/samples/$sampleId/rights'
+    | '/subtractions/$subtractionId/files/$filename'
     | '/administration/users'
     | '/refs/$refId'
     | '/samples/$sampleId'
@@ -767,6 +779,7 @@ export interface FileRouteTypes {
     | '/_authenticated/samples/$sampleId/general'
     | '/_authenticated/samples/$sampleId/quality'
     | '/_authenticated/samples/$sampleId/rights'
+    | '/subtractions/$subtractionId/files/$filename'
     | '/_authenticated/administration/users/'
     | '/_authenticated/refs/$refId/'
     | '/_authenticated/samples/$sampleId/'
@@ -794,6 +807,7 @@ export interface RootRouteChildren {
   HealthLiveRoute: typeof HealthLiveRoute
   HealthReadyRoute: typeof HealthReadyRoute
   AnalysesDocumentsDocumentRoute: typeof AnalysesDocumentsDocumentRoute
+  SubtractionsSubtractionIdFilesFilenameRoute: typeof SubtractionsSubtractionIdFilesFilenameRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -1147,6 +1161,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/samples/$sampleId/rights'
       preLoaderRoute: typeof AuthenticatedSamplesSampleIdRightsRouteImport
       parentRoute: typeof AuthenticatedSamplesSampleIdRoute
+    }
+    '/subtractions/$subtractionId/files/$filename': {
+      id: '/subtractions/$subtractionId/files/$filename'
+      path: '/subtractions/$subtractionId/files/$filename'
+      fullPath: '/subtractions/$subtractionId/files/$filename'
+      preLoaderRoute: typeof SubtractionsSubtractionIdFilesFilenameRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/_authenticated/refs/$refId/indexes/': {
       id: '/_authenticated/refs/$refId/indexes/'
@@ -1519,6 +1540,8 @@ const rootRouteChildren: RootRouteChildren = {
   HealthLiveRoute: HealthLiveRoute,
   HealthReadyRoute: HealthReadyRoute,
   AnalysesDocumentsDocumentRoute: AnalysesDocumentsDocumentRoute,
+  SubtractionsSubtractionIdFilesFilenameRoute:
+    SubtractionsSubtractionIdFilesFilenameRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/subtractions.$subtractionId.files.$filename.ts
+++ b/apps/web/src/routes/subtractions.$subtractionId.files.$filename.ts
@@ -1,0 +1,16 @@
+import { handleSubtractionFile } from "@server/subtraction/download";
+import { createFileRoute } from "@tanstack/react-router";
+
+// A raw route, not a server function: the client reaches this with a plain
+// `<a href>`, so the browser has to receive a real response carrying a
+// `Content-Disposition` header, and the bytes stream straight out of storage.
+export const Route = createFileRoute(
+	"/subtractions/$subtractionId/files/$filename",
+)({
+	server: {
+		handlers: {
+			GET: ({ request, params }) =>
+				handleSubtractionFile(request, params.subtractionId, params.filename),
+		},
+	},
+});

--- a/apps/web/src/server/db/schema/subtractions.ts
+++ b/apps/web/src/server/db/schema/subtractions.ts
@@ -3,9 +3,9 @@
 // migrations from this side. Keep the columns in sync with
 // `../../../../../../virtool/virtool/subtractions/pg.py`.
 //
-// The `legacy_id` column (the Mongo `_id`) is intentionally omitted: every
-// subtraction served from this side is Postgres-native and keyed by its integer
-// id, so nothing here reads or writes it.
+// `legacy_id` (the Mongo `_id`) is null for Postgres-native subtractions. Every
+// endpoint addresses a subtraction by its integer id, but its files live under
+// the legacy id when it has one — see `subtractionStorageId`.
 
 import {
 	bigint,
@@ -31,6 +31,7 @@ export type SubtractionFileType = "fasta" | "bowtie2";
 
 export const subtractions = pgTable("subtractions", {
 	id: bigint("id", { mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
+	legacy_id: text("legacy_id").unique(),
 	name: text("name").notNull(),
 	nickname: text("nickname")
 		.$defaultFn(() => "")

--- a/apps/web/src/server/storage/keys.ts
+++ b/apps/web/src/server/storage/keys.ts
@@ -55,6 +55,18 @@ function normalizeSubtractionId(subtractionId: string): string {
 	return subtractionId.replaceAll(" ", "_");
 }
 
+/**
+ * The prefix segment a subtraction's files live under, fixed for its life.
+ * Mongo-migrated subtractions keep their legacy id; Postgres-native ones use
+ * the integer primary key.
+ */
+export function subtractionStorageId(
+	subtractionId: number,
+	legacyId: string | null,
+): string {
+	return legacyId || String(subtractionId);
+}
+
 /** Key for a subtraction file. */
 export function subtractionFileKey(
 	subtractionId: string,

--- a/apps/web/src/server/subtraction/data.test.ts
+++ b/apps/web/src/server/subtraction/data.test.ts
@@ -363,6 +363,28 @@ describe("deleteSubtraction", () => {
 		expect(await db.select().from(legacySampleSubtractions)).toHaveLength(0);
 	});
 
+	// A subtraction migrated out of Mongo keeps its legacy slug as its storage
+	// prefix, so cleaning up under the integer id would orphan every byte.
+	it("clears storage under a migrated subtraction's legacy prefix", async () => {
+		const storage = new MemoryStorage();
+		const subtractionId = await seedSubtraction({ legacy_id: "arabidopsis 1" });
+
+		await storage.write(
+			"subtractions/arabidopsis_1/subtraction.fa.gz",
+			(async function* () {
+				yield new TextEncoder().encode("hello");
+			})(),
+		);
+
+		await deleteSubtraction(db, storage, subtractionId);
+
+		const remaining = [];
+		for await (const object of storage.list("subtractions/")) {
+			remaining.push(object.key);
+		}
+		expect(remaining).toEqual([]);
+	});
+
 	it("throws when the subtraction is already deleted", async () => {
 		const storage = new MemoryStorage();
 		const subtractionId = await seedSubtraction({ deleted: true });

--- a/apps/web/src/server/subtraction/data.ts
+++ b/apps/web/src/server/subtraction/data.ts
@@ -349,9 +349,6 @@ export async function getSubtraction(
 	};
 }
 
-/** The storage location and size of a subtraction file being downloaded. */
-export type SubtractionFileLocation = { key: string; size: number };
-
 // A subtraction's files live under the prefix its storage id names, which is
 // the legacy Mongo id for anything migrated out of Mongo and the integer
 // primary key for everything created since. Mirrors Python's
@@ -372,21 +369,26 @@ async function resolveSubtractionStorageId(
 }
 
 /**
- * Locate a subtraction file in storage by the name it is registered under.
+ * Resolve the storage key of a subtraction file by the name it is registered
+ * under.
  *
  * Returns null when the subtraction, or a file of that name on it, does not
  * exist. The key is composed only from a name that matched a row, so a filename
  * taken from a URL can never traverse out of the subtraction's prefix.
+ *
+ * The row's `size` is deliberately not returned. It is nullable, and it records
+ * what the create job wrote rather than what the bucket currently holds — a
+ * caller that needs a byte count asks storage.
  */
-export async function getSubtractionFileLocation(
+export async function getSubtractionFileKey(
 	db: DbOrTx,
 	subtractionId: number,
 	filename: string,
-): Promise<SubtractionFileLocation | null> {
+): Promise<string | null> {
 	const [storageId, [file]] = await Promise.all([
 		resolveSubtractionStorageId(db, subtractionId),
 		db
-			.select({ name: subtractionFiles.name, size: subtractionFiles.size })
+			.select({ name: subtractionFiles.name })
 			.from(subtractionFiles)
 			.where(
 				and(
@@ -401,10 +403,7 @@ export async function getSubtractionFileLocation(
 		return null;
 	}
 
-	return {
-		key: subtractionFileKey(storageId, file.name),
-		size: file.size ?? 0,
-	};
+	return subtractionFileKey(storageId, file.name);
 }
 
 export async function createSubtraction(
@@ -486,18 +485,11 @@ export async function deleteSubtraction(
 	subtractionId: number,
 ): Promise<void> {
 	const storageId = await db.transaction(async (tx) => {
-		const [row] = await tx
-			.select({ id: subtractions.id, legacy_id: subtractions.legacy_id })
-			.from(subtractions)
-			.where(
-				and(
-					eq(subtractions.id, subtractionId),
-					eq(subtractions.deleted, false),
-				),
-			)
-			.limit(1);
+		// Doubles as the existence check: the resolver filters out deleted rows and
+		// returns null when nothing matches.
+		const resolved = await resolveSubtractionStorageId(tx, subtractionId);
 
-		if (!row) {
+		if (resolved === null) {
 			return null;
 		}
 
@@ -512,7 +504,7 @@ export async function deleteSubtraction(
 			.delete(legacySampleSubtractions)
 			.where(eq(legacySampleSubtractions.subtraction_id, subtractionId));
 
-		return subtractionStorageId(row.id, row.legacy_id);
+		return resolved;
 	});
 
 	if (storageId === null) {

--- a/apps/web/src/server/subtraction/data.ts
+++ b/apps/web/src/server/subtraction/data.ts
@@ -15,7 +15,12 @@ import { users } from "../db/schema/users";
 import { AppError } from "../errors";
 import { logger } from "../logger";
 import type { StorageBackend } from "../storage";
-import { deletePrefix, subtractionPrefix } from "../storage";
+import {
+	deletePrefix,
+	subtractionFileKey,
+	subtractionPrefix,
+	subtractionStorageId,
+} from "../storage";
 
 /** A user reduced to the fields shown alongside a resource. */
 export type UserNested = { id: number; handle: string };
@@ -292,8 +297,8 @@ async function getSubtractionFiles(
 		.where(eq(subtractionFiles.subtraction_id, subtractionId));
 
 	return rows.map((row) => ({
-		// The download route stays on the Python service; the client renders this
-		// path under its `/api` proxy prefix.
+		// Served from this server by `routes/subtractions.$subtractionId.files
+		// .$filename.ts`, so the client links to it directly.
 		download_url: `/subtractions/${subtractionId}/files/${row.name ?? ""}`,
 		id: row.id,
 		name: row.name ?? "",
@@ -341,6 +346,64 @@ export async function getSubtraction(
 		files,
 		gc: row.gc,
 		linked_samples,
+	};
+}
+
+/** The storage location and size of a subtraction file being downloaded. */
+export type SubtractionFileLocation = { key: string; size: number };
+
+// A subtraction's files live under the prefix its storage id names, which is
+// the legacy Mongo id for anything migrated out of Mongo and the integer
+// primary key for everything created since. Mirrors Python's
+// `_resolve_storage_id`.
+async function resolveSubtractionStorageId(
+	db: DbOrTx,
+	subtractionId: number,
+): Promise<string | null> {
+	const [row] = await db
+		.select({ id: subtractions.id, legacy_id: subtractions.legacy_id })
+		.from(subtractions)
+		.where(
+			and(eq(subtractions.id, subtractionId), eq(subtractions.deleted, false)),
+		)
+		.limit(1);
+
+	return row ? subtractionStorageId(row.id, row.legacy_id) : null;
+}
+
+/**
+ * Locate a subtraction file in storage by the name it is registered under.
+ *
+ * Returns null when the subtraction, or a file of that name on it, does not
+ * exist. The key is composed only from a name that matched a row, so a filename
+ * taken from a URL can never traverse out of the subtraction's prefix.
+ */
+export async function getSubtractionFileLocation(
+	db: DbOrTx,
+	subtractionId: number,
+	filename: string,
+): Promise<SubtractionFileLocation | null> {
+	const [storageId, [file]] = await Promise.all([
+		resolveSubtractionStorageId(db, subtractionId),
+		db
+			.select({ name: subtractionFiles.name, size: subtractionFiles.size })
+			.from(subtractionFiles)
+			.where(
+				and(
+					eq(subtractionFiles.subtraction_id, subtractionId),
+					eq(subtractionFiles.name, filename),
+				),
+			)
+			.limit(1),
+	]);
+
+	if (storageId === null || !file?.name) {
+		return null;
+	}
+
+	return {
+		key: subtractionFileKey(storageId, file.name),
+		size: file.size ?? 0,
 	};
 }
 
@@ -422,9 +485,9 @@ export async function deleteSubtraction(
 	storage: StorageBackend,
 	subtractionId: number,
 ): Promise<void> {
-	const deleted = await db.transaction(async (tx) => {
+	const storageId = await db.transaction(async (tx) => {
 		const [row] = await tx
-			.select({ id: subtractions.id })
+			.select({ id: subtractions.id, legacy_id: subtractions.legacy_id })
 			.from(subtractions)
 			.where(
 				and(
@@ -435,7 +498,7 @@ export async function deleteSubtraction(
 			.limit(1);
 
 		if (!row) {
-			return false;
+			return null;
 		}
 
 		// Soft delete: the row stays so historical analyses that reference it still
@@ -449,19 +512,16 @@ export async function deleteSubtraction(
 			.delete(legacySampleSubtractions)
 			.where(eq(legacySampleSubtractions.subtraction_id, subtractionId));
 
-		return true;
+		return subtractionStorageId(row.id, row.legacy_id);
 	});
 
-	if (!deleted) {
+	if (storageId === null) {
 		throw new SubtractionNotFoundError();
 	}
 
 	// The database write has committed, so a storage failure only orphans bytes
 	// rather than failing the delete. Log the orphans so they stay observable.
-	const failures = await deletePrefix(
-		storage,
-		subtractionPrefix(String(subtractionId)),
-	);
+	const failures = await deletePrefix(storage, subtractionPrefix(storageId));
 
 	for (const failure of failures) {
 		logger.warn(

--- a/apps/web/src/server/subtraction/download.test.ts
+++ b/apps/web/src/server/subtraction/download.test.ts
@@ -1,3 +1,4 @@
+import { eq } from "drizzle-orm";
 import {
 	afterAll,
 	beforeAll,
@@ -166,6 +167,31 @@ describe("handleSubtractionFile", () => {
 
 		expect(response.status).toBe(200);
 		expect(await response.text()).toBe("hello");
+	});
+
+	// `subtraction_files.size` records what the create job wrote and is nullable,
+	// so the header has to come from the object or the client truncates.
+	it("sizes the response from storage, not the row", async () => {
+		const subtractionId = await seedSubtraction();
+		await seedFile(subtractionId);
+		await db
+			.update(subtractionFiles)
+			.set({ size: null })
+			.where(eq(subtractionFiles.subtraction_id, subtractionId));
+		await write(
+			`subtractions/${subtractionId}/subtraction.fa.gz`,
+			"considerably longer than five bytes",
+		);
+
+		const response = await handleSubtractionFile(
+			await request(userId),
+			String(subtractionId),
+			"subtraction.fa.gz",
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-length")).toBe("35");
+		expect(await response.text()).toBe("considerably longer than five bytes");
 	});
 
 	it("rejects an anonymous caller with a 401", async () => {

--- a/apps/web/src/server/subtraction/download.test.ts
+++ b/apps/web/src/server/subtraction/download.test.ts
@@ -1,0 +1,262 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+
+import type { Db } from "../db/pg";
+import { takeFirstOrThrow } from "../db/rows";
+import { apiKeys } from "../db/schema/apiKeys";
+import { sessions } from "../db/schema/sessions";
+import { subtractionFiles, subtractions } from "../db/schema/subtractions";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { MemoryStorage } from "../storage/memory";
+
+vi.mock("@tanstack/react-start/server", () => ({
+	deleteCookie: vi.fn(),
+	getCookie: vi.fn(),
+	getRequest: vi.fn(),
+	setCookie: vi.fn(),
+	setResponseStatus: vi.fn(),
+}));
+
+vi.mock("@sentry/tanstackstart-react", () => ({
+	captureException: vi.fn(),
+	setUser: vi.fn(),
+}));
+
+let db: Db;
+vi.mock("../db/pg", () => ({
+	client: {},
+	get db() {
+		return db;
+	},
+}));
+
+const storage = new MemoryStorage();
+vi.mock("../storage", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../storage")>()),
+	storage,
+}));
+
+const { handleSubtractionFile } = await import("./download");
+const { SESSION_ID_COOKIE, SESSION_TOKEN_COOKIE } = await import(
+	"../auth/cookies"
+);
+const { basicAuthHeader, seedApiKey, seedSession, seedUser } = await import(
+	"../auth/test/fixtures"
+);
+
+let database: TestDatabase;
+let userId: number;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	await db.delete(subtractionFiles);
+	await db.delete(subtractions);
+	await db.delete(apiKeys);
+	await db.delete(sessions);
+	await db.delete(users);
+
+	userId = await seedUser(db);
+});
+
+async function seedSubtraction(
+	overrides: Partial<typeof subtractions.$inferInsert> = {},
+): Promise<number> {
+	return takeFirstOrThrow(
+		await db
+			.insert(subtractions)
+			.values({
+				name: "Arabidopsis",
+				nickname: "",
+				created_at: new Date(),
+				ready: true,
+				user_id: userId,
+				...overrides,
+			})
+			.returning({ id: subtractions.id }),
+	).id;
+}
+
+async function seedFile(
+	subtractionId: number,
+	name = "subtraction.fa.gz",
+): Promise<void> {
+	await db.insert(subtractionFiles).values({
+		name,
+		subtraction_id: subtractionId,
+		size: 5,
+		type: "fasta",
+	});
+}
+
+async function write(key: string, contents: string): Promise<void> {
+	await storage.write(
+		key,
+		(async function* () {
+			yield new TextEncoder().encode(contents);
+		})(),
+	);
+}
+
+/** Build a `GET /subtractions/{id}/files/{filename}` request for a user. */
+async function request(userId: number | null): Promise<Request> {
+	const headers: Record<string, string> = {};
+
+	if (userId !== null) {
+		const { sessionId, token } = await seedSession(db, userId);
+		headers.cookie = `${SESSION_ID_COOKIE}=${sessionId}; ${SESSION_TOKEN_COOKIE}=${token}`;
+	}
+
+	return new Request("https://virtool.test/subtractions/1/files/x", {
+		headers,
+	});
+}
+
+describe("handleSubtractionFile", () => {
+	it("streams a Postgres-native subtraction's file from its integer prefix", async () => {
+		const subtractionId = await seedSubtraction();
+		await seedFile(subtractionId);
+		await write(`subtractions/${subtractionId}/subtraction.fa.gz`, "hello");
+
+		const response = await handleSubtractionFile(
+			await request(userId),
+			String(subtractionId),
+			"subtraction.fa.gz",
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-disposition")).toBe(
+			"attachment; filename=subtraction.fa.gz",
+		);
+		expect(response.headers.get("content-length")).toBe("5");
+		expect(response.headers.get("content-type")).toBe(
+			"application/octet-stream",
+		);
+		expect(await response.text()).toBe("hello");
+	});
+
+	// A subtraction migrated out of Mongo keeps its legacy slug as the storage
+	// prefix, even though it is addressed by its integer id.
+	it("reads a migrated subtraction's file from its legacy prefix", async () => {
+		const subtractionId = await seedSubtraction({ legacy_id: "arabidopsis 1" });
+		await seedFile(subtractionId);
+		await write("subtractions/arabidopsis_1/subtraction.fa.gz", "hello");
+
+		const response = await handleSubtractionFile(
+			await request(userId),
+			String(subtractionId),
+			"subtraction.fa.gz",
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("hello");
+	});
+
+	it("rejects an anonymous caller with a 401", async () => {
+		const subtractionId = await seedSubtraction();
+		await seedFile(subtractionId);
+
+		const response = await handleSubtractionFile(
+			await request(null),
+			String(subtractionId),
+			"subtraction.fa.gz",
+		);
+
+		expect(response.status).toBe(401);
+	});
+
+	it("accepts an api key", async () => {
+		const key = await seedApiKey(db, userId, {});
+		const subtractionId = await seedSubtraction();
+		await seedFile(subtractionId);
+		await write(`subtractions/${subtractionId}/subtraction.fa.gz`, "hello");
+
+		const response = await handleSubtractionFile(
+			new Request("https://virtool.test/subtractions/1/files/x", {
+				headers: { authorization: basicAuthHeader("alice", key) },
+			}),
+			String(subtractionId),
+			"subtraction.fa.gz",
+		);
+
+		expect(response.status).toBe(200);
+	});
+
+	it("returns a 400 for a non-numeric subtraction id", async () => {
+		const response = await handleSubtractionFile(
+			await request(userId),
+			"not-a-number",
+			"subtraction.fa.gz",
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns a 404 when the subtraction does not exist", async () => {
+		const response = await handleSubtractionFile(
+			await request(userId),
+			"404404",
+			"subtraction.fa.gz",
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	it("returns a 404 when the subtraction is deleted", async () => {
+		const subtractionId = await seedSubtraction({ deleted: true });
+		await seedFile(subtractionId);
+		await write(`subtractions/${subtractionId}/subtraction.fa.gz`, "hello");
+
+		const response = await handleSubtractionFile(
+			await request(userId),
+			String(subtractionId),
+			"subtraction.fa.gz",
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	// The filename only ever reaches a key after it has matched a registered
+	// file, so it cannot escape the subtraction's prefix.
+	it("returns a 404 for a filename the subtraction has no row for", async () => {
+		const subtractionId = await seedSubtraction();
+		await seedFile(subtractionId);
+
+		const response = await handleSubtractionFile(
+			await request(userId),
+			String(subtractionId),
+			"../../etc/passwd",
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	it("returns a 404 when the row exists but its bytes do not", async () => {
+		const subtractionId = await seedSubtraction();
+		await seedFile(subtractionId);
+
+		const response = await handleSubtractionFile(
+			await request(userId),
+			String(subtractionId),
+			"subtraction.fa.gz",
+		);
+
+		expect(response.status).toBe(404);
+	});
+});

--- a/apps/web/src/server/subtraction/download.ts
+++ b/apps/web/src/server/subtraction/download.ts
@@ -1,26 +1,22 @@
 import { requireAuthenticatedRequest } from "../auth/middleware";
 import { db } from "../db/pg";
 import { StorageKeyNotFoundError, storage } from "../storage";
-import { getSubtractionFileLocation } from "./data";
+import { getSubtractionFileKey } from "./data";
 
 function textResponse(message: string, status: number): Response {
 	return new Response(message, { status });
 }
 
-// One chunk is pulled before the stream is built (see below), so it is enqueued
-// ahead of whatever the iterator has left. `ReadableStream.from` would do this
-// in one line but is absent from the DOM lib the app project type-checks
-// against.
+// `ReadableStream.from` would do this in one line, but it is absent from the DOM
+// lib the app project type-checks against.
 function toStream(
-	first: Uint8Array,
-	rest: AsyncIterator<Uint8Array>,
+	chunks: AsyncIterable<Uint8Array>,
 ): ReadableStream<Uint8Array> {
+	const iterator = chunks[Symbol.asyncIterator]();
+
 	return new ReadableStream<Uint8Array>({
-		start(controller) {
-			controller.enqueue(first);
-		},
 		async pull(controller) {
-			const { done, value } = await rest.next();
+			const { done, value } = await iterator.next();
 
 			if (done) {
 				controller.close();
@@ -32,7 +28,7 @@ function toStream(
 		async cancel(reason) {
 			// A client that aborts the download mid-stream leaves the backend's
 			// request open otherwise.
-			await rest.return?.(reason);
+			await iterator.return?.(reason);
 		},
 	});
 }
@@ -67,21 +63,21 @@ export async function handleSubtractionFile(
 		return textResponse("Invalid subtraction id", 400);
 	}
 
-	const location = await getSubtractionFileLocation(db, id, filename);
+	const key = await getSubtractionFileKey(db, id, filename);
 
-	if (location === null) {
+	if (key === null) {
 		return textResponse("Not found", 404);
 	}
 
-	// Headers cannot be taken back once the response is returned, so the first
-	// chunk is pulled up front: a row whose bytes are missing becomes a 404 rather
-	// than a 200 that fails halfway through. Mirrors what Python's handler does.
-	const chunks = storage.read(location.key)[Symbol.asyncIterator]();
-
-	let first: IteratorResult<Uint8Array>;
+	// `Content-Length` comes from the object rather than the `subtraction_files`
+	// row: the column is nullable and records what the create job wrote, so a
+	// stale or null value would truncate the download client-side. Sizing first
+	// also settles existence before any header is committed — a row whose bytes
+	// are missing becomes a 404 rather than a 200 that dies mid-stream.
+	let size: number;
 
 	try {
-		first = await chunks.next();
+		size = await storage.size(key);
 	} catch (err) {
 		if (err instanceof StorageKeyNotFoundError) {
 			return textResponse("Not found", 404);
@@ -89,14 +85,10 @@ export async function handleSubtractionFile(
 		throw err;
 	}
 
-	if (first.done) {
-		return textResponse("Not found", 404);
-	}
-
-	return new Response(toStream(first.value, chunks), {
+	return new Response(toStream(storage.read(key)), {
 		headers: {
 			"content-disposition": `attachment; filename=${filename}`,
-			"content-length": String(location.size),
+			"content-length": String(size),
 			"content-type": "application/octet-stream",
 		},
 	});

--- a/apps/web/src/server/subtraction/download.ts
+++ b/apps/web/src/server/subtraction/download.ts
@@ -1,0 +1,103 @@
+import { requireAuthenticatedRequest } from "../auth/middleware";
+import { db } from "../db/pg";
+import { StorageKeyNotFoundError, storage } from "../storage";
+import { getSubtractionFileLocation } from "./data";
+
+function textResponse(message: string, status: number): Response {
+	return new Response(message, { status });
+}
+
+// One chunk is pulled before the stream is built (see below), so it is enqueued
+// ahead of whatever the iterator has left. `ReadableStream.from` would do this
+// in one line but is absent from the DOM lib the app project type-checks
+// against.
+function toStream(
+	first: Uint8Array,
+	rest: AsyncIterator<Uint8Array>,
+): ReadableStream<Uint8Array> {
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(first);
+		},
+		async pull(controller) {
+			const { done, value } = await rest.next();
+
+			if (done) {
+				controller.close();
+				return;
+			}
+
+			controller.enqueue(value);
+		},
+		async cancel(reason) {
+			// A client that aborts the download mid-stream leaves the backend's
+			// request open otherwise.
+			await rest.return?.(reason);
+		},
+	});
+}
+
+/**
+ * Serve a subtraction's FASTA or Bowtie2 file, backing
+ * `GET /subtractions/{id}/files/{filename}`.
+ *
+ * This is a raw route rather than a server function because the client reaches
+ * it with a plain `<a href>` — the browser has to see a real response with a
+ * `Content-Disposition`, which an RPC call cannot produce. The bytes are
+ * streamed straight out of storage, so a multi-GB Bowtie2 index never sits in
+ * the Node heap.
+ *
+ * Being a route means no policy middleware runs, so the authorization floor is
+ * enforced here. It is a valid session and nothing more: subtractions carry no
+ * per-row rights, and every signed-in user can already read them.
+ */
+export async function handleSubtractionFile(
+	request: Request,
+	subtractionId: string,
+	filename: string,
+): Promise<Response> {
+	const session = await requireAuthenticatedRequest(request);
+	if (session instanceof Response) {
+		return session;
+	}
+
+	const id = Number(subtractionId);
+
+	if (!Number.isInteger(id) || id <= 0) {
+		return textResponse("Invalid subtraction id", 400);
+	}
+
+	const location = await getSubtractionFileLocation(db, id, filename);
+
+	if (location === null) {
+		return textResponse("Not found", 404);
+	}
+
+	// Headers cannot be taken back once the response is returned, so the first
+	// chunk is pulled up front: a row whose bytes are missing becomes a 404 rather
+	// than a 200 that fails halfway through. Mirrors what Python's handler does.
+	const chunks = storage.read(location.key)[Symbol.asyncIterator]();
+
+	let first: IteratorResult<Uint8Array>;
+
+	try {
+		first = await chunks.next();
+	} catch (err) {
+		if (err instanceof StorageKeyNotFoundError) {
+			return textResponse("Not found", 404);
+		}
+		throw err;
+	}
+
+	if (first.done) {
+		return textResponse("Not found", 404);
+	}
+
+	return new Response(toStream(first.value, chunks), {
+		headers: {
+			"content-disposition": `attachment; filename=${filename}`,
+			"content-length": String(location.size),
+			"content-type": "application/octet-stream",
+		},
+	});
+}

--- a/apps/web/src/subtraction/components/Detail/SubtractionDetail.tsx
+++ b/apps/web/src/subtraction/components/Detail/SubtractionDetail.tsx
@@ -89,7 +89,7 @@ export default function SubtractionDetail() {
 						<a
 							className="font-medium"
 							download={fastaName}
-							href={`/api${fastaFile.download_url}`}
+							href={fastaFile.download_url}
 						>
 							{fastaName}
 						</a>

--- a/apps/web/src/subtraction/components/Detail/__tests__/SubtractionDetail.test.tsx
+++ b/apps/web/src/subtraction/components/Detail/__tests__/SubtractionDetail.test.tsx
@@ -44,7 +44,7 @@ describe("<SubtractionDetail />", () => {
 		const download = await screen.findByRole("link", { name: fastaName });
 		expect(download).toHaveAttribute(
 			"href",
-			`/api${subtraction.files[0]?.download_url}`,
+			subtraction.files[0]?.download_url,
 		);
 		expect(download).toHaveAttribute("download", fastaName);
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -153,7 +153,9 @@ Python's `authentication_middleware` branches the same way.
 **Only raw routes accept a key.** Server functions stay cookie-only:
 they are the app's own RPC transport, not a public API, and the
 generated client always sends cookies. The raw routes — `POST
-/uploads` and `/events` — are what a script can actually reach.
+/uploads`, `/events`, `GET /analyses/documents/{id}.{extension}` and
+`GET /subtractions/{id}/files/{filename}` — are what a script can
+actually reach.
 
 ### The key's permissions are a cap
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -58,8 +58,8 @@ orphans whatever it writes.
 | `sampleFileKey(storageId, filename)` | `samples/{storageId}/{filename}` |
 | `samplePrefix(storageId)` | `samples/{storageId}/` |
 | `analysisPrefix(sampleStorageId, analysisLegacyId)` | `samples/{sampleStorageId}/analysis/{analysisLegacyId}/` |
-| `subtractionFileKey(id, filename)` | `subtractions/{id}/{filename}` |
-| `subtractionPrefix(id)` | `subtractions/{id}/` |
+| `subtractionFileKey(storageId, filename)` | `subtractions/{storageId}/{filename}` |
+| `subtractionPrefix(storageId)` | `subtractions/{storageId}/` |
 | `indexFileKey(indexId, filename)` | `indexes/{indexId}/{filename}` |
 | `indexPrefix(indexId)` | `indexes/{indexId}/` |
 | `cacheKey(uuid)` | `caches/v1/{uuid}` |
@@ -72,6 +72,11 @@ Two subtleties are load-bearing:
   `sampleStorageId(sampleId, legacyId)`, which returns the legacy Mongo id when
   the sample has one and the integer primary key otherwise. A sample keeps one
   prefix for life.
+- **Neither is a subtraction's.** `subtractionStorageId(subtractionId,
+  legacyId)` follows the same rule, and mirrors Python's
+  `_resolve_storage_id`. A subtraction is addressed by its integer id
+  everywhere else, so it is easy to reach for `String(id)` and silently orphan
+  every migrated subtraction's files.
 - **Subtraction ids may contain spaces**, and Python substitutes underscores
   when composing the key. `subtractionFileKey` and `subtractionPrefix` do the
   same. Never build a subtraction key by hand.


### PR DESCRIPTION
## Summary

- Moves subtraction FASTA/Bowtie2 file downloads off the Python service and onto a new raw TypeScript route that streams bytes straight out of storage, so a multi-GB Bowtie2 index never buffers in the Node heap. This was the last consumer of the public Python subtraction API.
- Restores `subtractions.legacy_id` to the Drizzle mirror and adds a `subtractionStorageId` helper, so Mongo-migrated subtractions resolve to their legacy storage prefix rather than the integer id — matching Python's `_resolve_storage_id`. This also fixes `deleteSubtraction`, which was cleaning up under the wrong prefix and silently orphaning every byte a migrated subtraction owned.
- The filename is only composed into a storage key after it has matched a `subtraction_files` row, so a URL param cannot traverse out of the subtraction's prefix.