### PR TITLE
chore: drop the legacy space column from the labels and uploads mirrors

### DIFF
--- a/packages/contracts/src/uploads.ts
+++ b/packages/contracts/src/uploads.ts
@@ -9,7 +9,7 @@ export type UploadType = (typeof UPLOAD_TYPES)[number];
 
 /**
  * An upload as returned to the client. Mirrors Python's `UploadMinimal`:
- * `name_on_disk` and `space` are internal and never exposed.
+ * `name_on_disk` is internal and never exposed.
  *
  * Every field but `removed_at` and `user` is non-null: the columns are nullable
  * at the database level, but Python sets them all when it creates a row and

--- a/packages/data/src/db/schema/labels.ts
+++ b/packages/data/src/db/schema/labels.ts
@@ -9,7 +9,6 @@ export const labels = pgTable("labels", {
 	color: varchar("color", { length: 7 }),
 	description: text("description").$defaultFn(() => ""),
 	name: text("name").unique(),
-	space: integer("space"),
 });
 
 /** A row from the `labels` table. */

--- a/packages/data/src/db/schema/uploads.ts
+++ b/packages/data/src/db/schema/uploads.ts
@@ -1,10 +1,6 @@
 // Read-only mirror of the `uploads` table managed by the upstream Python
 // service via Alembic. Do not generate or push migrations from this side. Keep
 // the columns in sync with `../../../../../../virtool/virtool/uploads/sql.py`.
-//
-// The legacy `space` column is a multi-tenant remnant that is never read or
-// written from this side and never appears in a response, so it is left out of
-// the mirror.
 
 import {
 	bigint,


### PR DESCRIPTION
## Summary
- Removes the unused `space` column from the `labels` and `uploads` Drizzle schema mirrors, and its mention in `UploadMinimal`'s docs — a multi-tenant remnant never read or written from the TS side.