### PR TITLE
fix: respect the browser's font-size preference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,6 +370,9 @@ patterns.
   a class does **not** render its documented px figure: `text-sm` is 12.25px,
   `md:` breaks at 672px.
 - Size anything that holds text in `rem`; keep px for graphics that hold none.
+  Where a size has to be a number — a threshold compared against a measured
+  width — write it as a rem multiple and resolve it with `useRootFontSize`
+  (`@app/hooks`), never as a px constant.
 
 See [docs/type-scale.md](docs/type-scale.md) for which token families are
 overridden and why they move together, the class-to-px table, and the px

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,15 +364,16 @@ patterns.
   `apps/web/src/app/style.css` under `@theme`, with keyframes in
   `apps/web/src/app/animations.css`. Check there before inventing a color or
   spacing value, and add a token rather than hardcoding a hex.
-- The root font size is `100%` — the reader's browser preference. Every
-  rem-valued token Tailwind ships (`--text-*`, `--spacing`, `--container-*`,
-  `--breakpoint-*`, `--radius-*`) is overridden in `@theme` at 0.875 of its
-  stock value, so a class does **not** render its documented px figure:
-  `text-sm` is 12.25px, `md:` breaks at 672px. `body` carries the app's base
-  size; never put a font size back on `html`.
-- A px figure reserving space for text is overrun by a reader who asked for a
-  larger font. Size anything holding text in `rem`, and keep px for graphics
-  that hold none, as `PathoscopeCoverageChart` does.
+- The root font size is `100%` — the reader's browser preference. Never put a
+  length back on `html`; `body` carries the app's base size.
+- Every rem-valued token Tailwind ships is overridden in `@theme` at 0.875, so
+  a class does **not** render its documented px figure: `text-sm` is 12.25px,
+  `md:` breaks at 672px.
+- Size anything that holds text in `rem`; keep px for graphics that hold none.
+
+See [docs/type-scale.md](docs/type-scale.md) for which token families are
+overridden and why they move together, the class-to-px table, and the px
+holdouts that still need fixing.
 
 ### Base component color props
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,6 +364,15 @@ patterns.
   `apps/web/src/app/style.css` under `@theme`, with keyframes in
   `apps/web/src/app/animations.css`. Check there before inventing a color or
   spacing value, and add a token rather than hardcoding a hex.
+- The root font size is `100%` — the reader's browser preference. Every
+  rem-valued token Tailwind ships (`--text-*`, `--spacing`, `--container-*`,
+  `--breakpoint-*`, `--radius-*`) is overridden in `@theme` at 0.875 of its
+  stock value, so a class does **not** render its documented px figure:
+  `text-sm` is 12.25px, `md:` breaks at 672px. `body` carries the app's base
+  size; never put a font size back on `html`.
+- A px figure reserving space for text is overrun by a reader who asked for a
+  larger font. Size anything holding text in `rem`, and keep px for graphics
+  that hold none, as `PathoscopeCoverageChart` does.
 
 ### Base component color props
 

--- a/apps/web/src/analyses/components/Pathoscope/PathoscopeCoverageChart.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/PathoscopeCoverageChart.tsx
@@ -21,18 +21,24 @@ const gutter = 4;
  * without it, a chart whose panels have nothing to say sits flush against the
  * bottom of its box while one with labelled panels grows to fit them, and the
  * two read as different components rather than the same chart in two states.
+ *
+ * In rem, not px: the caption it holds grows with the reader's font-size
+ * preference.
  */
-const labelHeight = 18;
+const labelHeight = "1.125rem";
 
 /**
  * The space above a panel's curve, which the depth ceiling and its label sit in.
  *
- * It belongs to the panel's own svg rather than to the box around it, so that a
- * panel's hover and focus styling covers the full height of the chart. Held on
- * the box, it left a strip along the top that was inside the border but outside
- * every panel, and so stayed unhighlighted while the panel below it was hovered.
+ * It is reserved by a spacer inside the panel rather than by padding on the box
+ * around it, so that a panel's hover and focus styling covers the full height of
+ * the chart. Held on the box, it left a strip along the top that was inside the
+ * border but outside every panel, and so stayed unhighlighted while the panel
+ * below it was hovered.
+ *
+ * In rem, like the label row: the depth label sits in it.
  */
-const headroom = 18;
+const headroom = "1.125rem";
 
 /** The narrowest panel that carries both a label and its length. */
 const lengthMinWidth = 120;
@@ -162,15 +168,19 @@ export default function PathoscopeCoverageChart({
 		// than exposed as an unlabelled graphic of its own.
 		const body = (
 			<>
+				<div style={{ height: headroom }} />
 				<svg
 					aria-hidden="true"
 					className="block"
-					height={height + headroom}
+					height={height}
 					width={panel.width}
 				>
 					{/* Every panel draws the ceiling, but only the chart labels it: the
 					    domain is shared, so the curves are what differ from panel to
-					    panel and the line they are measured against does not. */}
+					    panel and the line they are measured against does not.
+
+					    Half a pixel down, so a one-pixel stroke lands inside the svg
+					    rather than being clipped by its top edge. */}
 					{maxDepth > 0 && (
 						<line
 							className="stroke-gray-500"
@@ -178,13 +188,11 @@ export default function PathoscopeCoverageChart({
 							strokeDasharray="2 3"
 							x1={0}
 							x2={panel.width}
-							y1={headroom}
-							y2={headroom}
+							y1={0.5}
+							y2={0.5}
 						/>
 					)}
-					<g transform={`translate(0,${headroom})`}>
-						{d ? <path className="fill-blue-500" d={d} /> : null}
-					</g>
+					{d ? <path className="fill-blue-500" d={d} /> : null}
 				</svg>
 				{/* The label gives way first: an ellipsis destroys a length outright
 				    where a truncated label is still recognisable.
@@ -247,7 +255,10 @@ export default function PathoscopeCoverageChart({
 
 	// The height is fixed rather than left to the panels, so the box does not
 	// collapse in the frame before the container has been measured.
-	const style = { gap, height: height + labelHeight + headroom };
+	const style = {
+		gap,
+		height: `calc(${height}px + ${headroom} + ${labelHeight})`,
+	};
 
 	// The label is drawn over the chart rather than inside a panel's svg, which
 	// clips its own overflow — a narrow first panel would cut it off.

--- a/apps/web/src/analyses/components/Pathoscope/PathoscopeCoverageChart.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/PathoscopeCoverageChart.tsx
@@ -1,4 +1,4 @@
-import { useElementSize } from "@app/hooks";
+import { useElementSize, useRootFontSize } from "@app/hooks";
 import Icon from "@base/Icon";
 import Popover from "@base/Popover";
 import Tooltip from "@base/Tooltip";
@@ -40,8 +40,15 @@ const labelHeight = "1.125rem";
  */
 const headroom = "1.125rem";
 
-/** The narrowest panel that carries both a label and its length. */
-const lengthMinWidth = 120;
+/**
+ * The narrowest panel that carries both a label and its length, in rem.
+ *
+ * The caption it has to fit is sized in rem, so this is too. Held in px it
+ * would be right at the default preference and wrong at every other, letting a
+ * panel just over the bar draw a length too wide to sit inside it — the length
+ * does not shrink, so it spills into the panel alongside.
+ */
+const lengthMinWidth = 7.5;
 
 // The ceiling is read at a glance against the curve below it, so it is rounded
 // hard rather than given the exact figure the depth column already carries.
@@ -117,10 +124,10 @@ function layOutPanels(panels: CoveragePanel[], width: number): Panel[] {
 
 // A panel with no label has nothing else to identify it, so it keeps its length
 // at any width rather than be left with a blank caption.
-function showsLength(panel: Panel): boolean {
+function showsLength(panel: Panel, rootFontSize: number): boolean {
 	return (
 		Boolean(panel.lengthLabel) &&
-		(!panel.label || panel.width >= lengthMinWidth)
+		(!panel.label || panel.width >= lengthMinWidth * rootFontSize)
 	);
 }
 
@@ -151,6 +158,7 @@ export default function PathoscopeCoverageChart({
 	panels,
 }: PathoscopeCoverageChartProps) {
 	const [ref, { width }] = useElementSize<HTMLDivElement>();
+	const rootFontSize = useRootFontSize();
 
 	const laidOut = width > 0 ? layOutPanels(panels, width) : [];
 
@@ -204,7 +212,7 @@ export default function PathoscopeCoverageChart({
 					style={{ height: labelHeight }}
 				>
 					<span className="min-w-0 text-left truncate">{panel.label}</span>
-					{showsLength(panel) && (
+					{showsLength(panel, rootFontSize) && (
 						<>
 							{panel.label && (
 								<span aria-hidden="true" className="shrink-0">

--- a/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeOtuCoverage.test.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeOtuCoverage.test.tsx
@@ -12,6 +12,15 @@ function mockElementWidth(width: number) {
 	vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(width);
 }
 
+/**
+ * jsdom resolves no root font size of its own, so the chart falls back to 16px
+ * and every other test here reads against that. Set one to stand in for a
+ * reader who has asked for larger text.
+ */
+function mockRootFontSize(pixels: number) {
+	document.documentElement.style.fontSize = `${pixels}px`;
+}
+
 function segment(
 	align: Coordinate[],
 	length: number,
@@ -48,6 +57,7 @@ function xValuesOf(path: SVGPathElement | undefined): number[] {
 
 afterEach(() => {
 	vi.restoreAllMocks();
+	document.documentElement.style.fontSize = "";
 });
 
 describe("<PathoscopeOtuCoverage />", () => {
@@ -347,6 +357,25 @@ describe("<PathoscopeOtuCoverage />", () => {
 
 		expect(screen.getByText("3,400 nt")).toBeVisible();
 		expect(screen.getByText("800 nt")).toBeVisible();
+	});
+
+	it("should raise the bar a panel clears to hold its length as the reader's text grows", () => {
+		// Two equal panels in 414px are 200px each — room for a length at the
+		// default preference, and none at twice it. The bar is in rem, so it
+		// doubles with the caption instead of letting it overrun the panel.
+		mockElementWidth(414);
+		mockRootFontSize(32);
+
+		renderWithProviders(
+			<PathoscopeOtuCoverage
+				maxDepth={12}
+				segments={[segment(align, 3400, "L"), segment(align, 3400, "S")]}
+			/>,
+		);
+
+		expect(screen.getByText("L")).toBeVisible();
+		expect(screen.getByText("S")).toBeVisible();
+		expect(screen.queryByText(/nt$/)).toBeNull();
 	});
 
 	it("should say why a segment nothing mapped to is blank", () => {

--- a/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeOtuCoverage.test.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeOtuCoverage.test.tsx
@@ -238,6 +238,10 @@ describe("<PathoscopeOtuCoverage />", () => {
 			"0.5",
 			"0.5",
 		]);
+		expect(rules.map((rule) => rule.getAttribute("y2"))).toEqual([
+			"0.5",
+			"0.5",
+		]);
 		expect(rules.map((rule) => rule.getAttribute("x2"))).toEqual([
 			"300",
 			"100",

--- a/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeOtuCoverage.test.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeOtuCoverage.test.tsx
@@ -231,10 +231,13 @@ describe("<PathoscopeOtuCoverage />", () => {
 
 		const rules = [...container.querySelectorAll("line")];
 
-		// The curve area starts below the rule, so a curve reaching the ceiling
-		// meets it rather than running off the top of the panel.
+		// The rule sits at the top of the curve area, so a curve reaching the
+		// ceiling meets it rather than running off the top of the panel.
 		expect(rules).toHaveLength(2);
-		expect(rules.map((rule) => rule.getAttribute("y1"))).toEqual(["18", "18"]);
+		expect(rules.map((rule) => rule.getAttribute("y1"))).toEqual([
+			"0.5",
+			"0.5",
+		]);
 		expect(rules.map((rule) => rule.getAttribute("x2"))).toEqual([
 			"300",
 			"100",
@@ -388,7 +391,9 @@ describe("<PathoscopeOtuCoverage />", () => {
 		const labelRow = container.querySelector(".text-gray-600.text-sm");
 
 		expect(labelRow).not.toBeNull();
-		expect((labelRow as HTMLElement).style.height).toBe("18px");
+
+		// In rem, so it grows with the reader's font-size preference.
+		expect((labelRow as HTMLElement).style.height).toBe("1.125rem");
 	});
 
 	it("should left-justify segment labels", () => {

--- a/apps/web/src/app/hooks.tsx
+++ b/apps/web/src/app/hooks.tsx
@@ -71,6 +71,94 @@ export function useDebounce<T>(
 	return [draft, setDraft];
 }
 
+const defaultRootFontSize = 16;
+
+const rootFontSizeListeners = new Set<() => void>();
+
+let rootFontSizeProbe: HTMLDivElement | null = null;
+let rootFontSizeObserver: ResizeObserver | null = null;
+let rootFontSize = defaultRootFontSize;
+
+function measureRootFontSize(): number {
+	const size = Number.parseFloat(
+		getComputedStyle(document.documentElement).fontSize,
+	);
+
+	// A document that has resolved no size of its own reports a keyword, and a
+	// font size cannot be zero, so neither answer is one to divide a layout by.
+	return size > 0 ? size : defaultRootFontSize;
+}
+
+function subscribeToRootFontSize(callback: () => void) {
+	rootFontSizeListeners.add(callback);
+
+	if (!rootFontSizeProbe) {
+		// Changing the preference fires no event, and the root's own box need not
+		// resize when it does — but a 1rem-wide element always does. One is kept
+		// off-screen and watched, once for the page rather than once per caller.
+		rootFontSizeProbe = document.createElement("div");
+		rootFontSizeProbe.setAttribute("aria-hidden", "true");
+		rootFontSizeProbe.style.cssText =
+			"height:0;position:absolute;visibility:hidden;width:1rem";
+
+		document.body.appendChild(rootFontSizeProbe);
+
+		rootFontSize = measureRootFontSize();
+
+		rootFontSizeObserver = new ResizeObserver(() => {
+			const next = measureRootFontSize();
+
+			if (next !== rootFontSize) {
+				rootFontSize = next;
+				for (const listener of rootFontSizeListeners) {
+					listener();
+				}
+			}
+		});
+
+		rootFontSizeObserver.observe(rootFontSizeProbe);
+	}
+
+	return () => {
+		rootFontSizeListeners.delete(callback);
+
+		if (rootFontSizeListeners.size === 0) {
+			rootFontSizeObserver?.disconnect();
+			rootFontSizeObserver = null;
+			rootFontSizeProbe?.remove();
+			rootFontSizeProbe = null;
+			rootFontSize = defaultRootFontSize;
+		}
+	};
+}
+
+function getRootFontSize(): number {
+	return rootFontSize;
+}
+
+function getDefaultRootFontSize(): number {
+	return defaultRootFontSize;
+}
+
+/**
+ * The reader's font-size preference, in CSS pixels.
+ *
+ * Sizes belong in rem, where the browser scales them without being asked. This
+ * is for the few that cannot be a CSS length and have to be a number — a
+ * threshold compared against a measured width, a virtualizer's row height.
+ *
+ * It is subscribed to rather than read during render. The compiler caches
+ * render against its inputs, and a figure read out of the document is not one
+ * of them, so a preference that changed would never reach the screen.
+ */
+export function useRootFontSize(): number {
+	return useSyncExternalStore(
+		subscribeToRootFontSize,
+		getRootFontSize,
+		getDefaultRootFontSize,
+	);
+}
+
 type Size = {
 	height: number;
 	width: number;

--- a/apps/web/src/app/style.css
+++ b/apps/web/src/app/style.css
@@ -24,10 +24,65 @@
 	--z-dropdown: 60; /* dropdown menus, selects, comboboxes */
 	--z-popover: 70; /* tooltips and popovers — above dialog content */
 	--z-toast: 80; /* toasts and upload progress — topmost */
+
+	/* Every rem-valued token Tailwind ships is scaled to 0.875 of its stock
+	   value, which is what the app got from the 14px root this replaced. Holding
+	   the shrink on the scale rather than the root is what lets it be walked back
+	   a token at a time.
+
+	   Line heights are unitless ratios and letter spacing is in em, so both
+	   follow their font size untouched. */
+
+	--text-xs: 0.65625rem;
+	--text-sm: 0.765625rem;
+	--text-base: 0.875rem;
+	--text-lg: 0.984375rem;
+	--text-xl: 1.09375rem;
+	--text-2xl: 1.3125rem;
+	--text-3xl: 1.640625rem;
+	--text-4xl: 1.96875rem;
+	--text-5xl: 2.625rem;
+	--text-6xl: 3.28125rem;
+	--text-7xl: 3.9375rem;
+	--text-8xl: 5.25rem;
+	--text-9xl: 7rem;
+
+	--spacing: 0.21875rem;
+
+	--breakpoint-sm: 35rem;
+	--breakpoint-md: 42rem;
+	--breakpoint-lg: 56rem;
+	--breakpoint-xl: 70rem;
+	--breakpoint-2xl: 84rem;
+
+	--container-3xs: 14rem;
+	--container-2xs: 15.75rem;
+	--container-xs: 17.5rem;
+	--container-sm: 21rem;
+	--container-md: 24.5rem;
+	--container-lg: 28rem;
+	--container-xl: 31.5rem;
+	--container-2xl: 36.75rem;
+	--container-3xl: 42rem;
+	--container-4xl: 49rem;
+	--container-5xl: 56rem;
+	--container-6xl: 63rem;
+	--container-7xl: 70rem;
+
+	--radius-xs: 0.109375rem;
+	--radius-sm: 0.21875rem;
+	--radius-md: 0.328125rem;
+	--radius-lg: 0.4375rem;
+	--radius-xl: 0.65625rem;
+	--radius-2xl: 0.875rem;
+	--radius-3xl: 1.3125rem;
+	--radius-4xl: 1.75rem;
 }
 
+/* The reader's font-size preference is an accessibility setting; a px root
+   discards it. */
 html {
-	font-size: 14px;
+	font-size: 100%;
 }
 
 @utility scrollbar-gutter-stable {
@@ -73,6 +128,12 @@ html {
 }
 
 @layer base {
+	/* The app's own base size, which came from the root before the root became
+	   the reader's. */
+	body {
+		font-size: var(--text-base);
+	}
+
 	h1 {
 		font-size: var(--text-4xl);
 	}
@@ -85,11 +146,11 @@ html {
 	h5 {
 		font-size: var(--text-base);
 		font-weight: var(--font-weight-medium);
-		margin: 5px 0 10px;
+		margin: 0.3125rem 0 0.625rem;
 	}
 
 	p {
-		margin: 0 0 10px;
+		margin: 0 0 0.625rem;
 	}
 
 	a {

--- a/docs/type-scale.md
+++ b/docs/type-scale.md
@@ -1,0 +1,102 @@
+# Type and spacing scale
+
+## The root belongs to the reader
+
+`html` is at `font-size: 100%`. It used to be `14px`, which discards the
+font-size preference a reader sets in their browser — an accessibility setting
+a low-vision reader depends on, and one a px root overrides outright.
+
+`100%` is already the initial value, so the rule earns its place by saying so
+explicitly. Don't delete it, and don't put a length back on `html`. The app's
+own base size lives on `body` instead, as `var(--text-base)`; without it, text
+carrying no size class of its own would take the reader's figure rather than
+the app's.
+
+## The 0.875 override
+
+The app was drawn against that 14px root, so every rem-valued token Tailwind
+ships is overridden in `@theme` at 0.875 of its stock value. Against a 16px
+default that renders exactly what the 14px root did — the shrink moved off the
+root and onto the scale.
+
+That move is the point. On the root, the shrink applied to everything at once
+and could only be removed the same way. On the scale it can be walked back a
+token at a time, which is a separate pass still to come.
+
+Five families are overridden, and they are overridden together:
+
+| Family | Drives |
+| --- | --- |
+| `--text-*` | `text-xs` … `text-9xl` |
+| `--spacing` | every `p-*`, `m-*`, `gap-*`, `size-*`, `w-*`, `h-*`, `max-h-*` … |
+| `--container-*` | `max-w-xs` … `max-w-7xl` |
+| `--breakpoint-*` | the `sm:` … `2xl:` variants |
+| `--radius-*` | `rounded-xs` … `rounded-4xl` |
+
+Leaving a family out is not a smaller change than including it — it is an
+unannounced visual change riding along inside a pass whose whole claim is that
+nothing moves. Breakpoints are the sharpest case: left at stock, `2xl:` would
+have gone from 1344px to 1536px, which hides the pathoscope panel labels on a
+1440px screen.
+
+Line heights and letter spacing are **not** overridden and must not be. Tailwind
+states line heights as unitless ratios and letter spacing in `em`, so both
+already follow whatever font size they land on.
+
+## A class does not render its documented px figure
+
+Against a 16px default:
+
+| Class | Tailwind docs | Here |
+| --- | --- | --- |
+| `text-xs` | 12px | 10.5px |
+| `text-sm` | 14px | 12.25px |
+| `text-base` | 16px | 14px |
+| `p-4` | 16px | 14px |
+| `gap-2` | 8px | 7px |
+| `md:` | 768px | 672px |
+| `2xl:` | 1536px | 1344px |
+
+So don't reason from the px column of the Tailwind documentation, and don't
+convert a design's px figure into a class by dividing it by 4. Multiply by
+0.875 first, or work in the class scale directly and check the result.
+
+## Anything that holds text is sized in rem
+
+A px figure reserving space for text is correct only at the default preference.
+A reader who has asked for larger text overruns it, and the text spills out of
+whatever was meant to contain it. Size it in `rem` and it grows with them.
+
+px stays right for a graphic that holds no text. `PathoscopeCoverageChart` is
+the worked example of both halves at once:
+
+- its label row and its headroom are `"1.125rem"`, because a caption sits in
+  one and the depth label in the other;
+- its plot area is a px number, because a coverage curve is a graphic with no
+  text in it, and the path geometry is built against a px width measured off
+  the container.
+
+That component also shows the one real constraint on the rule. Headroom used to
+be reserved inside the panel's `<svg>`, and an SVG coordinate cannot carry a
+CSS unit — so it moved out into a spacer element beside the svg. The spacer sits
+inside the panel rather than on the box around it, so a panel's hover and focus
+styling still covers it; held on the box it left a strip along the top that no
+panel covered and that stayed unhighlighted while the panel below it was
+hovered.
+
+## Known px holdouts
+
+These are px today and will misbehave at a large preference. They are known,
+not overlooked, and each needs more than a unit swap:
+
+- **Virtualized row heights** — `NuvsList` (`ROW_HEIGHT = 75`) and
+  `IsolateList` (`ROW_HEIGHT = 48`) feed a virtualizer's `estimateSize`. The
+  scroll geometry is tied to the constant, so scaling it needs measured rows or
+  a resolved px-per-rem, not a rem string.
+- **`lengthMinWidth`** in `PathoscopeCoverageChart` — a px threshold compared
+  against a measured px panel width, deciding whether a panel is wide enough to
+  carry both its label and its length. The text either side of the comparison
+  scales and the threshold does not, so at a large preference a panel just over
+  the cutoff draws a length it cannot fit.
+- **`InitialIcon`** — sets avatar font sizes in px, so initials don't scale.
+  Arguably correct for a fixed-size avatar.

--- a/docs/type-scale.md
+++ b/docs/type-scale.md
@@ -84,19 +84,45 @@ styling still covers it; held on the box it left a strip along the top that no
 panel covered and that stayed unhighlighted while the panel below it was
 hovered.
 
+## When it has to be a number
+
+Some sizes cannot be a CSS length. A threshold compared against a width
+measured off the DOM is a number on both sides of the comparison; so is a
+virtualizer's row height. For those, `useRootFontSize` (`@app/hooks`) reports
+the reader's preference in CSS pixels, and the figure is written as a rem
+multiple and resolved at the point of use:
+
+```ts
+const lengthMinWidth = 7.5;
+
+function showsLength(panel: Panel, rootFontSize: number): boolean {
+	return (
+		Boolean(panel.lengthLabel) &&
+		(!panel.label || panel.width >= lengthMinWidth * rootFontSize)
+	);
+}
+```
+
+Reach for it only when a rem genuinely cannot do the job. It is a subscription,
+not a read: the preference change fires no event and does not resize the root's
+own box, so the hook watches a shared off-screen 1rem probe with a
+`ResizeObserver`. Reading the size during render instead would be cached
+against inputs that never change, and a reader who enlarged their text would
+see nothing happen.
+
+The hook falls back to 16 when the document resolves no size of its own, which
+is what jsdom does — so a component test reads against the same figure the
+default preference gives, and a test that wants another sets
+`document.documentElement.style.fontSize`.
+
 ## Known px holdouts
 
-These are px today and will misbehave at a large preference. They are known,
-not overlooked, and each needs more than a unit swap:
+These are px today and misbehave at a large preference:
 
 - **Virtualized row heights** — `NuvsList` (`ROW_HEIGHT = 75`) and
-  `IsolateList` (`ROW_HEIGHT = 48`) feed a virtualizer's `estimateSize`. The
-  scroll geometry is tied to the constant, so scaling it needs measured rows or
-  a resolved px-per-rem, not a rem string.
-- **`lengthMinWidth`** in `PathoscopeCoverageChart` — a px threshold compared
-  against a measured px panel width, deciding whether a panel is wide enough to
-  carry both its label and its length. The text either side of the comparison
-  scales and the threshold does not, so at a large preference a panel just over
-  the cutoff draws a length it cannot fit.
+  `IsolateList` (`ROW_HEIGHT = 48`) feed a virtualizer's `estimateSize`. These
+  are the case `useRootFontSize` exists for, but the rows also have to actually
+  render at the height the virtualizer positions them by, so the fix is a
+  measurement question and not only a scaling one.
 - **`InitialIcon`** — sets avatar font sizes in px, so initials don't scale.
   Arguably correct for a fixed-size avatar.


### PR DESCRIPTION
## Summary
- The root was pinned to `14px`, which discards the font-size preference a low-vision reader sets in their browser. It is `100%` now, and the 0.875 the app got from that root moves onto the scale instead — every rem-valued Tailwind token (`--text-*`, `--spacing`, `--container-*`, `--breakpoint-*`, `--radius-*`) is overridden at 0.875 of its stock value, so rendering against a 16px default is unchanged and the shrink can be walked back a token at a time.
- `body` carries the app's base size explicitly, since text with no size class of its own used to inherit the root's 14px. The base layer's remaining px margins become rem.
- `PathoscopeCoverageChart` reserved space for its captions in px, which a larger preference overruns. Its label row and headroom are rem now; the headroom moves out of the panel's svg into a spacer beside it, since an svg coordinate cannot carry the unit.