### PR TITLE
test: deduplicate the pathoscope hit helper into a shared fake

### DIFF
--- a/apps/web/src/analyses/__tests__/hooks.test.tsx
+++ b/apps/web/src/analyses/__tests__/hooks.test.tsx
@@ -10,47 +10,30 @@ import type {
 	FormattedPathoscopeAnalysis,
 } from "@analyses/types";
 import { renderHook } from "@testing-library/react";
-import type { PathoscopeHit } from "@virtool/contracts";
+import { createFakePathoscopeHit } from "@tests/fake/analyses";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
-
-function createHit(overrides: Partial<PathoscopeHit>): PathoscopeHit {
-	return {
-		abbreviation: "",
-		coverage: 0,
-		depth: 0,
-		id: "otu",
-		isolates: [],
-		length: 100,
-		maxDepth: 0,
-		name: "OTU",
-		pi: 0,
-		segments: [],
-		version: 1,
-		...overrides,
-	};
-}
 
 // Three hits whose name, coverage, depth and weight each rank them differently,
 // so a sort that reads the wrong field cannot accidentally produce the right
 // order. Only one name is capitalised out of alphabetical order, so a raw
 // codepoint comparison ranks them differently again.
 const hits = [
-	createHit({
+	createFakePathoscopeHit({
 		id: "a",
 		name: "adenovirus",
 		coverage: 0.1,
 		depth: 30,
 		pi: 0.5,
 	}),
-	createHit({
+	createFakePathoscopeHit({
 		id: "b",
 		name: "Betaflexivirus",
 		coverage: 0.9,
 		depth: 10,
 		pi: 0.2,
 	}),
-	createHit({
+	createFakePathoscopeHit({
 		id: "c",
 		name: "Cucumovirus",
 		coverage: 0.5,

--- a/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeExport.test.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeExport.test.tsx
@@ -3,9 +3,12 @@ import { type AnalysisSearch, DEFAULT_ANALYSIS_SEARCH } from "@analyses/search";
 import type { FormattedPathoscopeAnalysis } from "@analyses/types";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createFakeAnalysisMinimal } from "@tests/fake/analyses";
+import {
+	createFakeAnalysisMinimal,
+	createFakePathoscopeHit,
+} from "@tests/fake/analyses";
 import { renderWithProviders } from "@tests/setup";
-import type { PathoscopeHit, PathoscopeIsolate } from "@virtool/contracts";
+import type { PathoscopeIsolate } from "@virtool/contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import PathoscopeExport from "../PathoscopeExport";
 
@@ -24,29 +27,12 @@ function createIsolate(
 	};
 }
 
-function createHit(overrides: Partial<PathoscopeHit>): PathoscopeHit {
-	return {
-		abbreviation: "TMV",
-		coverage: 0.5,
-		depth: 12,
-		id: "hit",
-		isolates: [],
-		length: 6000,
-		maxDepth: 20,
-		name: "Tobacco mosaic virus",
-		pi: 0.25,
-		segments: [],
-		version: 3,
-		...overrides,
-	};
-}
-
 const analysis: FormattedPathoscopeAnalysis = {
 	...createFakeAnalysisMinimal({ id: 5, workflow: "pathoscope" }),
 	files: [],
 	results: {
 		hits: [
-			createHit({
+			createFakePathoscopeHit({
 				id: "a",
 				isolates: [
 					createIsolate({ id: "a1", name: "Isolate A" }),
@@ -60,7 +46,7 @@ const analysis: FormattedPathoscopeAnalysis = {
 				],
 				name: "Alpha virus",
 			}),
-			createHit({
+			createFakePathoscopeHit({
 				coverage: 0.25,
 				depth: 7,
 				id: "b",

--- a/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeList.test.tsx
+++ b/apps/web/src/analyses/components/Pathoscope/__tests__/PathoscopeList.test.tsx
@@ -4,32 +4,23 @@ import type { FormattedPathoscopeAnalysis } from "@analyses/types";
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expectNoViolations } from "@tests/axe";
-import { createFakeAnalysisMinimal } from "@tests/fake/analyses";
+import {
+	createFakeAnalysisMinimal,
+	createFakePathoscopeHit,
+} from "@tests/fake/analyses";
 import { renderWithProviders } from "@tests/setup";
 import type { PathoscopeHit } from "@virtool/contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PathoscopeList } from "../PathoscopeList";
 
-function createHit(overrides: Partial<PathoscopeHit>): PathoscopeHit {
-	return {
-		abbreviation: "TMV",
-		coverage: 0.5,
-		depth: 12,
-		id: "hit",
-		isolates: [],
-		length: 6000,
-		maxDepth: 20,
-		name: "Tobacco mosaic virus",
-		pi: 0.25,
-		segments: [],
-		version: 3,
-		...overrides,
-	};
-}
-
 const hits = [
-	createHit({ id: "a", name: "Alpha virus" }),
-	createHit({ coverage: 0.25, depth: 7, id: "b", name: "Beta virus" }),
+	createFakePathoscopeHit({ id: "a", name: "Alpha virus" }),
+	createFakePathoscopeHit({
+		coverage: 0.25,
+		depth: 7,
+		id: "b",
+		name: "Beta virus",
+	}),
 ];
 
 const analysis: FormattedPathoscopeAnalysis = {
@@ -224,7 +215,7 @@ describe("<PathoscopeList />", () => {
 
 	// Nothing fills the column, so a heading would sit over empty space.
 	it("should not label the abbreviation column when no hit has one", () => {
-		renderList({}, [createHit({ abbreviation: "", id: "a" })]);
+		renderList({}, [createFakePathoscopeHit({ abbreviation: "", id: "a" })]);
 
 		expect(headerLabels().queryByText("Abbreviation")).not.toBeInTheDocument();
 		expect(headerLabels().getByText("Coverage")).toBeInTheDocument();

--- a/apps/web/src/analyses/components/Pathoscope/__tests__/table.test.ts
+++ b/apps/web/src/analyses/components/Pathoscope/__tests__/table.test.ts
@@ -1,33 +1,17 @@
-import type { PathoscopeHit, PathoscopeIsolate } from "@virtool/contracts";
+import { createFakePathoscopeHit } from "@tests/fake/analyses";
+import type { PathoscopeIsolate } from "@virtool/contracts";
 import { describe, expect, it } from "vitest";
 import {
 	formatPathoscopeHitsAsTsv,
 	formatPathoscopeIsolatesAsTsv,
 } from "../table";
 
-function createHit(overrides: Partial<PathoscopeHit>): PathoscopeHit {
-	return {
-		abbreviation: "TMV",
-		coverage: 0.5,
-		depth: 12,
-		id: "hit",
-		isolates: [],
-		length: 6000,
-		maxDepth: 20,
-		name: "Tobacco mosaic virus",
-		pi: 0.25,
-		segments: [],
-		version: 3,
-		...overrides,
-	};
-}
-
 describe("formatPathoscopeHitsAsTsv()", () => {
 	it("should render a header row and one tab-separated row per hit", () => {
 		const table = formatPathoscopeHitsAsTsv(
 			[
-				createHit({ id: "a", name: "Alpha virus" }),
-				createHit({
+				createFakePathoscopeHit({ id: "a", name: "Alpha virus" }),
+				createFakePathoscopeHit({
 					coverage: 0.123456,
 					depth: 7,
 					id: "b",
@@ -49,7 +33,7 @@ describe("formatPathoscopeHitsAsTsv()", () => {
 
 	it("should render read pseudo-counts when reads are shown", () => {
 		const table = formatPathoscopeHitsAsTsv(
-			[createHit({ name: "Alpha virus", pi: 0.25 })],
+			[createFakePathoscopeHit({ name: "Alpha virus", pi: 0.25 })],
 			{ headers: true, mappedCount: 1000, showReads: true },
 		);
 
@@ -63,7 +47,7 @@ describe("formatPathoscopeHitsAsTsv()", () => {
 	// A table pasted under one that already has headers must not repeat them.
 	it("should render the rows alone when headers are not wanted", () => {
 		const table = formatPathoscopeHitsAsTsv(
-			[createHit({ name: "Alpha virus" })],
+			[createFakePathoscopeHit({ name: "Alpha virus" })],
 			{ headers: false, mappedCount: 1000, showReads: false },
 		);
 
@@ -84,7 +68,7 @@ describe("formatPathoscopeHitsAsTsv()", () => {
 	// of its own and shift every field after it out of line.
 	it("should collapse tabs and newlines in a name", () => {
 		const table = formatPathoscopeHitsAsTsv(
-			[createHit({ name: "Alpha\tvirus\nstrain" })],
+			[createFakePathoscopeHit({ name: "Alpha\tvirus\nstrain" })],
 			{ headers: false, mappedCount: 1000, showReads: false },
 		);
 
@@ -111,7 +95,7 @@ describe("formatPathoscopeIsolatesAsTsv()", () => {
 	it("should render one row per isolate, each naming its OTU", () => {
 		const table = formatPathoscopeIsolatesAsTsv(
 			[
-				createHit({
+				createFakePathoscopeHit({
 					id: "a",
 					isolates: [
 						createIsolate({ id: "a1", name: "Isolate A" }),
@@ -125,7 +109,7 @@ describe("formatPathoscopeIsolatesAsTsv()", () => {
 					],
 					name: "Alpha virus",
 				}),
-				createHit({
+				createFakePathoscopeHit({
 					id: "b",
 					isolates: [createIsolate({ id: "b1", name: "Isolate C" })],
 					name: "Beta virus",
@@ -147,7 +131,7 @@ describe("formatPathoscopeIsolatesAsTsv()", () => {
 	it("should render read pseudo-counts when reads are shown", () => {
 		const table = formatPathoscopeIsolatesAsTsv(
 			[
-				createHit({
+				createFakePathoscopeHit({
 					isolates: [createIsolate({ pi: 0.25 })],
 					name: "Alpha virus",
 				}),
@@ -162,11 +146,14 @@ describe("formatPathoscopeIsolatesAsTsv()", () => {
 	// an empty row.
 	it("should render nothing for a hit with no isolates", () => {
 		expect(
-			formatPathoscopeIsolatesAsTsv([createHit({ isolates: [] })], {
-				headers: false,
-				mappedCount: 1000,
-				showReads: false,
-			}),
+			formatPathoscopeIsolatesAsTsv(
+				[createFakePathoscopeHit({ isolates: [] })],
+				{
+					headers: false,
+					mappedCount: 1000,
+					showReads: false,
+				},
+			),
 		).toBe("");
 	});
 });

--- a/apps/web/src/tests/fake/analyses.ts
+++ b/apps/web/src/tests/fake/analyses.ts
@@ -1,6 +1,6 @@
 import type { Blast, FormattedNuvsAnalysis } from "@analyses/types";
 import { faker } from "@faker-js/faker";
-import type { AnalysisMinimal } from "@virtool/contracts";
+import type { AnalysisMinimal, PathoscopeHit } from "@virtool/contracts";
 import { createFakeSubtractionNested } from "./subtractions";
 import { createFakeUserNested } from "./user";
 
@@ -65,6 +65,34 @@ type FakeFormattedNuVsHit = {
 	blast?: Blast;
 	index?: number;
 };
+
+/**
+ * Create a fake pathoscope hit object
+ *
+ * Its defaults are fixed rather than faked: the export tests assert the exact
+ * TSV a hit renders to, and every column of that string comes from a default
+ * left unoverridden.
+ *
+ * @param overrides - optional properties for creating a pathoscope hit with specific values
+ */
+export function createFakePathoscopeHit(
+	overrides?: Partial<PathoscopeHit>,
+): PathoscopeHit {
+	return {
+		abbreviation: "TMV",
+		coverage: 0.5,
+		depth: 12,
+		id: "hit",
+		isolates: [],
+		length: 6000,
+		maxDepth: 20,
+		name: "Tobacco mosaic virus",
+		pi: 0.25,
+		segments: [],
+		version: 3,
+		...overrides,
+	};
+}
 
 /**
  * Create a fake nuvs hit object


### PR DESCRIPTION
## Summary
- Four test files each declared their own `createHit`, so every change to `PathoscopeHit` cost four identical edits. `createFakePathoscopeHit` now lives in `src/tests/fake/analyses.ts` alongside the other fakes.
- Its defaults are fixed rather than faked: the export tests assert the exact TSV a hit renders to, and every column of that string comes from a default left unoverridden.
- `hooks.test.tsx` was the one variant, defaulting its fields to zero. It moves onto the shared defaults — every hit it builds overrides the five fields its assertions read.

Closes VIR-2912.