### PR TITLE
fix: restore sign-in and password changes on deployed servers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,6 +358,32 @@ every bundle that wants *any* of its exports. `cn()` (`@app/cn`) is split out
 of `@app/utils` for exactly this reason — it keeps `tailwind-merge` out of every
 bundle that only wants a plain utility. Don't merge it back.
 
+### A native dependency must never be bundled
+
+A package that loads a `.node` addon finds it relative to `__dirname`, which
+has no value in an ES module — so bundling one produces a server that builds
+cleanly and throws `ReferenceError: __dirname is not defined` the first time
+anything imports it. `bcrypt` shipped that way and took the whole auth path
+down with it.
+
+Nitro knows the common native packages and traces them out of its own bundle
+automatically, copying each into `.output/server/node_modules` — the dist
+image ships only `.output`, so nothing else puts them there. Reach for
+`traceDeps` on the `nitro()` plugin only for one it does not already know.
+What it cannot do is reclaim a package the **Vite** stage inlined first, and
+Nitro bundles the server in two stages. So a native package needs:
+
+- `environments.ssr.resolve.external` in `apps/web/vite.config.js`, so the Vite
+  stage leaves the import alone;
+- an entry in `apps/web/package.json` dependencies, even when no file in
+  `apps/web` imports it. Nitro resolves the external from the app root, and a
+  package reached only through a workspace package is not there under pnpm.
+  Add it to `ignoreDependencies` for `apps/web` in `knip.json` alongside.
+
+Check the built output rather than trusting a green build:
+`grep -rn "__dirname" apps/web/.output/server/_ssr/` should turn up no bare
+read — only lines that define one first.
+
 ### Routing: in-app navigation uses `<Link>`
 
 Internal links use `<Link>` from `@tanstack/react-router`. A plain `<a>` to an

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
 		"@virtool/logger": "workspace:*",
 		"@virtool/sentry": "workspace:*",
 		"@virtool/storage": "workspace:*",
+		"bcrypt": "^6.0.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"d3": "^7.9.0",

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -47,6 +47,24 @@ export default defineConfig(({ command, mode }) => ({
 	define: {
 		__APP_VERSION__: JSON.stringify(pkg.version),
 	},
+	environments: {
+		ssr: {
+			resolve: {
+				// `bcrypt` loads its prebuilt binary through
+				// `node-gyp-build(path.resolve(__dirname))`. Bundled, that `__dirname`
+				// has no value in ES module scope and the first import of the module
+				// throws, taking the whole auth path down with it.
+				//
+				// Nitro already knows `bcrypt` is native and traces it out of its own
+				// bundle — but it bundles the server in two stages and cannot reclaim
+				// what the Vite stage inlined first, so the import has to survive this
+				// stage untouched. That in turn is why `bcrypt` is a dependency of this
+				// app: Nitro resolves the external from the app root, and pnpm does not
+				// hoist a package reached only through `@virtool/data`.
+				external: ["bcrypt"],
+			},
+		},
+	},
 	envPrefix: ["VITE_", "VT_"],
 	resolve: {
 		alias: {
@@ -89,9 +107,10 @@ export default defineConfig(({ command, mode }) => ({
 		mode !== "test" &&
 			nitro({
 				// `@sentry/profiling-node` ships native `.node` addons the bundler can't
-				// inline. Tracing it (and its native helper) keeps the packages external
-				// and copies them into the server output, so the build doesn't choke on
-				// the binaries and the runtime import resolves. The dist image ships only
+				// inline, and Nitro's builtin native-package list does not cover it.
+				// Tracing it (and its native helper) keeps the packages external and
+				// copies them into the server output, so the build doesn't choke on the
+				// binaries and the runtime import resolves. The dist image ships only
 				// `.output`, so the trace is what makes the package available at runtime.
 				traceDeps: ["@sentry/profiling-node*", "@sentry/node-cpu-profiler*"],
 			}),

--- a/knip.json
+++ b/knip.json
@@ -16,7 +16,7 @@
 				"src/tests/postgresGuard.ts"
 			],
 			"project": ["src/**/*.{ts,tsx}"],
-			"ignoreDependencies": ["tailwindcss", "@tanstack/router-cli"]
+			"ignoreDependencies": ["bcrypt", "tailwindcss", "@tanstack/router-cli"]
 		},
 		"packages/bio": {
 			"entry": ["src/**/*.test.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       '@virtool/storage':
         specifier: workspace:*
         version: link:../../packages/storage
+      bcrypt:
+        specifier: ^6.0.0
+        version: 6.0.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1


### PR DESCRIPTION
## Summary

- Vite's stage of the server build was inlining `bcrypt`, which locates its
  prebuilt binary with `node-gyp-build(path.resolve(__dirname))`. `__dirname`
  has no value in ES module scope, so the first import of the chunk carrying
  `@virtool/data/auth/password` threw `ReferenceError: __dirname is not
  defined` and every server function on the auth path failed. It dates from
  the extraction of `@virtool/data` into a workspace package, which moved
  `bcrypt` out of the web app's own dependencies.
- Externalize `bcrypt` from the SSR environment so the import survives to
  Nitro's stage, which already knows the package is native and traces it into
  `.output/server/node_modules` along with its prebuilds — including the musl
  build the Alpine dist image needs.
- Nitro resolves that external from the app root and pnpm does not hoist a
  package reached only through `@virtool/data`, so `bcrypt` becomes a
  dependency of `apps/web` too, with a matching `knip.json` ignore.