### PR TITLE
refactor: import data functions under their own names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -702,7 +702,9 @@ The basics:
   (`loginFn`, `getSampleFn`) — it's an RPC call, not a plain function,
   and the suffix marks that at every call site. The domain function it
   wraps keeps the plain name (`login`, `getSample`) and never crosses
-  the network.
+  the network. `functions.ts` imports that data function under its own
+  name — the `Fn` suffix already keeps the two apart, so don't alias it
+  to `...Impl` on the way in.
 - **Comments:** Default to none. Document *why* when non-obvious, not
   *what*.
 - **Concurrency:** Independent awaits go in `Promise.all` — don't pay

--- a/apps/web/src/server/account/functions.ts
+++ b/apps/web/src/server/account/functions.ts
@@ -8,10 +8,10 @@ import { ClientError } from "../errors";
 import { rowIdSchema } from "../validation";
 import {
 	ApiKeyNotFoundError,
-	createApiKey as createApiKeyImpl,
-	deleteApiKey as deleteApiKeyImpl,
-	findApiKeys as findApiKeysImpl,
-	updateApiKey as updateApiKeyImpl,
+	createApiKey,
+	deleteApiKey,
+	findApiKeys,
+	updateApiKey,
 } from "./data";
 
 const createApiKeySchema = z.object({
@@ -41,13 +41,13 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 
 export const findApiKeysFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
-	.handler(async ({ context }) => findApiKeysImpl(db, context.session.userId));
+	.handler(async ({ context }) => findApiKeys(db, context.session.userId));
 
 export const createApiKeyFn = createServerFn({ method: "POST" })
 	.middleware([authenticated()])
 	.validator(createApiKeySchema)
 	.handler(async ({ context, data }) => {
-		const { key, apiKey } = await createApiKeyImpl(db, context.session.userId, {
+		const { key, apiKey } = await createApiKey(db, context.session.userId, {
 			name: data.name,
 			permissions: data.permissions,
 		});
@@ -60,7 +60,7 @@ export const updateApiKeyFn = createServerFn({ method: "POST" })
 	.validator(updateApiKeySchema)
 	.handler(async ({ context, data }) => {
 		try {
-			return await updateApiKeyImpl(
+			return await updateApiKey(
 				db,
 				context.session.userId,
 				data.keyId,
@@ -76,7 +76,7 @@ export const deleteApiKeyFn = createServerFn({ method: "POST" })
 	.validator(keyIdSchema)
 	.handler(async ({ context, data }) => {
 		try {
-			await deleteApiKeyImpl(db, context.session.userId, data.keyId);
+			await deleteApiKey(db, context.session.userId, data.keyId);
 			setResponseStatus(204);
 			return null;
 		} catch (err) {

--- a/apps/web/src/server/analyses/functions.ts
+++ b/apps/web/src/server/analyses/functions.ts
@@ -23,11 +23,11 @@ import {
 	AnalysisRelationNotFoundError,
 	AnalysisRunningError,
 	AnalysisSequenceNotFoundError,
-	blastNuvs as blastNuvsImpl,
-	createAnalysis as createAnalysisImpl,
-	deleteAnalysis as deleteAnalysisImpl,
-	findAnalyses as findAnalysesImpl,
-	getAnalysis as getAnalysisImpl,
+	blastNuvs,
+	createAnalysis,
+	deleteAnalysis,
+	findAnalyses,
+	getAnalysis,
 	getAnalysisSampleRights,
 } from "./data";
 
@@ -119,7 +119,7 @@ export const findAnalysesFn = createServerFn({ method: "GET" })
 	.handler(async ({ context, data }) => {
 		const actor = await resolveSampleActor(db, context.session.userId);
 
-		return findAnalysesImpl(
+		return findAnalyses(
 			db,
 			{ page: data.page, perPage: data.perPage, sampleId: data.sampleId },
 			actor,
@@ -134,7 +134,7 @@ export const getAnalysisFn = createServerFn({ method: "GET" })
 			await authorizeAnalysis(data.analysisId, context.session.userId, [
 				"read",
 			]);
-			return await getAnalysisImpl(db, data.analysisId);
+			return await getAnalysis(db, data.analysisId);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -160,7 +160,7 @@ export const createAnalysisFn = createServerFn({ method: "POST" })
 				throw new ForbiddenError();
 			}
 
-			const analysis = await createAnalysisImpl(db, {
+			const analysis = await createAnalysis(db, {
 				sampleId: data.sampleId,
 				referenceId: data.refId,
 				subtractionIds: data.subtractionIds,
@@ -185,7 +185,7 @@ export const deleteAnalysisFn = createServerFn({ method: "POST" })
 				"read",
 				"write",
 			]);
-			await deleteAnalysisImpl(db, storage, data.analysisId);
+			await deleteAnalysis(db, storage, data.analysisId);
 			setResponseStatus(204);
 
 			return null;
@@ -203,11 +203,7 @@ export const blastNuvsFn = createServerFn({ method: "POST" })
 				"write",
 			]);
 
-			const blast = await blastNuvsImpl(
-				db,
-				data.analysisId,
-				data.sequenceIndex,
-			);
+			const blast = await blastNuvs(db, data.analysisId, data.sequenceIndex);
 
 			setResponseStatus(201);
 

--- a/apps/web/src/server/groups/functions.ts
+++ b/apps/web/src/server/groups/functions.ts
@@ -7,14 +7,14 @@ import { db } from "../db/pg";
 import { ClientError } from "../errors";
 import { pageSchema, perPageSchema, rowIdSchema } from "../validation";
 import {
-	createGroup as createGroupImpl,
-	deleteGroup as deleteGroupImpl,
-	findGroups as findGroupsImpl,
+	createGroup,
+	deleteGroup,
+	findGroups,
 	GroupConflictError,
 	GroupNotFoundError,
-	getGroup as getGroupImpl,
-	listGroups as listGroupsImpl,
-	updateGroup as updateGroupImpl,
+	getGroup,
+	listGroups,
+	updateGroup,
 } from "./data";
 
 const groupIdSchema = z.object({
@@ -58,13 +58,13 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 // group, so the reads are open to any signed-in user.
 export const listGroupsFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
-	.handler(async () => listGroupsImpl(db));
+	.handler(async () => listGroups(db));
 
 export const findGroupsFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(findGroupsSchema)
 	.handler(async ({ data }) =>
-		findGroupsImpl(db, data?.term ?? "", data?.page ?? 1, data?.per_page ?? 25),
+		findGroups(db, data?.term ?? "", data?.page ?? 1, data?.per_page ?? 25),
 	);
 
 export const getGroupFn = createServerFn({ method: "GET" })
@@ -72,7 +72,7 @@ export const getGroupFn = createServerFn({ method: "GET" })
 	.validator(groupIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			return await getGroupImpl(db, data.groupId);
+			return await getGroup(db, data.groupId);
 		} catch (err) {
 			rethrowAsHttp(err);
 		}
@@ -86,7 +86,7 @@ export const createGroupFn = createServerFn({ method: "POST" })
 	.validator(createGroupSchema)
 	.handler(async ({ data }) => {
 		try {
-			const group = await createGroupImpl(db, data.name);
+			const group = await createGroup(db, data.name);
 			setResponseStatus(201);
 			return group;
 		} catch (err) {
@@ -100,7 +100,7 @@ export const updateGroupFn = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		const { groupId, ...values } = data;
 		try {
-			return await updateGroupImpl(db, groupId, values);
+			return await updateGroup(db, groupId, values);
 		} catch (err) {
 			rethrowAsHttp(err);
 		}
@@ -111,7 +111,7 @@ export const deleteGroupFn = createServerFn({ method: "POST" })
 	.validator(groupIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			await deleteGroupImpl(db, data.groupId);
+			await deleteGroup(db, data.groupId);
 			setResponseStatus(204);
 			return null;
 		} catch (err) {

--- a/apps/web/src/server/hmm/functions.ts
+++ b/apps/web/src/server/hmm/functions.ts
@@ -5,8 +5,8 @@ import { authenticated, permission } from "../auth/policy";
 import { db } from "../db/pg";
 import { rowIdSchema } from "../validation";
 import {
-	findHmms as findHmmsImpl,
-	getHmm as getHmmImpl,
+	findHmms,
+	getHmm,
 	HmmInstallConflictError,
 	HmmNotFoundError,
 	HmmReleaseError,
@@ -46,14 +46,14 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 export const findHmmsFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(findHmmsSchema)
-	.handler(async ({ data }) => findHmmsImpl(db, data));
+	.handler(async ({ data }) => findHmms(db, data));
 
 export const getHmmFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(hmmIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			return await getHmmImpl(db, data.hmmId);
+			return await getHmm(db, data.hmmId);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}

--- a/apps/web/src/server/jobs/functions.ts
+++ b/apps/web/src/server/jobs/functions.ts
@@ -6,9 +6,9 @@ import { db } from "../db/pg";
 import { ClientError } from "../errors";
 import { rowIdSchema } from "../validation";
 import {
-	findJobs as findJobsImpl,
-	getJob as getJobImpl,
-	getJobs as getJobsImpl,
+	findJobs,
+	getJob,
+	getJobs,
 	JOB_STATES,
 	JobNotFoundError,
 } from "./data";
@@ -47,19 +47,19 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 export const findJobsFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(findJobsSchema)
-	.handler(async ({ data }) => findJobsImpl(db, data));
+	.handler(async ({ data }) => findJobs(db, data));
 
 export const getJobsFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(jobIdsSchema)
-	.handler(async ({ data }) => getJobsImpl(db, data.jobIds));
+	.handler(async ({ data }) => getJobs(db, data.jobIds));
 
 export const getJobFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(jobIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			return await getJobImpl(db, data.jobId);
+			return await getJob(db, data.jobId);
 		} catch (err) {
 			await rethrowAsHttp(err);
 		}

--- a/apps/web/src/server/labels/functions.ts
+++ b/apps/web/src/server/labels/functions.ts
@@ -6,13 +6,13 @@ import { db } from "../db/pg";
 import { ClientError } from "../errors";
 import { rowIdSchema } from "../validation";
 import {
-	createLabel as createLabelImpl,
-	deleteLabel as deleteLabelImpl,
-	findLabels as findLabelsImpl,
-	getLabel as getLabelImpl,
+	createLabel,
+	deleteLabel,
+	findLabels,
+	getLabel,
 	LabelConflictError,
 	LabelNotFoundError,
-	updateLabel as updateLabelImpl,
+	updateLabel,
 } from "./data";
 
 const colorSchema = z
@@ -61,14 +61,14 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 export const findLabelsFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(findLabelsSchema)
-	.handler(async ({ data }) => findLabelsImpl(db, data?.term ?? ""));
+	.handler(async ({ data }) => findLabels(db, data?.term ?? ""));
 
 export const getLabelFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(labelIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			return await getLabelImpl(db, data.labelId);
+			return await getLabel(db, data.labelId);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -79,7 +79,7 @@ export const createLabelFn = createServerFn({ method: "POST" })
 	.validator(labelValuesSchema)
 	.handler(async ({ data }) => {
 		try {
-			const label = await createLabelImpl(db, normalizeValues(data));
+			const label = await createLabel(db, normalizeValues(data));
 			setResponseStatus(201);
 			return label;
 		} catch (err) {
@@ -93,7 +93,7 @@ export const updateLabelFn = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		const { labelId, ...values } = data;
 		try {
-			return await updateLabelImpl(db, labelId, normalizeValues(values));
+			return await updateLabel(db, labelId, normalizeValues(values));
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -104,7 +104,7 @@ export const deleteLabelFn = createServerFn({ method: "POST" })
 	.validator(labelIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			await deleteLabelImpl(db, data.labelId);
+			await deleteLabel(db, data.labelId);
 			setResponseStatus(204);
 			return null;
 		} catch (err) {

--- a/apps/web/src/server/messages/functions.ts
+++ b/apps/web/src/server/messages/functions.ts
@@ -7,14 +7,14 @@ import { db } from "../db/pg";
 import { ClientError } from "../errors";
 import { rowIdSchema } from "../validation";
 import {
-	clearActiveMessage as clearActiveMessageImpl,
-	createMessage as createMessageImpl,
-	deleteMessage as deleteMessageImpl,
-	findMessage as findMessageImpl,
-	findMessages as findMessagesImpl,
+	clearActiveMessage,
+	createMessage,
+	deleteMessage,
+	findMessage,
+	findMessages,
 	MessageNotFoundError,
-	setActiveMessage as setActiveMessageImpl,
-	updateMessage as updateMessageImpl,
+	setActiveMessage,
+	updateMessage,
 } from "./data";
 
 const colorSchema = z.enum(bannerColors);
@@ -47,17 +47,17 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 
 export const findMessageFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
-	.handler(async () => findMessageImpl(db));
+	.handler(async () => findMessage(db));
 
 export const findMessagesFn = createServerFn({ method: "GET" })
 	.middleware([adminRole("settings")])
-	.handler(async () => findMessagesImpl(db));
+	.handler(async () => findMessages(db));
 
 export const createMessageFn = createServerFn({ method: "POST" })
 	.middleware([adminRole("settings")])
 	.validator(createMessageSchema)
 	.handler(async ({ context, data }) => {
-		const message = await createMessageImpl(
+		const message = await createMessage(
 			db,
 			data.message,
 			data.color,
@@ -72,7 +72,7 @@ export const updateMessageFn = createServerFn({ method: "POST" })
 	.validator(updateMessageSchema)
 	.handler(async ({ context, data }) => {
 		try {
-			return await updateMessageImpl(
+			return await updateMessage(
 				db,
 				data.id,
 				{ message: data.message, color: data.color },
@@ -88,7 +88,7 @@ export const deleteMessageFn = createServerFn({ method: "POST" })
 	.validator(idSchema)
 	.handler(async ({ data }) => {
 		try {
-			await deleteMessageImpl(db, data.id);
+			await deleteMessage(db, data.id);
 			setResponseStatus(204);
 			return null;
 		} catch (err) {
@@ -101,7 +101,7 @@ export const setActiveMessageFn = createServerFn({ method: "POST" })
 	.validator(idSchema)
 	.handler(async ({ data }) => {
 		try {
-			return await setActiveMessageImpl(db, data.id);
+			return await setActiveMessage(db, data.id);
 		} catch (err) {
 			rethrowAsHttp(err);
 		}
@@ -110,6 +110,6 @@ export const setActiveMessageFn = createServerFn({ method: "POST" })
 export const clearActiveMessageFn = createServerFn({ method: "POST" })
 	.middleware([adminRole("settings")])
 	.handler(async () => {
-		await clearActiveMessageImpl(db);
+		await clearActiveMessage(db);
 		return null;
 	});

--- a/apps/web/src/server/otus/functions.ts
+++ b/apps/web/src/server/otus/functions.ts
@@ -22,14 +22,14 @@ import {
 } from "../references/data";
 import { pageSchema, perPageSchema, rowIdSchema } from "../validation";
 import {
-	createIsolate as createIsolateImpl,
-	createOtu as createOtuImpl,
-	createSequence as createSequenceImpl,
-	deleteIsolate as deleteIsolateImpl,
-	deleteOtu as deleteOtuImpl,
-	deleteSequence as deleteSequenceImpl,
-	findOtus as findOtusImpl,
-	getOtu as getOtuImpl,
+	createIsolate,
+	createOtu,
+	createSequence,
+	deleteIsolate,
+	deleteOtu,
+	deleteSequence,
+	findOtus,
+	getOtu,
 	getOtuReference,
 	IsolateNotFoundError,
 	OtuNameConflictError,
@@ -38,10 +38,10 @@ import {
 	SequenceNotFoundError,
 	SourceTypeNotAllowedError,
 	sequenceExists,
-	setIsolateAsDefault as setIsolateAsDefaultImpl,
-	updateIsolate as updateIsolateImpl,
-	updateOtu as updateOtuImpl,
-	updateSequence as updateSequenceImpl,
+	setIsolateAsDefault,
+	updateIsolate,
+	updateOtu,
+	updateSequence,
 } from "./data";
 
 // An OTU, isolate, or sequence id is the 8-character string Mongo's `_id` held,
@@ -169,7 +169,7 @@ export const findOtusFn = createServerFn({ method: "GET" })
 	.validator(findOtusSchema)
 	.handler(async ({ data }) => {
 		try {
-			return await findOtusImpl(db, data.referenceId, {
+			return await findOtus(db, data.referenceId, {
 				page: data.page,
 				perPage: data.per_page,
 				term: data.term,
@@ -184,7 +184,7 @@ export const getOtuFn = createServerFn({ method: "GET" })
 	.validator(otuIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			return await getOtuImpl(db, data.otuId);
+			return await getOtu(db, data.otuId);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -217,7 +217,7 @@ export const createOtuFn = createServerFn({ method: "POST" })
 				throw new ForbiddenError();
 			}
 
-			const otu = await createOtuImpl(
+			const otu = await createOtu(
 				db,
 				referenceId,
 				values,
@@ -241,7 +241,7 @@ export const updateOtuFn = createServerFn({ method: "POST" })
 		try {
 			await authorizeOtu(otuId, context.session.userId);
 
-			return await updateOtuImpl(db, otuId, values, context.session.userId);
+			return await updateOtu(db, otuId, values, context.session.userId);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -254,7 +254,7 @@ export const deleteOtuFn = createServerFn({ method: "POST" })
 		try {
 			await authorizeOtu(data.otuId, context.session.userId);
 
-			await deleteOtuImpl(db, data.otuId, context.session.userId);
+			await deleteOtu(db, data.otuId, context.session.userId);
 
 			setResponseStatus(204);
 
@@ -273,7 +273,7 @@ export const createIsolateFn = createServerFn({ method: "POST" })
 		try {
 			await authorizeOtu(otuId, context.session.userId);
 
-			const isolate = await createIsolateImpl(
+			const isolate = await createIsolate(
 				db,
 				otuId,
 				values,
@@ -297,7 +297,7 @@ export const updateIsolateFn = createServerFn({ method: "POST" })
 		try {
 			await authorizeOtu(otuId, context.session.userId, isolateId);
 
-			return await updateIsolateImpl(
+			return await updateIsolate(
 				db,
 				otuId,
 				isolateId,
@@ -316,7 +316,7 @@ export const setIsolateAsDefaultFn = createServerFn({ method: "POST" })
 		try {
 			await authorizeOtu(data.otuId, context.session.userId, data.isolateId);
 
-			return await setIsolateAsDefaultImpl(
+			return await setIsolateAsDefault(
 				db,
 				data.otuId,
 				data.isolateId,
@@ -334,7 +334,7 @@ export const deleteIsolateFn = createServerFn({ method: "POST" })
 		try {
 			await authorizeOtu(data.otuId, context.session.userId, data.isolateId);
 
-			await deleteIsolateImpl(
+			await deleteIsolate(
 				db,
 				data.otuId,
 				data.isolateId,
@@ -358,7 +358,7 @@ export const createSequenceFn = createServerFn({ method: "POST" })
 		try {
 			await authorizeOtu(otuId, context.session.userId, isolateId);
 
-			const sequence = await createSequenceImpl(
+			const sequence = await createSequence(
 				db,
 				otuId,
 				isolateId,
@@ -390,7 +390,7 @@ export const updateSequenceFn = createServerFn({ method: "POST" })
 
 			await authorizeOtu(otuId, context.session.userId, isolateId);
 
-			return await updateSequenceImpl(
+			return await updateSequence(
 				db,
 				otuId,
 				isolateId,
@@ -416,7 +416,7 @@ export const deleteSequenceFn = createServerFn({ method: "POST" })
 
 			await authorizeOtu(data.otuId, context.session.userId, data.isolateId);
 
-			await deleteSequenceImpl(
+			await deleteSequence(
 				db,
 				data.otuId,
 				data.isolateId,

--- a/apps/web/src/server/references/functions.ts
+++ b/apps/web/src/server/references/functions.ts
@@ -12,26 +12,26 @@ import { db } from "../db/pg";
 import { ClientError } from "../errors";
 import { pageSchema, perPageSchema, rowIdSchema } from "../validation";
 import {
-	addReferenceGroup as addReferenceGroupImpl,
-	addReferenceUser as addReferenceUserImpl,
+	addReferenceGroup,
+	addReferenceUser,
 	checkReferenceRight,
 	checkReferenceVisibility,
-	createReference as createReferenceImpl,
-	findReferences as findReferencesImpl,
-	getReference as getReferenceImpl,
+	createReference,
+	findReferences,
+	getReference,
 	ReferenceArchivedError,
 	ReferenceCloneSourceNotFoundError,
 	ReferenceImportUploadNotFoundError,
 	ReferenceMemberConflictError,
 	ReferenceMemberNotFoundError,
 	ReferenceNotFoundError,
-	removeReferenceGroup as removeReferenceGroupImpl,
-	removeReferenceUser as removeReferenceUserImpl,
+	removeReferenceGroup,
+	removeReferenceUser,
 	resolveReferenceActor,
-	setReferenceArchived as setReferenceArchivedImpl,
-	updateReferenceGroup as updateReferenceGroupImpl,
-	updateReference as updateReferenceImpl,
-	updateReferenceUser as updateReferenceUserImpl,
+	setReferenceArchived,
+	updateReference,
+	updateReferenceGroup,
+	updateReferenceUser,
 } from "./data";
 
 const referenceIdSchema = z.object({
@@ -132,7 +132,7 @@ export const findReferencesFn = createServerFn({ method: "GET" })
 	.handler(async ({ context, data }) => {
 		const actor = await resolveReferenceActor(db, context.session.userId);
 
-		return findReferencesImpl(
+		return findReferences(
 			db,
 			{
 				page: data.page,
@@ -156,7 +156,7 @@ export const getReferenceFn = createServerFn({ method: "GET" })
 			if (!(await checkReferenceVisibility(db, data.referenceId, actor))) {
 				throw new ReferenceNotFoundError();
 			}
-			return await getReferenceImpl(db, data.referenceId);
+			return await getReference(db, data.referenceId);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -167,7 +167,7 @@ export const createReferenceFn = createServerFn({ method: "POST" })
 	.validator(createReferenceSchema)
 	.handler(async ({ context, data }) => {
 		try {
-			const reference = await createReferenceImpl(db, {
+			const reference = await createReference(db, {
 				name: data.name,
 				description: data.description,
 				organism: data.organism,
@@ -189,7 +189,7 @@ export const updateReferenceFn = createServerFn({ method: "POST" })
 		const { referenceId, ...values } = data;
 		try {
 			await authorizeReference(referenceId, context.session.userId, "modify");
-			return await updateReferenceImpl(db, referenceId, values);
+			return await updateReference(db, referenceId, values);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -205,7 +205,7 @@ export const archiveReferenceFn = createServerFn({ method: "POST" })
 				context.session.userId,
 				"modify",
 			);
-			return await setReferenceArchivedImpl(db, data.referenceId, true);
+			return await setReferenceArchived(db, data.referenceId, true);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -221,7 +221,7 @@ export const unarchiveReferenceFn = createServerFn({ method: "POST" })
 				context.session.userId,
 				"modify",
 			);
-			return await setReferenceArchivedImpl(db, data.referenceId, false);
+			return await setReferenceArchived(db, data.referenceId, false);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -234,12 +234,7 @@ export const addReferenceUserFn = createServerFn({ method: "POST" })
 		const { referenceId, userId, ...rights } = data;
 		try {
 			await authorizeReference(referenceId, context.session.userId, "modify");
-			const member = await addReferenceUserImpl(
-				db,
-				referenceId,
-				userId,
-				rights,
-			);
+			const member = await addReferenceUser(db, referenceId, userId, rights);
 			setResponseStatus(201);
 			return member;
 		} catch (err) {
@@ -256,12 +251,7 @@ export const addReferenceGroupFn = createServerFn({ method: "POST" })
 			// The user-membership add checks `modify`; this closes the asymmetry with
 			// the Python service, which left group-add unguarded.
 			await authorizeReference(referenceId, context.session.userId, "modify");
-			const member = await addReferenceGroupImpl(
-				db,
-				referenceId,
-				groupId,
-				rights,
-			);
+			const member = await addReferenceGroup(db, referenceId, groupId, rights);
 			setResponseStatus(201);
 			return member;
 		} catch (err) {
@@ -276,7 +266,7 @@ export const updateReferenceUserFn = createServerFn({ method: "POST" })
 		const { referenceId, userId, ...rights } = data;
 		try {
 			await authorizeReference(referenceId, context.session.userId, "modify");
-			return await updateReferenceUserImpl(db, referenceId, userId, rights);
+			return await updateReferenceUser(db, referenceId, userId, rights);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -289,7 +279,7 @@ export const updateReferenceGroupFn = createServerFn({ method: "POST" })
 		const { referenceId, groupId, ...rights } = data;
 		try {
 			await authorizeReference(referenceId, context.session.userId, "modify");
-			return await updateReferenceGroupImpl(db, referenceId, groupId, rights);
+			return await updateReferenceGroup(db, referenceId, groupId, rights);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -305,7 +295,7 @@ export const removeReferenceUserFn = createServerFn({ method: "POST" })
 				context.session.userId,
 				"modify",
 			);
-			await removeReferenceUserImpl(db, data.referenceId, data.userId);
+			await removeReferenceUser(db, data.referenceId, data.userId);
 			setResponseStatus(204);
 			return null;
 		} catch (err) {
@@ -323,7 +313,7 @@ export const removeReferenceGroupFn = createServerFn({ method: "POST" })
 				context.session.userId,
 				"modify",
 			);
-			await removeReferenceGroupImpl(db, data.referenceId, data.groupId);
+			await removeReferenceGroup(db, data.referenceId, data.groupId);
 			setResponseStatus(204);
 			return null;
 		} catch (err) {

--- a/apps/web/src/server/samples/functions.ts
+++ b/apps/web/src/server/samples/functions.ts
@@ -11,10 +11,10 @@ import { UploadNotFoundError, UploadReservedError } from "../uploads/data";
 import { pageSchema, perPageSchema, rowIdSchema } from "../validation";
 import {
 	checkSampleRight,
-	createSample as createSampleImpl,
-	deleteSample as deleteSampleImpl,
-	findSamples as findSamplesImpl,
-	getSample as getSampleImpl,
+	createSample,
+	deleteSample,
+	findSamples,
+	getSample,
 	getSampleOwnerId,
 	resolveSampleActor,
 	SampleFileDuplicateError,
@@ -25,8 +25,8 @@ import {
 	SampleNotFoundError,
 	type SampleRight,
 	SampleSubtractionsNotFoundError,
-	updateSample as updateSampleImpl,
-	updateSampleRights as updateSampleRightsImpl,
+	updateSample,
+	updateSampleRights,
 } from "./data";
 
 const sampleIdSchema = z.object({
@@ -126,7 +126,7 @@ export const findSamplesFn = createServerFn({ method: "GET" })
 	.handler(async ({ context, data }) => {
 		const actor = await resolveSampleActor(db, context.session.userId);
 
-		return findSamplesImpl(
+		return findSamples(
 			db,
 			{
 				page: data.page,
@@ -146,7 +146,7 @@ export const getSampleFn = createServerFn({ method: "GET" })
 	.handler(async ({ context, data }) => {
 		try {
 			await authorizeSample(data.sampleId, context.session.userId, "read");
-			return await getSampleImpl(db, data.sampleId);
+			return await getSample(db, data.sampleId);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -157,7 +157,7 @@ export const createSampleFn = createServerFn({ method: "POST" })
 	.validator(SampleCreateRequest)
 	.handler(async ({ context, data }) => {
 		try {
-			const sample = await createSampleImpl(db, {
+			const sample = await createSample(db, {
 				name: data.name,
 				host: data.host,
 				isolate: data.isolate,
@@ -184,7 +184,7 @@ export const updateSampleFn = createServerFn({ method: "POST" })
 		const { sampleId, ...values } = data;
 		try {
 			await authorizeSample(sampleId, context.session.userId, "write");
-			return await updateSampleImpl(db, sampleId, values);
+			return await updateSample(db, sampleId, values);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -197,7 +197,7 @@ export const deleteSampleFn = createServerFn({ method: "POST" })
 		try {
 			await authorizeSample(data.sampleId, context.session.userId, "write");
 
-			const sample = await getSampleImpl(db, data.sampleId);
+			const sample = await getSample(db, data.sampleId);
 
 			// A sample whose creation job is still running cannot be deleted.
 			if (!sample.ready) {
@@ -217,7 +217,7 @@ export const deleteSampleFn = createServerFn({ method: "POST" })
 				}
 			}
 
-			await deleteSampleImpl(db, storage, data.sampleId);
+			await deleteSample(db, storage, data.sampleId);
 			setResponseStatus(204);
 			return null;
 		} catch (err) {
@@ -250,7 +250,7 @@ export const updateSampleRightsFn = createServerFn({ method: "POST" })
 		}
 
 		try {
-			return await updateSampleRightsImpl(db, sampleId, values);
+			return await updateSampleRights(db, sampleId, values);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}

--- a/apps/web/src/server/settings/functions.ts
+++ b/apps/web/src/server/settings/functions.ts
@@ -4,11 +4,7 @@ import { adminRole, open } from "../auth/policy";
 
 import { db } from "../db/pg";
 import { type SampleGroup, sampleGroups } from "../db/schema/settings";
-import {
-	getSettings as getSettingsImpl,
-	type Settings,
-	updateSettings as updateSettingsImpl,
-} from "./data";
+import { getSettings, type Settings, updateSettings } from "./data";
 
 /** The password rules a client needs to validate a new password before submitting it. */
 export type PasswordPolicy = {
@@ -27,7 +23,7 @@ export type PasswordPolicy = {
 export const getPasswordPolicyFn = createServerFn({ method: "GET" })
 	.middleware([open()])
 	.handler(async (): Promise<PasswordPolicy> => {
-		const { minimumPasswordLength } = await getSettingsImpl(db);
+		const { minimumPasswordLength } = await getSettings(db);
 		return { minimumPasswordLength };
 	});
 
@@ -56,9 +52,9 @@ const updateSettingsSchema = z
 
 export const getSettingsFn = createServerFn({ method: "GET" })
 	.middleware([adminRole("settings")])
-	.handler(async (): Promise<Settings> => getSettingsImpl(db));
+	.handler(async (): Promise<Settings> => getSettings(db));
 
 export const updateSettingsFn = createServerFn({ method: "POST" })
 	.middleware([adminRole("settings")])
 	.validator(updateSettingsSchema)
-	.handler(async ({ data }): Promise<Settings> => updateSettingsImpl(db, data));
+	.handler(async ({ data }): Promise<Settings> => updateSettings(db, data));

--- a/apps/web/src/server/subtraction/functions.ts
+++ b/apps/web/src/server/subtraction/functions.ts
@@ -6,14 +6,14 @@ import { db } from "../db/pg";
 import { storage } from "../storage";
 import { pageSchema, perPageSchema, rowIdSchema } from "../validation";
 import {
-	createSubtraction as createSubtractionImpl,
-	deleteSubtraction as deleteSubtractionImpl,
-	findSubtractions as findSubtractionsImpl,
-	getSubtraction as getSubtractionImpl,
-	listSubtractionsShortlist as listSubtractionsShortlistImpl,
+	createSubtraction,
+	deleteSubtraction,
+	findSubtractions,
+	getSubtraction,
+	listSubtractionsShortlist,
 	SubtractionNotFoundError,
 	SubtractionUploadNotFoundError,
-	updateSubtraction as updateSubtractionImpl,
+	updateSubtraction,
 } from "./data";
 
 const findSubtractionsSchema = z.object({
@@ -56,7 +56,7 @@ export const findSubtractionsFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(findSubtractionsSchema)
 	.handler(async ({ data }) =>
-		findSubtractionsImpl(db, {
+		findSubtractions(db, {
 			page: data.page,
 			perPage: data.per_page,
 			term: data.term,
@@ -66,14 +66,14 @@ export const findSubtractionsFn = createServerFn({ method: "GET" })
 
 export const listSubtractionsShortlistFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
-	.handler(async () => listSubtractionsShortlistImpl(db));
+	.handler(async () => listSubtractionsShortlist(db));
 
 export const getSubtractionFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(subtractionIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			return await getSubtractionImpl(db, data.subtractionId);
+			return await getSubtraction(db, data.subtractionId);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -84,7 +84,7 @@ export const createSubtractionFn = createServerFn({ method: "POST" })
 	.validator(createSubtractionSchema)
 	.handler(async ({ context, data }) => {
 		try {
-			const subtraction = await createSubtractionImpl(db, {
+			const subtraction = await createSubtraction(db, {
 				name: data.name,
 				nickname: data.nickname,
 				uploadId: data.uploadId,
@@ -103,7 +103,7 @@ export const updateSubtractionFn = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		const { subtractionId, ...values } = data;
 		try {
-			return await updateSubtractionImpl(db, subtractionId, values);
+			return await updateSubtraction(db, subtractionId, values);
 		} catch (err) {
 			return rethrowAsHttp(err);
 		}
@@ -114,7 +114,7 @@ export const deleteSubtractionFn = createServerFn({ method: "POST" })
 	.validator(subtractionIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			await deleteSubtractionImpl(db, storage, data.subtractionId);
+			await deleteSubtraction(db, storage, data.subtractionId);
 			setResponseStatus(204);
 			return null;
 		} catch (err) {

--- a/apps/web/src/server/tasks/functions.ts
+++ b/apps/web/src/server/tasks/functions.ts
@@ -5,7 +5,7 @@ import { authenticated } from "../auth/policy";
 import { db } from "../db/pg";
 import { ClientError } from "../errors";
 import { rowIdSchema } from "../validation";
-import { getTask as getTaskImpl, TaskNotFoundError } from "./data";
+import { getTask, TaskNotFoundError } from "./data";
 
 const taskIdSchema = z.object({
 	taskId: rowIdSchema,
@@ -28,7 +28,7 @@ export const getTaskFn = createServerFn({ method: "GET" })
 	.validator(taskIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			return await getTaskImpl(db, data.taskId);
+			return await getTask(db, data.taskId);
 		} catch (err) {
 			rethrowAsHttp(err);
 		}

--- a/apps/web/src/server/uploads/functions.ts
+++ b/apps/web/src/server/uploads/functions.ts
@@ -7,8 +7,8 @@ import { ClientError } from "../errors";
 import { storage } from "../storage";
 import { pageSchema, perPageSchema, rowIdSchema } from "../validation";
 import {
-	deleteUpload as deleteUploadImpl,
-	findUploads as findUploadsImpl,
+	deleteUpload,
+	findUploads,
 	UPLOAD_TYPES,
 	UploadNotFoundError,
 	UploadReservedError,
@@ -51,7 +51,7 @@ export const findUploadsFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(findUploadsSchema)
 	.handler(async ({ data }) =>
-		findUploadsImpl(
+		findUploads(
 			db,
 			data?.upload_type,
 			data?.page ?? 1,
@@ -65,7 +65,7 @@ export const deleteUploadFn = createServerFn({ method: "POST" })
 	.validator(uploadIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			await deleteUploadImpl(db, storage, data.id);
+			await deleteUpload(db, storage, data.id);
 			setResponseStatus(204);
 			return null;
 		} catch (err) {

--- a/apps/web/src/server/users/functions.ts
+++ b/apps/web/src/server/users/functions.ts
@@ -11,21 +11,21 @@ import { db } from "../db/pg";
 import { ClientError } from "../errors";
 import { pageSchema, perPageSchema, rowIdSchema } from "../validation";
 import {
-	changePassword as changePasswordImpl,
-	createUser as createUserImpl,
-	findUsers as findUsersImpl,
+	changePassword,
+	createUser,
+	findUsers,
 	GroupMembershipError,
-	getAccount as getAccountImpl,
-	getAdministratorRole as getAdministratorRoleImpl,
-	getUser as getUserImpl,
+	getAccount,
+	getAdministratorRole,
+	getUser,
 	InvalidPasswordError,
-	listAdministratorRoles as listAdministratorRolesImpl,
-	listUsers as listUsersImpl,
-	setAdministratorRole as setAdministratorRoleImpl,
+	listAdministratorRoles,
+	listUsers,
+	setAdministratorRole,
 	UserConflictError,
 	UserNotFoundError,
-	updateAccountEmail as updateAccountEmailImpl,
-	updateUser as updateUserImpl,
+	updateAccountEmail,
+	updateUser,
 } from "./data";
 
 const administratorRoleSchema = z.enum([
@@ -150,19 +150,19 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 
 export const listAdministratorRolesFn = createServerFn({ method: "GET" })
 	.middleware([adminRole("base")])
-	.handler(async () => listAdministratorRolesImpl());
+	.handler(async () => listAdministratorRoles());
 
 // Any authenticated user can see who else exists — the handles are already
 // visible on samples, jobs, and analyses they can read.
 export const listUsersFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
-	.handler(async () => listUsersImpl(db));
+	.handler(async () => listUsers(db));
 
 export const findUsersFn = createServerFn({ method: "GET" })
 	.middleware([adminRole("users")])
 	.validator(findUsersSchema)
 	.handler(async ({ data }) => {
-		return findUsersImpl(db, {
+		return findUsers(db, {
 			term: data?.term ?? "",
 			page: data?.page ?? 1,
 			perPage: data?.perPage ?? 25,
@@ -180,7 +180,7 @@ export const searchUsersFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
 	.validator(searchUsersSchema)
 	.handler(async ({ data }) =>
-		findUsersImpl(db, {
+		findUsers(db, {
 			term: data?.term ?? "",
 			page: data?.page ?? 1,
 			perPage: data?.perPage ?? 25,
@@ -192,14 +192,14 @@ export const searchUsersFn = createServerFn({ method: "GET" })
 // rejected call is how they learn there is no session.
 export const getAccountFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])
-	.handler(async ({ context }) => getAccountImpl(db, context.session.userId));
+	.handler(async ({ context }) => getAccount(db, context.session.userId));
 
 export const getUserFn = createServerFn({ method: "GET" })
 	.middleware([adminRole("users")])
 	.validator(userIdSchema)
 	.handler(async ({ data }) => {
 		try {
-			return await getUserImpl(db, data.userId);
+			return await getUser(db, data.userId);
 		} catch (err) {
 			// `throw` keeps the handler's inferred return type `User` rather than
 			// `User | undefined`, so suspense consumers get a non-nullable user.
@@ -216,7 +216,7 @@ export const createUserFn = createServerFn({ method: "POST" })
 		try {
 			await checkConfiguredPasswordLength(db, data.password);
 
-			const user = await createUserImpl(db, {
+			const user = await createUser(db, {
 				handle: data.handle,
 				password: data.password,
 				forceReset: data.forceReset,
@@ -235,7 +235,7 @@ export const updateUserFn = createServerFn({ method: "POST" })
 		// A policy states the floor. This one depends on the target row, so it can
 		// only be checked here: editing a user who is themselves an administrator
 		// requires the full role, mirroring the Python service.
-		const targetRole = await getAdministratorRoleImpl(db, data.userId);
+		const targetRole = await getAdministratorRole(db, data.userId);
 		if (targetRole !== null) {
 			await requireAdminRole(context.session, "full");
 		}
@@ -248,7 +248,7 @@ export const updateUserFn = createServerFn({ method: "POST" })
 			if (values.password !== undefined) {
 				await checkConfiguredPasswordLength(db, values.password);
 			}
-			return await updateUserImpl(db, userId, values);
+			return await updateUser(db, userId, values);
 		} catch (err) {
 			throw rethrowAsHttp(err);
 		}
@@ -261,7 +261,7 @@ export const updateAccountHandleFn = createServerFn({ method: "POST" })
 		checkReservedHandle(data.handle);
 
 		try {
-			return await updateUserImpl(db, context.session.userId, {
+			return await updateUser(db, context.session.userId, {
 				handle: data.handle,
 			});
 		} catch (err) {
@@ -276,11 +276,7 @@ export const updateAccountEmailFn = createServerFn({ method: "POST" })
 		checkEmail(data.email);
 
 		try {
-			return await updateAccountEmailImpl(
-				db,
-				context.session.userId,
-				data.email,
-			);
+			return await updateAccountEmail(db, context.session.userId, data.email);
 		} catch (err) {
 			throw rethrowAsHttp(err);
 		}
@@ -293,7 +289,7 @@ export const changePasswordFn = createServerFn({ method: "POST" })
 		try {
 			await checkConfiguredPasswordLength(db, data.password);
 
-			const { account, sessionId, token } = await changePasswordImpl(db, {
+			const { account, sessionId, token } = await changePassword(db, {
 				userId: context.session.userId,
 				oldPassword: data.oldPassword,
 				password: data.password,
@@ -322,7 +318,7 @@ export const setAdministratorRoleFn = createServerFn({ method: "POST" })
 		}
 
 		try {
-			return await setAdministratorRoleImpl(db, data.userId, data.role);
+			return await setAdministratorRole(db, data.userId, data.role);
 		} catch (err) {
 			throw rethrowAsHttp(err);
 		}


### PR DESCRIPTION
## Summary
- Drops all 83 `... as ...Impl` import aliases from the fifteen server `functions.ts` modules that still had them, finishing what 96c5fe85 started on `indexes`. The `Fn` suffix already distinguishes a server function from the data function it wraps, so the alias only gave one thing a second name.
- Keeps the alias in `auth/policy.test.ts` and `groups/functions.test.ts`, where it earns its place — each defines a local `seedGroup`/`addToGroup` that closes over `db` and genuinely shadows the imported fixture.
- Records the convention in `AGENTS.md` under **Naming**; `docs/code-style.md` already said aliasing wasn't needed for this pair.

Every rename was checked for shadows first. The only two plain names appearing elsewhere in their own file — `findJobs` and `createOtu` — turned out to be prose in comments, not bindings.