### PR TITLE
feat: serve index and sample reads downloads from typescript

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -547,6 +547,23 @@ rights. The filename is only ever composed into a storage key *after* it has
 matched a `subtraction_files` row, which is what keeps a URL param from
 traversing out of the prefix.
 
+Index file downloads (`routes/indexes.$indexId.files.$filename.ts` →
+`@server/indexes/download`) are a raw route for the same reason. Their floor is
+`requireAuthenticatedRequest` **and** the caller being able to see the index's
+parent reference (`checkReferenceVisibility`), which is the TypeScript spelling
+of Python's reference `read` right — an index is only as visible as the
+reference it was built from, and without the check every signed-in user could
+read every reference's builds. The filename is matched against a whitelist of
+the names a build produces before it is looked up, and the storage key is
+composed from the `index_files` row's own `name` and the index's `storage_key`
+column, never the row id.
+
+Sample reads downloads (`routes/samples.$sampleId.reads.$filename.ts` →
+`@server/samples/download`) are a raw route for the same reason. Their floor is
+`requireAuthenticatedRequest` then the **read** right on the sample, matching
+the analysis export. The Python endpoint this replaced checked only the session;
+that gap was deliberately not carried over.
+
 The Prometheus scrape endpoint (`routes/metrics.ts` → `@server/metrics/handler`)
 is a raw route for the same reason as the upload: Prometheus speaks plain HTTP,
 not the generated RPC client. It enforces its own floor too — a bearer token

--- a/apps/web/src/indexes/components/IndexFileItem.tsx
+++ b/apps/web/src/indexes/components/IndexFileItem.tsx
@@ -10,7 +10,7 @@ export type IndexFileItemProps = {
 export function IndexFileItem({ downloadUrl, name, size }: IndexFileItemProps) {
 	return (
 		<BoxGroupSection className="flex items-center">
-			<a className="mr-auto font-medium" href={`/api${downloadUrl}`}>
+			<a className="mr-auto font-medium" href={downloadUrl}>
 				{name}
 			</a>
 			<strong>{byteSize(size)}</strong>

--- a/apps/web/src/indexes/components/__tests__/IndexDetail.test.tsx
+++ b/apps/web/src/indexes/components/__tests__/IndexDetail.test.tsx
@@ -35,11 +35,10 @@ describe("<IndexDetail />", () => {
 		expect(screen.getByText("alice")).toBeInTheDocument();
 		expect(screen.getByText("Tobacco mosaic virus")).toBeInTheDocument();
 
-		// Index files are still served by the Python API, so the download URL keeps
-		// the `/api` prefix.
+		// The download URL is the raw route's own path, linked to unmodified.
 		expect(screen.getByText("reference.fa.gz").closest("a")).toHaveAttribute(
 			"href",
-			"/api/indexes/7/files/reference.fa.gz",
+			"/indexes/7/files/reference.fa.gz",
 		);
 	});
 

--- a/apps/web/src/indexes/components/__tests__/IndexFileItem.test.tsx
+++ b/apps/web/src/indexes/components/__tests__/IndexFileItem.test.tsx
@@ -8,7 +8,7 @@ describe("<IndexFileItem />", () => {
 
 	beforeEach(() => {
 		props = {
-			downloadUrl: "/api/subtractions/xl8faqqz/uploads/subtraction.fa.gz",
+			downloadUrl: "/indexes/7/files/reference.fa.gz",
 			name: "foo",
 			size: 36461731,
 		};

--- a/apps/web/src/indexes/components/__tests__/IndexFiles.test.tsx
+++ b/apps/web/src/indexes/components/__tests__/IndexFiles.test.tsx
@@ -32,12 +32,12 @@ describe("<IndexFiles />", () => {
 
 		expect(foo.closest("div")).toHaveTextContent("1.0KB");
 		expect(foo.closest("div")).toHaveTextContent("foo");
-		expect(foo.closest("a")).toHaveAttribute("href", "/api/testUrl/foo");
+		expect(foo.closest("a")).toHaveAttribute("href", "/testUrl/foo");
 
 		const bar = screen.getByText("bar");
 
 		expect(bar.closest("div")).toHaveTextContent("2.0KB");
 		expect(bar.closest("div")).toHaveTextContent("bar");
-		expect(bar.closest("a")).toHaveAttribute("href", "/api/testUrl/bar");
+		expect(bar.closest("a")).toHaveAttribute("href", "/testUrl/bar");
 	});
 });

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -1698,3 +1698,13 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { startInstance } from './start.ts'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
+  }
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -62,6 +62,8 @@ import { Route as AuthenticatedSamplesSampleIdFilesRouteImport } from './routes/
 import { Route as AuthenticatedSamplesSampleIdGeneralRouteImport } from './routes/_authenticated/samples/$sampleId/general'
 import { Route as AuthenticatedSamplesSampleIdQualityRouteImport } from './routes/_authenticated/samples/$sampleId/quality'
 import { Route as AuthenticatedSamplesSampleIdRightsRouteImport } from './routes/_authenticated/samples/$sampleId/rights'
+import { Route as IndexesIndexIdFilesFilenameRouteImport } from './routes/indexes.$indexId.files.$filename'
+import { Route as SamplesSampleIdReadsFilenameRouteImport } from './routes/samples.$sampleId.reads.$filename'
 import { Route as SubtractionsSubtractionIdFilesFilenameRouteImport } from './routes/subtractions.$subtractionId.files.$filename'
 import { Route as AuthenticatedRefsRefIdIndexesIndexRouteImport } from './routes/_authenticated/refs/$refId/indexes/index'
 import { Route as AuthenticatedRefsRefIdIndexesIndexIdRouteImport } from './routes/_authenticated/refs/$refId/indexes/$indexId'
@@ -372,6 +374,18 @@ const AuthenticatedSamplesSampleIdRightsRoute =
     path: '/rights',
     getParentRoute: () => AuthenticatedSamplesSampleIdRoute,
   } as any)
+const IndexesIndexIdFilesFilenameRoute =
+  IndexesIndexIdFilesFilenameRouteImport.update({
+    id: '/indexes/$indexId/files/$filename',
+    path: '/indexes/$indexId/files/$filename',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const SamplesSampleIdReadsFilenameRoute =
+  SamplesSampleIdReadsFilenameRouteImport.update({
+    id: '/samples/$sampleId/reads/$filename',
+    path: '/samples/$sampleId/reads/$filename',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const SubtractionsSubtractionIdFilesFilenameRoute =
   SubtractionsSubtractionIdFilesFilenameRouteImport.update({
     id: '/subtractions/$subtractionId/files/$filename',
@@ -513,6 +527,8 @@ export interface FileRoutesByFullPath {
   '/samples/$sampleId/general': typeof AuthenticatedSamplesSampleIdGeneralRoute
   '/samples/$sampleId/quality': typeof AuthenticatedSamplesSampleIdQualityRoute
   '/samples/$sampleId/rights': typeof AuthenticatedSamplesSampleIdRightsRoute
+  '/indexes/$indexId/files/$filename': typeof IndexesIndexIdFilesFilenameRoute
+  '/samples/$sampleId/reads/$filename': typeof SamplesSampleIdReadsFilenameRoute
   '/subtractions/$subtractionId/files/$filename': typeof SubtractionsSubtractionIdFilesFilenameRoute
   '/administration/users/': typeof AuthenticatedAdministrationUsersIndexRoute
   '/refs/$refId/': typeof AuthenticatedRefsRefIdIndexRoute
@@ -572,6 +588,8 @@ export interface FileRoutesByTo {
   '/samples/$sampleId/general': typeof AuthenticatedSamplesSampleIdGeneralRoute
   '/samples/$sampleId/quality': typeof AuthenticatedSamplesSampleIdQualityRoute
   '/samples/$sampleId/rights': typeof AuthenticatedSamplesSampleIdRightsRoute
+  '/indexes/$indexId/files/$filename': typeof IndexesIndexIdFilesFilenameRoute
+  '/samples/$sampleId/reads/$filename': typeof SamplesSampleIdReadsFilenameRoute
   '/subtractions/$subtractionId/files/$filename': typeof SubtractionsSubtractionIdFilesFilenameRoute
   '/administration/users': typeof AuthenticatedAdministrationUsersIndexRoute
   '/refs/$refId': typeof AuthenticatedRefsRefIdIndexRoute
@@ -641,6 +659,8 @@ export interface FileRoutesById {
   '/_authenticated/samples/$sampleId/general': typeof AuthenticatedSamplesSampleIdGeneralRoute
   '/_authenticated/samples/$sampleId/quality': typeof AuthenticatedSamplesSampleIdQualityRoute
   '/_authenticated/samples/$sampleId/rights': typeof AuthenticatedSamplesSampleIdRightsRoute
+  '/indexes/$indexId/files/$filename': typeof IndexesIndexIdFilesFilenameRoute
+  '/samples/$sampleId/reads/$filename': typeof SamplesSampleIdReadsFilenameRoute
   '/subtractions/$subtractionId/files/$filename': typeof SubtractionsSubtractionIdFilesFilenameRoute
   '/_authenticated/administration/users/': typeof AuthenticatedAdministrationUsersIndexRoute
   '/_authenticated/refs/$refId/': typeof AuthenticatedRefsRefIdIndexRoute
@@ -712,6 +732,8 @@ export interface FileRouteTypes {
     | '/samples/$sampleId/general'
     | '/samples/$sampleId/quality'
     | '/samples/$sampleId/rights'
+    | '/indexes/$indexId/files/$filename'
+    | '/samples/$sampleId/reads/$filename'
     | '/subtractions/$subtractionId/files/$filename'
     | '/administration/users/'
     | '/refs/$refId/'
@@ -771,6 +793,8 @@ export interface FileRouteTypes {
     | '/samples/$sampleId/general'
     | '/samples/$sampleId/quality'
     | '/samples/$sampleId/rights'
+    | '/indexes/$indexId/files/$filename'
+    | '/samples/$sampleId/reads/$filename'
     | '/subtractions/$subtractionId/files/$filename'
     | '/administration/users'
     | '/refs/$refId'
@@ -839,6 +863,8 @@ export interface FileRouteTypes {
     | '/_authenticated/samples/$sampleId/general'
     | '/_authenticated/samples/$sampleId/quality'
     | '/_authenticated/samples/$sampleId/rights'
+    | '/indexes/$indexId/files/$filename'
+    | '/samples/$sampleId/reads/$filename'
     | '/subtractions/$subtractionId/files/$filename'
     | '/_authenticated/administration/users/'
     | '/_authenticated/refs/$refId/'
@@ -872,6 +898,8 @@ export interface RootRouteChildren {
   UploadsUploadIdRoute: typeof UploadsUploadIdRoute
   AnalysesDocumentsDocumentRoute: typeof AnalysesDocumentsDocumentRoute
   OtusOtuIdFastaRoute: typeof OtusOtuIdFastaRoute
+  IndexesIndexIdFilesFilenameRoute: typeof IndexesIndexIdFilesFilenameRoute
+  SamplesSampleIdReadsFilenameRoute: typeof SamplesSampleIdReadsFilenameRoute
   SubtractionsSubtractionIdFilesFilenameRoute: typeof SubtractionsSubtractionIdFilesFilenameRoute
   OtusOtuIdIsolatesIsolateIdFastaRoute: typeof OtusOtuIdIsolatesIsolateIdFastaRoute
   OtusOtuIdIsolatesIsolateIdSequencesSequenceIdFastaRoute: typeof OtusOtuIdIsolatesIsolateIdSequencesSequenceIdFastaRoute
@@ -1249,6 +1277,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/samples/$sampleId/rights'
       preLoaderRoute: typeof AuthenticatedSamplesSampleIdRightsRouteImport
       parentRoute: typeof AuthenticatedSamplesSampleIdRoute
+    }
+    '/indexes/$indexId/files/$filename': {
+      id: '/indexes/$indexId/files/$filename'
+      path: '/indexes/$indexId/files/$filename'
+      fullPath: '/indexes/$indexId/files/$filename'
+      preLoaderRoute: typeof IndexesIndexIdFilesFilenameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/samples/$sampleId/reads/$filename': {
+      id: '/samples/$sampleId/reads/$filename'
+      path: '/samples/$sampleId/reads/$filename'
+      fullPath: '/samples/$sampleId/reads/$filename'
+      preLoaderRoute: typeof SamplesSampleIdReadsFilenameRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/subtractions/$subtractionId/files/$filename': {
       id: '/subtractions/$subtractionId/files/$filename'
@@ -1645,6 +1687,8 @@ const rootRouteChildren: RootRouteChildren = {
   UploadsUploadIdRoute: UploadsUploadIdRoute,
   AnalysesDocumentsDocumentRoute: AnalysesDocumentsDocumentRoute,
   OtusOtuIdFastaRoute: OtusOtuIdFastaRoute,
+  IndexesIndexIdFilesFilenameRoute: IndexesIndexIdFilesFilenameRoute,
+  SamplesSampleIdReadsFilenameRoute: SamplesSampleIdReadsFilenameRoute,
   SubtractionsSubtractionIdFilesFilenameRoute:
     SubtractionsSubtractionIdFilesFilenameRoute,
   OtusOtuIdIsolatesIsolateIdFastaRoute: OtusOtuIdIsolatesIsolateIdFastaRoute,
@@ -1654,13 +1698,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { startInstance } from './start.ts'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>
-  }
-}

--- a/apps/web/src/routes/indexes.$indexId.files.$filename.ts
+++ b/apps/web/src/routes/indexes.$indexId.files.$filename.ts
@@ -1,0 +1,14 @@
+import { handleIndexFile } from "@server/indexes/download";
+import { createFileRoute } from "@tanstack/react-router";
+
+// A raw route, not a server function: the client reaches this with a plain
+// `<a href>`, so the browser has to receive a real response carrying a
+// `Content-Disposition` header, and the bytes stream straight out of storage.
+export const Route = createFileRoute("/indexes/$indexId/files/$filename")({
+	server: {
+		handlers: {
+			GET: ({ request, params }) =>
+				handleIndexFile(request, params.indexId, params.filename),
+		},
+	},
+});

--- a/apps/web/src/routes/samples.$sampleId.reads.$filename.ts
+++ b/apps/web/src/routes/samples.$sampleId.reads.$filename.ts
@@ -1,0 +1,14 @@
+import { handleSampleReads } from "@server/samples/download";
+import { createFileRoute } from "@tanstack/react-router";
+
+// A raw route, not a server function: the client reaches this with a plain
+// `<a href>`, so the browser has to receive a real response carrying a
+// `Content-Disposition` header, and the bytes stream straight out of storage.
+export const Route = createFileRoute("/samples/$sampleId/reads/$filename")({
+	server: {
+		handlers: {
+			GET: ({ request, params }) =>
+				handleSampleReads(request, params.sampleId, params.filename),
+		},
+	},
+});

--- a/apps/web/src/samples/components/Files/ReadItem.tsx
+++ b/apps/web/src/samples/components/Files/ReadItem.tsx
@@ -32,7 +32,7 @@ export default function ReadItem({
 		<BoxGroupSection className="flex items-start font-medium justify-between">
 			<div className="flex items-center">
 				<div>
-					<a href={`/api/${downloadUrl}`} download={downloadName}>
+					<a href={downloadUrl} download={downloadName}>
 						{downloadName}
 					</a>
 				</div>

--- a/apps/web/src/server/http.ts
+++ b/apps/web/src/server/http.ts
@@ -2,6 +2,9 @@
 // themselves rather than returning a value through the server-function RPC
 // layer, because the browser has to see real headers.
 
+import { StorageKeyNotFoundError } from "./storage/errors";
+import type { StorageBackend } from "./storage/types";
+
 /**
  * A plain-text response, for the statuses a raw route answers with directly.
  *
@@ -73,6 +76,47 @@ export function toStream(
 			// A client that aborts the download mid-stream leaves the backend's
 			// request open otherwise.
 			await iterator.return?.(reason);
+		},
+	});
+}
+
+/**
+ * Stream the object at `key` as a download named `filename`, or a 404 when it
+ * has no bytes in storage.
+ *
+ * Every file download ends this way, so the rule that makes it correct lives
+ * here rather than in each handler: `Content-Length` comes from the object and
+ * never from the row's size column, which is nullable everywhere and records
+ * only what the writing job reported — a stale or null value would truncate the
+ * download client-side. Sizing first also settles existence before any header
+ * is committed, so a row whose bytes are missing becomes a 404 rather than a
+ * 200 that dies mid-stream.
+ *
+ * The backend is passed in the way `db` is, so this stays testable against
+ * `MemoryStorage` without reaching for the process-wide singleton.
+ */
+export async function streamStorageObject(
+	storage: StorageBackend,
+	key: string,
+	filename: string,
+	contentType: string,
+): Promise<Response> {
+	let size: number;
+
+	try {
+		size = await storage.size(key);
+	} catch (err) {
+		if (err instanceof StorageKeyNotFoundError) {
+			return textResponse("Not found", 404);
+		}
+		throw err;
+	}
+
+	return new Response(toStream(storage.read(key)), {
+		headers: {
+			"content-disposition": contentDisposition(filename),
+			"content-length": String(size),
+			"content-type": contentType,
 		},
 	});
 }

--- a/apps/web/src/server/indexes/data.ts
+++ b/apps/web/src/server/indexes/data.ts
@@ -39,6 +39,7 @@ import {
 	ReferenceArchivedError,
 	ReferenceNotFoundError,
 } from "../references/data";
+import { indexFileKey } from "../storage/keys";
 import { createTask } from "../tasks/data";
 
 /** Thrown when a requested index does not exist. */
@@ -343,8 +344,9 @@ async function getIndexOtus(db: DbOrTx, indexId: number): Promise<IndexOtu[]> {
 	return rows.sort((a, b) => a.name.localeCompare(b.name));
 }
 
-// The files a finished build produced. They are still served by the Python API,
-// so the download URL is the path its route answers on, relative to the API root.
+// The files a finished build produced. The download URL is the path the raw
+// route in `./download` answers on, so it is site-relative and the client links
+// to it unmodified.
 async function getIndexFiles(
 	db: DbOrTx,
 	indexId: number,
@@ -390,6 +392,70 @@ export async function getIndex(db: Db, indexId: number): Promise<Index> {
 		manifest: row.manifest,
 		otus,
 	};
+}
+
+// The files a finished build produces, and so the only names the download route
+// will serve. Mirrors Python's `INDEX_FILE_NAMES`; a build's other artifacts
+// stay unreachable even once a row exists for them.
+const INDEX_FILE_NAMES = new Set([
+	"reference.fa.gz",
+	"reference.json.gz",
+	"reference.1.bt2",
+	"reference.2.bt2",
+	"reference.3.bt2",
+	"reference.4.bt2",
+	"reference.rev.1.bt2",
+	"reference.rev.2.bt2",
+	"reference-v2.json.gz",
+]);
+
+/**
+ * The reference a build belongs to, or `null` when the build does not exist.
+ *
+ * The download route resolves it to decide who may read the build's files: an
+ * index is only as visible as the reference it was built from.
+ */
+export async function getIndexReferenceId(
+	db: DbOrTx,
+	indexId: number,
+): Promise<number | null> {
+	const [row] = await db
+		.select({ referenceId: indexes.reference_id })
+		.from(indexes)
+		.where(eq(indexes.id, indexId))
+		.limit(1);
+
+	return row?.referenceId ?? null;
+}
+
+/**
+ * The storage key of one of a build's files, or `null` when the build has no
+ * such file.
+ *
+ * The key is composed from the row's own `name`, never the caller's, so a
+ * filename carrying path segments cannot traverse out of the index's prefix.
+ */
+export async function getIndexFileKey(
+	db: DbOrTx,
+	indexId: number,
+	filename: string,
+): Promise<string | null> {
+	if (!INDEX_FILE_NAMES.has(filename)) {
+		return null;
+	}
+
+	const [row] = await db
+		.select({ name: indexFiles.name, storageKey: indexes.storage_key })
+		.from(indexFiles)
+		.innerJoin(indexes, eq(indexes.id, indexFiles.index_id))
+		.where(and(eq(indexFiles.index_id, indexId), eq(indexFiles.name, filename)))
+		.limit(1);
+
+	if (!row) {
+		return null;
+	}
+
+	return indexFileKey(row.storageKey, row.name);
 }
 
 // Whether the reference has a build that has not finished.

--- a/apps/web/src/server/indexes/download.test.ts
+++ b/apps/web/src/server/indexes/download.test.ts
@@ -1,0 +1,344 @@
+import { eq } from "drizzle-orm";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+
+import type { Db } from "../db/pg";
+import { takeFirstOrThrow } from "../db/rows";
+import { apiKeys } from "../db/schema/apiKeys";
+import { groups, userGroups } from "../db/schema/groups";
+import { legacyHistory } from "../db/schema/history";
+import { indexes, indexFiles } from "../db/schema/indexes";
+import { legacyOtus } from "../db/schema/otus";
+import {
+	legacyReferenceGroups,
+	legacyReferences,
+	legacyReferenceUsers,
+} from "../db/schema/references";
+import { sessions } from "../db/schema/sessions";
+import { tasks } from "../db/schema/tasks";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { MemoryStorage } from "../storage/memory";
+
+vi.mock("@tanstack/react-start/server", () => ({
+	deleteCookie: vi.fn(),
+	getCookie: vi.fn(),
+	getRequest: vi.fn(),
+	setCookie: vi.fn(),
+	setResponseStatus: vi.fn(),
+}));
+
+vi.mock("@sentry/tanstackstart-react", () => ({
+	captureException: vi.fn(),
+	setUser: vi.fn(),
+}));
+
+let db: Db;
+vi.mock("../db/pg", () => ({
+	client: {},
+	get db() {
+		return db;
+	},
+}));
+
+const storage = new MemoryStorage();
+vi.mock("../storage", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../storage")>()),
+	storage,
+}));
+
+const { handleIndexFile } = await import("./download");
+const { basicAuthHeader, seedApiKey, seedSession, seedUser, sessionCookie } =
+	await import("../auth/test/fixtures");
+const { seedIndex, seedReference } = await import("./test/fixtures");
+
+let database: TestDatabase;
+let ownerId: number;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	await db.delete(indexFiles);
+	await db.delete(legacyHistory);
+	await db.delete(legacyOtus);
+	await db.delete(indexes);
+	await db.delete(legacyReferenceUsers);
+	await db.delete(legacyReferenceGroups);
+	await db.delete(legacyReferences);
+	await db.delete(tasks);
+	await db.delete(apiKeys);
+	await db.delete(sessions);
+	await db.delete(userGroups);
+	await db.delete(groups);
+	await db.delete(users);
+
+	ownerId = await seedUser(db, { handle: "alice" });
+});
+
+async function seedFile(
+	indexId: number,
+	name = "reference.fa.gz",
+): Promise<void> {
+	await db.insert(indexFiles).values({
+		name,
+		index_id: indexId,
+		size: 5,
+		type: "fasta",
+	});
+}
+
+// `storage_key` is minted by the seeder and cannot be derived from the row id,
+// so the key a test writes under has to be read back.
+async function storageKey(indexId: number): Promise<string> {
+	return takeFirstOrThrow(
+		await db
+			.select({ storageKey: indexes.storage_key })
+			.from(indexes)
+			.where(eq(indexes.id, indexId)),
+	).storageKey;
+}
+
+async function write(key: string, contents: string): Promise<void> {
+	await storage.write(
+		key,
+		(async function* () {
+			yield new TextEncoder().encode(contents);
+		})(),
+	);
+}
+
+/** Build a `GET /indexes/{id}/files/{filename}` request for a user. */
+async function request(userId: number | null): Promise<Request> {
+	const headers: Record<string, string> = {};
+
+	if (userId !== null) {
+		const { sessionId, token } = await seedSession(db, userId);
+		headers.cookie = sessionCookie({ sessionId, token });
+	}
+
+	return new Request("https://virtool.test/indexes/1/files/x", { headers });
+}
+
+/** Seed a reference owned by `ownerId` with one finished build and its file. */
+async function seedBuild(): Promise<{ referenceId: number; indexId: number }> {
+	const referenceId = await seedReference(db, ownerId);
+	const indexId = await seedIndex(db, {
+		referenceId,
+		userId: ownerId,
+		version: 0,
+	});
+
+	await seedFile(indexId);
+	await write(`indexes/${await storageKey(indexId)}/reference.fa.gz`, "hello");
+
+	return { referenceId, indexId };
+}
+
+describe("handleIndexFile", () => {
+	it("streams a build's file from its storage-key prefix", async () => {
+		const { indexId } = await seedBuild();
+
+		const response = await handleIndexFile(
+			await request(ownerId),
+			String(indexId),
+			"reference.fa.gz",
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-disposition")).toBe(
+			'attachment; filename="reference.fa.gz"',
+		);
+		expect(response.headers.get("content-length")).toBe("5");
+		expect(response.headers.get("content-type")).toBe(
+			"application/octet-stream",
+		);
+		expect(await response.text()).toBe("hello");
+	});
+
+	// `index_files.size` records what the build task wrote and is nullable, so the
+	// header has to come from the object or the client truncates.
+	it("sizes the response from storage, not the row", async () => {
+		const { indexId } = await seedBuild();
+		await db
+			.update(indexFiles)
+			.set({ size: null })
+			.where(eq(indexFiles.index_id, indexId));
+		await write(
+			`indexes/${await storageKey(indexId)}/reference.fa.gz`,
+			"considerably longer than five bytes",
+		);
+
+		const response = await handleIndexFile(
+			await request(ownerId),
+			String(indexId),
+			"reference.fa.gz",
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-length")).toBe("35");
+		expect(await response.text()).toBe("considerably longer than five bytes");
+	});
+
+	it("rejects an anonymous caller with a 401", async () => {
+		const { indexId } = await seedBuild();
+
+		const response = await handleIndexFile(
+			await request(null),
+			String(indexId),
+			"reference.fa.gz",
+		);
+
+		expect(response.status).toBe(401);
+	});
+
+	it("accepts an api key", async () => {
+		const key = await seedApiKey(db, ownerId, {});
+		const { indexId } = await seedBuild();
+
+		const response = await handleIndexFile(
+			new Request("https://virtool.test/indexes/1/files/x", {
+				headers: { authorization: basicAuthHeader("alice", key) },
+			}),
+			String(indexId),
+			"reference.fa.gz",
+		);
+
+		expect(response.status).toBe(200);
+	});
+
+	// An index is only as visible as the reference it was built from. Dropping
+	// this check would expose every reference's builds to any signed-in user.
+	it("rejects a user who cannot see the reference with a 403", async () => {
+		const { indexId } = await seedBuild();
+		const strangerId = await seedUser(db, { handle: "bob" });
+
+		const response = await handleIndexFile(
+			await request(strangerId),
+			String(indexId),
+			"reference.fa.gz",
+		);
+
+		expect(response.status).toBe(403);
+	});
+
+	it("serves a user holding a membership row on the reference", async () => {
+		const { referenceId, indexId } = await seedBuild();
+		const memberId = await seedUser(db, { handle: "bob" });
+
+		// Membership alone grants read; none of the rights flags is set.
+		await db.insert(legacyReferenceUsers).values({
+			reference_id: referenceId,
+			user_id: memberId,
+			build: false,
+			modify: false,
+			modify_otu: false,
+		});
+
+		const response = await handleIndexFile(
+			await request(memberId),
+			String(indexId),
+			"reference.fa.gz",
+		);
+
+		expect(response.status).toBe(200);
+	});
+
+	it("serves a full administrator who is not a member", async () => {
+		const { indexId } = await seedBuild();
+		const adminId = await seedUser(db, {
+			handle: "bob",
+			administratorRole: "full",
+		});
+
+		const response = await handleIndexFile(
+			await request(adminId),
+			String(indexId),
+			"reference.fa.gz",
+		);
+
+		expect(response.status).toBe(200);
+	});
+
+	it("returns a 400 for a non-numeric index id", async () => {
+		const response = await handleIndexFile(
+			await request(ownerId),
+			"not-a-number",
+			"reference.fa.gz",
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns a 404 when the index does not exist", async () => {
+		const response = await handleIndexFile(
+			await request(ownerId),
+			"404404",
+			"reference.fa.gz",
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	// The name whitelist keeps a build's other artifacts unreachable even once a
+	// row exists for them.
+	it("returns a 404 for a file the whitelist does not name", async () => {
+		const { indexId } = await seedBuild();
+		await seedFile(indexId, "secret.txt");
+		await write(`indexes/${await storageKey(indexId)}/secret.txt`, "hello");
+
+		const response = await handleIndexFile(
+			await request(ownerId),
+			String(indexId),
+			"secret.txt",
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	// The filename only ever reaches a key after it has matched a registered
+	// file, so it cannot escape the index's prefix.
+	it("returns a 404 for a filename the index has no row for", async () => {
+		const { indexId } = await seedBuild();
+
+		const response = await handleIndexFile(
+			await request(ownerId),
+			String(indexId),
+			"../../etc/passwd",
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	it("returns a 404 when the row exists but its bytes do not", async () => {
+		const referenceId = await seedReference(db, ownerId);
+		const indexId = await seedIndex(db, {
+			referenceId,
+			userId: ownerId,
+			version: 0,
+		});
+		await seedFile(indexId);
+
+		const response = await handleIndexFile(
+			await request(ownerId),
+			String(indexId),
+			"reference.fa.gz",
+		);
+
+		expect(response.status).toBe(404);
+	});
+});

--- a/apps/web/src/server/indexes/download.ts
+++ b/apps/web/src/server/indexes/download.ts
@@ -1,0 +1,84 @@
+import { requireAuthenticatedRequest } from "../auth/middleware";
+import { db } from "../db/pg";
+import { contentDisposition, textResponse, toStream } from "../http";
+import {
+	checkReferenceVisibility,
+	resolveReferenceActor,
+} from "../references/data";
+import { StorageKeyNotFoundError, storage } from "../storage";
+import { getIndexFileKey, getIndexReferenceId } from "./data";
+
+/**
+ * Serve one of a build's artifacts, backing
+ * `GET /indexes/{indexId}/files/{filename}`.
+ *
+ * This is a raw route rather than a server function because the client reaches
+ * it with a plain `<a href>` — the browser has to see a real response with a
+ * `Content-Disposition`, which an RPC call cannot produce. The bytes are
+ * streamed straight out of storage, so a multi-GB Bowtie2 index never sits in
+ * the Node heap.
+ *
+ * Being a route means no policy middleware runs, so the authorization floor is
+ * enforced here, and it is more than a valid session: an index is only as
+ * visible as the reference it was built from, so the caller must be able to see
+ * that reference. Without this any signed-in user could read every reference's
+ * builds.
+ */
+export async function handleIndexFile(
+	request: Request,
+	indexId: string,
+	filename: string,
+): Promise<Response> {
+	const session = await requireAuthenticatedRequest(request);
+	if (session instanceof Response) {
+		return session;
+	}
+
+	const id = Number(indexId);
+
+	if (!Number.isInteger(id) || id <= 0) {
+		return textResponse("Invalid index id", 400);
+	}
+
+	const referenceId = await getIndexReferenceId(db, id);
+
+	if (referenceId === null) {
+		return textResponse("Not found", 404);
+	}
+
+	const actor = await resolveReferenceActor(db, session.userId);
+
+	if (!(await checkReferenceVisibility(db, referenceId, actor))) {
+		return textResponse("Forbidden", 403);
+	}
+
+	const key = await getIndexFileKey(db, id, filename);
+
+	if (key === null) {
+		return textResponse("Not found", 404);
+	}
+
+	// `Content-Length` comes from the object rather than the `index_files` row:
+	// the column is nullable and records what the build task wrote, so a stale or
+	// null value would truncate the download client-side. Sizing first also
+	// settles existence before any header is committed — a row whose bytes are
+	// missing becomes a 404 rather than a 200 that dies mid-stream.
+	let size: number;
+
+	try {
+		size = await storage.size(key);
+	} catch (err) {
+		if (err instanceof StorageKeyNotFoundError) {
+			return textResponse("Not found", 404);
+		}
+		throw err;
+	}
+
+	return new Response(toStream(storage.read(key)), {
+		headers: {
+			"content-disposition": contentDisposition(filename),
+			"content-length": String(size),
+			"content-type": "application/octet-stream",
+		},
+	});
+}

--- a/apps/web/src/server/indexes/download.ts
+++ b/apps/web/src/server/indexes/download.ts
@@ -1,11 +1,11 @@
 import { requireAuthenticatedRequest } from "../auth/middleware";
 import { db } from "../db/pg";
-import { contentDisposition, textResponse, toStream } from "../http";
+import { streamStorageObject, textResponse } from "../http";
 import {
 	checkReferenceVisibility,
 	resolveReferenceActor,
 } from "../references/data";
-import { StorageKeyNotFoundError, storage } from "../storage";
+import { storage } from "../storage";
 import { getIndexFileKey, getIndexReferenceId } from "./data";
 
 /**
@@ -58,27 +58,10 @@ export async function handleIndexFile(
 		return textResponse("Not found", 404);
 	}
 
-	// `Content-Length` comes from the object rather than the `index_files` row:
-	// the column is nullable and records what the build task wrote, so a stale or
-	// null value would truncate the download client-side. Sizing first also
-	// settles existence before any header is committed — a row whose bytes are
-	// missing becomes a 404 rather than a 200 that dies mid-stream.
-	let size: number;
-
-	try {
-		size = await storage.size(key);
-	} catch (err) {
-		if (err instanceof StorageKeyNotFoundError) {
-			return textResponse("Not found", 404);
-		}
-		throw err;
-	}
-
-	return new Response(toStream(storage.read(key)), {
-		headers: {
-			"content-disposition": contentDisposition(filename),
-			"content-length": String(size),
-			"content-type": "application/octet-stream",
-		},
-	});
+	return streamStorageObject(
+		storage,
+		key,
+		filename,
+		"application/octet-stream",
+	);
 }

--- a/apps/web/src/server/samples/data.ts
+++ b/apps/web/src/server/samples/data.ts
@@ -791,8 +791,13 @@ export async function checkSampleRight(
  * The storage key of one of a sample's read files, or `null` when the sample
  * has no read by that name.
  *
- * The key is composed from the reads row's own `sample` and `name` columns and
- * never the caller's filename, so a filename carrying path segments cannot
+ * The row is matched on `name`, which is what the URL carries, but the key is
+ * composed from `name_on_disk`, which is what the object was written under.
+ * `upload_reads` sets the two from the same argument, so they agree on every
+ * row today; keying on the column that means "the name on disk" is what keeps
+ * that an implementation detail rather than a load-bearing assumption.
+ *
+ * Neither comes from the caller, so a filename carrying path segments cannot
  * traverse out of the sample's prefix. `sample` is the prefix the file was
  * written under, which for a Mongo-migrated sample is its legacy id rather than
  * its integer one.
@@ -815,7 +820,10 @@ export async function getSampleReadsFileKey(
 	const storageId = sampleStorageId(sampleId, sample.legacy_id);
 
 	const [read] = await db
-		.select({ name: sampleReads.name, sample: sampleReads.sample })
+		.select({
+			nameOnDisk: sampleReads.name_on_disk,
+			sample: sampleReads.sample,
+		})
 		.from(sampleReads)
 		.where(
 			and(
@@ -832,7 +840,7 @@ export async function getSampleReadsFileKey(
 		return null;
 	}
 
-	return sampleFileKey(read.sample, read.name);
+	return sampleFileKey(read.sample, read.nameOnDisk);
 }
 
 async function checkNameInUse(

--- a/apps/web/src/server/samples/data.ts
+++ b/apps/web/src/server/samples/data.ts
@@ -56,6 +56,7 @@ import { getSettings } from "../settings/data";
 import {
 	deletePrefix,
 	type StorageBackend,
+	sampleFileKey,
 	samplePrefix,
 	sampleStorageId,
 } from "../storage";
@@ -330,6 +331,8 @@ async function getReads(
 		)
 		.orderBy(asc(sampleReads.id));
 
+	// The download URL is the path the raw route in `./download` answers on, so
+	// it is site-relative and the client links to it unmodified.
 	return rows.map(({ read, upload, uploadUser }) => ({
 		downloadUrl: `/samples/${sampleId}/reads/${read.name}`,
 		id: read.id,
@@ -782,6 +785,54 @@ export async function checkSampleRight(
 	}
 
 	return hasSampleRight(row, actor, right);
+}
+
+/**
+ * The storage key of one of a sample's read files, or `null` when the sample
+ * has no read by that name.
+ *
+ * The key is composed from the reads row's own `sample` and `name` columns and
+ * never the caller's filename, so a filename carrying path segments cannot
+ * traverse out of the sample's prefix. `sample` is the prefix the file was
+ * written under, which for a Mongo-migrated sample is its legacy id rather than
+ * its integer one.
+ */
+export async function getSampleReadsFileKey(
+	db: DbOrTx,
+	sampleId: number,
+	filename: string,
+): Promise<string | null> {
+	const [sample] = await db
+		.select({ legacy_id: legacySamples.legacy_id })
+		.from(legacySamples)
+		.where(eq(legacySamples.id, sampleId))
+		.limit(1);
+
+	if (!sample) {
+		return null;
+	}
+
+	const storageId = sampleStorageId(sampleId, sample.legacy_id);
+
+	const [read] = await db
+		.select({ name: sampleReads.name, sample: sampleReads.sample })
+		.from(sampleReads)
+		.where(
+			and(
+				or(
+					eq(sampleReads.sample_id, sampleId),
+					eq(sampleReads.sample, storageId),
+				),
+				eq(sampleReads.name, filename),
+			),
+		)
+		.limit(1);
+
+	if (!read) {
+		return null;
+	}
+
+	return sampleFileKey(read.sample, read.name);
 }
 
 async function checkNameInUse(

--- a/apps/web/src/server/samples/download.test.ts
+++ b/apps/web/src/server/samples/download.test.ts
@@ -109,11 +109,15 @@ async function seedSample(
 // is the legacy id for a migrated sample and the integer id otherwise.
 async function seedRead(
 	sampleId: number,
-	{ name = "reads_1.fq.gz", sample = String(sampleId) } = {},
+	{
+		name = "reads_1.fq.gz",
+		nameOnDisk = name,
+		sample = String(sampleId),
+	}: { name?: string; nameOnDisk?: string; sample?: string } = {},
 ): Promise<void> {
 	await db.insert(sampleReads).values({
 		name,
-		name_on_disk: name,
+		name_on_disk: nameOnDisk,
 		sample,
 		sample_id: sampleId,
 		size: 5,
@@ -177,6 +181,29 @@ describe("handleSampleReads", () => {
 
 		expect(response.status).toBe(200);
 		expect(await response.text()).toBe("hello");
+	});
+
+	// `upload_reads` sets `name` and `name_on_disk` from the same argument, so
+	// the two agree on every row today. The URL still carries `name`, so the
+	// match and the key have to come from different columns for that to stay an
+	// implementation detail rather than something the route depends on.
+	it("matches on name but keys the object on name_on_disk", async () => {
+		const sampleId = await seedSample();
+		await seedRead(sampleId, { nameOnDisk: "stored_1.fq.gz" });
+		await write(`samples/${sampleId}/stored_1.fq.gz`, "hello");
+
+		const response = await handleSampleReads(
+			await request(ownerId),
+			String(sampleId),
+			"reads_1.fq.gz",
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("hello");
+		// The download is still named for the public name, not the stored one.
+		expect(response.headers.get("content-disposition")).toBe(
+			'attachment; filename="reads_1.fq.gz"',
+		);
 	});
 
 	// `sample_reads.size` records what the create job wrote and is nullable, so

--- a/apps/web/src/server/samples/download.test.ts
+++ b/apps/web/src/server/samples/download.test.ts
@@ -1,0 +1,317 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+
+import type { Db } from "../db/pg";
+import { takeFirstOrThrow } from "../db/rows";
+import { analyses } from "../db/schema/analyses";
+import { apiKeys } from "../db/schema/apiKeys";
+import { groups, userGroups } from "../db/schema/groups";
+import {
+	legacySampleLabels,
+	legacySampleSubtractions,
+	legacySamples,
+	sampleArtifacts,
+	sampleReads,
+	sampleUploads,
+} from "../db/schema/samples";
+import { sessions } from "../db/schema/sessions";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { MemoryStorage } from "../storage/memory";
+
+vi.mock("@tanstack/react-start/server", () => ({
+	deleteCookie: vi.fn(),
+	getCookie: vi.fn(),
+	getRequest: vi.fn(),
+	setCookie: vi.fn(),
+	setResponseStatus: vi.fn(),
+}));
+
+vi.mock("@sentry/tanstackstart-react", () => ({
+	captureException: vi.fn(),
+	setUser: vi.fn(),
+}));
+
+let db: Db;
+vi.mock("../db/pg", () => ({
+	client: {},
+	get db() {
+		return db;
+	},
+}));
+
+const storage = new MemoryStorage();
+vi.mock("../storage", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../storage")>()),
+	storage,
+}));
+
+const { handleSampleReads } = await import("./download");
+const { basicAuthHeader, seedApiKey, seedSession, seedUser, sessionCookie } =
+	await import("../auth/test/fixtures");
+const { addToGroup, seedGroup } = await import("../groups/test/fixtures");
+
+let database: TestDatabase;
+let ownerId: number;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	await db.delete(analyses);
+	await db.delete(legacySampleLabels);
+	await db.delete(legacySampleSubtractions);
+	await db.delete(sampleUploads);
+	await db.delete(sampleArtifacts);
+	await db.delete(sampleReads);
+	await db.delete(legacySamples);
+	await db.delete(apiKeys);
+	await db.delete(sessions);
+	await db.delete(userGroups);
+	await db.delete(groups);
+	await db.delete(users);
+
+	ownerId = await seedUser(db, { handle: "alice" });
+});
+
+async function seedSample(
+	overrides: Partial<typeof legacySamples.$inferInsert> = {},
+): Promise<number> {
+	return takeFirstOrThrow(
+		await db
+			.insert(legacySamples)
+			.values({
+				name: "Sample",
+				library_type: "normal",
+				created_at: new Date(),
+				user_id: ownerId,
+				...overrides,
+			})
+			.returning({ id: legacySamples.id }),
+	).id;
+}
+
+// `sample_reads.sample` is the storage prefix the file was written under, which
+// is the legacy id for a migrated sample and the integer id otherwise.
+async function seedRead(
+	sampleId: number,
+	{ name = "reads_1.fq.gz", sample = String(sampleId) } = {},
+): Promise<void> {
+	await db.insert(sampleReads).values({
+		name,
+		name_on_disk: name,
+		sample,
+		sample_id: sampleId,
+		size: 5,
+	});
+}
+
+async function write(key: string, contents: string): Promise<void> {
+	await storage.write(
+		key,
+		(async function* () {
+			yield new TextEncoder().encode(contents);
+		})(),
+	);
+}
+
+/** Build a `GET /samples/{id}/reads/{filename}` request for a user. */
+async function request(userId: number | null): Promise<Request> {
+	const headers: Record<string, string> = {};
+
+	if (userId !== null) {
+		const { sessionId, token } = await seedSession(db, userId);
+		headers.cookie = sessionCookie({ sessionId, token });
+	}
+
+	return new Request("https://virtool.test/samples/1/reads/x", { headers });
+}
+
+describe("handleSampleReads", () => {
+	it("streams a Postgres-native sample's read from its integer prefix", async () => {
+		const sampleId = await seedSample();
+		await seedRead(sampleId);
+		await write(`samples/${sampleId}/reads_1.fq.gz`, "hello");
+
+		const response = await handleSampleReads(
+			await request(ownerId),
+			String(sampleId),
+			"reads_1.fq.gz",
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-disposition")).toBe(
+			'attachment; filename="reads_1.fq.gz"',
+		);
+		expect(response.headers.get("content-length")).toBe("5");
+		expect(response.headers.get("content-type")).toBe("application/gzip");
+		expect(await response.text()).toBe("hello");
+	});
+
+	// A sample migrated out of Mongo keeps its legacy id as the storage prefix,
+	// even though it is addressed by its integer id.
+	it("reads a migrated sample's read from its legacy prefix", async () => {
+		const sampleId = await seedSample({ legacy_id: "abc123" });
+		await seedRead(sampleId, { sample: "abc123" });
+		await write("samples/abc123/reads_1.fq.gz", "hello");
+
+		const response = await handleSampleReads(
+			await request(ownerId),
+			String(sampleId),
+			"reads_1.fq.gz",
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("hello");
+	});
+
+	// `sample_reads.size` records what the create job wrote and is nullable, so
+	// the header has to come from the object or the client truncates.
+	it("sizes the response from storage, not the row", async () => {
+		const sampleId = await seedSample();
+		await seedRead(sampleId);
+		await db.update(sampleReads).set({ size: null });
+		await write(
+			`samples/${sampleId}/reads_1.fq.gz`,
+			"considerably longer than five bytes",
+		);
+
+		const response = await handleSampleReads(
+			await request(ownerId),
+			String(sampleId),
+			"reads_1.fq.gz",
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-length")).toBe("35");
+		expect(await response.text()).toBe("considerably longer than five bytes");
+	});
+
+	it("rejects an anonymous caller with a 401", async () => {
+		const sampleId = await seedSample();
+		await seedRead(sampleId);
+
+		const response = await handleSampleReads(
+			await request(null),
+			String(sampleId),
+			"reads_1.fq.gz",
+		);
+
+		expect(response.status).toBe(401);
+	});
+
+	it("accepts an api key", async () => {
+		const key = await seedApiKey(db, ownerId, {});
+		const sampleId = await seedSample();
+		await seedRead(sampleId);
+		await write(`samples/${sampleId}/reads_1.fq.gz`, "hello");
+
+		const response = await handleSampleReads(
+			new Request("https://virtool.test/samples/1/reads/x", {
+				headers: { authorization: basicAuthHeader("alice", key) },
+			}),
+			String(sampleId),
+			"reads_1.fq.gz",
+		);
+
+		expect(response.status).toBe(200);
+	});
+
+	// The Python endpoint this replaces checked only the session, which let any
+	// signed-in caller download the reads of a sample they could not see.
+	it("rejects a user without the read right with a 403", async () => {
+		const sampleId = await seedSample();
+		await seedRead(sampleId);
+		await write(`samples/${sampleId}/reads_1.fq.gz`, "hello");
+
+		const strangerId = await seedUser(db, { handle: "bob" });
+
+		const response = await handleSampleReads(
+			await request(strangerId),
+			String(sampleId),
+			"reads_1.fq.gz",
+		);
+
+		expect(response.status).toBe(403);
+	});
+
+	it("serves a member of the sample's group when it grants group read", async () => {
+		const groupId = await seedGroup(db, { name: "lab" });
+		const sampleId = await seedSample({ group_id: groupId, group_read: true });
+		await seedRead(sampleId);
+		await write(`samples/${sampleId}/reads_1.fq.gz`, "hello");
+
+		const memberId = await seedUser(db, { handle: "bob" });
+		await addToGroup(db, memberId, groupId);
+
+		const response = await handleSampleReads(
+			await request(memberId),
+			String(sampleId),
+			"reads_1.fq.gz",
+		);
+
+		expect(response.status).toBe(200);
+	});
+
+	it("returns a 400 for a non-numeric sample id", async () => {
+		const response = await handleSampleReads(
+			await request(ownerId),
+			"not-a-number",
+			"reads_1.fq.gz",
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns a 404 when the sample does not exist", async () => {
+		const response = await handleSampleReads(
+			await request(ownerId),
+			"404404",
+			"reads_1.fq.gz",
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	// The filename only ever reaches a key after it has matched a registered
+	// read, so it cannot escape the sample's prefix.
+	it("returns a 404 for a filename the sample has no row for", async () => {
+		const sampleId = await seedSample();
+		await seedRead(sampleId);
+
+		const response = await handleSampleReads(
+			await request(ownerId),
+			String(sampleId),
+			"../../etc/passwd",
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	it("returns a 404 when the row exists but its bytes do not", async () => {
+		const sampleId = await seedSample();
+		await seedRead(sampleId);
+
+		const response = await handleSampleReads(
+			await request(ownerId),
+			String(sampleId),
+			"reads_1.fq.gz",
+		);
+
+		expect(response.status).toBe(404);
+	});
+});

--- a/apps/web/src/server/samples/download.ts
+++ b/apps/web/src/server/samples/download.ts
@@ -1,0 +1,78 @@
+import { requireAuthenticatedRequest } from "../auth/middleware";
+import { db } from "../db/pg";
+import { contentDisposition, textResponse, toStream } from "../http";
+import { StorageKeyNotFoundError, storage } from "../storage";
+import {
+	checkSampleRight,
+	getSampleReadsFileKey,
+	resolveSampleActor,
+} from "./data";
+
+/**
+ * Serve one of a sample's read files, backing
+ * `GET /samples/{sampleId}/reads/{filename}`.
+ *
+ * This is a raw route rather than a server function because the client reaches
+ * it with a plain `<a href>` — the browser has to see a real response with a
+ * `Content-Disposition`, which an RPC call cannot produce. The bytes are
+ * streamed straight out of storage, so a multi-GB read file never sits in the
+ * Node heap.
+ *
+ * Being a route means no policy middleware runs, so the authorization floor is
+ * enforced here: a valid session, then the read right on the sample. The Python
+ * endpoint this replaces checked only the session, which let any signed-in
+ * caller download a sample's reads whether or not they could see the sample
+ * itself.
+ */
+export async function handleSampleReads(
+	request: Request,
+	sampleId: string,
+	filename: string,
+): Promise<Response> {
+	const session = await requireAuthenticatedRequest(request);
+	if (session instanceof Response) {
+		return session;
+	}
+
+	const id = Number(sampleId);
+
+	if (!Number.isInteger(id) || id <= 0) {
+		return textResponse("Invalid sample id", 400);
+	}
+
+	const actor = await resolveSampleActor(db, session.userId);
+
+	if (!(await checkSampleRight(db, id, actor, "read"))) {
+		return textResponse("Forbidden", 403);
+	}
+
+	const key = await getSampleReadsFileKey(db, id, filename);
+
+	if (key === null) {
+		return textResponse("Not found", 404);
+	}
+
+	// `Content-Length` comes from the object rather than the `sample_reads` row:
+	// the column is nullable and records what the create job wrote, so a stale or
+	// null value would truncate the download client-side. Sizing first also
+	// settles existence before any header is committed — a row whose bytes are
+	// missing becomes a 404 rather than a 200 that dies mid-stream.
+	let size: number;
+
+	try {
+		size = await storage.size(key);
+	} catch (err) {
+		if (err instanceof StorageKeyNotFoundError) {
+			return textResponse("Not found", 404);
+		}
+		throw err;
+	}
+
+	return new Response(toStream(storage.read(key)), {
+		headers: {
+			"content-disposition": contentDisposition(filename),
+			"content-length": String(size),
+			"content-type": "application/gzip",
+		},
+	});
+}

--- a/apps/web/src/server/samples/download.ts
+++ b/apps/web/src/server/samples/download.ts
@@ -1,7 +1,7 @@
 import { requireAuthenticatedRequest } from "../auth/middleware";
 import { db } from "../db/pg";
-import { contentDisposition, textResponse, toStream } from "../http";
-import { StorageKeyNotFoundError, storage } from "../storage";
+import { streamStorageObject, textResponse } from "../http";
+import { storage } from "../storage";
 import {
 	checkSampleRight,
 	getSampleReadsFileKey,
@@ -52,27 +52,5 @@ export async function handleSampleReads(
 		return textResponse("Not found", 404);
 	}
 
-	// `Content-Length` comes from the object rather than the `sample_reads` row:
-	// the column is nullable and records what the create job wrote, so a stale or
-	// null value would truncate the download client-side. Sizing first also
-	// settles existence before any header is committed — a row whose bytes are
-	// missing becomes a 404 rather than a 200 that dies mid-stream.
-	let size: number;
-
-	try {
-		size = await storage.size(key);
-	} catch (err) {
-		if (err instanceof StorageKeyNotFoundError) {
-			return textResponse("Not found", 404);
-		}
-		throw err;
-	}
-
-	return new Response(toStream(storage.read(key)), {
-		headers: {
-			"content-disposition": contentDisposition(filename),
-			"content-length": String(size),
-			"content-type": "application/gzip",
-		},
-	});
+	return streamStorageObject(storage, key, filename, "application/gzip");
 }

--- a/apps/web/src/server/storage/keys.ts
+++ b/apps/web/src/server/storage/keys.ts
@@ -80,14 +80,20 @@ export function subtractionPrefix(subtractionId: string): string {
 	return `subtractions/${normalizeSubtractionId(subtractionId)}/`;
 }
 
-/** Key for an index file. */
-export function indexFileKey(indexId: string, filename: string): string {
-	return `indexes/${indexId}/${filename}`;
+/**
+ * Key for an index file.
+ *
+ * The segment is the index's `storage_key` column, not its row id — a migrated
+ * index keys on its old Mongo id and a natively-created one on a minted UUID,
+ * so neither can be derived from the id.
+ */
+export function indexFileKey(storageKey: string, filename: string): string {
+	return `indexes/${storageKey}/${filename}`;
 }
 
 /** Prefix holding every file for an index. */
-export function indexPrefix(indexId: string): string {
-	return `indexes/${indexId}/`;
+export function indexPrefix(storageKey: string): string {
+	return `indexes/${storageKey}/`;
 }
 
 /** Key for a cache. Persisted on the cache row rather than recomputed. */

--- a/apps/web/src/server/subtraction/download.ts
+++ b/apps/web/src/server/subtraction/download.ts
@@ -1,7 +1,7 @@
 import { requireAuthenticatedRequest } from "../auth/middleware";
 import { db } from "../db/pg";
-import { contentDisposition, textResponse, toStream } from "../http";
-import { StorageKeyNotFoundError, storage } from "../storage";
+import { streamStorageObject, textResponse } from "../http";
+import { storage } from "../storage";
 import { getSubtractionFileKey } from "./data";
 
 /**
@@ -40,27 +40,10 @@ export async function handleSubtractionFile(
 		return textResponse("Not found", 404);
 	}
 
-	// `Content-Length` comes from the object rather than the `subtraction_files`
-	// row: the column is nullable and records what the create job wrote, so a
-	// stale or null value would truncate the download client-side. Sizing first
-	// also settles existence before any header is committed — a row whose bytes
-	// are missing becomes a 404 rather than a 200 that dies mid-stream.
-	let size: number;
-
-	try {
-		size = await storage.size(key);
-	} catch (err) {
-		if (err instanceof StorageKeyNotFoundError) {
-			return textResponse("Not found", 404);
-		}
-		throw err;
-	}
-
-	return new Response(toStream(storage.read(key)), {
-		headers: {
-			"content-disposition": contentDisposition(filename),
-			"content-length": String(size),
-			"content-type": "application/octet-stream",
-		},
-	});
+	return streamStorageObject(
+		storage,
+		key,
+		filename,
+		"application/octet-stream",
+	);
 }

--- a/apps/web/src/server/uploads/download.ts
+++ b/apps/web/src/server/uploads/download.ts
@@ -1,7 +1,7 @@
 import { requireAuthenticatedRequest } from "../auth/middleware";
 import { db } from "../db/pg";
-import { contentDisposition, textResponse, toStream } from "../http";
-import { StorageKeyNotFoundError, storage } from "../storage";
+import { streamStorageObject, textResponse } from "../http";
+import { storage } from "../storage";
 import { getUploadFile } from "./data";
 
 /**
@@ -39,27 +39,10 @@ export async function handleUploadDownload(
 		return textResponse("Not found", 404);
 	}
 
-	// `Content-Length` comes from the object rather than the `uploads.size`
-	// column: the column is nullable and records what the writer reported, so a
-	// stale or null value would truncate the download client-side. Sizing first
-	// also settles existence before any header is committed — a row whose bytes
-	// are missing becomes a 404 rather than a 200 that dies mid-stream.
-	let size: number;
-
-	try {
-		size = await storage.size(file.key);
-	} catch (err) {
-		if (err instanceof StorageKeyNotFoundError) {
-			return textResponse("Not found", 404);
-		}
-		throw err;
-	}
-
-	return new Response(toStream(storage.read(file.key)), {
-		headers: {
-			"content-disposition": contentDisposition(file.name),
-			"content-length": String(size),
-			"content-type": "application/octet-stream",
-		},
-	});
+	return streamStorageObject(
+		storage,
+		file.key,
+		file.name,
+		"application/octet-stream",
+	);
 }

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -153,9 +153,11 @@ Python's `authentication_middleware` branches the same way.
 **Only raw routes accept a key.** Server functions stay cookie-only:
 they are the app's own RPC transport, not a public API, and the
 generated client always sends cookies. The raw routes — `POST
-/uploads`, `/events`, `GET /analyses/documents/{id}.{extension}` and
-`GET /subtractions/{id}/files/{filename}` — are what a script can
-actually reach.
+/uploads`, `/events`, `GET /analyses/documents/{id}.{extension}`,
+`GET /subtractions/{id}/files/{filename}`,
+`GET /indexes/{id}/files/{filename}` and
+`GET /samples/{id}/reads/{filename}` — are what a script can actually
+reach.
 
 ### The key's permissions are a cap
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -60,8 +60,8 @@ orphans whatever it writes.
 | `analysisPrefix(sampleStorageId, analysisLegacyId)` | `samples/{sampleStorageId}/analysis/{analysisLegacyId}/` |
 | `subtractionFileKey(storageId, filename)` | `subtractions/{storageId}/{filename}` |
 | `subtractionPrefix(storageId)` | `subtractions/{storageId}/` |
-| `indexFileKey(indexId, filename)` | `indexes/{indexId}/{filename}` |
-| `indexPrefix(indexId)` | `indexes/{indexId}/` |
+| `indexFileKey(storageKey, filename)` | `indexes/{storageKey}/{filename}` |
+| `indexPrefix(storageKey)` | `indexes/{storageKey}/` |
 | `cacheKey(uuid)` | `caches/v1/{uuid}` |
 | `HMM_PROFILES_KEY` | `hmm/profiles.hmm` |
 | `HMM_ANNOTATIONS_KEY` | `hmm/annotations.json.gz` |
@@ -77,6 +77,10 @@ Two subtleties are load-bearing:
   `_resolve_storage_id`. A subtraction is addressed by its integer id
   everywhere else, so it is easy to reach for `String(id)` and silently orphan
   every migrated subtraction's files.
+- **An index's prefix is neither.** It is the `indexes.storage_key` column,
+  persisted because it cannot be derived from the row id at all — a migrated
+  index keys on its old Mongo id and a natively-created one on a minted UUID.
+  Read the column; never pass the index id.
 - **Subtraction ids may contain spaces**, and Python substitutes underscores
   when composing the key. `subtractionFileKey` and `subtractionPrefix` do the
   same. Never build a subtraction key by hand.


### PR DESCRIPTION
## Summary
- Moves the last two Python REST endpoints the UI still linked to directly — index build files and sample reads — onto raw TypeScript routes, streaming bytes straight out of storage like the existing subtraction download.
- Index downloads keep the reference-visibility check `IndexFileView` performed; sample reads downloads gain a read-right check the Python handler never had, closing a gap where any signed-in user could fetch another user's reads.
- Both download links drop their hand-written `/api` prefix and use the `downloadUrl` the server now returns.