### PR TITLE
feat: add file downloads to the upload manager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -519,6 +519,16 @@ middleware runs on a route, the handler enforces the floor itself:
 check. Don't fold it back into a server function — the RPC client uses `fetch`
 and would lose progress.
 
+Reading an upload back is a separate raw route
+(`routes/uploads_.$uploadId.ts` → `@server/uploads/download`), reached from the
+uploads list with a plain `<a href>` and streamed out of storage. Its floor is
+`requireAuthenticatedRequest` alone — uploads carry no per-row rights, and
+`upload_file` gates *writing* one, not reading it back. The trailing underscore
+in the filename keeps it from nesting under `routes/uploads.ts` merely because
+the two share a URL segment; the URL is `/uploads/{uploadId}` either way. The
+`Content-Disposition` is built from the row's `name`, never the UUID-prefixed
+`name_on_disk` that keys the object.
+
 The analysis CSV/XLSX export (`routes/analyses.documents.$document.ts` →
 `@server/analyses/download`) is a raw route for the mirror-image reason: the
 client reaches it with a plain `<a href>`, so the browser has to receive a real

--- a/apps/web/src/base/IconLink.tsx
+++ b/apps/web/src/base/IconLink.tsx
@@ -1,0 +1,57 @@
+import { cn } from "@app/cn";
+import type { LucideIcon } from "lucide-react";
+import { iconButtonVariants } from "./iconButtonVariants";
+import Tooltip from "./Tooltip";
+import type { IconColor } from "./types";
+
+export type IconLinkProps = {
+	/** Accessible name for the link. Defaults to ``tip``. */
+	ariaLabel?: string;
+	className?: string;
+	color?: IconColor;
+	/** Save the target instead of navigating to it, named as given. */
+	download?: boolean | string;
+	href: string;
+	IconComponent: LucideIcon;
+	size?: number;
+	tip: string;
+	tipPlacement?: "top" | "right" | "bottom" | "left";
+};
+
+/**
+ * A styled icon anchor with a tooltip describing its action, sharing
+ * `IconButton`'s treatment so the two sit together in a row of controls.
+ *
+ * This is an anchor rather than a button because the browser has to make the
+ * request itself: a download's `Content-Disposition` only reaches the user
+ * through a real navigation, not a fetch. `href` is therefore a plain URL, not
+ * a `<Link>` — these targets are responses, not routes.
+ */
+export default function IconLink({
+	ariaLabel,
+	className,
+	color,
+	download,
+	href,
+	IconComponent,
+	size,
+	tip,
+	tipPlacement,
+}: IconLinkProps) {
+	return (
+		<Tooltip position={tipPlacement || "top"} tip={tip}>
+			<a
+				aria-label={ariaLabel ?? tip}
+				className={cn(
+					iconButtonVariants({ color }),
+					"inline-flex justify-center",
+					className,
+				)}
+				download={download}
+				href={href}
+			>
+				<IconComponent size={size ?? "1.2em"} />
+			</a>
+		</Tooltip>
+	);
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as AuthenticatedSamplesRouteImport } from './routes/_authenticate
 import { Route as AuthenticatedSubtractionsRouteImport } from './routes/_authenticated/subtractions'
 import { Route as HealthLiveRouteImport } from './routes/health/live'
 import { Route as HealthReadyRouteImport } from './routes/health/ready'
+import { Route as UploadsUploadIdRouteImport } from './routes/uploads_.$uploadId'
 import { Route as AuthenticatedAccountIndexRouteImport } from './routes/_authenticated/account/index'
 import { Route as AuthenticatedAccountApiRouteImport } from './routes/_authenticated/account/api'
 import { Route as AuthenticatedAccountProfileRouteImport } from './routes/_authenticated/account/profile'
@@ -161,6 +162,11 @@ const HealthLiveRoute = HealthLiveRouteImport.update({
 const HealthReadyRoute = HealthReadyRouteImport.update({
   id: '/health/ready',
   path: '/health/ready',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const UploadsUploadIdRoute = UploadsUploadIdRouteImport.update({
+  id: '/uploads_/$uploadId',
+  path: '/uploads/$uploadId',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthenticatedAccountIndexRoute =
@@ -474,6 +480,7 @@ export interface FileRoutesByFullPath {
   '/subtractions': typeof AuthenticatedSubtractionsRouteWithChildren
   '/health/live': typeof HealthLiveRoute
   '/health/ready': typeof HealthReadyRoute
+  '/uploads/$uploadId': typeof UploadsUploadIdRoute
   '/refs/$refId': typeof AuthenticatedRefsRefIdRouteRouteWithChildren
   '/account/api': typeof AuthenticatedAccountApiRoute
   '/account/profile': typeof AuthenticatedAccountProfileRoute
@@ -534,6 +541,7 @@ export interface FileRoutesByTo {
   '/uploads': typeof UploadsRoute
   '/health/live': typeof HealthLiveRoute
   '/health/ready': typeof HealthReadyRoute
+  '/uploads/$uploadId': typeof UploadsUploadIdRoute
   '/': typeof AuthenticatedIndexRoute
   '/account/api': typeof AuthenticatedAccountApiRoute
   '/account/profile': typeof AuthenticatedAccountProfileRoute
@@ -599,6 +607,7 @@ export interface FileRoutesById {
   '/_authenticated/subtractions': typeof AuthenticatedSubtractionsRouteWithChildren
   '/health/live': typeof HealthLiveRoute
   '/health/ready': typeof HealthReadyRoute
+  '/uploads_/$uploadId': typeof UploadsUploadIdRoute
   '/_authenticated/': typeof AuthenticatedIndexRoute
   '/_authenticated/refs/$refId': typeof AuthenticatedRefsRefIdRouteRouteWithChildren
   '/_authenticated/account/api': typeof AuthenticatedAccountApiRoute
@@ -670,6 +679,7 @@ export interface FileRouteTypes {
     | '/subtractions'
     | '/health/live'
     | '/health/ready'
+    | '/uploads/$uploadId'
     | '/refs/$refId'
     | '/account/api'
     | '/account/profile'
@@ -730,6 +740,7 @@ export interface FileRouteTypes {
     | '/uploads'
     | '/health/live'
     | '/health/ready'
+    | '/uploads/$uploadId'
     | '/'
     | '/account/api'
     | '/account/profile'
@@ -794,6 +805,7 @@ export interface FileRouteTypes {
     | '/_authenticated/subtractions'
     | '/health/live'
     | '/health/ready'
+    | '/uploads_/$uploadId'
     | '/_authenticated/'
     | '/_authenticated/refs/$refId'
     | '/_authenticated/account/api'
@@ -857,6 +869,7 @@ export interface RootRouteChildren {
   UploadsRoute: typeof UploadsRoute
   HealthLiveRoute: typeof HealthLiveRoute
   HealthReadyRoute: typeof HealthReadyRoute
+  UploadsUploadIdRoute: typeof UploadsUploadIdRoute
   AnalysesDocumentsDocumentRoute: typeof AnalysesDocumentsDocumentRoute
   OtusOtuIdFastaRoute: typeof OtusOtuIdFastaRoute
   SubtractionsSubtractionIdFilesFilenameRoute: typeof SubtractionsSubtractionIdFilesFilenameRoute
@@ -983,6 +996,13 @@ declare module '@tanstack/react-router' {
       path: '/health/ready'
       fullPath: '/health/ready'
       preLoaderRoute: typeof HealthReadyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/uploads_/$uploadId': {
+      id: '/uploads_/$uploadId'
+      path: '/uploads/$uploadId'
+      fullPath: '/uploads/$uploadId'
+      preLoaderRoute: typeof UploadsUploadIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authenticated/account/': {
@@ -1622,6 +1642,7 @@ const rootRouteChildren: RootRouteChildren = {
   UploadsRoute: UploadsRoute,
   HealthLiveRoute: HealthLiveRoute,
   HealthReadyRoute: HealthReadyRoute,
+  UploadsUploadIdRoute: UploadsUploadIdRoute,
   AnalysesDocumentsDocumentRoute: AnalysesDocumentsDocumentRoute,
   OtusOtuIdFastaRoute: OtusOtuIdFastaRoute,
   SubtractionsSubtractionIdFilesFilenameRoute:

--- a/apps/web/src/routes/uploads_.$uploadId.ts
+++ b/apps/web/src/routes/uploads_.$uploadId.ts
@@ -1,0 +1,19 @@
+import { handleUploadDownload } from "@server/uploads/download";
+import { createFileRoute } from "@tanstack/react-router";
+
+// A raw route, not a server function: the client reaches this with a plain
+// `<a href>`, so the browser has to receive a real response carrying a
+// `Content-Disposition` header, and the bytes stream straight out of storage.
+//
+// The trailing underscore keeps this out of `routes/uploads.ts`, which would
+// otherwise become its parent purely because the URLs share a segment. The two
+// routes have nothing to do with each other — that one takes the POST that
+// creates an upload — and the URL is `/uploads/$uploadId` either way.
+export const Route = createFileRoute("/uploads_/$uploadId")({
+	server: {
+		handlers: {
+			GET: ({ request, params }) =>
+				handleUploadDownload(request, params.uploadId),
+		},
+	},
+});

--- a/apps/web/src/server/http.ts
+++ b/apps/web/src/server/http.ts
@@ -45,3 +45,34 @@ export function contentDisposition(filename: string): string {
 
 	return `attachment; filename="${fallback}"; filename*=UTF-8''${encodeRfc5987(filename)}`;
 }
+
+/**
+ * Adapt a storage read into the `ReadableStream` a `Response` body takes, so a
+ * multi-GB object never sits in the Node heap.
+ *
+ * `ReadableStream.from` would do this in one line, but it is absent from the
+ * DOM lib the app project type-checks against.
+ */
+export function toStream(
+	chunks: AsyncIterable<Uint8Array>,
+): ReadableStream<Uint8Array> {
+	const iterator = chunks[Symbol.asyncIterator]();
+
+	return new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			const { done, value } = await iterator.next();
+
+			if (done) {
+				controller.close();
+				return;
+			}
+
+			controller.enqueue(value);
+		},
+		async cancel(reason) {
+			// A client that aborts the download mid-stream leaves the backend's
+			// request open otherwise.
+			await iterator.return?.(reason);
+		},
+	});
+}

--- a/apps/web/src/server/uploads/data.ts
+++ b/apps/web/src/server/uploads/data.ts
@@ -190,6 +190,42 @@ export async function createUpload(
 	return toUpload(row, await fetchUser(db, row.userId));
 }
 
+/** The storage key of an upload's bytes, with the name to download them as. */
+export type UploadFile = {
+	key: string;
+	name: string;
+};
+
+/**
+ * Resolve an upload to the storage key holding its bytes and the name it was
+ * uploaded under, or `null` if there is nothing to download.
+ *
+ * `name_on_disk` is what the object is keyed by — a UUID-prefixed name that
+ * keeps two uploads of `reads.fq.gz` apart — while `name` is what the user
+ * chose and what the download is named. Both columns are nullable at the
+ * database level, so a row missing either has no downloadable file.
+ *
+ * A removed upload is excluded, matching Python. `ready` is deliberately not
+ * filtered on: Python does not either, and an upload created from this side is
+ * only inserted once its bytes are written.
+ */
+export async function getUploadFile(
+	db: DbOrTx,
+	uploadId: number,
+): Promise<UploadFile | null> {
+	const [row] = await db
+		.select({ name: uploadsTable.name, nameOnDisk: uploadsTable.nameOnDisk })
+		.from(uploadsTable)
+		.where(and(eq(uploadsTable.id, uploadId), eq(uploadsTable.removed, false)))
+		.limit(1);
+
+	if (!row?.name || !row.nameOnDisk) {
+		return null;
+	}
+
+	return { key: uploadFileKey(row.nameOnDisk), name: row.name };
+}
+
 /**
  * Reserve the given uploads so they cannot be used for another sample.
  *

--- a/apps/web/src/server/uploads/download.test.ts
+++ b/apps/web/src/server/uploads/download.test.ts
@@ -1,0 +1,252 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+
+import type { Db } from "../db/pg";
+import { takeFirstOrThrow } from "../db/rows";
+import { apiKeys } from "../db/schema/apiKeys";
+import { sessions } from "../db/schema/sessions";
+import { uploads } from "../db/schema/uploads";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { MemoryStorage } from "../storage/memory";
+
+vi.mock("@tanstack/react-start/server", () => ({
+	deleteCookie: vi.fn(),
+	getCookie: vi.fn(),
+	getRequest: vi.fn(),
+	setCookie: vi.fn(),
+	setResponseStatus: vi.fn(),
+}));
+
+vi.mock("@sentry/tanstackstart-react", () => ({
+	captureException: vi.fn(),
+	setUser: vi.fn(),
+}));
+
+let db: Db;
+vi.mock("../db/pg", () => ({
+	client: {},
+	get db() {
+		return db;
+	},
+}));
+
+const storage = new MemoryStorage();
+vi.mock("../storage", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../storage")>()),
+	storage,
+}));
+
+const { handleUploadDownload } = await import("./download");
+const { basicAuthHeader, seedApiKey, seedSession, seedUser, sessionCookie } =
+	await import("../auth/test/fixtures");
+
+let database: TestDatabase;
+let userId: number;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	await db.delete(uploads);
+	await db.delete(apiKeys);
+	await db.delete(sessions);
+	await db.delete(users);
+
+	userId = await seedUser(db);
+});
+
+async function seedUpload(
+	overrides: Partial<typeof uploads.$inferInsert> = {},
+): Promise<number> {
+	return takeFirstOrThrow(
+		await db
+			.insert(uploads)
+			.values({
+				createdAt: new Date(),
+				name: "reads.fq.gz",
+				nameOnDisk: "abc-reads.fq.gz",
+				ready: true,
+				removed: false,
+				reserved: false,
+				size: 5,
+				type: "reads",
+				uploadedAt: new Date(),
+				userId,
+				...overrides,
+			})
+			.returning({ id: uploads.id }),
+	).id;
+}
+
+async function write(key: string, contents: string): Promise<void> {
+	await storage.write(
+		key,
+		(async function* () {
+			yield new TextEncoder().encode(contents);
+		})(),
+	);
+}
+
+/** Build a `GET /uploads/{id}` request for a user. */
+async function request(userId: number | null): Promise<Request> {
+	const headers: Record<string, string> = {};
+
+	if (userId !== null) {
+		const { sessionId, token } = await seedSession(db, userId);
+		headers.cookie = sessionCookie({ sessionId, token });
+	}
+
+	return new Request("https://virtool.test/uploads/1", { headers });
+}
+
+describe("handleUploadDownload", () => {
+	it("streams the upload from its name_on_disk key", async () => {
+		const uploadId = await seedUpload();
+		await write("files/abc-reads.fq.gz", "hello");
+
+		const response = await handleUploadDownload(
+			await request(userId),
+			String(uploadId),
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-disposition")).toBe(
+			'attachment; filename="reads.fq.gz"',
+		);
+		expect(response.headers.get("content-length")).toBe("5");
+		expect(response.headers.get("content-type")).toBe(
+			"application/octet-stream",
+		);
+		expect(await response.text()).toBe("hello");
+	});
+
+	// The object is keyed by the UUID-prefixed `name_on_disk`, but the download
+	// is named after what the user chose.
+	it("names the download after the upload's name, not its key", async () => {
+		const uploadId = await seedUpload({
+			name: "my reads.fq.gz",
+			nameOnDisk: "f0e1-my reads.fq.gz",
+		});
+		await write("files/f0e1-my reads.fq.gz", "hello");
+
+		const response = await handleUploadDownload(
+			await request(userId),
+			String(uploadId),
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-disposition")).toBe(
+			`attachment; filename="my_reads.fq.gz"; filename*=UTF-8''my%20reads.fq.gz`,
+		);
+	});
+
+	// `uploads.size` is nullable, so the header has to come from the object or
+	// the client truncates.
+	it("sizes the response from storage, not the row", async () => {
+		const uploadId = await seedUpload({ size: null });
+		await write("files/abc-reads.fq.gz", "considerably longer than five bytes");
+
+		const response = await handleUploadDownload(
+			await request(userId),
+			String(uploadId),
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-length")).toBe("35");
+		expect(await response.text()).toBe("considerably longer than five bytes");
+	});
+
+	it("rejects an anonymous caller with a 401", async () => {
+		const uploadId = await seedUpload();
+		await write("files/abc-reads.fq.gz", "hello");
+
+		const response = await handleUploadDownload(
+			await request(null),
+			String(uploadId),
+		);
+
+		expect(response.status).toBe(401);
+	});
+
+	it("accepts an api key", async () => {
+		const key = await seedApiKey(db, userId, {});
+		const uploadId = await seedUpload();
+		await write("files/abc-reads.fq.gz", "hello");
+
+		const response = await handleUploadDownload(
+			new Request("https://virtool.test/uploads/1", {
+				headers: { authorization: basicAuthHeader("alice", key) },
+			}),
+			String(uploadId),
+		);
+
+		expect(response.status).toBe(200);
+	});
+
+	it("returns a 400 for a non-numeric upload id", async () => {
+		const response = await handleUploadDownload(
+			await request(userId),
+			"not-a-number",
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns a 404 when the upload does not exist", async () => {
+		const response = await handleUploadDownload(
+			await request(userId),
+			"404404",
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	it("returns a 404 when the upload is removed", async () => {
+		const uploadId = await seedUpload({ removed: true, removedAt: new Date() });
+		await write("files/abc-reads.fq.gz", "hello");
+
+		const response = await handleUploadDownload(
+			await request(userId),
+			String(uploadId),
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	it("returns a 404 when the row has no name_on_disk", async () => {
+		const uploadId = await seedUpload({ nameOnDisk: null });
+
+		const response = await handleUploadDownload(
+			await request(userId),
+			String(uploadId),
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	it("returns a 404 when the row exists but its bytes do not", async () => {
+		const uploadId = await seedUpload({ nameOnDisk: "missing-reads.fq.gz" });
+
+		const response = await handleUploadDownload(
+			await request(userId),
+			String(uploadId),
+		);
+
+		expect(response.status).toBe(404);
+	});
+});

--- a/apps/web/src/server/uploads/download.ts
+++ b/apps/web/src/server/uploads/download.ts
@@ -2,53 +2,52 @@ import { requireAuthenticatedRequest } from "../auth/middleware";
 import { db } from "../db/pg";
 import { contentDisposition, textResponse, toStream } from "../http";
 import { StorageKeyNotFoundError, storage } from "../storage";
-import { getSubtractionFileKey } from "./data";
+import { getUploadFile } from "./data";
 
 /**
- * Serve a subtraction's FASTA or Bowtie2 file, backing
- * `GET /subtractions/{id}/files/{filename}`.
+ * Serve an upload's bytes, backing `GET /uploads/{uploadId}`.
  *
  * This is a raw route rather than a server function because the client reaches
- * it with a plain `<a href>` — the browser has to see a real response with a
- * `Content-Disposition`, which an RPC call cannot produce. The bytes are
- * streamed straight out of storage, so a multi-GB Bowtie2 index never sits in
- * the Node heap.
+ * it with a plain `<a href>` — the browser has to see a real response carrying
+ * a `Content-Disposition`, which an RPC call cannot produce. The bytes are
+ * streamed straight out of storage, so a multi-GB read file never sits in the
+ * Node heap.
  *
  * Being a route means no policy middleware runs, so the authorization floor is
- * enforced here. It is a valid session and nothing more: subtractions carry no
- * per-row rights, and every signed-in user can already read them.
+ * enforced here. It is a valid session and nothing more: uploads carry no
+ * per-row rights, and any signed-in user can already list them. The
+ * `upload_file` permission gates *writing* an upload, not reading one back.
  */
-export async function handleSubtractionFile(
+export async function handleUploadDownload(
 	request: Request,
-	subtractionId: string,
-	filename: string,
+	uploadId: string,
 ): Promise<Response> {
 	const session = await requireAuthenticatedRequest(request);
 	if (session instanceof Response) {
 		return session;
 	}
 
-	const id = Number(subtractionId);
+	const id = Number(uploadId);
 
 	if (!Number.isInteger(id) || id <= 0) {
-		return textResponse("Invalid subtraction id", 400);
+		return textResponse("Invalid upload id", 400);
 	}
 
-	const key = await getSubtractionFileKey(db, id, filename);
+	const file = await getUploadFile(db, id);
 
-	if (key === null) {
+	if (file === null) {
 		return textResponse("Not found", 404);
 	}
 
-	// `Content-Length` comes from the object rather than the `subtraction_files`
-	// row: the column is nullable and records what the create job wrote, so a
+	// `Content-Length` comes from the object rather than the `uploads.size`
+	// column: the column is nullable and records what the writer reported, so a
 	// stale or null value would truncate the download client-side. Sizing first
 	// also settles existence before any header is committed — a row whose bytes
 	// are missing becomes a 404 rather than a 200 that dies mid-stream.
 	let size: number;
 
 	try {
-		size = await storage.size(key);
+		size = await storage.size(file.key);
 	} catch (err) {
 		if (err instanceof StorageKeyNotFoundError) {
 			return textResponse("Not found", 404);
@@ -56,9 +55,9 @@ export async function handleSubtractionFile(
 		throw err;
 	}
 
-	return new Response(toStream(storage.read(key)), {
+	return new Response(toStream(storage.read(file.key)), {
 		headers: {
-			"content-disposition": contentDisposition(filename),
+			"content-disposition": contentDisposition(file.name),
 			"content-length": String(size),
 			"content-type": "application/octet-stream",
 		},

--- a/apps/web/src/uploads/components/UploadItem.tsx
+++ b/apps/web/src/uploads/components/UploadItem.tsx
@@ -3,9 +3,10 @@ import Attribution from "@base/Attribution";
 import BoxGroupSection from "@base/BoxGroupSection";
 import Checkbox from "@base/Checkbox";
 import IconButton from "@base/IconButton";
+import IconLink from "@base/IconLink";
 import RelativeTime from "@base/RelativeTime";
 import type { UserNested } from "@users/types";
-import { Trash } from "lucide-react";
+import { Download, Trash } from "lucide-react";
 import type { MouseEvent, ReactNode } from "react";
 import { useDeleteFile } from "../queries";
 
@@ -67,6 +68,14 @@ export default function UploadItem({
 						<div>{byteSize(size, true)}</div>
 						<span className="flex items-center gap-1">
 							{action}
+							<IconLink
+								ariaLabel={`Download ${name}`}
+								color="gray"
+								download={name}
+								href={`/uploads/${id}`}
+								IconComponent={Download}
+								tip="download"
+							/>
 							{canDelete && (
 								<IconButton
 									color="red"

--- a/apps/web/src/uploads/components/__tests__/UploadItem.test.tsx
+++ b/apps/web/src/uploads/components/__tests__/UploadItem.test.tsx
@@ -42,6 +42,30 @@ describe("<UploadItem />", () => {
 		expect(screen.getByRole("button", { name: "remove" })).toBeInTheDocument();
 	});
 
+	it("should link to the download route, named after the file", () => {
+		renderWithProviders(<UploadItem {...props} />);
+
+		const link = screen.getByRole("link", { name: `Download ${props.name}` });
+
+		expect(link).toHaveAttribute("href", `/uploads/${props.id}`);
+		expect(link).toHaveAttribute("download", props.name);
+	});
+
+	// Downloading is not gated on the delete permission — every signed-in user
+	// can already list the files.
+	it("should render the download link when [canDelete=false]", () => {
+		props.canDelete = false;
+
+		renderWithProviders(<UploadItem {...props} />);
+
+		expect(
+			screen.getByRole("link", { name: `Download ${props.name}` }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "remove" }),
+		).not.toBeInTheDocument();
+	});
+
 	it("should have [props.onRemove] called when trash icon clicked", async () => {
 		uploadServerFnMocks.deleteUploadFn.mockResolvedValue(null);
 		renderWithProviders(<UploadItem {...props} />);


### PR DESCRIPTION
## Summary
- Add a download link to each item in the uploads list, reachable to any signed-in user rather than gated behind the delete permission.
- Serve `GET /uploads/{uploadId}` as a raw route that streams the file straight out of storage, so multi-GB uploads never buffer in the Node heap.
- Add a reusable `IconLink` base component for icon-styled anchors, alongside `IconButton`, for actions that need a real browser navigation instead of an in-app route.