### PR TITLE
fix: stop mislabelling pathoscope segments as absent from an isolate

### DIFF
--- a/apps/web/src/analyses/components/Pathoscope/PathoscopeDetail.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/PathoscopeDetail.tsx
@@ -34,6 +34,7 @@ export default function PathoscopeDetail({
 		return (
 			<PathoscopeIsolate
 				key={isolate.id}
+				absentSegmentKeys={isolate.absentSegmentKeys}
 				coverage={isolate.coverage}
 				depth={isolate.depth}
 				maxDepth={hit.maxDepth}

--- a/apps/web/src/analyses/components/Pathoscope/PathoscopeIsolate.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/PathoscopeIsolate.tsx
@@ -17,12 +17,18 @@ const height = 60;
 // is declared — the accession and definition move into a popover instead,
 // alongside every other detail the row doesn't have room for. A segment the
 // schema left unnamed has nothing to label it with but the accession itself.
-// An unmatched segment names the reason: distinct from the OTU-wide "no
-// reads", so this isolate reads as lacking the segment rather than the
-// segment being absent everywhere.
+//
+// An unmatched segment names the reason, and only the server can tell the two
+// apart: `sequences` holds the hits alone, so an isolate that does not carry a
+// segment looks exactly like one that carries it and was assigned no reads.
+// `absentSegmentKeys` is the isolate's reference read against the OTU version
+// the analysis saw. Anything not on it falls to "no reads", which holds whether
+// or not the isolate carries the segment — so a length-inferred segment, whose
+// membership is not knowable at all, is never claimed either way.
 function labelOf(
 	segment: PathoscopeSegmentCoverage,
 	sequence: PathoscopeSequenceData | undefined,
+	absentSegmentKeys: string[],
 ): string {
 	if (sequence) {
 		return segment.name ?? sequence.accession;
@@ -30,12 +36,15 @@ function labelOf(
 
 	const name = segment.name ?? "Segment";
 
-	return segment.detected
+	return absentSegmentKeys.includes(segment.key)
 		? `${name} · not in this isolate`
 		: `${name} · no reads`;
 }
 
 type PathoscopeIsolateProps = {
+	/** The OTU segments the isolate declares no sequence for, hit or not */
+	absentSegmentKeys: string[];
+
 	coverage: number;
 	depth: number;
 	maxDepth: number;
@@ -50,6 +59,7 @@ type PathoscopeIsolateProps = {
 };
 
 export default function PathoscopeIsolate({
+	absentSegmentKeys,
 	coverage,
 	depth,
 	maxDepth,
@@ -76,7 +86,7 @@ export default function PathoscopeIsolate({
 				<PathoscopeSequenceDetail sequence={sequence} />
 			) : undefined,
 			key: segment.key,
-			label: labelOf(segment, sequence),
+			label: labelOf(segment, sequence, absentSegmentKeys),
 			length: segment.length,
 			// The sequence's own length, not the segment's — which is the longest any
 			// isolate gave it, and would attribute a length to a sequence that is not

--- a/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeDetail.test.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeDetail.test.tsx
@@ -12,6 +12,7 @@ function createIsolate(
 	pi: number,
 ): PathoscopeIsolate {
 	return {
+		absentSegmentKeys: [],
 		coverage,
 		depth: 5,
 		id: name,

--- a/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeDetail.test.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeDetail.test.tsx
@@ -3,8 +3,12 @@ import { type AnalysisSearch, DEFAULT_ANALYSIS_SEARCH } from "@analyses/search";
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@tests/setup";
 import type { PathoscopeHit, PathoscopeIsolate } from "@virtool/contracts";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import PathoscopeDetailComponent from "../PathoscopeDetail";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 function createIsolate(
 	name: string,
@@ -37,6 +41,23 @@ const hit = {
 	segments: [],
 } as unknown as PathoscopeHit;
 
+// A segmented OTU whose one isolate was hit on neither segment. Nothing in
+// `sequences` distinguishes the two panels, so `absentSegmentKeys` is the only
+// thing that can — which is what makes this a test of the wiring.
+const segmentedHit = {
+	coverage: 0.9,
+	id: "otu",
+	isolates: [
+		{ ...createIsolate("Segmented", 0.9, 0.5), absentSegmentKeys: ["seg:M"] },
+	],
+	maxDepth: 40,
+	pi: 1,
+	segments: [
+		{ align: [], detected: true, key: "seg:L", length: 8900, name: "L" },
+		{ align: [], detected: true, key: "seg:M", length: 4800, name: "M" },
+	],
+} as unknown as PathoscopeHit;
+
 function renderDetail(search: Partial<AnalysisSearch> = {}) {
 	renderWithProviders(
 		<AnalysisSearchProvider
@@ -67,5 +88,26 @@ describe("<PathoscopeDetail />", () => {
 		renderDetail({ minCoverage: 0.95 });
 
 		expect(screen.queryByText("Covered")).not.toBeInTheDocument();
+	});
+
+	it("should tell each isolate which of the otu's segments it does not carry", () => {
+		// jsdom lays nothing out, so the chart measures its container at zero and
+		// draws no panels to label without a width.
+		vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(400);
+
+		renderWithProviders(
+			<AnalysisSearchProvider
+				search={DEFAULT_ANALYSIS_SEARCH}
+				setSearch={vi.fn()}
+			>
+				<PathoscopeDetailComponent hit={segmentedHit} mappedCount={1000} />
+			</AnalysisSearchProvider>,
+		);
+
+		// Both segments are equally empty in the isolate's own data. Failing to hand
+		// the list down would label M "no reads" alongside L, which is the claim the
+		// isolate cannot make for itself.
+		expect(screen.getByText("M · not in this isolate")).toBeVisible();
+		expect(screen.getByText("L · no reads")).toBeVisible();
 	});
 });

--- a/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeExport.test.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeExport.test.tsx
@@ -13,6 +13,7 @@ function createIsolate(
 	overrides: Partial<PathoscopeIsolate>,
 ): PathoscopeIsolate {
 	return {
+		absentSegmentKeys: [],
 		coverage: 0.5,
 		depth: 12,
 		id: "isolate",

--- a/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeIsolate.test.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeIsolate.test.tsx
@@ -67,9 +67,13 @@ function render(children: ReactNode) {
 	);
 }
 
-function renderIsolate(sequences: PathoscopeSequence[]) {
+function renderIsolate(
+	sequences: PathoscopeSequence[],
+	absentSegmentKeys: string[] = [],
+) {
 	render(
 		<PathoscopeIsolate
+			absentSegmentKeys={absentSegmentKeys}
 			coverage={0.9}
 			depth={12}
 			maxDepth={20}
@@ -121,10 +125,10 @@ describe("<PathoscopeIsolate />", () => {
 	it("should give no length to a panel the isolate has no sequence for", () => {
 		mockElementWidth(1200);
 
-		renderIsolate([
-			sequence("seg:L", "NC_L", 8900),
-			sequence("seg:S", "NC_S", 2900),
-		]);
+		renderIsolate(
+			[sequence("seg:L", "NC_L", 8900), sequence("seg:S", "NC_S", 2900)],
+			["seg:M"],
+		);
 
 		expect(screen.getByText("M · not in this isolate")).toBeVisible();
 		expect(screen.queryByText("4,800 nt")).toBeNull();
@@ -135,6 +139,7 @@ describe("<PathoscopeIsolate />", () => {
 
 		render(
 			<PathoscopeIsolate
+				absentSegmentKeys={[]}
 				coverage={0.9}
 				depth={12}
 				maxDepth={20}
@@ -154,12 +159,27 @@ describe("<PathoscopeIsolate />", () => {
 
 		// No M sequence. The panel has to stay in place, or L and S would read as
 		// though they were the isolate's first two segments.
-		renderIsolate([
-			sequence("seg:L", "NC_L", 8900),
-			sequence("seg:S", "NC_S", 2900),
-		]);
+		renderIsolate(
+			[sequence("seg:L", "NC_L", 8900), sequence("seg:S", "NC_S", 2900)],
+			["seg:M"],
+		);
 
 		expect(screen.getByText("M · not in this isolate")).toBeVisible();
+	});
+
+	it("should not claim the isolate lacks a segment it carries but nothing mapped to", () => {
+		mockElementWidth(400);
+
+		// M is missing from `sequences` because it took no reads, not because the
+		// isolate lacks it — the two are indistinguishable from the hits alone, and
+		// the server says which by leaving M off `absentSegmentKeys`. Another isolate
+		// having mapped to M is no evidence either way, so `detected` must not decide
+		// this.
+		renderIsolate([sequence("seg:L", "NC_L", 8900)], ["seg:S"]);
+
+		expect(screen.getByText("M · no reads")).toBeVisible();
+		expect(screen.queryByText("M · not in this isolate")).toBeNull();
+		expect(screen.getByText("S · not in this isolate")).toBeVisible();
 	});
 
 	it("should not claim the isolate lacks a segment nothing mapped to", () => {
@@ -170,6 +190,7 @@ describe("<PathoscopeIsolate />", () => {
 		// this isolate does not carry it.
 		render(
 			<PathoscopeIsolate
+				absentSegmentKeys={[]}
 				coverage={0.9}
 				depth={12}
 				maxDepth={20}
@@ -186,6 +207,30 @@ describe("<PathoscopeIsolate />", () => {
 
 		expect(screen.getByText("M · no reads")).toBeVisible();
 		expect(screen.queryByText("M · not in this isolate")).toBeNull();
+	});
+
+	it("should not claim the isolate lacks a length-inferred segment", () => {
+		mockElementWidth(400);
+
+		// A bin is derived from the sequences that were hit, so an unhit sequence has
+		// no bin to fall in and the server can place no isolate in or out of one. The
+		// label has to hold whichever it is.
+		render(
+			<PathoscopeIsolate
+				absentSegmentKeys={[]}
+				coverage={0.9}
+				depth={12}
+				maxDepth={20}
+				name="Isolate A"
+				pi={0.5}
+				reads={30}
+				segments={[segment("len:0", 8900, null), segment("len:1", 2900, null)]}
+				sequences={[sequence("len:0", "NC_X", 8900)]}
+			/>,
+		);
+
+		expect(screen.getByText("Segment · no reads")).toBeVisible();
+		expect(screen.queryByText(/not in this isolate/)).toBeNull();
 	});
 
 	it("should reveal a sequence's figures in a popover when its panel is clicked", async () => {
@@ -241,6 +286,7 @@ describe("<PathoscopeIsolate />", () => {
 	it("should render nothing but the heading for an isolate with no segments", () => {
 		render(
 			<PathoscopeIsolate
+				absentSegmentKeys={[]}
 				coverage={0}
 				depth={0}
 				maxDepth={0}

--- a/apps/web/src/analyses/components/Pathoscope/__tests__/table.test.ts
+++ b/apps/web/src/analyses/components/Pathoscope/__tests__/table.test.ts
@@ -96,6 +96,7 @@ function createIsolate(
 	overrides: Partial<PathoscopeIsolate>,
 ): PathoscopeIsolate {
 	return {
+		absentSegmentKeys: [],
 		coverage: 0.5,
 		depth: 12,
 		id: "isolate",

--- a/packages/contracts/src/pathoscope.ts
+++ b/packages/contracts/src/pathoscope.ts
@@ -58,6 +58,22 @@ export type PathoscopeSequence = {
 
 /** A detected isolate, with the metrics derived from the sequences it owns. */
 export type PathoscopeIsolate = {
+	/**
+	 * The keys of the OTU's segments the isolate declares no sequence for.
+	 *
+	 * Read against the OTU version the analysis saw, over every sequence it
+	 * declares rather than only the ones that were hit — so it separates an
+	 * isolate that does not carry a segment from one that carries it and was
+	 * assigned no reads. The two are indistinguishable from {@link sequences},
+	 * which holds only the hits.
+	 *
+	 * Only named segments can appear. A length-inferred segment is a bin over the
+	 * sequences that *were* hit, so an unhit sequence has no bin to fall in and
+	 * the isolate's membership is not knowable; those are absent from this list
+	 * whether the isolate carries them or not.
+	 */
+	absentSegmentKeys: string[];
+
 	/** The proportion of the isolate's positions with mapped read coverage */
 	coverage: number;
 

--- a/packages/data/src/analyses/format.test.ts
+++ b/packages/data/src/analyses/format.test.ts
@@ -490,6 +490,17 @@ describe("formatAnalysis for pathoscope", () => {
 		expect(otu.isolates[0]?.name).toBe("Isolate A");
 	});
 
+	it("reports no isolate as lacking a length-inferred segment", async () => {
+		const otu = await formatPathoscope();
+
+		// The OTU declares no schema, so its one segment is a bin over the sequences
+		// that were hit. `seq_a1` was not, so nothing can say which bin it would have
+		// fallen in — and the isolate is claimed neither to carry the segment nor to
+		// lack it.
+		expect(otu.segments.map((segment) => segment.key)).toEqual(["len:0"]);
+		expect(otu.isolates[0]?.absentSegmentKeys).toEqual([]);
+	});
+
 	it("reports the longest sequence in the OTU as its length", async () => {
 		const otu = await formatPathoscope();
 
@@ -877,6 +888,40 @@ describe("formatAnalysis for a segmented pathoscope hit", () => {
 		// The isolate with no S sequence names only L, so the detail view can leave
 		// the S column empty rather than sliding L into it.
 		expect(keys.get("Isolate D")).toEqual(["seg:L"]);
+	});
+
+	it("reports the segments each isolate declares no sequence for", async () => {
+		const otu = await formatPathoscope("pathoscope", segmentedResults());
+
+		const absent = new Map(
+			otu.isolates.map((isolate) => [isolate.name, isolate.absentSegmentKeys]),
+		);
+
+		// `iso_c` declares all three. Its M sequence recorded no hit, so it is missing
+		// from `sequences` — but the isolate carries it, and saying otherwise is the
+		// claim this list exists to stop.
+		expect(absent.get("Isolate C")).toEqual([]);
+
+		// `iso_d` declares L alone, so M and S really are not in it.
+		expect(absent.get("Isolate D")).toEqual(["seg:M", "seg:S"]);
+	});
+
+	it("reads the declared segments at the analysed version, not from the hits", async () => {
+		const results = segmentedResults();
+
+		// Drop `iso_c`'s S hit, leaving it detected on L alone. Its S sequence is
+		// still declared, so the isolate must not be reported as lacking it — a rule
+		// reading the hits would have no way to tell.
+		results.hits = results.hits.filter((hit) => hit.id !== "seq_c_s");
+
+		const otu = await formatPathoscope("pathoscope", results);
+
+		const isolate = otu.isolates.find((entry) => entry.name === "Isolate C");
+
+		expect(isolate?.sequences.map((sequence) => sequence.segmentKey)).toEqual([
+			"seg:L",
+		]);
+		expect(isolate?.absentSegmentKeys).toEqual([]);
 	});
 });
 

--- a/packages/data/src/analyses/format.ts
+++ b/packages/data/src/analyses/format.ts
@@ -69,9 +69,15 @@ type MeasuredSequence = {
 
 // The same pairing one level up, so an OTU can match its isolates' sequences up
 // segment by segment.
+//
+// `declaredSegments` is read from the isolate's sequences before the unhit ones
+// are dropped, and is the only record of them that survives. The OTU turns it
+// into the segment keys the isolate is missing once it knows what its segments
+// are.
 type MeasuredIsolate = {
+	declaredSegments: Set<string>;
 	depths: number[];
-	isolate: Omit<PathoscopeIsolate, "sequences">;
+	isolate: Omit<PathoscopeIsolate, "absentSegmentKeys" | "sequences">;
 	sequences: MeasuredSequence[];
 };
 
@@ -153,6 +159,23 @@ function formatSequences(
 	return measured.sort((a, b) => compareBySegment(a, b, schemaNames));
 }
 
+// The schema segments an isolate declares a sequence for, hit or not. It is what
+// makes an isolate's silence on a segment readable: one that never declared the
+// segment does not carry it, where one that declared it was assigned no reads.
+function readDeclaredSegments(sequences: unknown[]): Set<string> {
+	const declared = new Set<string>();
+
+	for (const entry of sequences) {
+		const segment = asRecord(entry)?.segment;
+
+		if (typeof segment === "string" && segment !== "") {
+			declared.add(segment);
+		}
+	}
+
+	return declared;
+}
+
 function formatIsolates(
 	isolates: unknown[],
 	hitsBySequenceId: Map<string, Record<string, unknown>>,
@@ -185,6 +208,7 @@ function formatIsolates(
 		const depths = sequences.flatMap((entry) => entry.depths);
 
 		measured.push({
+			declaredSegments: readDeclaredSegments(asArray(isolate.sequences)),
 			depths,
 			sequences,
 			isolate: {
@@ -266,6 +290,13 @@ function formatHits(
 		}
 	}
 
+	// Only a named segment can be reported missing from an isolate. A
+	// length-inferred one is a bin over the sequences that were hit, so an unhit
+	// sequence has no bin to fall in and nothing here could place it.
+	const namedGroups = groups.flatMap((group) =>
+		group.name === null ? [] : [{ key: group.key, name: group.name }],
+	);
+
 	const merged = groups.map((group) => {
 		const depths = mergeDepths(segmentDepths(group));
 
@@ -306,6 +337,9 @@ function formatHits(
 		isolates: measured
 			.map((entry, index) => ({
 				...entry.isolate,
+				absentSegmentKeys: namedGroups
+					.filter((group) => !entry.declaredSegments.has(group.name))
+					.map((group) => group.key),
 				sequences: sequencesByIsolate[index] ?? [],
 			}))
 			.sort((a, b) => b.coverage - a.coverage),


### PR DESCRIPTION
## Summary
- The pathoscope isolate panel labelled any segment missing from the hit list as "not in this isolate" — including segments the isolate genuinely carries but that took no reads, since a hit-only view can't tell the two cases apart.
- The server now reports `absentSegmentKeys` per isolate, read from the isolate's declared sequences at the analysed OTU version rather than inferred from which sequences were hit, so a segment only reads as "not in this isolate" when it truly isn't declared — everything else falls back to "no reads".
- Length-inferred segments (no schema name) are excluded from this list entirely, since membership in an unnamed bin isn't knowable for a sequence that was never hit.

Closes VIR-2910