### PR TITLE
feat: read secrets from a mounted file via a _FILE variable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -699,6 +699,22 @@ Bad: `WORKER_MODE`, `POSTGRES_URL`.
 The only exception is upstream-defined names (e.g. `SENTRY_AUTH_TOKEN`,
 `NODE_OPTIONS`) — leave those as the third party expects.
 
+### Every config key also reads from a `_FILE` variant
+
+`parseServerConfig` resolves `<KEY>_FILE` before zod parses: the named
+file is read, trimmed, and used as `<KEY>`'s value. It applies to every
+key in the schema — add one and it gets the behaviour for free — so
+secrets reach a pod through the secrets-store CSI driver's file mount
+(`VT_METRICS_TOKEN_FILE=/mnt/secrets-store/metrics-token`) instead of a
+Kubernetes `Secret`, which goes stale when a key is added to the
+`SecretProviderClass`. Plain variables still work for local dev.
+
+**The file wins over a plain variable of the same name.** A rollout
+moving to the mount can still carry the stale env var from the `Secret`
+it replaces, and erroring on the overlap would crashloop the rollout
+that fixes it. An unreadable path throws at startup; an empty file is an
+unset value.
+
 ## Logging
 
 Server code logs through `@virtool/logger`, not `console.*`. Biome's

--- a/apps/web/src/server/__tests__/config.test.ts
+++ b/apps/web/src/server/__tests__/config.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { parseServerConfig } from "../config";
 
 const postgresUrl = "postgres://virtool:virtool@localhost:5432/virtool";
@@ -195,6 +198,117 @@ describe("parseServerConfig", () => {
 					VT_STORAGE_AZURE_ACCOUNT: "devstoreaccount1",
 				} as NodeJS.ProcessEnv),
 			).toThrow(/VT_STORAGE_AZURE_CONTAINER/);
+		});
+	});
+
+	describe("metrics token", () => {
+		it("reads the token from the environment", () => {
+			const config = parseServerConfig({
+				...minimalS3,
+				VT_METRICS_TOKEN: "secret",
+			} as NodeJS.ProcessEnv);
+
+			expect(config.metricsToken).toBe("secret");
+		});
+
+		it("treats a blank token as unset", () => {
+			const config = parseServerConfig({
+				...minimalS3,
+				VT_METRICS_TOKEN: "",
+			} as NodeJS.ProcessEnv);
+
+			expect(config.metricsToken).toBeUndefined();
+		});
+	});
+
+	describe("file-backed values", () => {
+		let directory: string;
+
+		function write(name: string, contents: string): string {
+			const path = join(directory, name);
+			writeFileSync(path, contents);
+
+			return path;
+		}
+
+		beforeAll(() => {
+			directory = mkdtempSync(join(tmpdir(), "vt-config-"));
+		});
+
+		afterAll(() => {
+			rmSync(directory, { force: true, recursive: true });
+		});
+
+		it("reads a value from the file the _FILE variant names", () => {
+			const config = parseServerConfig({
+				...minimalS3,
+				VT_METRICS_TOKEN_FILE: write("metrics-token", "from-file"),
+			} as NodeJS.ProcessEnv);
+
+			expect(config.metricsToken).toBe("from-file");
+		});
+
+		it("strips the trailing newline a mounted secret carries", () => {
+			const config = parseServerConfig({
+				...minimalS3,
+				VT_METRICS_TOKEN_FILE: write("trailing-newline", "  from-file\n"),
+			} as NodeJS.ProcessEnv);
+
+			expect(config.metricsToken).toBe("from-file");
+		});
+
+		it("prefers the file over a stale plain variable", () => {
+			const config = parseServerConfig({
+				...minimalS3,
+				VT_METRICS_TOKEN: "stale",
+				VT_METRICS_TOKEN_FILE: write("preferred", "fresh"),
+			} as NodeJS.ProcessEnv);
+
+			expect(config.metricsToken).toBe("fresh");
+		});
+
+		it("treats an empty file as an unset value", () => {
+			const config = parseServerConfig({
+				...minimalS3,
+				VT_METRICS_TOKEN: "stale",
+				VT_METRICS_TOKEN_FILE: write("empty", "\n"),
+			} as NodeJS.ProcessEnv);
+
+			expect(config.metricsToken).toBeUndefined();
+		});
+
+		it("ignores a blank _FILE variant", () => {
+			const config = parseServerConfig({
+				...minimalS3,
+				VT_METRICS_TOKEN: "from-env",
+				VT_METRICS_TOKEN_FILE: "",
+			} as NodeJS.ProcessEnv);
+
+			expect(config.metricsToken).toBe("from-env");
+		});
+
+		it("applies to every key, not only the metrics token", () => {
+			const config = parseServerConfig({
+				VT_POSTGRES_URL: postgresUrl,
+				VT_STORAGE_BACKEND: "s3",
+				VT_STORAGE_S3_BUCKET: "virtool",
+				VT_STORAGE_S3_ACCESS_KEY_ID_FILE: write("access-key-id", "ak\n"),
+				VT_STORAGE_S3_SECRET_ACCESS_KEY_FILE: write("secret-key", "sk\n"),
+			} as NodeJS.ProcessEnv);
+
+			expect(config.storage).toMatchObject({
+				accessKeyId: "ak",
+				secretAccessKey: "sk",
+			});
+		});
+
+		it("errors when the file cannot be read", () => {
+			expect(() =>
+				parseServerConfig({
+					...minimalS3,
+					VT_METRICS_TOKEN_FILE: join(directory, "missing"),
+				} as NodeJS.ProcessEnv),
+			).toThrow(/VT_METRICS_TOKEN_FILE/);
 		});
 	});
 });

--- a/apps/web/src/server/__tests__/config.test.ts
+++ b/apps/web/src/server/__tests__/config.test.ts
@@ -302,6 +302,19 @@ describe("parseServerConfig", () => {
 			});
 		});
 
+		it("pairs a file-backed credential with a plain one", () => {
+			const config = parseServerConfig({
+				...minimalS3,
+				VT_STORAGE_S3_ACCESS_KEY_ID: "ak",
+				VT_STORAGE_S3_SECRET_ACCESS_KEY_FILE: write("mixed-pair", "sk\n"),
+			} as NodeJS.ProcessEnv);
+
+			expect(config.storage).toMatchObject({
+				accessKeyId: "ak",
+				secretAccessKey: "sk",
+			});
+		});
+
 		it("errors when the file cannot be read", () => {
 			expect(() =>
 				parseServerConfig({

--- a/apps/web/src/server/config.ts
+++ b/apps/web/src/server/config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { z } from "zod";
 
 /** Object storage backend configuration resolved from the environment. */
@@ -159,10 +160,44 @@ function buildStorage(raw: StorageEnv, ctx: z.RefinementCtx): StorageConfig {
 	};
 }
 
+const FILE_SUFFIX = "_FILE";
+
+// Every key also accepts a `<KEY>_FILE` variant naming a file to read the value
+// from — the convention Prometheus and Docker use. A Kubernetes `Secret`
+// populated by the secrets-store CSI driver goes stale when a key is added to
+// the SecretProviderClass, so a pod can start with an env var the cluster
+// believes it has updated; the driver's file mount has no such staleness.
+//
+// The file wins over the plain variable deliberately. A rollout that moves to
+// the mount can still carry the stale env var from the `Secret` it replaces,
+// and failing on the overlap would crashloop the very rollout that fixes it.
+function resolveFileBacked(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+	const resolved = { ...env };
+
+	for (const key of Object.keys(ServerEnv.shape)) {
+		const path = env[`${key}${FILE_SUFFIX}`];
+
+		if (!path) {
+			continue;
+		}
+
+		try {
+			resolved[key] = readFileSync(path, "utf8").trim();
+		} catch (error) {
+			throw new Error(
+				`${key}${FILE_SUFFIX} points at ${path}, which could not be read`,
+				{ cause: error },
+			);
+		}
+	}
+
+	return resolved;
+}
+
 export function parseServerConfig(
 	env: NodeJS.ProcessEnv = process.env,
 ): ServerConfig {
-	return ServerEnvSchema.parse(env);
+	return ServerEnvSchema.parse(resolveFileBacked(env));
 }
 
 export const config: ServerConfig = parseServerConfig();

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -34,6 +34,12 @@ authorization floor — see below.
 - **Set** — the request must carry `Authorization: Bearer <token>`.
   Anything else gets `401` with a `WWW-Authenticate: Bearer` header.
 
+In a cluster the token comes from a mounted file rather than the
+variable: `VT_METRICS_TOKEN_FILE=/mnt/secrets-store/metrics-token`. That
+is the general `_FILE` convention `config.ts` applies to every key, and
+the file wins over a plain variable of the same name. The handler is
+unaware of either — it reads `config.metricsToken`.
+
 The comparison uses `timingSafeEqual`, screening for a length mismatch
 first because it throws on unequal lengths. That screen reveals the
 configured token's length; an attacker learns nothing from it that

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -103,12 +103,23 @@ it is `s3` or `azure`. There is no filesystem backend; Python dropped it.
 | `VT_STORAGE_AZURE_ACCESS_KEY` | azure | Optional; managed identity if unset. |
 | `VT_STORAGE_AZURE_ENDPOINT` | azure | Optional. |
 
+Every variable in the table also has a `_FILE` variant naming a file to read
+the value from — `VT_STORAGE_S3_SECRET_ACCESS_KEY_FILE=/mnt/secrets-store/s3-secret-key`.
+`config.ts` reads and trims that file before validating, so the credentials can
+arrive on a secrets-store CSI mount instead of a Kubernetes `Secret`, which goes
+stale when a key is added to the `SecretProviderClass`. The file wins over a
+plain variable of the same name, an unreadable path throws at startup, and an
+empty file counts as unset.
+
 The **S3 credentials are both-or-neither**. Setting both authenticates with
 them; setting neither falls through to the AWS credential chain and an IAM
 role. Setting exactly one is rejected at startup rather than quietly ignored,
 because the failure mode is a process running in production as the wrong
 principal. Empty strings count as unset — deployment tooling routinely injects
 an empty value for something it has nothing to put in.
+
+Both-or-neither is judged **after** the files are read, so an S3 access key id
+supplied by env and a secret access key supplied by a mount are a valid pair.
 
 The backend is built once at startup. `src/server/storage/index.ts` exports the
 `storage` singleton; **pass it into `data.ts` functions the way `db` is


### PR DESCRIPTION
## Summary
- `parseServerConfig` now resolves a `<KEY>_FILE` variant for every config key, reading and trimming the named file before validation, so secrets like `VT_METRICS_TOKEN` can be mounted by the secrets-store CSI driver instead of a `Secret` that goes stale when a key is added to the `SecretProviderClass`.
- The file wins over a same-named plain variable, so a rollout moving to the mount can carry a stale env var without crashlooping.
- Plain variables still work for local dev; an unreadable path throws at startup and an empty file resolves to an unset value.