### PR TITLE
chore: move sentry profiling onto the ui profiling api

### DIFF
--- a/packages/sentry/src/browser.ts
+++ b/packages/sentry/src/browser.ts
@@ -13,7 +13,8 @@ export type CommonBrowserSentryOptions = {
 	environment: string;
 	sendDefaultPii: boolean;
 	tracesSampleRate: number;
-	profilesSampleRate: number;
+	profileSessionSampleRate: number;
+	profileLifecycle: "trace";
 	replaysSessionSampleRate: number;
 	replaysOnErrorSampleRate: number;
 	enableLogs: boolean;
@@ -29,9 +30,15 @@ export function getCommonOptions(
 		environment,
 		sendDefaultPii: true,
 		tracesSampleRate: isProd ? 0.1 : 1.0,
-		// Relative to traced transactions, so the effective profiling rate is
-		// tracesSampleRate * profilesSampleRate.
-		profilesSampleRate: isProd ? 0.5 : 1.0,
+		// Decided once per `Sentry.init`, so once per page-load session, not per
+		// transaction the way the deprecated `profilesSampleRate` was: half of
+		// sessions are eligible, and within those `profileLifecycle: "trace"`
+		// profiles only the pageload/navigation spans that tracing already
+		// sampled. Do not set both this and `profilesSampleRate` — the SDK takes
+		// the legacy path whenever the latter is present and ignores this one
+		// entirely.
+		profileSessionSampleRate: isProd ? 0.5 : 1.0,
+		profileLifecycle: "trace",
 		replaysSessionSampleRate: isProd ? 0.1 : 0,
 		replaysOnErrorSampleRate: 1.0,
 		enableLogs: true,

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -11,7 +11,8 @@ export type CommonSentryOptions = {
 	environment: string;
 	sendDefaultPii: boolean;
 	tracesSampleRate: number;
-	profilesSampleRate: number;
+	profileSessionSampleRate: number;
+	profileLifecycle: "trace";
 	enableLogs: boolean;
 };
 
@@ -23,9 +24,16 @@ export function getCommonOptions(): CommonSentryOptions {
 		environment,
 		sendDefaultPii: true,
 		tracesSampleRate: isProd ? 0.1 : 1.0,
-		// Relative to traced transactions, so the effective profiling rate is
-		// tracesSampleRate * profilesSampleRate.
-		profilesSampleRate: isProd ? 0.5 : 1.0,
+		// Decided once per `Sentry.init` — that is, once per server process, not
+		// per transaction the way the deprecated `profilesSampleRate` was. Half
+		// the replicas therefore profile and half do not, which is what bounds
+		// the cost: `profileLifecycle: "trace"` runs the profiler for as long as
+		// any sampled root span is in flight, and on a busy server that is close
+		// to continuously. Do not set both this and `profilesSampleRate` — the
+		// SDK takes the legacy path whenever the latter is present and ignores
+		// this one entirely.
+		profileSessionSampleRate: isProd ? 0.5 : 1.0,
+		profileLifecycle: "trace",
 		enableLogs: true,
 	};
 }


### PR DESCRIPTION
## Summary

- Replace the deprecated `profilesSampleRate` with `profileSessionSampleRate` and `profileLifecycle: "trace"` in both `@virtool/sentry` option builders. Setting the old option does more than warn — `browserProfilingIntegration` branches on its presence, takes the legacy transaction-profiling path, and ignores `profileSessionSampleRate` outright.
- The prod rate stays `0.5` but no longer means the same thing: it is evaluated once per `Sentry.init` rather than per transaction, so it samples server processes and browser page-load sessions instead of individual traces.
- Trace lifecycle keeps the profiler running for as long as any sampled root span is in flight, which on a busy server approaches continuous sampling — and continuous profiling bills by profile hours. The session rate is what caps that exposure, so both call sites now carry a comment saying so.