### PR TITLE
refactor: import contracts types directly, not via feature modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,8 +442,7 @@ a server file reaching into a DOM-typed module breaks the server project
 at a distance. Shapes and helpers both sides need live *down* in
 `@virtool/contracts` (roles, permissions, banner colors, the SSE schema,
 the reference wire shapes, `UserNested`, `Task`, `SearchResult`);
-the server imports them from the package, and the client feature module
-re-exports them so its own call sites are undisturbed.
+both sides import them straight from the package.
 
 **A domain's wire shapes belong in `@virtool/contracts`, not in
 `data.ts`.** What a server function returns is read by both sides, so
@@ -458,6 +457,19 @@ does not own, and drags a data-layer module into the browser's type
 graph to get it. `data.ts` still owns what only it uses: its `*Values`
 and `*Options` argument types, its `AppError` subclasses, and its row
 mappers.
+
+**A feature module must never re-export a name that originates in
+`@virtool/contracts`.** Consumers import it from the package directly.
+A `types.ts` that re-exports `UserNested`, or a `utils.ts` that
+re-exports `hasSufficientAdminRole`, makes the feature a middleman on a
+shape it does not own: the real definition site stops being greppable,
+and a module that wanted one client-only type now drags the feature in
+to get a package one. Keep the client-only shapes that genuinely live
+there — `administration/types.ts` still owns `AdministratorRole` and
+`Settings`, `banner/types.ts` still owns `Banner` and
+`bannerColorClasses` — and delete only the pass-through lines. The rule
+covers values as well as types, and applies just as much inside
+`src/server/**`.
 
 ### Every server function declares an authorization policy
 

--- a/apps/web/src/account/components/ApiKeyAdministratorInfo.tsx
+++ b/apps/web/src/account/components/ApiKeyAdministratorInfo.tsx
@@ -1,6 +1,6 @@
-import { hasSufficientAdminRole } from "@administration/utils";
 import Alert from "@base/Alert";
 import QueryError from "@base/QueryError";
+import { hasSufficientAdminRole } from "@virtool/contracts";
 import { useFetchAccount } from "../account";
 
 /**

--- a/apps/web/src/account/components/ApiKeyPermissions.tsx
+++ b/apps/web/src/account/components/ApiKeyPermissions.tsx
@@ -1,14 +1,14 @@
 import { useFetchAccount } from "@account/account";
-import {
-	AdministratorPermissions,
-	hasSufficientAdminRole,
-} from "@administration/utils";
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupSection from "@base/BoxGroupSection";
 import Checkbox from "@base/Checkbox";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import QueryError from "@base/QueryError";
 import type { Permission, Permissions } from "@virtool/contracts";
+import {
+	AdministratorPermissions,
+	hasSufficientAdminRole,
+} from "@virtool/contracts";
 import { sortBy } from "es-toolkit";
 
 type ApiPermissionsProps = {

--- a/apps/web/src/administration/components/AdministrationTabs.tsx
+++ b/apps/web/src/administration/components/AdministrationTabs.tsx
@@ -1,8 +1,8 @@
 import NavTab from "@base/NavTab";
 import NavTabs from "@base/NavTabs";
+import type { AdministratorRoleName } from "@virtool/contracts";
+import { hasSufficientAdminRole } from "@virtool/contracts";
 import type { ReactNode } from "react";
-import type { AdministratorRoleName } from "../types";
-import { hasSufficientAdminRole } from "../utils";
 
 type AdministratorTabsProps = {
 	administratorRole: AdministratorRoleName | null;

--- a/apps/web/src/administration/components/AdministratorRoleSelect.tsx
+++ b/apps/web/src/administration/components/AdministratorRoleSelect.tsx
@@ -1,11 +1,9 @@
-import type {
-	AdministratorRole,
-	AdministratorRoleName,
-} from "@administration/types";
+import type { AdministratorRole } from "@administration/types";
 import Select from "@base/Select";
 import SelectButton from "@base/SelectButton";
 import SelectContent from "@base/SelectContent";
 import SelectItem from "@base/SelectItem";
+import type { AdministratorRoleName } from "@virtool/contracts";
 import { ChevronDown } from "lucide-react";
 
 type RoleSelectProps = {

--- a/apps/web/src/administration/components/BannerColorPicker.tsx
+++ b/apps/web/src/administration/components/BannerColorPicker.tsx
@@ -1,9 +1,6 @@
 import { cn } from "@app/cn";
-import {
-	type BannerColor,
-	bannerColorClasses,
-	bannerColors,
-} from "@banner/types";
+import { bannerColorClasses } from "@banner/types";
+import { type BannerColor, bannerColors } from "@virtool/contracts";
 
 const labels: Record<BannerColor, string> = {
 	red: "Red",

--- a/apps/web/src/administration/components/BannerForm.tsx
+++ b/apps/web/src/administration/components/BannerForm.tsx
@@ -1,10 +1,10 @@
-import type { BannerColor } from "@banner/types";
 import Button from "@base/Button";
 import { DialogFooter } from "@base/Dialog";
 import InputError from "@base/InputError";
 import InputGroup from "@base/InputGroup";
 import InputLabel from "@base/InputLabel";
 import InputSimple from "@base/InputSimple";
+import type { BannerColor } from "@virtool/contracts";
 import { Controller, useForm } from "react-hook-form";
 import BannerColorPicker from "./BannerColorPicker";
 

--- a/apps/web/src/administration/components/BannerItem.tsx
+++ b/apps/web/src/administration/components/BannerItem.tsx
@@ -1,7 +1,8 @@
 import { cn } from "@app/cn";
-import { type BannerColor, bannerColorClasses } from "@banner/types";
+import { bannerColorClasses } from "@banner/types";
 import BoxGroupSection from "@base/BoxGroupSection";
 import { RadioGroupItem } from "@base/RadioGroup";
+import type { BannerColor } from "@virtool/contracts";
 import type { BannerFormValues } from "./BannerForm";
 import DeleteBanner from "./DeleteBanner";
 import EditBanner from "./EditBanner";

--- a/apps/web/src/administration/components/EditBanner.tsx
+++ b/apps/web/src/administration/components/EditBanner.tsx
@@ -1,6 +1,6 @@
-import type { BannerColor } from "@banner/types";
 import { Dialog, DialogContent, DialogTitle } from "@base/Dialog";
 import IconButton from "@base/IconButton";
+import type { BannerColor } from "@virtool/contracts";
 import { Pen } from "lucide-react";
 import { useState } from "react";
 import BannerForm, { type BannerFormValues } from "./BannerForm";

--- a/apps/web/src/administration/hooks.ts
+++ b/apps/web/src/administration/hooks.ts
@@ -1,10 +1,10 @@
 import { useFetchAccount } from "@account/account";
-import type { Permission } from "@virtool/contracts";
-import type { AdministratorRoleName } from "./types";
 import {
-	checkAdminRoleOrPermissionsFromAccount,
+	type AdministratorRoleName,
 	hasSufficientAdminRole,
-} from "./utils";
+	type Permission,
+} from "@virtool/contracts";
+import { checkAdminRoleOrPermissionsFromAccount } from "./utils";
 
 export type PermissionQueryResult = {
 	hasPermission: boolean | null;

--- a/apps/web/src/administration/types.ts
+++ b/apps/web/src/administration/types.ts
@@ -4,8 +4,6 @@
 
 import type { AdministratorRoleName } from "@virtool/contracts";
 
-export type { AdministratorRoleName };
-
 /**
  * Full model of an administrator role
  */

--- a/apps/web/src/administration/utils.ts
+++ b/apps/web/src/administration/utils.ts
@@ -5,8 +5,6 @@ import {
 	hasSufficientAdminRole,
 } from "@virtool/contracts";
 
-export { AdministratorPermissions, hasSufficientAdminRole };
-
 /**
  * Check if a user has a sufficient admin role or legacy permissions to perform an action
  *

--- a/apps/web/src/app/sse/SseConnection.ts
+++ b/apps/web/src/app/sse/SseConnection.ts
@@ -2,8 +2,8 @@ import { useServerVersionStore } from "@app/serverVersion";
 import { endSession } from "@app/session";
 import * as Sentry from "@sentry/tanstackstart-react";
 import type { QueryClient } from "@tanstack/react-query";
+import { SseDomainSchema, SseMessageSchema } from "@virtool/contracts";
 import { reactQueryHandler } from "./reactQueryHandler";
-import { SseDomainSchema, SseMessageSchema } from "./schema";
 
 type ConnectionStatus =
 	| "initializing"

--- a/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
+++ b/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
@@ -12,10 +12,10 @@ import { QueryClient } from "@tanstack/react-query";
 import { taskQueryKeys } from "@tasks/keys";
 import { fileQueryKeys } from "@uploads/keys";
 import { userQueryKeys } from "@users/keys";
+import type { SseMessage } from "@virtool/contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { reactQueryHandler } from "../reactQueryHandler";
 import handlerSource from "../reactQueryHandler.ts?raw";
-import type { SseMessage } from "../schema";
 
 describe("reactQueryHandler", () => {
 	let queryClient: QueryClient;

--- a/apps/web/src/app/sse/__tests__/schema.test.ts
+++ b/apps/web/src/app/sse/__tests__/schema.test.ts
@@ -1,5 +1,5 @@
+import { SseDomainSchema, SseMessageSchema } from "@virtool/contracts";
 import { describe, expect, it } from "vitest";
-import { SseDomainSchema, SseMessageSchema } from "../schema";
 
 describe("SseMessageSchema", () => {
 	it("accepts a frame for a number-id domain", () => {

--- a/apps/web/src/app/sse/reactQueryHandler.ts
+++ b/apps/web/src/app/sse/reactQueryHandler.ts
@@ -14,7 +14,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { taskQueryKeys } from "@tasks/keys";
 import { fileQueryKeys } from "@uploads/keys";
 import { userQueryKeys } from "@users/keys";
-import type { SseDomain, SseMessage } from "./schema";
+import type { SseDomain, SseMessage } from "@virtool/contracts";
 
 /**
  * What a domain caches, and therefore how narrowly its frames can be

--- a/apps/web/src/app/sse/schema.ts
+++ b/apps/web/src/app/sse/schema.ts
@@ -1,6 +1,0 @@
-export {
-	type SseDomain,
-	SseDomainSchema,
-	type SseMessage,
-	SseMessageSchema,
-} from "@virtool/contracts";

--- a/apps/web/src/banner/queries.ts
+++ b/apps/web/src/banner/queries.ts
@@ -9,7 +9,8 @@ import {
 	updateMessageFn,
 } from "@server/messages/functions";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type { Banner, BannerColor } from "./types";
+import type { BannerColor } from "@virtool/contracts";
+import type { Banner } from "./types";
 
 /**
  * Fetch the active banner from the API.

--- a/apps/web/src/banner/types.ts
+++ b/apps/web/src/banner/types.ts
@@ -1,7 +1,4 @@
-import type { UserNested } from "@users/types";
-import { type BannerColor, bannerColors } from "@virtool/contracts";
-
-export { type BannerColor, bannerColors };
+import type { BannerColor, UserNested } from "@virtool/contracts";
 
 /** Tailwind background-color class for each banner color. */
 export const bannerColorClasses: Record<BannerColor, string> = {

--- a/apps/web/src/groups/components/GroupMembers.tsx
+++ b/apps/web/src/groups/components/GroupMembers.tsx
@@ -2,7 +2,7 @@ import BoxGroup from "@base/BoxGroup";
 import BoxGroupHeader from "@base/BoxGroupHeader";
 import BoxGroupSection from "@base/BoxGroupSection";
 import InitialIcon from "@base/InitialIcon";
-import type { UserNested } from "@users/types";
+import type { UserNested } from "@virtool/contracts";
 
 type MemberProps = {
 	members: UserNested[];

--- a/apps/web/src/jobs/components/JobItem.tsx
+++ b/apps/web/src/jobs/components/JobItem.tsx
@@ -5,7 +5,7 @@ import Link from "@base/Link";
 import ProgressCircle from "@base/ProgressCircle";
 import JobStateIcon from "@jobs/components/JobStateIcon";
 import type { JobState, Workflow } from "@jobs/types";
-import type { UserNested } from "@users/types";
+import type { UserNested } from "@virtool/contracts";
 import type { ElementType } from "react";
 
 export type JobItemProps = {

--- a/apps/web/src/nav/components/Nav.tsx
+++ b/apps/web/src/nav/components/Nav.tsx
@@ -1,6 +1,4 @@
 import { useLogout } from "@account/queries";
-import type { AdministratorRoleName } from "@administration/types";
-import { hasSufficientAdminRole } from "@administration/utils";
 import Dropdown from "@base/Dropdown";
 import DropdownMenuContent from "@base/DropdownMenuContent";
 import DropdownMenuItem from "@base/DropdownMenuItem";
@@ -10,6 +8,8 @@ import DropdownMenuTrigger from "@base/DropdownMenuTrigger";
 import IconButton from "@base/IconButton";
 import InitialIcon from "@base/InitialIcon";
 import Logo from "@base/Logo";
+import type { AdministratorRoleName } from "@virtool/contracts";
+import { hasSufficientAdminRole } from "@virtool/contracts";
 import { Info } from "lucide-react";
 import { useState } from "react";
 import AboutDialog from "./AboutDialog";

--- a/apps/web/src/nav/components/Sidebar.tsx
+++ b/apps/web/src/nav/components/Sidebar.tsx
@@ -1,6 +1,6 @@
-import type { AdministratorRoleName } from "@administration/types";
-import { hasSufficientAdminRole } from "@administration/utils";
 import { useLocation } from "@tanstack/react-router";
+import type { AdministratorRoleName } from "@virtool/contracts";
+import { hasSufficientAdminRole } from "@virtool/contracts";
 import { FolderOpen, List, Settings, Tag } from "lucide-react";
 import type { ReactNode } from "react";
 import SidebarLink from "./SidebarLink";

--- a/apps/web/src/nav/components/__tests__/Nav.test.tsx
+++ b/apps/web/src/nav/components/__tests__/Nav.test.tsx
@@ -1,7 +1,7 @@
-import type { AdministratorRoleName } from "@administration/types";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithRouter } from "@tests/setup";
+import type { AdministratorRoleName } from "@virtool/contracts";
 import { describe, expect, it } from "vitest";
 import Nav from "../Nav";
 

--- a/apps/web/src/routes/_authenticated/administration/index.tsx
+++ b/apps/web/src/routes/_authenticated/administration/index.tsx
@@ -1,5 +1,5 @@
-import { hasSufficientAdminRole } from "@administration/utils";
 import { createFileRoute, redirect } from "@tanstack/react-router";
+import { hasSufficientAdminRole } from "@virtool/contracts";
 
 export const Route = createFileRoute("/_authenticated/administration/")({
 	beforeLoad: async ({ context }) => {

--- a/apps/web/src/routes/_authenticated/administration/route.tsx
+++ b/apps/web/src/routes/_authenticated/administration/route.tsx
@@ -1,10 +1,10 @@
 import AdministrationTabs from "@administration/components/AdministrationTabs";
-import { hasSufficientAdminRole } from "@administration/utils";
 import ContainerNarrow from "@base/ContainerNarrow";
 import ContainerWide from "@base/ContainerWide";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+import { hasSufficientAdminRole } from "@virtool/contracts";
 
 export const Route = createFileRoute("/_authenticated/administration")({
 	beforeLoad: async ({ context }) => {

--- a/apps/web/src/samples/components/Filter/UserFilterMenu.tsx
+++ b/apps/web/src/samples/components/Filter/UserFilterMenu.tsx
@@ -6,7 +6,7 @@ import DropdownMenuSeparator from "@base/DropdownMenuSeparator";
 import Input from "@base/Input";
 import QueryError from "@base/QueryError";
 import { useListUsers } from "@users/queries";
-import type { UserNested } from "@users/types";
+import type { UserNested } from "@virtool/contracts";
 import { useState } from "react";
 
 type UserFilterMenuProps = {

--- a/apps/web/src/samples/hooks.ts
+++ b/apps/web/src/samples/hooks.ts
@@ -1,5 +1,5 @@
 import { useFetchAccount } from "@account/account";
-import { hasSufficientAdminRole } from "@administration/utils";
+import { hasSufficientAdminRole } from "@virtool/contracts";
 import { useFetchSample } from "./queries";
 
 /**

--- a/apps/web/src/subtraction/components/SubtractionFileItem.tsx
+++ b/apps/web/src/subtraction/components/SubtractionFileItem.tsx
@@ -1,6 +1,6 @@
 import Attribution from "@base/Attribution";
 import SelectBoxGroupSection from "@base/SelectBoxGroupSection";
-import type { UserNested } from "@users/types";
+import type { UserNested } from "@virtool/contracts";
 
 type SubtractionFileItemProps = {
 	/** Whether the file is selected */

--- a/apps/web/src/tests/fake/user.ts
+++ b/apps/web/src/tests/fake/user.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
-import type { User, UserNested } from "@users/types";
+import type { User } from "@users/types";
+import type { UserNested } from "@virtool/contracts";
 import { createFakeGroupMinimal } from "./groups";
 import { createFakePermissions } from "./permissions";
 

--- a/apps/web/src/tests/server-fn/users.ts
+++ b/apps/web/src/tests/server-fn/users.ts
@@ -1,6 +1,7 @@
 import type { Account } from "@account/types";
 import type { AdministratorRole } from "@administration/types";
-import type { User, UserNested } from "@users/types";
+import type { User } from "@users/types";
+import type { UserNested } from "@virtool/contracts";
 import { expect, type Mock, vi } from "vitest";
 
 /**

--- a/apps/web/src/uploads/components/UploadItem.tsx
+++ b/apps/web/src/uploads/components/UploadItem.tsx
@@ -5,7 +5,7 @@ import Checkbox from "@base/Checkbox";
 import IconButton from "@base/IconButton";
 import IconLink from "@base/IconLink";
 import RelativeTime from "@base/RelativeTime";
-import type { UserNested } from "@users/types";
+import type { UserNested } from "@virtool/contracts";
 import { Download, Trash } from "lucide-react";
 import type { MouseEvent, ReactNode } from "react";
 import { useDeleteFile } from "../queries";

--- a/apps/web/src/users/components/UserAdministratorRole.tsx
+++ b/apps/web/src/users/components/UserAdministratorRole.tsx
@@ -2,10 +2,10 @@ import { useFetchAccount } from "@account/account";
 import AdministratorRoleSelect from "@administration/components/AdministratorRoleSelect";
 import { useCheckAdminRole } from "@administration/hooks";
 import { useGetAdministratorRoles } from "@administration/queries";
-import type { AdministratorRoleName } from "@administration/types";
 import IconButton from "@base/IconButton";
 import InputLabel from "@base/InputLabel";
 import { useSetAdministratorRole } from "@users/queries";
+import type { AdministratorRoleName } from "@virtool/contracts";
 import { Trash } from "lucide-react";
 
 type UserAdministratorRoleProps = {

--- a/apps/web/src/users/components/UserItem.tsx
+++ b/apps/web/src/users/components/UserItem.tsx
@@ -1,10 +1,9 @@
 import { useCheckAdminRole } from "@administration/hooks";
-import type { AdministratorRoleName } from "@administration/types";
 import BoxGroupSection from "@base/BoxGroupSection";
 import InitialIcon from "@base/InitialIcon";
 import Label from "@base/Label";
 import Link from "@base/Link";
-import type { GroupMinimal } from "@virtool/contracts";
+import type { AdministratorRoleName, GroupMinimal } from "@virtool/contracts";
 import type { ReactElement } from "react";
 
 type UserItemProps = {

--- a/apps/web/src/users/queries.ts
+++ b/apps/web/src/users/queries.ts
@@ -1,4 +1,3 @@
-import type { AdministratorRoleName } from "@administration/types";
 import {
 	createUserFn,
 	findUsersFn,
@@ -18,7 +17,7 @@ import {
 	useSuspenseQuery,
 } from "@tanstack/react-query";
 import { userQueryKeys } from "@users/keys";
-import type { UserNested } from "./types";
+import type { AdministratorRoleName, UserNested } from "@virtool/contracts";
 
 /**
  * Fetch every active user, for populating selectors and filters

--- a/apps/web/src/users/types.ts
+++ b/apps/web/src/users/types.ts
@@ -1,7 +1,9 @@
-import type { AdministratorRoleName } from "@administration/types";
-import type { GroupMinimal, Permissions, UserNested } from "@virtool/contracts";
-
-export type { UserNested } from "@virtool/contracts";
+import type {
+	AdministratorRoleName,
+	GroupMinimal,
+	Permissions,
+	UserNested,
+} from "@virtool/contracts";
 
 /** A Virtool user */
 export type User = UserNested & {

--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -174,11 +174,11 @@ application's own doing.
   frames NOTIFYed while the stream was down — including a server-side
   queue-overflow drop — never arrived; the initial connect skips this
   because the route loaders just populated the cache.
-- `app/sse/schema.ts` defines `SseMessageSchema`, which validates the
-  wire frame and strips unknown fields. `SseConnection` runs it on every
-  frame: a frame for an unrecognised `domain` is dropped silently, while
-  a frame for a known domain that fails validation is reported to Sentry
-  (`sse: message-validation`).
+- `SseMessageSchema`, imported straight from `@virtool/contracts`,
+  validates the wire frame and strips unknown fields. `SseConnection`
+  runs it on every frame: a frame for an unrecognised `domain` is
+  dropped silently, while a frame for a known domain that fails
+  validation is reported to Sentry (`sse: message-validation`).
 - `app/sse/reactQueryHandler.ts` maps `message.domain` to a query-key
   factory and invalidates the narrowest key the domain actually caches
   under. `update` prefers `detail(id)`, falling to `lists()` for a


### PR DESCRIPTION
## Summary

- Four feature modules re-exported names that originate in `@virtool/contracts`, making them a middleman on shapes they don't own: `administration/types.ts` (`AdministratorRoleName`), `banner/types.ts` (`BannerColor`, `bannerColors`), `users/types.ts` (`UserNested`), and `administration/utils.ts` (`AdministratorPermissions`, `hasSufficientAdminRole`). The pass-through lines are gone and all 23 consumers now import from the package; each module keeps the client-only shapes it genuinely owns.
- `AGENTS.md` gains the rule, and an older sentence in the same section that prescribed the opposite — "the client feature module re-exports them so its own call sites are undisturbed" — is corrected.
- Two items in VIR-2866 turned out not to apply: `groups/types.ts` was already clean, and `server/history/data.ts`'s `OtuDocument` re-export is not a contracts type (it originates in `server/otus/data.ts`) and is live, so it is left as-is.