### PR TITLE
fix: stop deletions reporting an error after they succeed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -407,6 +407,14 @@ a name conflict). The Sentry `beforeSend` filter drops `ClientError`
 `Error` is reported as a false incident. A bare `throw` stays reserved
 for the genuinely unexpected.
 
+**Never set a null-body status — 204, 205, or 304 — from a server
+function.** Start always serializes a body for an RPC call, so the
+`Response` constructor rejects the pair and the operation reports a
+failure it already completed. A deletion returns `null` and answers 200;
+the RPC client reads the body and never the status.
+`server/__tests__/responseStatus.test.ts` fails the build on any of the
+three.
+
 See [docs/architecture.md](docs/architecture.md) for the import-direction
 invariant in full, the labels (minimal) and auth (carve-out) shapes,
 the pure-policy-vs-framework-shell principle, and when to introduce

--- a/apps/web/src/server/__tests__/responseStatus.test.ts
+++ b/apps/web/src/server/__tests__/responseStatus.test.ts
@@ -28,8 +28,23 @@ const SOURCES = import.meta.glob("../**/functions.ts", {
 }) as Record<string, string>;
 
 describe("server functions", () => {
-	it("covers every functions.ts", () => {
-		expect(Object.keys(SOURCES).length).toBeGreaterThan(10);
+	// A glob that matched nothing, or that stopped yielding source text, would
+	// make every scan below pass while asserting nothing. Naming known modules
+	// pins the pattern without pinning how many features the server has.
+	it("reads every functions.ts as source", () => {
+		expect(Object.keys(SOURCES)).toEqual(
+			expect.arrayContaining([
+				"../groups/functions.ts",
+				"../samples/functions.ts",
+				"../uploads/functions.ts",
+			]),
+		);
+
+		for (const [path, source] of Object.entries(SOURCES)) {
+			expect(typeof source, `${path} did not load as source text`).toBe(
+				"string",
+			);
+		}
 	});
 
 	it.each(NULL_BODY_STATUSES)(

--- a/apps/web/src/server/__tests__/responseStatus.test.ts
+++ b/apps/web/src/server/__tests__/responseStatus.test.ts
@@ -1,0 +1,48 @@
+/// <reference types="vite/client" />
+// The server tsconfig carries Node types, not Vite's, so `import.meta.glob` —
+// used below to read every functions.ts as source — needs the reference.
+
+import { describe, expect, it } from "vitest";
+
+// 204, 205, and 304 are the null-body statuses: the fetch spec forbids a
+// response carrying a body on any of them, and undici enforces it in the
+// `Response` constructor.
+//
+// A server function can never answer with one. Start's server-function handler
+// always serializes a body — the value it serializes is the `{ result, error }`
+// wrapper, which is never `undefined`, so the `new Response(undefined, ...)`
+// branch is unreachable from an RPC call. Setting a null-body status therefore
+// makes the constructor throw *after* the handler has already done its work,
+// and the handler's own catch rebuilds the error response with the same status
+// still set, so it throws a second time with nothing left to catch it. The
+// caller sees a failed request for an operation that succeeded.
+//
+// Deletions return `null` and answer 200. The status is invisible to the RPC
+// client either way — it deserializes the body and never reads the code.
+const NULL_BODY_STATUSES = [204, 205, 304];
+
+const SOURCES = import.meta.glob("../**/functions.ts", {
+	eager: true,
+	query: "?raw",
+	import: "default",
+}) as Record<string, string>;
+
+describe("server functions", () => {
+	it("covers every functions.ts", () => {
+		expect(Object.keys(SOURCES).length).toBeGreaterThan(10);
+	});
+
+	it.each(NULL_BODY_STATUSES)(
+		"never answer with the null-body status %i",
+		(status) => {
+			const pattern = new RegExp(`setResponseStatus\\(\\s*${status}\\b`);
+
+			const offenders = Object.entries(SOURCES)
+				.filter(([, source]) => pattern.test(source))
+				.map(([path]) => path)
+				.sort();
+
+			expect(offenders).toEqual([]);
+		},
+	);
+});

--- a/apps/web/src/server/account/functions.test.ts
+++ b/apps/web/src/server/account/functions.test.ts
@@ -133,7 +133,7 @@ describe("updateApiKey", () => {
 });
 
 describe("deleteApiKey", () => {
-	it("removes the signed-in user's key with a 204", async () => {
+	it("removes the signed-in user's key", async () => {
 		await signIn(db, getRequest);
 		const created = (await call("createApiKeyFn", {
 			name: "Robot",
@@ -142,7 +142,6 @@ describe("deleteApiKey", () => {
 
 		await call("deleteApiKeyFn", { keyId: created.id });
 
-		expect(setResponseStatus).toHaveBeenCalledWith(204);
 		expect(await db.select().from(apiKeys)).toHaveLength(0);
 	});
 

--- a/apps/web/src/server/account/functions.ts
+++ b/apps/web/src/server/account/functions.ts
@@ -77,7 +77,6 @@ export const deleteApiKeyFn = createServerFn({ method: "POST" })
 	.handler(async ({ context, data }) => {
 		try {
 			await deleteApiKey(db, context.session.userId, data.keyId);
-			setResponseStatus(204);
 			return null;
 		} catch (err) {
 			return rethrowAsHttp(err);

--- a/apps/web/src/server/analyses/functions.test.ts
+++ b/apps/web/src/server/analyses/functions.test.ts
@@ -347,13 +347,12 @@ describe("deleteAnalysis", () => {
 		).toHaveLength(1);
 	});
 
-	it("returns 204 for a caller with write rights", async () => {
+	it("deletes the analysis for a caller with write rights", async () => {
 		const userId = await signInAsNewUser();
 		const sampleId = await seedSample({ user_id: userId });
 		const analysisId = await seedAnalysis({ sample_id: sampleId });
 
 		await expect(call("deleteAnalysisFn", { analysisId })).resolves.toBeNull();
-		expect(setResponseStatus).toHaveBeenCalledWith(204);
 		expect(await db.select().from(analyses)).toHaveLength(0);
 	});
 });

--- a/apps/web/src/server/analyses/functions.ts
+++ b/apps/web/src/server/analyses/functions.ts
@@ -186,8 +186,6 @@ export const deleteAnalysisFn = createServerFn({ method: "POST" })
 				"write",
 			]);
 			await deleteAnalysis(db, storage, data.analysisId);
-			setResponseStatus(204);
-
 			return null;
 		} catch (err) {
 			return rethrowAsHttp(err);

--- a/apps/web/src/server/groups/functions.ts
+++ b/apps/web/src/server/groups/functions.ts
@@ -112,7 +112,6 @@ export const deleteGroupFn = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		try {
 			await deleteGroup(db, data.groupId);
-			setResponseStatus(204);
 			return null;
 		} catch (err) {
 			rethrowAsHttp(err);

--- a/apps/web/src/server/labels/functions.ts
+++ b/apps/web/src/server/labels/functions.ts
@@ -105,7 +105,6 @@ export const deleteLabelFn = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		try {
 			await deleteLabel(db, data.labelId);
-			setResponseStatus(204);
 			return null;
 		} catch (err) {
 			return rethrowAsHttp(err);

--- a/apps/web/src/server/messages/functions.ts
+++ b/apps/web/src/server/messages/functions.ts
@@ -89,7 +89,6 @@ export const deleteMessageFn = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		try {
 			await deleteMessage(db, data.id);
-			setResponseStatus(204);
 			return null;
 		} catch (err) {
 			rethrowAsHttp(err);

--- a/apps/web/src/server/otus/functions.ts
+++ b/apps/web/src/server/otus/functions.ts
@@ -256,8 +256,6 @@ export const deleteOtuFn = createServerFn({ method: "POST" })
 
 			await deleteOtu(db, data.otuId, context.session.userId);
 
-			setResponseStatus(204);
-
 			return null;
 		} catch (err) {
 			return rethrowAsHttp(err);
@@ -341,8 +339,6 @@ export const deleteIsolateFn = createServerFn({ method: "POST" })
 				context.session.userId,
 			);
 
-			setResponseStatus(204);
-
 			return null;
 		} catch (err) {
 			return rethrowAsHttp(err);
@@ -423,8 +419,6 @@ export const deleteSequenceFn = createServerFn({ method: "POST" })
 				data.sequenceId,
 				context.session.userId,
 			);
-
-			setResponseStatus(204);
 
 			return null;
 		} catch (err) {

--- a/apps/web/src/server/references/functions.ts
+++ b/apps/web/src/server/references/functions.ts
@@ -296,7 +296,6 @@ export const removeReferenceUserFn = createServerFn({ method: "POST" })
 				"modify",
 			);
 			await removeReferenceUser(db, data.referenceId, data.userId);
-			setResponseStatus(204);
 			return null;
 		} catch (err) {
 			return rethrowAsHttp(err);
@@ -314,7 +313,6 @@ export const removeReferenceGroupFn = createServerFn({ method: "POST" })
 				"modify",
 			);
 			await removeReferenceGroup(db, data.referenceId, data.groupId);
-			setResponseStatus(204);
 			return null;
 		} catch (err) {
 			return rethrowAsHttp(err);

--- a/apps/web/src/server/samples/functions.ts
+++ b/apps/web/src/server/samples/functions.ts
@@ -218,7 +218,6 @@ export const deleteSampleFn = createServerFn({ method: "POST" })
 			}
 
 			await deleteSample(db, storage, data.sampleId);
-			setResponseStatus(204);
 			return null;
 		} catch (err) {
 			return rethrowAsHttp(err);

--- a/apps/web/src/server/subtraction/functions.ts
+++ b/apps/web/src/server/subtraction/functions.ts
@@ -115,7 +115,6 @@ export const deleteSubtractionFn = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		try {
 			await deleteSubtraction(db, storage, data.subtractionId);
-			setResponseStatus(204);
 			return null;
 		} catch (err) {
 			return rethrowAsHttp(err);

--- a/apps/web/src/server/uploads/functions.test.ts
+++ b/apps/web/src/server/uploads/functions.test.ts
@@ -150,7 +150,6 @@ describe("deleteUpload", () => {
 
 		const [row] = await db.select().from(uploadsTable);
 		expect(row?.removed).toBe(true);
-		expect(setResponseStatus).toHaveBeenCalledWith(204);
 	});
 
 	it("maps a missing upload to a 404", async () => {

--- a/apps/web/src/server/uploads/functions.ts
+++ b/apps/web/src/server/uploads/functions.ts
@@ -66,7 +66,6 @@ export const deleteUploadFn = createServerFn({ method: "POST" })
 	.handler(async ({ data }) => {
 		try {
 			await deleteUpload(db, storage, data.id);
-			setResponseStatus(204);
 			return null;
 		} catch (err) {
 			return rethrowAsHttp(err);

--- a/apps/web/src/tests/server-fn/otus.ts
+++ b/apps/web/src/tests/server-fn/otus.ts
@@ -45,7 +45,7 @@ export function mockUpdateOtu(otu: Otu): Mock {
 	return otuServerFnMocks.updateOtuFn;
 }
 
-/** Sets up deleteOtu to resolve, as the 204 it answers with carries no body. */
+/** Sets up deleteOtu to resolve, as the deletion answers with no content. */
 export function mockDeleteOtu(): Mock {
 	otuServerFnMocks.deleteOtuFn.mockResolvedValue(null);
 	return otuServerFnMocks.deleteOtuFn;
@@ -59,7 +59,7 @@ export function mockCreateIsolate(overrides?: Partial<OtuIsolate>): Mock {
 	return otuServerFnMocks.createIsolateFn;
 }
 
-/** Sets up deleteIsolate to resolve, as the 204 it answers with carries no body. */
+/** Sets up deleteIsolate to resolve, as the deletion answers with no content. */
 export function mockDeleteIsolate(): Mock {
 	otuServerFnMocks.deleteIsolateFn.mockResolvedValue(null);
 	return otuServerFnMocks.deleteIsolateFn;
@@ -81,7 +81,7 @@ export function mockUpdateSequence(overrides?: Partial<OtuSequence>): Mock {
 	return otuServerFnMocks.updateSequenceFn;
 }
 
-/** Sets up deleteSequence to resolve, as the 204 it answers with carries no body. */
+/** Sets up deleteSequence to resolve, as the deletion answers with no content. */
 export function mockDeleteSequence(): Mock {
 	otuServerFnMocks.deleteSequenceFn.mockResolvedValue(null);
 	return otuServerFnMocks.deleteSequenceFn;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,6 +75,22 @@ import-direction invariant stays enforceable.
   logic — if a handler grows a multi-step orchestration with rollbacks
   or branching, that is the signal to extract a `service.ts`.
 
+  The status a handler sets is always a 4xx or a 2xx that carries a
+  body. **A null-body status — 204, 205, or 304 — is not available
+  here.** Start's server-function handler serializes the `{ result,
+  error }` wrapper into a body unconditionally, and the fetch spec
+  forbids a body on those three, so `new Response(body, { status: 204
+  })` throws — *after* the handler has done its work. The handler's own
+  catch then rebuilds the error response with the status still set and
+  throws a second time, with nothing left to catch it, so the caller
+  sees a failed request for an operation that succeeded. A deletion
+  returns `null` and answers 200; the RPC client deserializes the body
+  and never reads the code, so nothing observes the difference.
+  `server/__tests__/responseStatus.test.ts` scans every `functions.ts`
+  and fails the build on all three statuses. A raw route is unaffected —
+  it builds its own `Response`, and `new Response(null, { status: 204 })`
+  is fine.
+
 ### The underlying principle: keep policy logic pure
 
 The three-file layering is the structural form of a broader rule:


### PR DESCRIPTION
## Summary
- Deletions set a 204 status on their server functions, but Start always serializes a `{ result, error }` body for an RPC call — and the `Response` constructor rejects a body paired with a null-body status, so the request threw *after* the deletion had already succeeded. The handler's own catch then rebuilt the error response with the status still set and threw a second time, with nothing left to catch it.
- Drop `setResponseStatus(204)` from all twelve handlers (account, analyses, groups, labels, messages, otus/isolates/sequences, references, samples, subtractions, uploads). They now return `null` and answer 200, which the RPC client never inspects.
- Add `server/__tests__/responseStatus.test.ts`, which scans every `functions.ts` and fails the build on 204, 205, or 304, and document the constraint in `AGENTS.md` and `docs/architecture.md`.

Fixes VIRTOOL-9