### PR TITLE
fix: stop refetching a task on every progress update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -814,15 +814,16 @@ enforced on the refetch instead of in a fanout broadcast. Both
 Python and Node publish onto the Postgres `client_events` channel;
 `routes/events.ts` is the sole consumer.
 
-`jobs` update frames are the one exception: a running job emits one per
-progress wave and every job on screen holds its own `detail(id)` query,
-so invalidating per frame cost a request per running job. They route
-through `createJobRefreshQueue` (`jobs/refresh.ts`), which buffers ids
-and reads them with the batched `getJobs` server function instead. Don't
-add a `detail(id)` invalidation back for jobs.
+`jobs` and `tasks` update frames are the exceptions: a running job or
+task emits one per progress step and every one on screen holds its own
+`detail(id)` query, so invalidating per frame cost a request per record.
+They route through `createJobRefreshQueue` (`jobs/refresh.ts`) and
+`createTaskRefreshQueue` (`tasks/refresh.ts`), which buffer ids and read
+them with the batched `getJobs`/`getTasks` server functions instead.
+Don't add a `detail(id)` invalidation back for either.
 
 See [docs/server-push.md](docs/server-push.md) for the wire format,
-auth on the SSE side, the job-batching queue, and the follow-up TODOs.
+auth on the SSE side, the batching queues, and the follow-up TODOs.
 
 ## Linear
 

--- a/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
+++ b/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
@@ -117,11 +117,8 @@ describe("reactQueryHandler", () => {
 				queryKey: bannerQueryKeys.lists(),
 			},
 
-			// Tasks cache details but no list, so an insert falls back.
-			{
-				message: { domain: "tasks", operation: "update", id: 9 },
-				queryKey: taskQueryKeys.detail(9),
-			},
+			// Tasks cache details but no list, so an insert falls back. Their
+			// updates skip this mapping entirely — see the batching test below.
 			{
 				message: { domain: "tasks", operation: "insert", id: 9 },
 				queryKey: taskQueryKeys.all(),
@@ -260,6 +257,25 @@ describe("reactQueryHandler", () => {
 		expect(invalidate).not.toHaveBeenCalled();
 		expect(
 			queryClient.getQueryState(jobQueryKeys.detail(42))?.isInvalidated,
+		).toBe(false);
+	});
+
+	// A running task emits a frame per progress step — over a hundred for a
+	// reference clone — and every task-bearing row holds its own detail query.
+	// These frames go to the batching queue instead — see
+	// `tasks/__tests__/refresh.test.ts`.
+	it("batches task updates rather than invalidating a detail per frame", () => {
+		queryClient.setQueryData(taskQueryKeys.detail(9), { id: 9 });
+
+		reactQueryHandler(queryClient)({
+			domain: "tasks",
+			operation: "update",
+			id: 9,
+		});
+
+		expect(invalidate).not.toHaveBeenCalled();
+		expect(
+			queryClient.getQueryState(taskQueryKeys.detail(9))?.isInvalidated,
 		).toBe(false);
 	});
 

--- a/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
+++ b/apps/web/src/app/sse/__tests__/reactQueryHandler.test.ts
@@ -17,6 +17,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { reactQueryHandler } from "../reactQueryHandler";
 import handlerSource from "../reactQueryHandler.ts?raw";
 
+// The batching queues are covered by their own suites. Stubbing them here keeps
+// this file about routing: which frames reach a queue and which reach
+// `invalidateQueries`.
+const { queueJobRefresh, queueTaskRefresh } = vi.hoisted(() => ({
+	queueJobRefresh: vi.fn(),
+	queueTaskRefresh: vi.fn(),
+}));
+
+vi.mock("@jobs/refresh", () => ({
+	createJobRefreshQueue: () => queueJobRefresh,
+}));
+
+vi.mock("@tasks/refresh", () => ({
+	createTaskRefreshQueue: () => queueTaskRefresh,
+}));
+
 describe("reactQueryHandler", () => {
 	let queryClient: QueryClient;
 	let invalidate: ReturnType<typeof vi.spyOn>;
@@ -24,6 +40,8 @@ describe("reactQueryHandler", () => {
 	beforeEach(() => {
 		queryClient = new QueryClient();
 		invalidate = vi.spyOn(queryClient, "invalidateQueries");
+		queueJobRefresh.mockClear();
+		queueTaskRefresh.mockClear();
 	});
 
 	describe("selects the narrowest key the domain actually caches under", () => {
@@ -246,18 +264,14 @@ describe("reactQueryHandler", () => {
 	// detail is a request per running job per progress wave. These frames go to
 	// the batching queue instead — see `jobs/__tests__/refresh.test.ts`.
 	it("batches job updates rather than invalidating a detail per frame", () => {
-		queryClient.setQueryData(jobQueryKeys.detail(42), { id: 42 });
-
 		reactQueryHandler(queryClient)({
 			domain: "jobs",
 			operation: "update",
 			id: 42,
 		});
 
+		expect(queueJobRefresh).toHaveBeenCalledExactlyOnceWith(42);
 		expect(invalidate).not.toHaveBeenCalled();
-		expect(
-			queryClient.getQueryState(jobQueryKeys.detail(42))?.isInvalidated,
-		).toBe(false);
 	});
 
 	// A running task emits a frame per progress step — over a hundred for a
@@ -265,18 +279,29 @@ describe("reactQueryHandler", () => {
 	// These frames go to the batching queue instead — see
 	// `tasks/__tests__/refresh.test.ts`.
 	it("batches task updates rather than invalidating a detail per frame", () => {
-		queryClient.setQueryData(taskQueryKeys.detail(9), { id: 9 });
-
 		reactQueryHandler(queryClient)({
 			domain: "tasks",
 			operation: "update",
 			id: 9,
 		});
 
+		expect(queueTaskRefresh).toHaveBeenCalledExactlyOnceWith(9);
 		expect(invalidate).not.toHaveBeenCalled();
-		expect(
-			queryClient.getQueryState(taskQueryKeys.detail(9))?.isInvalidated,
-		).toBe(false);
+	});
+
+	// Only `update` frames are hot enough to batch. An insert or delete still
+	// takes the generic path, so a domain cannot lose them to the queue.
+	it("leaves non-update task frames on the invalidation path", () => {
+		reactQueryHandler(queryClient)({
+			domain: "tasks",
+			operation: "insert",
+			id: 9,
+		});
+
+		expect(queueTaskRefresh).not.toHaveBeenCalled();
+		expect(invalidate).toHaveBeenCalledExactlyOnceWith({
+			queryKey: taskQueryKeys.all(),
+		});
 	});
 
 	it("ignores messages for unknown domains", () => {

--- a/apps/web/src/app/sse/reactQueryHandler.ts
+++ b/apps/web/src/app/sse/reactQueryHandler.ts
@@ -12,6 +12,7 @@ import { referenceQueryKeys } from "@references/keys";
 import { samplesQueryKeys } from "@samples/keys";
 import type { QueryClient } from "@tanstack/react-query";
 import { taskQueryKeys } from "@tasks/keys";
+import { createTaskRefreshQueue } from "@tasks/refresh";
 import { fileQueryKeys } from "@uploads/keys";
 import { userQueryKeys } from "@users/keys";
 import type { SseDomain, SseMessage } from "@virtool/contracts";
@@ -101,6 +102,7 @@ function selectQueryKey(
 
 export function reactQueryHandler(queryClient: QueryClient) {
 	const queueJobRefresh = createJobRefreshQueue(queryClient);
+	const queueTaskRefresh = createTaskRefreshQueue(queryClient);
 
 	return (message: SseMessage) => {
 		const domain = domains[message.domain];
@@ -108,12 +110,17 @@ export function reactQueryHandler(queryClient: QueryClient) {
 			return;
 		}
 
-		// Jobs are the one domain where an update frame arrives per running job
-		// per progress wave, and every on-screen job holds its own detail query.
-		// Invalidating each one fans out to a request per row, so these frames go
-		// through a queue that batches the reads instead.
+		// Jobs and tasks are the two domains where an update frame arrives per
+		// running record per progress step, and every one on screen holds its own
+		// detail query. Invalidating each one fans out to a request per row, so
+		// these frames go through a queue that batches the reads instead.
 		if (message.domain === "jobs" && message.operation === "update") {
 			queueJobRefresh(message.id);
+			return;
+		}
+
+		if (message.domain === "tasks" && message.operation === "update") {
+			queueTaskRefresh(message.id);
 			return;
 		}
 

--- a/apps/web/src/server/tasks/functions.ts
+++ b/apps/web/src/server/tasks/functions.ts
@@ -1,6 +1,6 @@
 import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
-import { getTask, TaskNotFoundError } from "@virtool/data/tasks/data";
+import { getTask, getTasks, TaskNotFoundError } from "@virtool/data/tasks/data";
 import { z } from "zod";
 import { authenticated } from "../auth/policy";
 import { db } from "../composition";
@@ -9,6 +9,13 @@ import { rowIdSchema } from "../validation";
 
 const taskIdSchema = z.object({
 	taskId: rowIdSchema,
+});
+
+// Capped at 100, matching `getJobsFn`: the batch exists to collapse one refetch
+// per on-screen task into one request, and no view shows more than a page of
+// task-bearing rows at once.
+const taskIdsSchema = z.object({
+	taskIds: z.array(rowIdSchema).min(1).max(100),
 });
 
 // Wrapped in createServerOnlyFn so the compiler can strip this body — and the
@@ -22,6 +29,11 @@ const rethrowAsHttp = createServerOnlyFn((err: unknown): never => {
 	}
 	throw err;
 });
+
+export const getTasksFn = createServerFn({ method: "GET" })
+	.middleware([authenticated()])
+	.validator(taskIdsSchema)
+	.handler(async ({ data }) => getTasks(db, data.taskIds));
 
 export const getTaskFn = createServerFn({ method: "GET" })
 	.middleware([authenticated()])

--- a/apps/web/src/tasks/__tests__/refresh.test.ts
+++ b/apps/web/src/tasks/__tests__/refresh.test.ts
@@ -139,6 +139,22 @@ describe("createTaskRefreshQueue", () => {
 		expect(taskServerFnMocks.getTasksFn).not.toHaveBeenCalled();
 	});
 
+	// `useFetchTask` pins a seeded entry with `staleTime: Infinity`, so without
+	// this the remount would render the last in-progress step for the whole
+	// gcTime rather than refetching a task that finished while the page was away.
+	it("marks a cached but unmounted detail stale so its remount refetches", async () => {
+		queryClient.setQueryData(taskQueryKeys.detail(1), createTask(1));
+
+		const queue = createTaskRefreshQueue(queryClient);
+		queue(1);
+
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		expect(
+			queryClient.getQueryState(taskQueryKeys.detail(1))?.isInvalidated,
+		).toBe(true);
+	});
+
 	it("splits a wave larger than the request cap", async () => {
 		const ids = Array.from({ length: 150 }, (_, index) => index + 1);
 		mockGetTasks(ids.map((id) => createTask(id)));

--- a/apps/web/src/tasks/__tests__/refresh.test.ts
+++ b/apps/web/src/tasks/__tests__/refresh.test.ts
@@ -1,0 +1,246 @@
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { taskQueryKeys } from "@tasks/keys";
+import { createTaskRefreshQueue } from "@tasks/refresh";
+import type { ServerTask } from "@tasks/types";
+import { mockGetTasks, taskServerFnMocks } from "@tests/server-fn/tasks";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type Mock,
+	vi,
+} from "vitest";
+
+const FLUSH_MS = 500;
+
+function createTask(id: number, overrides?: Partial<ServerTask>): ServerTask {
+	return {
+		complete: false,
+		created_at: "2022-12-22T21:37:49.429000Z",
+		error: null,
+		id,
+		progress: 50,
+		step: "download",
+		type: "clone_reference",
+		...overrides,
+	};
+}
+
+describe("createTaskRefreshQueue", () => {
+	let queryClient: QueryClient;
+	let unsubscribes: (() => void)[];
+	let refetches: Map<number, Mock>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		queryClient = new QueryClient();
+		unsubscribes = [];
+		refetches = new Map();
+	});
+
+	afterEach(() => {
+		for (const unsubscribe of unsubscribes) {
+			unsubscribe();
+		}
+		vi.useRealTimers();
+	});
+
+	/**
+	 * Stand in for a rendered row's `useFetchTask`: seed the detail cache and hold
+	 * an active observer on it, pinned fresh the way a seeded call is. The queue
+	 * reads only tasks something is actually watching, so `setQueryData` alone
+	 * does not make a task on-screen.
+	 */
+	function watch(...ids: number[]): void {
+		for (const id of ids) {
+			queryClient.setQueryData(
+				taskQueryKeys.detail(id),
+				createTask(id, { progress: 0 }),
+			);
+
+			const queryFn = vi.fn(async () => createTask(id));
+			refetches.set(id, queryFn);
+
+			const observer = new QueryObserver(queryClient, {
+				queryKey: taskQueryKeys.detail(id),
+				queryFn,
+				staleTime: Number.POSITIVE_INFINITY,
+			});
+
+			unsubscribes.push(observer.subscribe(() => {}));
+		}
+	}
+
+	it("collapses a wave of frames into a single batched read", async () => {
+		mockGetTasks([createTask(1), createTask(2), createTask(3)]);
+		watch(1, 2, 3);
+
+		const queue = createTaskRefreshQueue(queryClient);
+		queue(1);
+		queue(2);
+		queue(3);
+		queue(1);
+
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		expect(taskServerFnMocks.getTasksFn).toHaveBeenCalledExactlyOnceWith({
+			data: { taskIds: [1, 2, 3] },
+		});
+	});
+
+	it("writes each fetched task into its own detail cache", async () => {
+		mockGetTasks([
+			createTask(1, { progress: 75 }),
+			createTask(2, { progress: 90 }),
+		]);
+		watch(1, 2);
+
+		const queue = createTaskRefreshQueue(queryClient);
+		queue(1);
+		queue(2);
+
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		expect(queryClient.getQueryData(taskQueryKeys.detail(1))).toMatchObject({
+			progress: 75,
+		});
+		expect(queryClient.getQueryData(taskQueryKeys.detail(2))).toMatchObject({
+			progress: 90,
+		});
+	});
+
+	// A resource whose row renders no progress — an archived reference, a
+	// completed install — mounts no task detail, so its frames cost nothing.
+	it("does not read a task nothing is watching", async () => {
+		mockGetTasks([createTask(1)]);
+
+		const queue = createTaskRefreshQueue(queryClient);
+		queue(1);
+
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		expect(taskServerFnMocks.getTasksFn).not.toHaveBeenCalled();
+	});
+
+	// React Query holds a detail's data for the whole gcTime after its row
+	// unmounts. Reading those would be a fan-out per wave that the invalidation
+	// this replaced never had, since it only ever refetched active queries.
+	it("does not read a task whose detail is cached but unmounted", async () => {
+		mockGetTasks([createTask(1)]);
+		queryClient.setQueryData(taskQueryKeys.detail(1), createTask(1));
+
+		const queue = createTaskRefreshQueue(queryClient);
+		queue(1);
+
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		expect(taskServerFnMocks.getTasksFn).not.toHaveBeenCalled();
+	});
+
+	it("splits a wave larger than the request cap", async () => {
+		const ids = Array.from({ length: 150 }, (_, index) => index + 1);
+		mockGetTasks(ids.map((id) => createTask(id)));
+		watch(...ids);
+
+		const queue = createTaskRefreshQueue(queryClient);
+		for (const id of ids) {
+			queue(id);
+		}
+
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		expect(taskServerFnMocks.getTasksFn).toHaveBeenCalledTimes(2);
+		expect(
+			taskServerFnMocks.getTasksFn.mock.calls.map(
+				([{ data }]) => data.taskIds.length,
+			),
+		).toEqual([100, 50]);
+	});
+
+	it("falls back to refetching each task when the batch fails", async () => {
+		taskServerFnMocks.getTasksFn.mockRejectedValue(new Error("boom"));
+		watch(1, 2);
+
+		const queue = createTaskRefreshQueue(queryClient);
+		queue(1);
+		queue(2);
+
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		for (const id of [1, 2]) {
+			expect(refetches.get(id)).toHaveBeenCalled();
+		}
+	});
+
+	// Two batches in flight at once can resolve out of order, and the loser
+	// would write a stale snapshot over a newer one — dragging a progress bar
+	// backwards, or reviving a finished task.
+	it("holds a later wave until the batch in flight resolves", async () => {
+		watch(1);
+
+		let resolveFirst: (tasks: ServerTask[]) => void = () => undefined;
+		taskServerFnMocks.getTasksFn
+			.mockImplementationOnce(
+				() =>
+					new Promise<ServerTask[]>((resolve) => {
+						resolveFirst = resolve;
+					}),
+			)
+			.mockResolvedValueOnce([createTask(1, { progress: 90 })]);
+
+		const queue = createTaskRefreshQueue(queryClient);
+
+		queue(1);
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+		expect(taskServerFnMocks.getTasksFn).toHaveBeenCalledTimes(1);
+
+		queue(1);
+		await vi.advanceTimersByTimeAsync(FLUSH_MS * 3);
+
+		expect(taskServerFnMocks.getTasksFn).toHaveBeenCalledTimes(1);
+
+		resolveFirst([createTask(1, { progress: 10 })]);
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(taskServerFnMocks.getTasksFn).toHaveBeenCalledTimes(2);
+		expect(queryClient.getQueryData(taskQueryKeys.detail(1))).toMatchObject({
+			progress: 90,
+		});
+	});
+
+	it("opens a new window for frames arriving after a flush", async () => {
+		mockGetTasks([createTask(1), createTask(2)]);
+		watch(1, 2);
+
+		const queue = createTaskRefreshQueue(queryClient);
+
+		queue(1);
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		queue(2);
+		await vi.advanceTimersByTimeAsync(FLUSH_MS);
+
+		expect(taskServerFnMocks.getTasksFn).toHaveBeenCalledTimes(2);
+		expect(taskServerFnMocks.getTasksFn).toHaveBeenNthCalledWith(2, {
+			data: { taskIds: [2] },
+		});
+	});
+
+	it("holds frames arriving inside an open window in the same batch", async () => {
+		mockGetTasks([createTask(1), createTask(2)]);
+		watch(1, 2);
+
+		const queue = createTaskRefreshQueue(queryClient);
+
+		queue(1);
+		await vi.advanceTimersByTimeAsync(FLUSH_MS / 2);
+		queue(2);
+		await vi.advanceTimersByTimeAsync(FLUSH_MS / 2);
+
+		expect(taskServerFnMocks.getTasksFn).toHaveBeenCalledExactlyOnceWith({
+			data: { taskIds: [1, 2] },
+		});
+	});
+});

--- a/apps/web/src/tasks/refresh.ts
+++ b/apps/web/src/tasks/refresh.ts
@@ -1,0 +1,131 @@
+import * as Sentry from "@sentry/tanstackstart-react";
+import { getTasksFn } from "@server/tasks/functions";
+import type { QueryClient } from "@tanstack/react-query";
+import { taskQueryKeys } from "@tasks/keys";
+
+/**
+ * How long to collect task ids before fetching them.
+ *
+ * A running task emits a frame per progress step — a reference clone reports
+ * over a hundred — and each frame reaches every connected browser. Anything
+ * long enough to catch a wave collapses it into one request; 500 ms is well
+ * under the interval a progress bar is read at.
+ */
+const FLUSH_MS = 500;
+
+/** Ids per request, matching the cap `getTasksFn` validates. */
+const BATCH_SIZE = 100;
+
+function chunk(ids: number[], size: number): number[][] {
+	const chunks: number[][] = [];
+
+	for (let i = 0; i < ids.length; i += size) {
+		chunks.push(ids.slice(i, i + size));
+	}
+
+	return chunks;
+}
+
+/**
+ * Build a queue that coalesces `tasks` update frames into batched refreshes.
+ *
+ * Every task-bearing row on screen mounts its own `detail(id)` query, so
+ * invalidating each frame's detail fires one `getTaskFn` request per row per
+ * progress step. The queue collects the ids instead and reads them in a single
+ * `getTasksFn` call, writing each result straight into its detail cache.
+ *
+ * Unlike jobs, there is no `lists()` invalidation: nothing caches a task
+ * collection, so there are no counts or ordering to drift.
+ *
+ * The queue holds its own buffer, so callers get one per `QueryClient`.
+ */
+export function createTaskRefreshQueue(
+	queryClient: QueryClient,
+): (taskId: number) => void {
+	const pending = new Set<number>();
+	let windowOpen = false;
+	let draining = false;
+
+	async function refreshBatch(taskIds: number[]): Promise<void> {
+		try {
+			const tasks = await getTasksFn({ data: { taskIds } });
+
+			for (const task of tasks) {
+				queryClient.setQueryData(taskQueryKeys.detail(task.id), task);
+			}
+		} catch (error) {
+			Sentry.captureException(error, { tags: { sse: "task-refresh" } });
+
+			// Fall back to the per-task refetch this batch replaced. It costs the
+			// fan-out again, but a failed batch leaving every progress bar frozen
+			// is worse than a slow window.
+			for (const taskId of taskIds) {
+				queryClient.invalidateQueries({
+					queryKey: taskQueryKeys.detail(taskId),
+				});
+			}
+		}
+	}
+
+	async function refresh(ids: number[]): Promise<void> {
+		// Only a mounted detail has anyone to show the result to. Cached-but-
+		// unmounted details would otherwise keep getting read for the whole
+		// gcTime after navigating off a task-bearing page — `invalidateQueries`
+		// defaults to `refetchType: "active"` and never refetched those, so
+		// reading them here would be a fan-out the old path did not have.
+		const cache = queryClient.getQueryCache();
+		const watched = ids.filter(
+			(id) =>
+				cache.find({ queryKey: taskQueryKeys.detail(id), type: "active" }) !==
+				undefined,
+		);
+
+		if (watched.length === 0) {
+			return;
+		}
+
+		await Promise.all(chunk(watched, BATCH_SIZE).map(refreshBatch));
+	}
+
+	/**
+	 * Run waves one at a time until the buffer is empty.
+	 *
+	 * Batches must not overlap. Two in flight at once can resolve out of order,
+	 * and the loser's `setQueryData` would write a stale snapshot over a newer
+	 * one — dragging a progress bar backwards, or reviving a task that has
+	 * already finished. Serializing also means a slow server widens the window on
+	 * its own: everything that arrives during a batch coalesces into the next one.
+	 */
+	async function drain(): Promise<void> {
+		draining = true;
+
+		try {
+			while (pending.size > 0) {
+				const ids = [...pending];
+				pending.clear();
+
+				await refresh(ids);
+			}
+		} finally {
+			draining = false;
+		}
+	}
+
+	return function queueTaskRefresh(taskId: number): void {
+		pending.add(taskId);
+
+		// A drain in flight takes these ids on its next pass, and an open window
+		// will take them when it elapses. The window is never cancelled, only
+		// allowed to elapse, so its timer handle is not worth keeping.
+		if (windowOpen || draining) {
+			return;
+		}
+
+		windowOpen = true;
+
+		setTimeout(() => {
+			windowOpen = false;
+			void drain();
+		}, FLUSH_MS);
+	};
+}

--- a/apps/web/src/tasks/refresh.ts
+++ b/apps/web/src/tasks/refresh.ts
@@ -74,11 +74,26 @@ export function createTaskRefreshQueue(
 		// defaults to `refetchType: "active"` and never refetched those, so
 		// reading them here would be a fan-out the old path did not have.
 		const cache = queryClient.getQueryCache();
-		const watched = ids.filter(
-			(id) =>
-				cache.find({ queryKey: taskQueryKeys.detail(id), type: "active" }) !==
-				undefined,
-		);
+		const watched: number[] = [];
+
+		for (const id of ids) {
+			const queryKey = taskQueryKeys.detail(id);
+
+			if (cache.find({ queryKey, type: "active" })) {
+				watched.push(id);
+				continue;
+			}
+
+			// Dropping the id is not the same as ignoring the frame. `useFetchTask`
+			// pins a seeded entry with `staleTime: Infinity`, and a remount reads
+			// the cached entry rather than the fresher seed its parent now holds —
+			// so a task that finished while the page was away would render its last
+			// in-progress step until gcTime elapsed. Marking it invalidated is what
+			// the per-frame invalidation this replaced did, and `isInvalidated`
+			// outranks `staleTime`, so the remount refetches. `refetchType: "none"`
+			// keeps that from becoming the fan-out the filter exists to avoid.
+			queryClient.invalidateQueries({ queryKey, refetchType: "none" });
+		}
 
 		if (watched.length === 0) {
 			return;

--- a/apps/web/src/tests/server-fn/tasks.ts
+++ b/apps/web/src/tests/server-fn/tasks.ts
@@ -1,0 +1,26 @@
+import type { ServerTask } from "@tasks/types";
+import { type Mock, vi } from "vitest";
+
+/**
+ * Mock handles for the `@server/tasks/functions` server-fn module. Wired in
+ * globally from `tests/setup.tsx` so any test importing this helper can stub
+ * the tasks server functions without per-file `vi.mock` boilerplate.
+ */
+export const taskServerFnMocks = {
+	getTaskFn: vi.fn(),
+	getTasksFn: vi.fn(),
+};
+
+/**
+ * Sets up getTasks to resolve with whichever of the given tasks were asked for.
+ *
+ * Mirrors the real batch read: ids that match nothing are simply absent from
+ * the result rather than an error.
+ */
+export function mockGetTasks(tasks: ServerTask[]): Mock {
+	taskServerFnMocks.getTasksFn.mockImplementation(
+		async ({ data }: { data: { taskIds: number[] } }) =>
+			tasks.filter((task) => data.taskIds.includes(task.id)),
+	);
+	return taskServerFnMocks.getTasksFn;
+}

--- a/apps/web/src/tests/setup.tsx
+++ b/apps/web/src/tests/setup.tsx
@@ -38,6 +38,7 @@ import {
 	settingsServerFnMocks,
 } from "./server-fn/settings";
 import { subtractionServerFnMocks } from "./server-fn/subtractions";
+import { taskServerFnMocks } from "./server-fn/tasks";
 import { uploadServerFnMocks } from "./server-fn/uploads";
 import { userServerFnMocks } from "./server-fn/users";
 
@@ -73,6 +74,10 @@ vi.mock("@server/hmm/functions", async () => {
 vi.mock("@server/jobs/functions", async () => {
 	const { jobServerFnMocks } = await import("./server-fn/jobs");
 	return jobServerFnMocks;
+});
+vi.mock("@server/tasks/functions", async () => {
+	const { taskServerFnMocks } = await import("./server-fn/tasks");
+	return taskServerFnMocks;
 });
 vi.mock("@server/settings/functions", async () => {
 	const { settingsServerFnMocks } = await import("./server-fn/settings");
@@ -124,6 +129,7 @@ beforeEach(() => {
 		...Object.values(userServerFnMocks),
 		...Object.values(accountServerFnMocks),
 		...Object.values(jobServerFnMocks),
+		...Object.values(taskServerFnMocks),
 		...Object.values(hmmServerFnMocks),
 		...Object.values(authServerFnMocks),
 		...Object.values(labelServerFnMocks),

--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -200,15 +200,17 @@ application's own doing.
   flipping to `ready`) changes a per-sample list row the frame can't
   target, since it carries only the analysis id and not the `sampleId`
   the list is keyed by. Unknown domains are ignored.
-- `jobs/refresh.ts` is the one exception to that mapping. See below.
+- `jobs/refresh.ts` and `tasks/refresh.ts` are the two exceptions to that
+  mapping. See below.
 
-## Job updates are batched, not invalidated
+## Job and task updates are batched, not invalidated
 
-Jobs are the only domain that emits an update frame per running job per
-progress wave, and every job on screen holds its own `detail(id)` query
-(see the nested-job sites below). Invalidating each frame's detail
-therefore cost one `getJobFn` request per running job per tick — 25 rows,
-25 requests.
+Jobs and tasks are the two domains that emit an update frame per running
+record per progress step, and every one on screen holds its own
+`detail(id)` query (see the nested sites below). Invalidating each
+frame's detail therefore cost one `getJobFn`/`getTaskFn` request per
+record per tick — 25 job rows, 25 requests; a reference clone reports
+~130 progress steps, each one a request per browser watching it.
 
 So `jobs`/`update` frames do not go through `selectQueryKey`. They go to
 a queue built by `createJobRefreshQueue` (`jobs/refresh.ts`), one per
@@ -233,7 +235,15 @@ a queue built by `createJobRefreshQueue` (`jobs/refresh.ts`), one per
 A failed batch falls back to invalidating each id's detail, taking the
 fan-out it was avoiding rather than leaving every progress bar frozen.
 
-Two properties of that queue are load-bearing, and both are easy to
+`tasks`/`update` frames go to `createTaskRefreshQueue`
+(`tasks/refresh.ts`), which is the same queue against `getTasksFn` and
+`taskQueryKeys` — **minus step 2**. Nothing caches a task collection, so
+there is no `lists()` key to mark stale and no counts or ordering to
+drift; adding the invalidation would be a no-op that reads as a
+requirement. Everything else carries over unchanged, including the
+active-observer filter and the serialized drain.
+
+Two properties of these queues are load-bearing, and both are easy to
 undo by accident:
 
 - **Active observers, not cached data.** Filtering on
@@ -277,13 +287,11 @@ undo by accident:
   until a batch's size, rather than its count, shows up in metrics.
 - **`hmm` has no push domain.** Task-nested sites
   (`references/components/ReferenceItem.tsx`,
-  `references/components/Detail/Remote.tsx`,
-  `hmm/components/HmmInstall.tsx`) now keep live task `progress`/`step`
+  `hmm/components/HmmInstall.tsx`) keep live task `progress`/`step`
   fresh by mounting `useFetchTask(id)` seeded with the nested task, so
-  a `tasks` update frame invalidates `taskQueryKeys.detail(id)` and
-  refetches through the `getTaskFn` server function. `hmm` itself is not
-  an `SseDomain` and has no `/hmms` refetch trigger; `HmmInstall`
-  bridges that gap by watching the live task's `complete` and
-  invalidating `hmmQueryKeys.lists()` from a `useEffect`. If HMM gains
-  its own push domain, drop that effect in favour of a direct
-  invalidation.
+  a `tasks` update frame refreshes `taskQueryKeys.detail(id)` through
+  the batching queue above. `hmm` itself is not an `SseDomain` and has
+  no `/hmms` refetch trigger; `HmmInstall` bridges that gap by watching
+  the live task's `complete` and invalidating `hmmQueryKeys.lists()`
+  from a `useEffect`. If HMM gains its own push domain, drop that effect
+  in favour of a direct invalidation.

--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -237,11 +237,25 @@ fan-out it was avoiding rather than leaving every progress bar frozen.
 
 `tasks`/`update` frames go to `createTaskRefreshQueue`
 (`tasks/refresh.ts`), which is the same queue against `getTasksFn` and
-`taskQueryKeys` — **minus step 2**. Nothing caches a task collection, so
-there is no `lists()` key to mark stale and no counts or ordering to
-drift; adding the invalidation would be a no-op that reads as a
-requirement. Everything else carries over unchanged, including the
-active-observer filter and the serialized drain.
+`taskQueryKeys`, with two differences.
+
+**No `lists()` invalidation (step 2).** Nothing caches a task
+collection, so there is no key to mark stale and no counts or ordering
+to drift; adding the invalidation would be a no-op that reads as a
+requirement.
+
+**An id the filter drops is still marked stale.** Step 3 skips reading
+a detail with no active observer, but it invalidates it with
+`refetchType: "none"` on the way past. `useFetchTask` pins a seeded
+entry with `staleTime: Infinity`, and a remount reads that cached entry
+rather than the fresher seed its parent now holds — so a task that
+finished while the page was away would render its last in-progress step
+for the whole `gcTime`. `isInvalidated` outranks `staleTime`, so
+marking it is what makes the remount refetch, and it is exactly what
+the per-frame `invalidateQueries` this replaced did. `refetchType:
+"none"` is what keeps it from becoming the fan-out the filter exists to
+avoid. **The jobs queue does not do this yet and has the same gap** —
+`useFetchJob` seeds and pins the same way (VIR-2882 review).
 
 Two properties of these queues are load-bearing, and both are easy to
 undo by accident:
@@ -250,9 +264,12 @@ undo by accident:
   `getQueryData(...) !== undefined` looks equivalent and is not.
   React Query keeps a detail's data for the whole `gcTime` after its row
   unmounts, and `invalidateQueries` defaults to `refetchType: "active"`
-  — so the invalidation this replaced never refetched those. Reading
-  them here would mean a batch per wave for minutes after navigating off
-  a job-heavy page: a fan-out the old path did not have.
+  — so the invalidation this replaced never refetched those *then*.
+  Reading them here would mean a batch per wave for minutes after
+  navigating off a job-heavy page: a fan-out the old path did not have.
+  Note what it *did* do, which the tasks queue restores and the jobs
+  queue still does not: mark them invalidated, so the remount refetches
+  rather than rendering a pinned, seeded entry until `gcTime` elapses.
 - **Batches never overlap.** `drain()` runs waves one at a time. Two
   reads in flight at once can resolve out of order, and the loser's
   `setQueryData` writes a stale snapshot over a newer one — dragging a

--- a/packages/data/src/tasks/data.test.ts
+++ b/packages/data/src/tasks/data.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { Db } from "../db/pg";
 import { tasks } from "../db/schema/tasks";
 import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
-import { createTask, getTask, TaskNotFoundError } from "./data";
+import { createTask, getTask, getTasks, TaskNotFoundError } from "./data";
 
 let database: TestDatabase;
 let db: Db;
@@ -62,5 +62,28 @@ describe("getTask", () => {
 
 	it("throws TaskNotFoundError when the task is absent", async () => {
 		await expect(getTask(db, 404_404)).rejects.toThrow(TaskNotFoundError);
+	});
+});
+
+describe("getTasks", () => {
+	it("returns every requested task", async () => {
+		const first = await createTask(db, "install_hmms");
+		const second = await createTask(db, "clone_reference");
+
+		const found = await getTasks(db, [first, second]);
+
+		expect(found.map((task) => task.id).sort()).toEqual([first, second].sort());
+	});
+
+	it("omits ids with no row rather than throwing", async () => {
+		const taskId = await createTask(db, "install_hmms");
+
+		await expect(getTasks(db, [taskId, 404_404])).resolves.toMatchObject([
+			{ id: taskId },
+		]);
+	});
+
+	it("returns an empty array for empty input", async () => {
+		await expect(getTasks(db, [])).resolves.toEqual([]);
 	});
 });

--- a/packages/data/src/tasks/data.ts
+++ b/packages/data/src/tasks/data.ts
@@ -1,5 +1,5 @@
 import type { Task } from "@virtool/contracts";
-import { eq } from "drizzle-orm";
+import { inArray } from "drizzle-orm";
 import type { Db, DbOrTx } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import { tasks as tasksTable } from "../db/schema/tasks";
@@ -47,8 +47,19 @@ export async function createTask(
 	return takeFirstOrThrow(rows).id;
 }
 
-export async function getTask(db: Db, taskId: number): Promise<Task> {
-	const [row] = await db
+/**
+ * Read the tasks matching `taskIds`.
+ *
+ * An id with no row is absent from the result rather than an error — the
+ * batched read exists to refresh whatever a client is watching, and a task
+ * deleted between the frame and the read is not a failure.
+ */
+export async function getTasks(db: Db, taskIds: number[]): Promise<Task[]> {
+	if (taskIds.length === 0) {
+		return [];
+	}
+
+	const rows = await db
 		.select({
 			complete: tasksTable.complete,
 			created_at: tasksTable.created_at,
@@ -59,13 +70,9 @@ export async function getTask(db: Db, taskId: number): Promise<Task> {
 			type: tasksTable.type,
 		})
 		.from(tasksTable)
-		.where(eq(tasksTable.id, taskId));
+		.where(inArray(tasksTable.id, taskIds));
 
-	if (!row) {
-		throw new TaskNotFoundError();
-	}
-
-	return {
+	return rows.map((row) => ({
 		complete: row.complete ?? false,
 		created_at: row.created_at,
 		error: row.error,
@@ -73,5 +80,15 @@ export async function getTask(db: Db, taskId: number): Promise<Task> {
 		progress: row.progress ?? 0,
 		step: row.step ?? "",
 		type: row.type,
-	};
+	}));
+}
+
+export async function getTask(db: Db, taskId: number): Promise<Task> {
+	const [task] = await getTasks(db, [taskId]);
+
+	if (!task) {
+		throw new TaskNotFoundError();
+	}
+
+	return task;
 }


### PR DESCRIPTION
## Summary
- A running task emits an SSE update frame per progress step — a reference clone reports over a hundred — and every task-bearing row on screen holds its own `detail(id)` query, so invalidating per frame cost one `getTaskFn` request per row per step, per connected browser.
- `tasks`/`update` frames now route through `createTaskRefreshQueue` (`tasks/refresh.ts`), the jobs queue ported to tasks: a 500 ms window buffers ids, drains serially so a slow batch cannot write a stale snapshot over a newer one, drops ids nothing is actively watching, and reads the rest through a new batched `getTasksFn`. Unlike jobs there is no `lists()` invalidation — nothing caches a task collection.
- `AGENTS.md` and `docs/server-push.md` now describe both batched domains; the stale reference to the deleted `references/components/Detail/Remote.tsx` is gone.

Closes VIR-2882.