### PR TITLE
fix: stop blank page shown after signing in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,6 +312,14 @@ internal route triggers a full page reload. For query strings, use `search` on
 
 `<a>` is only for external URLs and deliberate full reloads.
 
+`routes/index.tsx` — the `/` to `/samples` redirect — stays **outside**
+`_authenticated`, and its `beforeLoad` stays synchronous. Nested, resolving `/`
+ran that layout's async guard before throwing a second redirect, so signing in
+navigated `/login` to `/` to `/samples` with the layout match re-rendering
+mid-chain — the window the router throws `undefined` in. Moving it back under
+the guard reintroduces that. Nothing is exposed by leaving it unguarded: it
+renders nothing, and `/samples` carries the guard.
+
 ### API calls
 
 There is no HTTP client. The SPA reaches the backend through TanStack Start

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,16 @@ initial-load failure spins forever. See
 route-loader prefetch, the two-tier error/loading policy, and mutation
 patterns.
 
+Below both tiers sits `@base/ShellErrorBoundary`, mounted in the root route's
+shell inside `<body>`. It catches what the router's own boundaries cannot: a
+falsy thrown value. `MatchInner` throws a match's `loadPromise` to suspend, a
+chained redirect can clear that promise first, and TanStack's `CatchBoundary`
+tests the thrown value for truthiness — so `undefined` escapes every boundary
+and unmounts the app to a blank page (TanStack/router#7753, open). The shell
+boundary remounts the router once the race settles, and falls back to a reload
+prompt. It is a backstop for that upstream bug, not a place to route ordinary
+route or query errors — those belong in the two tiers above.
+
 ### Styling
 
 - Styling is Tailwind utility classes. There is no CSS-in-JS; styled-components

--- a/apps/web/src/base/ShellErrorBoundary.tsx
+++ b/apps/web/src/base/ShellErrorBoundary.tsx
@@ -1,0 +1,113 @@
+import * as Sentry from "@sentry/tanstackstart-react";
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import Button from "./Button";
+import ErrorState from "./ErrorState";
+import LoadingPlaceholder from "./LoadingPlaceholder";
+
+// Two, so a single stubborn navigation gets a second chance before the user is
+// shown a dead end. A third failure in a row is not a race, and remounting
+// again would only spin.
+const MAX_CONSECUTIVE_RECOVERIES = 2;
+
+type ShellErrorBoundaryProps = {
+	children: ReactNode;
+};
+
+type ShellErrorBoundaryState = {
+	// "recovering" is provisional: `getDerivedStateFromError` cannot tell a race
+	// from a real error, so it always parks here and `componentDidCatch` decides.
+	status: "ok" | "recovering" | "failed";
+};
+
+/**
+ * The shell's last-resort error boundary, mounted inside `<body>` above every
+ * route match.
+ *
+ * It exists because the router can throw a value that its own boundaries cannot
+ * catch. `MatchInner` throws `getMatchPromise(match, "loadPromise")` to suspend
+ * a match that is still settling, and a chained redirect — `/login` to `/`, then
+ * `/` to `/samples` — can clear that promise before the match re-renders, so it
+ * throws `undefined` instead. TanStack's `CatchBoundary` tests the thrown value
+ * for truthiness, so every nested one swallows it and re-throws; the error
+ * reaches `hydrateRoot`'s `onUncaughtError`, React unmounts the tree, and the
+ * user is left staring at a blank page immediately after signing in. See
+ * TanStack/router#7753, still open.
+ *
+ * A falsy throw is therefore treated as the transient race it is: render a
+ * placeholder, then remount the router once the navigation that raced has
+ * settled. A real error, or a race that will not settle, falls through to a
+ * reload prompt — the app shell is gone by then, so there is nothing left to
+ * recover in place.
+ */
+export default class ShellErrorBoundary extends Component<
+	ShellErrorBoundaryProps,
+	ShellErrorBoundaryState
+> {
+	override state: ShellErrorBoundaryState = { status: "ok" };
+
+	consecutiveRecoveries = 0;
+
+	static getDerivedStateFromError(): ShellErrorBoundaryState {
+		return { status: "recovering" };
+	}
+
+	override componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
+		const contexts = {
+			react: { componentStack: errorInfo.componentStack ?? undefined },
+		};
+
+		if (error) {
+			Sentry.captureException(error, { contexts });
+			this.setState({ status: "failed" });
+			return;
+		}
+
+		// The thrown value carries no stack and no message, so report a real Error
+		// that names the failure instead. The component stack is the only thing
+		// that identifies where it came from.
+		Sentry.captureException(
+			new Error("Router threw a falsy value and unmounted the app"),
+			{ contexts, tags: { router: "falsy-throw" } },
+		);
+
+		if (this.consecutiveRecoveries >= MAX_CONSECUTIVE_RECOVERIES) {
+			this.setState({ status: "failed" });
+			return;
+		}
+
+		this.consecutiveRecoveries += 1;
+
+		// A task rather than a microtask: the navigation that raced is still in
+		// flight, and remounting into the same half-settled match would only throw
+		// again and burn a retry.
+		setTimeout(() => {
+			this.setState({ status: "ok" });
+		}, 0);
+	}
+
+	override componentDidUpdate() {
+		// The remount rendered without throwing, so the race is over and the next
+		// one — minutes or hours from now — starts with a full budget again.
+		if (this.state.status === "ok") {
+			this.consecutiveRecoveries = 0;
+		}
+	}
+
+	override render() {
+		if (this.state.status === "ok") {
+			return this.props.children;
+		}
+
+		if (this.state.status === "recovering") {
+			return <LoadingPlaceholder />;
+		}
+
+		return (
+			<ErrorState message="Virtool ran into a problem and couldn't continue">
+				<Button color="blue" onClick={() => window.location.reload()}>
+					Reload
+				</Button>
+			</ErrorState>
+		);
+	}
+}

--- a/apps/web/src/base/__tests__/ShellErrorBoundary.test.tsx
+++ b/apps/web/src/base/__tests__/ShellErrorBoundary.test.tsx
@@ -1,0 +1,195 @@
+import * as Sentry from "@sentry/tanstackstart-react";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { act, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ShellErrorBoundary from "../ShellErrorBoundary";
+
+vi.mock("@sentry/tanstackstart-react", () => ({
+	captureException: vi.fn(),
+}));
+
+type Control = { throwing: boolean; value: unknown };
+
+/**
+ * Throws `control.value` for as long as `control.throwing` is set, standing in
+ * for `MatchInner` throwing a cleared `loadPromise` while a redirect settles.
+ *
+ * The flag is read fresh on every render rather than counted down: React
+ * re-renders the root synchronously after a concurrent render throws, so a
+ * counter would be spent by the retry before the boundary ever caught anything.
+ */
+function Thrower({
+	control,
+	children,
+}: {
+	control: Control;
+	children: ReactNode;
+}) {
+	if (control.throwing) {
+		throw control.value;
+	}
+
+	return children;
+}
+
+let unmount: (() => void) | undefined;
+
+/**
+ * Renders into a root whose error hooks are silenced.
+ *
+ * `@testing-library/react` gives no way to pass them, and without them React
+ * hands every error the boundary catches to `reportError`, which jsdom raises
+ * as an uncaught exception and Vitest fails the run on.
+ */
+function renderBoundary(ui: ReactNode) {
+	const container = document.createElement("div");
+	document.body.appendChild(container);
+
+	const root = createRoot(container, {
+		onCaughtError: () => undefined,
+		onRecoverableError: () => undefined,
+		onUncaughtError: () => undefined,
+	});
+
+	act(() => {
+		root.render(ui);
+	});
+
+	unmount = () => {
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+	};
+}
+
+/** Lets the boundary's `setTimeout` fire and React commit what follows. */
+async function settle() {
+	await act(async () => {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	});
+}
+
+const FAILED_MESSAGE = "Virtool ran into a problem and couldn't continue";
+
+afterEach(() => {
+	unmount?.();
+	unmount = undefined;
+	vi.restoreAllMocks();
+	vi.mocked(Sentry.captureException).mockReset();
+});
+
+describe("ShellErrorBoundary", () => {
+	it("should render its children when nothing throws", () => {
+		renderBoundary(
+			<ShellErrorBoundary>
+				<p>Samples</p>
+			</ShellErrorBoundary>,
+		);
+
+		expect(screen.getByText("Samples")).toBeInTheDocument();
+	});
+
+	it("should remount the tree after a falsy throw instead of going blank", async () => {
+		const control: Control = { throwing: true, value: undefined };
+
+		renderBoundary(
+			<ShellErrorBoundary>
+				<Thrower control={control}>
+					<p>Samples</p>
+				</Thrower>
+			</ShellErrorBoundary>,
+		);
+
+		expect(screen.queryByText("Samples")).not.toBeInTheDocument();
+
+		control.throwing = false;
+		await settle();
+
+		expect(screen.getByText("Samples")).toBeInTheDocument();
+		expect(screen.queryByText(FAILED_MESSAGE)).not.toBeInTheDocument();
+	});
+
+	it("should report a falsy throw to sentry as a named error", async () => {
+		const control: Control = { throwing: true, value: undefined };
+
+		renderBoundary(
+			<ShellErrorBoundary>
+				<Thrower control={control}>
+					<p>Samples</p>
+				</Thrower>
+			</ShellErrorBoundary>,
+		);
+
+		control.throwing = false;
+		await settle();
+
+		expect(Sentry.captureException).toHaveBeenCalledWith(
+			expect.objectContaining({
+				message: "Router threw a falsy value and unmounted the app",
+			}),
+			expect.objectContaining({ tags: { router: "falsy-throw" } }),
+		);
+	});
+
+	it("should offer a reload once the falsy throws stop being a race", async () => {
+		const control: Control = { throwing: true, value: undefined };
+
+		renderBoundary(
+			<ShellErrorBoundary>
+				<Thrower control={control}>
+					<p>Samples</p>
+				</Thrower>
+			</ShellErrorBoundary>,
+		);
+
+		// One settle per retry the boundary is allowed, plus one for the give-up.
+		await settle();
+		await settle();
+		await settle();
+
+		expect(screen.getByText(FAILED_MESSAGE)).toBeInTheDocument();
+
+		const reload = vi.fn();
+		const original = window.location;
+		Object.defineProperty(window, "location", {
+			configurable: true,
+			value: { ...original, reload },
+		});
+
+		try {
+			await userEvent.click(screen.getByRole("button", { name: "Reload" }));
+			expect(reload).toHaveBeenCalledOnce();
+		} finally {
+			Object.defineProperty(window, "location", {
+				configurable: true,
+				value: original,
+			});
+		}
+	});
+
+	it("should not retry a real error, and should report it as thrown", async () => {
+		const error = new Error("boom");
+		const control: Control = { throwing: true, value: error };
+
+		renderBoundary(
+			<ShellErrorBoundary>
+				<Thrower control={control}>
+					<p>Samples</p>
+				</Thrower>
+			</ShellErrorBoundary>,
+		);
+
+		control.throwing = false;
+		await settle();
+
+		expect(screen.getByText(FAILED_MESSAGE)).toBeInTheDocument();
+		expect(screen.queryByText("Samples")).not.toBeInTheDocument();
+		expect(Sentry.captureException).toHaveBeenCalledWith(
+			error,
+			expect.not.objectContaining({ tags: expect.anything() }),
+		);
+	});
+});

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as EventsRouteImport } from './routes/events'
 import { Route as LoginRouteImport } from './routes/login'
@@ -16,7 +17,6 @@ import { Route as MetricsRouteImport } from './routes/metrics'
 import { Route as MonitoringRouteImport } from './routes/monitoring'
 import { Route as SetupRouteImport } from './routes/setup'
 import { Route as UploadsRouteImport } from './routes/uploads'
-import { Route as AuthenticatedIndexRouteImport } from './routes/_authenticated/index'
 import { Route as AuthenticatedAccountRouteImport } from './routes/_authenticated/account'
 import { Route as AuthenticatedAdministrationRouteRouteImport } from './routes/_authenticated/administration/route'
 import { Route as AuthenticatedHmmsRouteImport } from './routes/_authenticated/hmms'
@@ -80,6 +80,11 @@ import { Route as AuthenticatedRefsRefIdOtusOtuIdIsolatesIndexRouteImport } from
 import { Route as AuthenticatedRefsRefIdOtusOtuIdIsolatesIsolateIdRouteImport } from './routes/_authenticated/refs/$refId/otus/$otuId/isolates/$isolateId'
 import { Route as OtusOtuIdIsolatesIsolateIdSequencesSequenceIdFastaRouteImport } from './routes/otus.$otuId.isolates.$isolateId.sequences.$sequenceId.fasta'
 
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: '/_authenticated',
   getParentRoute: () => rootRouteImport,
@@ -113,11 +118,6 @@ const UploadsRoute = UploadsRouteImport.update({
   id: '/uploads',
   path: '/uploads',
   getParentRoute: () => rootRouteImport,
-} as any)
-const AuthenticatedIndexRoute = AuthenticatedIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => AuthenticatedRoute,
 } as any)
 const AuthenticatedAccountRoute = AuthenticatedAccountRouteImport.update({
   id: '/account',
@@ -478,7 +478,7 @@ const OtusOtuIdIsolatesIsolateIdSequencesSequenceIdFastaRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof AuthenticatedIndexRoute
+  '/': typeof IndexRoute
   '/events': typeof EventsRoute
   '/login': typeof LoginRoute
   '/metrics': typeof MetricsRoute
@@ -549,6 +549,7 @@ export interface FileRoutesByFullPath {
   '/refs/$refId/otus/$otuId/isolates/': typeof AuthenticatedRefsRefIdOtusOtuIdIsolatesIndexRoute
 }
 export interface FileRoutesByTo {
+  '/': typeof IndexRoute
   '/events': typeof EventsRoute
   '/login': typeof LoginRoute
   '/metrics': typeof MetricsRoute
@@ -558,7 +559,6 @@ export interface FileRoutesByTo {
   '/health/live': typeof HealthLiveRoute
   '/health/ready': typeof HealthReadyRoute
   '/uploads/$uploadId': typeof UploadsUploadIdRoute
-  '/': typeof AuthenticatedIndexRoute
   '/account/api': typeof AuthenticatedAccountApiRoute
   '/account/profile': typeof AuthenticatedAccountProfileRoute
   '/administration/groups': typeof AuthenticatedAdministrationGroupsRoute
@@ -609,6 +609,7 @@ export interface FileRoutesByTo {
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/events': typeof EventsRoute
   '/login': typeof LoginRoute
@@ -626,7 +627,6 @@ export interface FileRoutesById {
   '/health/live': typeof HealthLiveRoute
   '/health/ready': typeof HealthReadyRoute
   '/uploads_/$uploadId': typeof UploadsUploadIdRoute
-  '/_authenticated/': typeof AuthenticatedIndexRoute
   '/_authenticated/refs/$refId': typeof AuthenticatedRefsRefIdRouteRouteWithChildren
   '/_authenticated/account/api': typeof AuthenticatedAccountApiRoute
   '/_authenticated/account/profile': typeof AuthenticatedAccountProfileRoute
@@ -754,6 +754,7 @@ export interface FileRouteTypes {
     | '/refs/$refId/otus/$otuId/isolates/'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/'
     | '/events'
     | '/login'
     | '/metrics'
@@ -763,7 +764,6 @@ export interface FileRouteTypes {
     | '/health/live'
     | '/health/ready'
     | '/uploads/$uploadId'
-    | '/'
     | '/account/api'
     | '/account/profile'
     | '/administration/groups'
@@ -813,6 +813,7 @@ export interface FileRouteTypes {
     | '/refs/$refId/otus/$otuId/isolates'
   id:
     | '__root__'
+    | '/'
     | '/_authenticated'
     | '/events'
     | '/login'
@@ -830,7 +831,6 @@ export interface FileRouteTypes {
     | '/health/live'
     | '/health/ready'
     | '/uploads_/$uploadId'
-    | '/_authenticated/'
     | '/_authenticated/refs/$refId'
     | '/_authenticated/account/api'
     | '/_authenticated/account/profile'
@@ -886,6 +886,7 @@ export interface FileRouteTypes {
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
+  IndexRoute: typeof IndexRoute
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
   EventsRoute: typeof EventsRoute
   LoginRoute: typeof LoginRoute
@@ -907,6 +908,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_authenticated': {
       id: '/_authenticated'
       path: ''
@@ -955,13 +963,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/uploads'
       preLoaderRoute: typeof UploadsRouteImport
       parentRoute: typeof rootRouteImport
-    }
-    '/_authenticated/': {
-      id: '/_authenticated/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof AuthenticatedIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/account': {
       id: '/_authenticated/account'
@@ -1655,7 +1656,6 @@ interface AuthenticatedRouteChildren {
   AuthenticatedJobsRoute: typeof AuthenticatedJobsRouteWithChildren
   AuthenticatedSamplesRoute: typeof AuthenticatedSamplesRouteWithChildren
   AuthenticatedSubtractionsRoute: typeof AuthenticatedSubtractionsRouteWithChildren
-  AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
@@ -1667,7 +1667,6 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedJobsRoute: AuthenticatedJobsRouteWithChildren,
   AuthenticatedSamplesRoute: AuthenticatedSamplesRouteWithChildren,
   AuthenticatedSubtractionsRoute: AuthenticatedSubtractionsRouteWithChildren,
-  AuthenticatedIndexRoute: AuthenticatedIndexRoute,
 }
 
 const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
@@ -1675,6 +1674,7 @@ const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
 )
 
 const rootRouteChildren: RootRouteChildren = {
+  IndexRoute: IndexRoute,
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
   EventsRoute: EventsRoute,
   LoginRoute: LoginRoute,

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -49,6 +49,12 @@ export function getRouter() {
 		// page. The window stays open for as long as the slowest loader in the
 		// chain runs, which is why only routes with a slow loader (a pathoscope
 		// analysis document) hit it. See TanStack/router#7753.
+		//
+		// Keeping the default only narrows that window; it does not close it. A
+		// chained redirect clears the same promise on a match the router is still
+		// rendering, which is how signing in could land on a blank page. The
+		// unmount itself is caught by `@base/ShellErrorBoundary` — this option is
+		// what keeps it rare, not what makes it survivable.
 		// Preload routes on hover/touch/focus. Loaders back onto React Query via
 		// `ensureQueryData`, so a 0 preload stale time hands freshness decisions
 		// entirely to React Query's own `staleTime`/`gcTime` instead of letting

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -3,6 +3,7 @@ import { readSentryDsn, SENTRY_DSN_META_NAME } from "@app/sentryDsn";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NotFound from "@base/NotFound";
 import RouteError from "@base/RouteError";
+import ShellErrorBoundary from "@base/ShellErrorBoundary";
 import interLatin from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url";
 import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
@@ -74,7 +75,10 @@ function RootShell({ children }: { children: ReactNode }) {
 				<HeadContent />
 			</head>
 			<body>
-				{children}
+				{/* Above every route match, so a value the router's own boundaries
+				    cannot catch stops here instead of unmounting the page. `Scripts`
+				    stays outside it — the reload prompt is worthless without them. */}
+				<ShellErrorBoundary>{children}</ShellErrorBoundary>
 				<Scripts />
 			</body>
 		</html>

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -1,7 +1,0 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
-
-export const Route = createFileRoute("/_authenticated/")({
-	beforeLoad: () => {
-		throw redirect({ to: "/samples" });
-	},
-});

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+/**
+ * Sends `/` to the samples list.
+ *
+ * Deliberately *not* nested under `_authenticated`, even though its target is.
+ * Nested, resolving `/` meant running that layout's async guard — a root fetch
+ * and an account fetch — and only then throwing a second redirect, so signing
+ * in navigated `/login` to `/` to `/samples` with the layout match re-rendering
+ * mid-chain. That is the window `MatchInner` throws `undefined` in (see
+ * `@base/ShellErrorBoundary`). Here the hop is synchronous and resolves before
+ * any match loads, so signing in navigates straight to `/samples`.
+ *
+ * Nothing is exposed by leaving it unguarded: the route renders nothing, and
+ * `/samples` carries the same guard it always did.
+ */
+export const Route = createFileRoute("/")({
+	beforeLoad: () => {
+		throw redirect({ to: "/samples" });
+	},
+});

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -393,8 +393,9 @@ The client mutation (`useCreateFirstUser` in `wall/queries.ts`) drops
 the cached `root` and `account` documents on success so the guard
 refetches them fresh instead of reusing the pre-setup snapshot (which
 still says `first_user: true` and would bounce the user back to
-`/setup`). It then navigates to `/`; the now-authenticated guard admits
-the user.
+`/setup`). It then navigates to `/`, which is an unguarded route that
+redirects straight to `/samples`; the now-authenticated guard admits the
+user there.
 
 ## Forced password reset
 


### PR DESCRIPTION
## Summary

- Signing in redirected `/login` → `/` → `/samples`, and `/` was nested under the `_authenticated` layout, so resolving it ran that layout's async guard before throwing the second redirect. That let the layout match re-render mid-chain, hitting a TanStack Router bug where a cleared `loadPromise` is thrown as `undefined`, escapes every `CatchBoundary` (which tests the thrown value for truthiness), and unmounts the whole tree.
- Move `/` to a top-level, synchronous `beforeLoad` (`routes/index.tsx`) so it redirects to `/samples` before any match loads, removing the chained-redirect window entirely.
- Add `@base/ShellErrorBoundary` as a backstop for the underlying bug (TanStack/router#7753, still open): it treats a falsy throw as the transient race it is, remounting the router up to twice before falling back to a reload prompt, and reports it to Sentry as a named error carrying the component stack.