### PR TITLE
chore: stand up the jobs API as an internal-only service

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,18 @@ jobs:
                   # have each matrix leg overwrite the last one's cache.
                   cache-from: type=gha,scope=${{ matrix.image }}
                   cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+    # Builds only — there is deliberately no publish counterpart, and adding one
+    # is not a gap to fill. `virtool/workflow-pathoscope` is still the repo that
+    # builds and releases the pathoscope workflow image, so this repo must not
+    # push a pathoscope image on release. That repo publishes
+    # `ghcr.io/virtool/pathoscope`; the Dockerfile here targets
+    # `ghcr.io/virtool/ts-pathoscope`, so nothing would be overwritten today —
+    # but two pipelines shipping the same workflow is the ambiguity to avoid,
+    # and the port is not finished. `apps/workflow-pathoscope` holds only a
+    # Dockerfile.
+    #
+    # Restore a publish job when `virtool/workflow-pathoscope` is retired, and
+    # settle which image name the cluster pulls in the same change.
     build-pathoscope:
         name: Build / Pathoscope
         runs-on: ubuntu-24.04
@@ -374,41 +386,3 @@ jobs:
                   cache-to: type=gha,mode=max,scope=${{ matrix.image }}
                   secrets: |
                       sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
-    publish-pathoscope:
-        name: Publish / Pathoscope
-        runs-on: ubuntu-24.04
-        timeout-minutes: 30
-        if: github.repository_owner == 'Virtool' && github.event_name == 'push' && needs.release.outputs.git-tag != ''
-        needs: [release]
-        permissions:
-            contents: read
-            packages: write
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v7
-              with:
-                  ref: ${{ needs.release.outputs.git-tag }}
-            - name: Setup Buildx
-              uses: docker/setup-buildx-action@v3
-            - name: Login
-              uses: docker/login-action@v4
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-            - name: Extract Metadata
-              id: meta
-              uses: docker/metadata-action@v6
-              with:
-                  context: git
-                  images: ${{ env.REGISTRY }}/virtool/ts-pathoscope
-            - name: Build & Push
-              uses: docker/build-push-action@v7
-              with:
-                  context: .
-                  file: apps/workflow-pathoscope/Dockerfile
-                  push: true
-                  tags: ${{ steps.meta.outputs.tags }}
-                  labels: ${{ steps.meta.outputs.labels }}
-                  cache-from: type=gha,scope=pathoscope
-                  cache-to: type=gha,mode=max,scope=pathoscope

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,21 @@ This is a **pnpm monorepo**:
   gates — Astro is not linted by biome and is opaque to knip — so its own
   Vite build (a `build-site` CI job) and Vitest suite are its gate. Deploy is
   manual: `pnpm --filter @virtool/site deploy`.
-- `apps/jobs-api/` — `@virtool/jobs-api`, the jobs control plane. A plain Node
-  HTTP service on port 9950, mirroring Python's `virtool/jobs/main.py`
-  (`api-jobs-service`, ClusterIP, no ingress). Serves `/health/live` and
-  `/health/ready` today. Image: `ghcr.io/virtool/jobs-api`, Alpine.
+- `apps/jobs-api/` — `@virtool/jobs-api`, the jobs API: the control plane
+  workflow runners call to claim, run and finish jobs. **Always "the jobs
+  API"** — the directory, the package, the image, the Kubernetes service and
+  the prose all use that one name, matching what Python and the workflow
+  runtime already call it. "Control plane" describes its role, not a second
+  name for it. A **Hono** app on `@hono/node-server`, port 9950, mirroring
+  Python's `virtool/jobs/main.py` (`api-jobs-service`, ClusterIP, **no
+  ingress** — that absence is the security boundary the service is built
+  around). Serves `/health/live`, `/health/ready` and a token-gated
+  `/metrics` today; every runner-facing endpoint lands in its own issue
+  against the wire contract in `packages/contracts/src/jobsApi.ts`. Image:
+  `ghcr.io/virtool/jobs-api`, Alpine. **Every route it exposes must refuse an
+  unauthenticated caller or be named in `PUBLIC_ROUTES` in `app.ts`** —
+  `src/__tests__/authorization.test.ts` enumerates `app.routes` and fails the
+  build on any that does neither. See [docs/jobs-api.md](docs/jobs-api.md).
 - `apps/create-subtraction/` — `@virtool/create-subtraction`, the first workflow
   executor: a one-shot process that starts, works, exits. Only its object
   storage half is wired so far. Image: `ghcr.io/virtool/ts-create-subtraction`,
@@ -1002,11 +1013,27 @@ it replaces, and erroring on the overlap would crashloop the rollout
 that fixes it. An unreadable path throws at startup; an empty file is an
 unset value.
 
-The non-Vite apps carry their own copy of the resolver in their
-`src/config.ts` — they cannot reach `apps/web/src/server`, and they parse
-a much smaller set of keys than the web app's zod schema. Keep the
-`<KEY>_FILE` behaviour in any new one; do not add a plain
-`process.env` read that skips it.
+**The resolver itself is shared, not copied.** It is
+`resolveFileBacked` in `@virtool/contracts/env`, and both
+`apps/web/src/server/config.ts` and `apps/jobs-api/src/config.ts` call
+it — a non-Vite app cannot reach `apps/web/src/server`, and a second
+copy would be free to drift on the precedence rule above. Each caller
+passes the keys it wants resolved (the web app hands it its zod schema's
+keys; the jobs API names a `KEYS` list), so **a key missing from that
+list silently loses its file variant**. Add a key to both places.
+
+It lives behind the `/env` subpath rather than the package barrel because
+it uses `node:fs`, and most of `@virtool/contracts` is imported by React
+components. `packages/contracts` therefore typechecks as two projects:
+`tsconfig.json` for the browser-safe modules, with no Node types at all,
+and `tsconfig.node.json` for the server-only ones (`env.ts`, `bearer.ts`).
+A new server-only module in that package needs its own subpath export and
+an entry in both tsconfigs.
+
+Never add a plain `process.env` read that skips this. `@virtool/sentry`'s
+`readDsn` is exactly that trap: it goes straight to `process.env`, so
+`VT_SENTRY_DSN` is resolved in `config.ts` and passed to `Sentry.init`
+explicitly instead.
 
 ## Logging
 
@@ -1050,6 +1077,18 @@ Prometheus scrapes `GET /metrics`, gated by a bearer token
 (`VT_METRICS_TOKEN`). With the variable unset the route reports 404, so
 metrics are off until a deployment opts in.
 
+**There are two scrape targets, not one.** `apps/jobs-api` is a separate
+process with its own registry and its own token-gated `/metrics`, and
+needs its own authenticated Prometheus job. The series names deliberately
+match this app's so one dashboard covers both; the two are told apart by
+the scrape's target labels and by `application_name`, never by renaming a
+metric. The rest of this section describes `apps/web` — see
+[docs/jobs-api.md](docs/jobs-api.md) for the other one.
+
+The bearer-token comparison is `isBearerTokenValid` from
+`@virtool/contracts/bearer`, shared by both services. It is constant-time;
+do not reimplement it locally, and do not reduce it to `===`.
+
 `server/metrics/registry.ts` owns the one process-wide `Registry`.
 Default process metrics keep prom-client's standard unprefixed names
 (`process_*`, `nodejs_*`) so off-the-shelf dashboards match; everything
@@ -1074,7 +1113,11 @@ unavailable and needs per-query instrumentation.
 
 That name is built by `@virtool/data/db/applicationName` and bounded to 63 bytes —
 Postgres truncates a longer one silently, and the filter would then match
-nothing and report every bucket as zero. The probe itself is bounded too:
+nothing and report every bucket as zero. It takes the **service** as well
+as the hostname (`createDb(config, "web")`, `createDb(config, "jobs-api")`),
+because the two services share a database and, on a developer machine, a
+hostname — without it each would count the other's backends and both
+would report the sum. The probe itself is bounded too:
 it queries the very pool it measures, so a saturated pool queues it
 client-side where nothing rejects, and an unbounded read would cost the
 whole scrape rather than just the pool gauges.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,21 +17,16 @@ This is a **pnpm monorepo**:
   gates — Astro is not linted by biome and is opaque to knip — so its own
   Vite build (a `build-site` CI job) and Vitest suite are its gate. Deploy is
   manual: `pnpm --filter @virtool/site deploy`.
-- `apps/jobs-api/` — `@virtool/jobs-api`, the jobs API: the control plane
-  workflow runners call to claim, run and finish jobs. **Always "the jobs
-  API"** — the directory, the package, the image, the Kubernetes service and
-  the prose all use that one name, matching what Python and the workflow
-  runtime already call it. "Control plane" describes its role, not a second
-  name for it. A **Hono** app on `@hono/node-server`, port 9950, mirroring
-  Python's `virtool/jobs/main.py` (`api-jobs-service`, ClusterIP, **no
-  ingress** — that absence is the security boundary the service is built
-  around). Serves `/health/live`, `/health/ready` and a token-gated
-  `/metrics` today; every runner-facing endpoint lands in its own issue
-  against the wire contract in `packages/contracts/src/jobsApi.ts`. Image:
-  `ghcr.io/virtool/jobs-api`, Alpine. **Every route it exposes must refuse an
-  unauthenticated caller or be named in `PUBLIC_ROUTES` in `app.ts`** —
-  `src/__tests__/authorization.test.ts` enumerates `app.routes` and fails the
-  build on any that does neither. See [docs/jobs-api.md](docs/jobs-api.md).
+- `apps/jobs-api/` — `@virtool/jobs-api`, the jobs API: the service workflow
+  runners call to claim, run and finish jobs. A Hono app on port 9950,
+  mirroring Python's `virtool/jobs/main.py` (`api-jobs-service`, ClusterIP,
+  **no ingress** — that absence is the security boundary). Serves
+  `/health/live`, `/health/ready` and a token-gated `/metrics` today. Image:
+  `ghcr.io/virtool/jobs-api`, Alpine. Two rules: it is **always "the jobs
+  API"**, never "the control plane" — that names its role, not the service;
+  and **every route must refuse an unauthenticated caller or be named in
+  `PUBLIC_ROUTES`**, which `src/__tests__/authorization.test.ts` enforces.
+  See [docs/jobs-api.md](docs/jobs-api.md).
 - `apps/create-subtraction/` — `@virtool/create-subtraction`, the first workflow
   executor: a one-shot process that starts, works, exits. Only its object
   storage half is wired so far. Image: `ghcr.io/virtool/ts-create-subtraction`,
@@ -1013,27 +1008,24 @@ it replaces, and erroring on the overlap would crashloop the rollout
 that fixes it. An unreadable path throws at startup; an empty file is an
 unset value.
 
-**The resolver itself is shared, not copied.** It is
-`resolveFileBacked` in `@virtool/contracts/env`, and both
-`apps/web/src/server/config.ts` and `apps/jobs-api/src/config.ts` call
-it — a non-Vite app cannot reach `apps/web/src/server`, and a second
-copy would be free to drift on the precedence rule above. Each caller
-passes the keys it wants resolved (the web app hands it its zod schema's
-keys; the jobs API names a `KEYS` list), so **a key missing from that
-list silently loses its file variant**. Add a key to both places.
+**The resolver is shared, not copied** — `resolveFileBacked` in
+`@virtool/contracts/env`, called by every service's `config.ts`. Each
+caller passes the keys it wants resolved, so **a key missing from that
+list silently loses its file variant**. Never add a plain `process.env`
+read that skips it (`@virtool/sentry`'s `readDsn` is exactly that trap).
 
-It lives behind the `/env` subpath rather than the package barrel because
-it uses `node:fs`, and most of `@virtool/contracts` is imported by React
-components. `packages/contracts` therefore typechecks as two projects:
-`tsconfig.json` for the browser-safe modules, with no Node types at all,
-and `tsconfig.node.json` for the server-only ones (`env.ts`, `bearer.ts`).
-A new server-only module in that package needs its own subpath export and
-an entry in both tsconfigs.
+It is one of the server-only helpers `@virtool/contracts` shares across
+services, each behind its own subpath so `node:*` never enters the browser
+graph:
 
-Never add a plain `process.env` read that skips this. `@virtool/sentry`'s
-`readDsn` is exactly that trap: it goes straight to `process.env`, so
-`VT_SENTRY_DSN` is resolved in `config.ts` and passed to `Sentry.init`
-explicitly instead.
+| Helper | Subpath | Purpose |
+| --- | --- | --- |
+| `resolveFileBacked` | `@virtool/contracts/env` | `<KEY>_FILE` resolution |
+| `isBearerTokenValid` | `@virtool/contracts/bearer` | constant-time `/metrics` token check |
+
+Adding one needs a subpath export **and** an entry in
+`packages/contracts/tsconfig.node.json`, which is why that package
+typechecks as two projects. See [docs/jobs-api.md](docs/jobs-api.md).
 
 ## Logging
 
@@ -1077,17 +1069,14 @@ Prometheus scrapes `GET /metrics`, gated by a bearer token
 (`VT_METRICS_TOKEN`). With the variable unset the route reports 404, so
 metrics are off until a deployment opts in.
 
-**There are two scrape targets, not one.** `apps/jobs-api` is a separate
-process with its own registry and its own token-gated `/metrics`, and
-needs its own authenticated Prometheus job. The series names deliberately
-match this app's so one dashboard covers both; the two are told apart by
-the scrape's target labels and by `application_name`, never by renaming a
-metric. The rest of this section describes `apps/web` — see
-[docs/jobs-api.md](docs/jobs-api.md) for the other one.
-
-The bearer-token comparison is `isBearerTokenValid` from
-`@virtool/contracts/bearer`, shared by both services. It is constant-time;
-do not reimplement it locally, and do not reduce it to `===`.
+**There are two scrape targets, not one** — `apps/web` and `apps/jobs-api`
+are separate processes with separate registries, each needing its own
+Prometheus job. Series names deliberately match so one dashboard covers
+both; they are told apart by the scrape's target labels and by
+`application_name`, **never by renaming a metric**. Both gate the endpoint
+with `isBearerTokenValid` (`@virtool/contracts/bearer`) — constant-time, so
+don't reimplement it or reduce it to `===`. The rest of this section is
+`apps/web`; see [docs/jobs-api.md](docs/jobs-api.md) for the other.
 
 `server/metrics/registry.ts` owns the one process-wide `Registry`.
 Default process metrics keep prom-client's standard unprefixed names
@@ -1114,10 +1103,8 @@ unavailable and needs per-query instrumentation.
 That name is built by `@virtool/data/db/applicationName` and bounded to 63 bytes —
 Postgres truncates a longer one silently, and the filter would then match
 nothing and report every bucket as zero. It takes the **service** as well
-as the hostname (`createDb(config, "web")`, `createDb(config, "jobs-api")`),
-because the two services share a database and, on a developer machine, a
-hostname — without it each would count the other's backends and both
-would report the sum. The probe itself is bounded too:
+as the hostname (`createDb(config, "web")`), without which the two
+services would count each other's backends. The probe itself is bounded too:
 it queries the very pool it measures, so a saturated pool queues it
 client-side where nothing rejects, and an unbounded read would cost the
 whole scrape rather than just the pool gauges.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,11 @@ This is a **pnpm monorepo**:
   (`ghcr.io/virtool/ts-pathoscope`). Holds only a `Dockerfile` today: it
   compiles `packages/pathoscope-core` and layers the `ghcr.io/virtool/tools`
   binaries on a Debian Node base. Built from the **repo root**
-  (`docker build -f apps/workflow-pathoscope/Dockerfile .`).
+  (`docker build -f apps/workflow-pathoscope/Dockerfile .`). **CI builds it but
+  must not publish it** — `virtool/workflow-pathoscope` still releases the
+  pathoscope workflow, and a second pipeline shipping it from here would leave
+  two candidates for what the cluster runs. Don't add a publish job until that
+  repo retires.
 - `packages/` — shared, framework-agnostic libraries published as workspace
   packages, plus one Rust crate:
   - `@virtool/logger` — pino wrapper, server-side log defaults and

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ COPY apps/jobs-api ./apps/jobs-api
 RUN pnpm --filter @virtool/jobs-api build \
     && pnpm deploy --filter @virtool/jobs-api --prod /prod/jobs-api
 
-# The control plane needs no bioinformatics tools, so it stays on Alpine. The
+# The jobs API needs no bioinformatics tools, so it stays on Alpine. The
 # Debian base below is a cost paid only to satisfy the tools binaries.
 FROM node:24-alpine AS jobs-api
 WORKDIR /jobs-api

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,13 @@ COPY --from=build-jobs-api /prod/jobs-api ./
 EXPOSE 9950
 ENV VT_JOBS_API_HOST="0.0.0.0"
 ENV VT_JOBS_API_PORT="9950"
-CMD ["node", "dist/index.mjs"]
+# `--import @sentry/node/preload` installs Sentry's module hooks before any
+# application import is evaluated. Without it the app's own static imports —
+# @hono/node-server, postgres — resolve before `Sentry.init` runs in the module
+# body, and neither HTTP nor database spans are ever recorded. The DSN is
+# resolved from `<KEY>_FILE`-backed config, so init genuinely cannot happen any
+# earlier than that; the preload hook is what makes late init safe.
+CMD ["node", "--import", "@sentry/node/preload", "dist/index.mjs"]
 
 FROM base AS build-create-subtraction
 COPY apps/create-subtraction ./apps/create-subtraction

--- a/apps/jobs-api/package.json
+++ b/apps/jobs-api/package.json
@@ -9,15 +9,23 @@
 	"scripts": {
 		"build": "tsdown",
 		"start": "node dist/index.mjs",
+		"test": "vitest run",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@hono/node-server": "^2.1.0",
+		"@sentry/node": "^10.69.0",
+		"@virtool/contracts": "workspace:*",
 		"@virtool/data": "workspace:*",
 		"@virtool/logger": "workspace:*",
+		"@virtool/sentry": "workspace:*",
+		"hono": "^4.13.0",
 		"pino": "^10.1.0",
-		"postgres": "^3.4.9"
+		"postgres": "^3.4.9",
+		"prom-client": "^15.1.3"
 	},
 	"devDependencies": {
-		"tsdown": "^0.22.14"
+		"tsdown": "^0.22.14",
+		"vitest": "^4.1.10"
 	}
 }

--- a/apps/jobs-api/package.json
+++ b/apps/jobs-api/package.json
@@ -8,7 +8,7 @@
 	],
 	"scripts": {
 		"build": "tsdown",
-		"start": "node dist/index.mjs",
+		"start": "node --import @sentry/node/preload dist/index.mjs",
 		"test": "vitest run",
 		"typecheck": "tsc --noEmit"
 	},

--- a/apps/jobs-api/src/__tests__/authorization.test.ts
+++ b/apps/jobs-api/src/__tests__/authorization.test.ts
@@ -1,0 +1,192 @@
+import type { PgClient } from "@virtool/data/db/pg";
+import type { Logger } from "@virtool/logger";
+import { describe, expect, it } from "vitest";
+import { type AppDeps, createApp, PUBLIC_ROUTES } from "../app";
+import { createMetrics } from "../metrics/registry";
+
+const METRICS_TOKEN = "a-metrics-token";
+
+/**
+ * Statuses that count as refusing an unauthenticated caller.
+ *
+ * 404 is in the set because that is how an unconfigured `/metrics` declines —
+ * withholding even the fact that the endpoint exists — and it is a refusal in
+ * the sense this test cares about: nothing privileged was served.
+ */
+const REFUSALS = [401, 403, 404];
+
+/**
+ * A postgres.js client stand-in.
+ *
+ * The real thing is called as a tagged template, so a plain function is enough
+ * for the two queries this app makes. Nothing here should reach it — a route
+ * that refuses should refuse before touching the database.
+ */
+function fakeClient(): PgClient {
+	return (() => Promise.resolve([])) as unknown as PgClient;
+}
+
+function fakeLogger(): Logger {
+	const noop = () => undefined;
+	return {
+		info: noop,
+		warn: noop,
+		error: noop,
+		debug: noop,
+	} as unknown as Logger;
+}
+
+function deps(overrides: Partial<AppDeps> = {}): AppDeps {
+	return {
+		client: fakeClient(),
+		logger: fakeLogger(),
+		metrics: createMetrics(10),
+		applicationName: "virtool-ts-jobs-api@test",
+		metricsToken: METRICS_TOKEN,
+		...overrides,
+	};
+}
+
+/**
+ * The app's endpoints, as registered.
+ *
+ * `app.routes` also carries the global metrics middleware, which is mounted at
+ * `/*` and is not an endpoint. Filtering it out by path keeps the list to
+ * things a caller can actually request.
+ */
+function endpoints(app: ReturnType<typeof createApp>) {
+	return app.routes.filter((route) => route.path !== "/*");
+}
+
+describe("authorization", () => {
+	// The floor. Every route this service exposes either refuses an
+	// unauthenticated caller or is named in PUBLIC_ROUTES with a reason. A new
+	// route added without either fails here, by name, rather than shipping open
+	// to a service whose whole premise is that its surface is guarded.
+	it.each(
+		endpoints(createApp(deps())).map((route) => [route.method, route.path]),
+	)(
+		"%s %s refuses an unauthenticated request or is explicitly public",
+		async (method, path) => {
+			const app = createApp(deps());
+			const response = await app.request(path, { method });
+
+			if ((PUBLIC_ROUTES as readonly string[]).includes(path)) {
+				expect(response.status).not.toBe(401);
+				return;
+			}
+
+			expect(REFUSALS).toContain(response.status);
+		},
+	);
+
+	// A stale exception is as much a bug as a missing one: it reads as a
+	// deliberate decision about a route that no longer exists.
+	it.each(PUBLIC_ROUTES)("%s is a route that actually exists", (path) => {
+		const paths = endpoints(createApp(deps())).map((route) => route.path);
+
+		expect(paths).toContain(path);
+	});
+});
+
+describe("health", () => {
+	it("reports alive without a credential", async () => {
+		const response = await createApp(deps()).request("/health/live");
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ status: "alive" });
+	});
+
+	it("reports ready when postgres answers", async () => {
+		const response = await createApp(deps()).request("/health/ready");
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			status: "ready",
+			checks: { postgres: { ok: true } },
+		});
+	});
+
+	// The readiness probe is what takes a pod out of service, so an unreachable
+	// database has to reach the kubelet as 503 rather than as a 200 with a sad
+	// body.
+	it("reports unavailable when postgres does not answer", async () => {
+		const client = (() =>
+			Promise.reject(new Error("down"))) as unknown as PgClient;
+
+		const response = await createApp(deps({ client })).request("/health/ready");
+
+		expect(response.status).toBe(503);
+		expect(await response.json()).toEqual({
+			status: "unavailable",
+			checks: { postgres: { ok: false } },
+		});
+	});
+});
+
+describe("metrics", () => {
+	// Unset means off, not open. An existing deployment must not start exposing
+	// internals merely by upgrading to a build that has the endpoint.
+	it("reports 404 when no token is configured", async () => {
+		const app = createApp(deps({ metricsToken: undefined }));
+
+		const response = await app.request("/metrics", {
+			headers: { authorization: `Bearer ${METRICS_TOKEN}` },
+		});
+
+		expect(response.status).toBe(404);
+	});
+
+	it("reports 401 without a token", async () => {
+		const response = await createApp(deps()).request("/metrics");
+
+		expect(response.status).toBe(401);
+		expect(response.headers.get("www-authenticate")).toBe("Bearer");
+	});
+
+	it("reports 401 for a wrong token", async () => {
+		const app = createApp(deps());
+
+		const response = await app.request("/metrics", {
+			headers: { authorization: "Bearer not-the-token" },
+		});
+
+		expect(response.status).toBe(401);
+	});
+
+	it("serves the exposition for the configured token", async () => {
+		const app = createApp(deps());
+
+		const response = await app.request("/metrics", {
+			headers: { authorization: `Bearer ${METRICS_TOKEN}` },
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toContain("virtool_postgres_pool_max 10");
+	});
+});
+
+describe("request metrics", () => {
+	// Ids in a label would grow one time series per job. The registered pattern
+	// is bounded by the number of routes instead.
+	it("labels an unmatched path with a bounded route pattern", async () => {
+		const metrics = createMetrics(10);
+		const app = createApp(deps({ metrics }));
+
+		await app.request("/jobs/12345");
+
+		const rendered = await metrics.render();
+
+		expect(rendered).not.toContain("12345");
+		expect(rendered).toContain("virtool_http_requests_total");
+	});
+
+	it("counts a handled request under its own route", async () => {
+		const metrics = createMetrics(10);
+		const app = createApp(deps({ metrics }));
+
+		await app.request("/health/live");
+
+		expect(await metrics.render()).toContain('route="/health/live"');
+	});
+});

--- a/apps/jobs-api/src/app.ts
+++ b/apps/jobs-api/src/app.ts
@@ -1,0 +1,96 @@
+import type { PgClient } from "@virtool/data/db/pg";
+import { checkPostgres, summarizeReadiness } from "@virtool/data/health/data";
+import type { Logger } from "@virtool/logger";
+import { Hono } from "hono";
+import { routePath } from "hono/route";
+import { handleMetrics } from "./metrics/handler";
+import type { Metrics } from "./metrics/registry";
+
+/**
+ * The routes that answer without a credential, and why each is allowed to.
+ *
+ * `authorization.test.ts` enumerates the app's routes and requires every one
+ * not named here to refuse an unauthenticated request. Adding a route without
+ * an authorization floor therefore fails the build by name, rather than
+ * shipping an open endpoint to a service whose whole premise is that its
+ * surface is guarded.
+ *
+ * Both entries are Kubernetes probes. The kubelet presents no credential, and a
+ * readiness probe that could fail closed on an auth problem would take the pod
+ * out of service for the wrong reason. Neither reveals anything beyond whether
+ * Postgres answers.
+ *
+ * `/metrics` is deliberately **not** here: it enforces its own bearer token and
+ * is expected to refuse like everything else.
+ */
+export const PUBLIC_ROUTES = ["/health/live", "/health/ready"] as const;
+
+/** What {@link createApp} needs to serve. */
+export type AppDeps = {
+	client: PgClient;
+	logger: Logger;
+	metrics: Metrics;
+	applicationName: string;
+	metricsToken: string | undefined;
+};
+
+/**
+ * Build the jobs API's Hono app.
+ *
+ * A factory rather than a module-scope singleton so a test can construct one
+ * over fakes without opening a pool, and so nothing is built at import time —
+ * the same rule `@virtool/data` and `@virtool/storage` follow.
+ *
+ * Hono is the framework here because the raw-route handlers this service will
+ * grow are already written against Web `Request`/`Response`, and port across
+ * verbatim.
+ */
+export function createApp(deps: AppDeps): Hono {
+	const app = new Hono();
+
+	// Every request, including ones that fall through to 404. `routePath` yields
+	// the *registered pattern* — `/jobs/:jobId`, never `/jobs/1234` — which is
+	// what keeps the label bounded by the number of routes rather than by the
+	// number of jobs.
+	app.use("*", async (c, next) => {
+		const start = performance.now();
+
+		try {
+			await next();
+		} finally {
+			deps.metrics.recordHttpRequest({
+				method: c.req.method,
+				route: routePath(c, -1),
+				// A thrown handler leaves no status behind. `"error"` is a bounded
+				// sentinel and keeps the counter's total honest either way.
+				status: c.error ? "error" : String(c.res.status),
+				durationSeconds: (performance.now() - start) / 1000,
+			});
+		}
+	});
+
+	app.get("/health/live", (c) => c.json({ status: "alive" }));
+
+	app.get("/health/ready", async (c) => {
+		const report = summarizeReadiness(
+			await checkPostgres(deps.client, deps.logger),
+		);
+
+		return c.json(
+			{ status: report.status, checks: report.checks },
+			report.statusCode,
+		);
+	});
+
+	app.get("/metrics", (c) =>
+		handleMetrics(c, {
+			metrics: deps.metrics,
+			client: deps.client,
+			applicationName: deps.applicationName,
+			logger: deps.logger,
+			token: deps.metricsToken,
+		}),
+	);
+
+	return app;
+}

--- a/apps/jobs-api/src/config.ts
+++ b/apps/jobs-api/src/config.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { resolveFileBacked } from "@virtool/contracts/env";
 
 /** Everything this process reads from the environment at startup. */
 export type Config = {
@@ -6,28 +6,47 @@ export type Config = {
 	port: number;
 	postgresUrl: string;
 	postgresPoolMax: number;
+	/**
+	 * Gates the Prometheus scrape endpoint. Unset leaves `/metrics` reporting
+	 * 404, so a deployment never starts exposing internals on upgrade.
+	 */
+	metricsToken: string | undefined;
+	/** Unset disables Sentry entirely, which is what dev and CI want. */
+	sentryDsn: string | undefined;
 };
 
 /**
- * Read `<key>`, preferring the contents of the file named by `<key>_FILE`.
+ * Every key this process reads.
  *
- * The file wins over a plain variable of the same name: a rollout moving to a
- * secrets-store mount can still carry the stale variable from the `Secret` it
- * replaces, and erroring on the overlap would crashloop the rollout that fixes
- * it.
+ * Named explicitly rather than derived, because the `<KEY>_FILE` resolution
+ * below walks this list: a key missing from it silently loses its file variant
+ * and reads only the plain environment.
+ *
+ * `VT_SENTRY_DSN` is here even though `@virtool/sentry` can read it itself.
+ * `readDsn` goes straight to `process.env` and so would skip the file variant;
+ * the DSN is resolved here and passed to `Sentry.init` explicitly instead.
  */
-function read(key: string): string | undefined {
-	const path = process.env[`${key}_FILE`];
+const KEYS = [
+	"VT_JOBS_API_HOST",
+	"VT_JOBS_API_PORT",
+	"VT_POSTGRES_URL",
+	"VT_POSTGRES_POOL_MAX",
+	"VT_METRICS_TOKEN",
+	"VT_SENTRY_DSN",
+] as const;
 
-	if (path) {
-		return readFileSync(path, "utf8").trim();
-	}
-
-	return process.env[key];
+// Deployment tooling routinely injects an empty string for a value it has
+// nothing to put in. Treat that as unset everywhere, so a default applies
+// rather than an empty credential being sent as a literal.
+function present(value: string | undefined): string | undefined {
+	return value ? value : undefined;
 }
 
-function requireEnv(key: string): string {
-	const value = read(key);
+function requireValue(
+	env: NodeJS.ProcessEnv,
+	key: (typeof KEYS)[number],
+): string {
+	const value = present(env[key]);
 
 	if (!value) {
 		throw new Error(`${key} is required`);
@@ -36,8 +55,12 @@ function requireEnv(key: string): string {
 	return value;
 }
 
-function readNumber(key: string, fallback: number): number {
-	const value = read(key);
+function readNumber(
+	env: NodeJS.ProcessEnv,
+	key: (typeof KEYS)[number],
+	fallback: number,
+): number {
+	const value = present(env[key]);
 
 	if (!value) {
 		return fallback;
@@ -55,14 +78,23 @@ function readNumber(key: string, fallback: number): number {
 /**
  * Resolve configuration from the environment.
  *
+ * Every key also accepts a `<KEY>_FILE` variant naming a file to read the value
+ * from, via the resolver shared with `apps/web` in `@virtool/contracts/env`. It
+ * is imported rather than copied so the precedence rule — the file wins over a
+ * plain variable of the same name — cannot drift between the two services.
+ *
  * The port mirrors Python's jobs API, which serves on 9950 as
  * `api-jobs-service`, so the two can be swapped behind the same ClusterIP.
  */
-export function readConfig(): Config {
+export function parseConfig(env: NodeJS.ProcessEnv = process.env): Config {
+	const resolved = resolveFileBacked(KEYS, env);
+
 	return {
-		host: read("VT_JOBS_API_HOST") ?? "0.0.0.0",
-		port: readNumber("VT_JOBS_API_PORT", 9950),
-		postgresUrl: requireEnv("VT_POSTGRES_URL"),
-		postgresPoolMax: readNumber("VT_POSTGRES_POOL_MAX", 10),
+		host: present(resolved.VT_JOBS_API_HOST) ?? "0.0.0.0",
+		port: readNumber(resolved, "VT_JOBS_API_PORT", 9950),
+		postgresUrl: requireValue(resolved, "VT_POSTGRES_URL"),
+		postgresPoolMax: readNumber(resolved, "VT_POSTGRES_POOL_MAX", 10),
+		metricsToken: present(resolved.VT_METRICS_TOKEN),
+		sentryDsn: present(resolved.VT_SENTRY_DSN),
 	};
 }

--- a/apps/jobs-api/src/index.ts
+++ b/apps/jobs-api/src/index.ts
@@ -1,50 +1,35 @@
-import { createServer, type ServerResponse } from "node:http";
+import { serve } from "@hono/node-server";
 import { createDb, logPostgresVersion } from "@virtool/data/db/pg";
-import { checkPostgres, summarizeReadiness } from "@virtool/data/health/data";
-import { createLogger } from "@virtool/logger";
-import { readConfig } from "./config";
+import { createApp } from "./app";
+import { parseConfig } from "./config";
+import { initSentry, SERVICE } from "./instrument";
+import { logger } from "./logger";
+import { createMetrics } from "./metrics/registry";
 
-const config = readConfig();
-const logger = createLogger({ name: "jobs-api" });
-const { client } = createDb(config);
+const config = parseConfig();
 
-function send(response: ServerResponse, status: number, body: unknown): void {
-	response.writeHead(status, { "content-type": "application/json" });
-	response.end(JSON.stringify(body));
-}
+// Before the pool opens or the server listens, so Sentry's Node
+// auto-instrumentation can install its import hooks ahead of what it patches.
+initSentry(config.sentryDsn);
 
-const server = createServer((request, response) => {
-	const path = new URL(request.url ?? "/", "http://localhost").pathname;
+const { client, applicationName } = createDb(config, SERVICE);
 
-	if (request.method !== "GET") {
-		send(response, 405, { error: "method not allowed" });
-		return;
-	}
-
-	if (path === "/health/live") {
-		send(response, 200, { status: "alive" });
-		return;
-	}
-
-	if (path === "/health/ready") {
-		void checkPostgres(client, logger).then((postgres) => {
-			const report = summarizeReadiness(postgres);
-			send(response, report.statusCode, {
-				status: report.status,
-				checks: report.checks,
-			});
-		});
-		return;
-	}
-
-	send(response, 404, { error: "not found" });
+const app = createApp({
+	client,
+	logger,
+	metrics: createMetrics(config.postgresPoolMax),
+	applicationName,
+	metricsToken: config.metricsToken,
 });
 
 logPostgresVersion(client, logger);
 
-server.listen(config.port, config.host, () => {
-	logger.info({ host: config.host, port: config.port }, "listening");
-});
+const server = serve(
+	{ fetch: app.fetch, hostname: config.host, port: config.port },
+	() => {
+		logger.info({ host: config.host, port: config.port }, "listening");
+	},
+);
 
 // A pod is deleted with SIGTERM. Close the listener and drain the pool so
 // in-flight readiness probes finish rather than being cut off mid-query.

--- a/apps/jobs-api/src/instrument.ts
+++ b/apps/jobs-api/src/instrument.ts
@@ -1,0 +1,48 @@
+import * as Sentry from "@sentry/node";
+import { getCommonOptions } from "@virtool/sentry";
+import { logger } from "./logger";
+
+/** The name this service reports under, in Sentry and in `application_name`. */
+export const SERVICE = "jobs-api";
+
+/**
+ * Initialise Sentry for this process.
+ *
+ * Called first thing in `index.ts`, before the pool is opened or the server
+ * listens, so the SDK's Node auto-instrumentation installs its import hooks
+ * before anything it patches is loaded.
+ *
+ * Reports to the same project as `apps/web`, tagged `service: jobs-api` and
+ * carrying its own `dist` so the two images' source maps do not collide under
+ * the shared release version. Both come from `getCommonOptions`.
+ *
+ * `dsn` is passed in rather than read from the environment here, because the
+ * value has already been through the `<KEY>_FILE` resolution in `config.ts` and
+ * `readDsn` would go straight back to `process.env` and miss it. No DSN means
+ * no `init`, so dev and unconfigured deploys are untouched.
+ *
+ * There is deliberately no `beforeSend` filter. The web app needs one because a
+ * server function signals an expected 4xx by *throwing* `ClientError`, which
+ * would otherwise be reported as an incident. This service has no such
+ * mechanism: a Hono handler returns a 4xx response rather than throwing, so
+ * nothing routine reaches Sentry in the first place. Add a filter here only if
+ * a route starts throwing for an expected outcome — and prefer not to.
+ */
+export function initSentry(dsn: string | undefined): void {
+	const options = getCommonOptions(SERVICE);
+
+	if (!dsn) {
+		logger.info(
+			{ environment: options.environment, foundSentryDsn: false },
+			"sentry disabled",
+		);
+		return;
+	}
+
+	Sentry.init({ ...options, dsn });
+
+	logger.info(
+		{ environment: options.environment, foundSentryDsn: true },
+		"sentry initialised",
+	);
+}

--- a/apps/jobs-api/src/instrument.ts
+++ b/apps/jobs-api/src/instrument.ts
@@ -8,9 +8,20 @@ export const SERVICE = "jobs-api";
 /**
  * Initialise Sentry for this process.
  *
- * Called first thing in `index.ts`, before the pool is opened or the server
- * listens, so the SDK's Node auto-instrumentation installs its import hooks
- * before anything it patches is loaded.
+ * **This runs after `@hono/node-server` and `postgres` have already been
+ * imported, and that is fine only because the process is started with
+ * `node --import @sentry/node/preload`.** ESM evaluates every static import
+ * before any top-level statement, and the bundle makes that concrete — the
+ * externals land at the top of `dist/index.mjs` while this call sits thousands
+ * of lines below. Without the preload flag the SDK's module hooks would install
+ * too late to patch either one, and the service would report errors while
+ * silently recording no HTTP or database spans.
+ *
+ * Init cannot simply move earlier: the DSN comes from `<KEY>_FILE`-backed
+ * config, which has to be read first. That is exactly the case Sentry's "late
+ * initialization" guidance covers, and the preload hook is its answer. If the
+ * flag is ever dropped from the Dockerfile or the `start` script, tracing goes
+ * quiet with nothing in the logs to say so.
  *
  * Reports to the same project as `apps/web`, tagged `service: jobs-api` and
  * carrying its own `dist` so the two images' source maps do not collide under

--- a/apps/jobs-api/src/logger.ts
+++ b/apps/jobs-api/src/logger.ts
@@ -1,0 +1,10 @@
+import { createLogger, type Logger } from "@virtool/logger";
+
+/**
+ * This process's logger.
+ *
+ * `name` is `jobs-api`, matching the Sentry `service` tag and the
+ * `application_name` segment this process connects to Postgres under, so one
+ * string identifies the service across logs, errors and pool metrics.
+ */
+export const logger: Logger = createLogger({ name: "jobs-api" });

--- a/apps/jobs-api/src/metrics/handler.ts
+++ b/apps/jobs-api/src/metrics/handler.ts
@@ -1,0 +1,85 @@
+import { isBearerTokenValid } from "@virtool/contracts/bearer";
+import type { PgClient } from "@virtool/data/db/pg";
+import { readConnectionCounts } from "@virtool/data/metrics/data";
+import type { Logger } from "@virtool/logger";
+import type { Context } from "hono";
+import type { Metrics } from "./registry";
+
+/**
+ * How long a scrape waits on the pool probe before abandoning it.
+ *
+ * The probe is a query on the very pool it measures, so a saturated pool queues
+ * it *client-side*, where nothing rejects and no statement timeout applies.
+ * Left unbounded it would hang past Prometheus' scrape deadline and lose the
+ * whole response — the process and request metrics included — exactly when
+ * saturation is the thing worth seeing. Two seconds sits well inside a default
+ * 10s scrape timeout.
+ */
+const POOL_PROBE_TIMEOUT_MS = 2000;
+
+/**
+ * Resolve `promise`, or reject once `ms` have passed.
+ *
+ * The abandoned promise is left to settle on its own; it is a single trivial
+ * query and its result is simply discarded.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	const deadline = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => reject(new Error("timed out")), ms);
+	});
+
+	return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
+}
+
+/** What {@link handleMetrics} needs to answer a scrape. */
+export type MetricsDeps = {
+	metrics: Metrics;
+	client: PgClient;
+	applicationName: string;
+	logger: Logger;
+	token: string | undefined;
+};
+
+/**
+ * Answer a Prometheus scrape at `GET /metrics`.
+ *
+ * This service is already unreachable from the internet, but the token is not
+ * redundant: everything inside the cluster can reach a ClusterIP, and the
+ * endpoint shares a socket with the API itself. With no token configured it
+ * reports **404** rather than serving openly, so an existing deployment does
+ * not start exposing internals on upgrade; with a token configured and a wrong
+ * one presented it reports **401**.
+ */
+export async function handleMetrics(
+	c: Context,
+	deps: MetricsDeps,
+): Promise<Response> {
+	if (!deps.token) {
+		return c.text("Not Found", 404);
+	}
+
+	if (!isBearerTokenValid(c.req.header("authorization"), deps.token)) {
+		return c.text("Unauthorized", 401, { "www-authenticate": "Bearer" });
+	}
+
+	// A Postgres outage is exactly when the rest of these metrics matter most, so
+	// a failed or slow read drops the pool gauges rather than the whole scrape.
+	// The series go stale at their last value; `up` and the process metrics carry
+	// on.
+	try {
+		deps.metrics.setPostgresConnections(
+			await withTimeout(
+				readConnectionCounts(deps.client, deps.applicationName),
+				POOL_PROBE_TIMEOUT_MS,
+			),
+		);
+	} catch (err) {
+		deps.logger.warn({ err }, "could not read postgres connection counts");
+	}
+
+	return c.text(await deps.metrics.render(), 200, {
+		"content-type": deps.metrics.contentType,
+	});
+}

--- a/apps/jobs-api/src/metrics/handler.ts
+++ b/apps/jobs-api/src/metrics/handler.ts
@@ -1,37 +1,9 @@
 import { isBearerTokenValid } from "@virtool/contracts/bearer";
 import type { PgClient } from "@virtool/data/db/pg";
-import { readConnectionCounts } from "@virtool/data/metrics/data";
+import { readConnectionCountsBounded } from "@virtool/data/metrics/data";
 import type { Logger } from "@virtool/logger";
 import type { Context } from "hono";
 import type { Metrics } from "./registry";
-
-/**
- * How long a scrape waits on the pool probe before abandoning it.
- *
- * The probe is a query on the very pool it measures, so a saturated pool queues
- * it *client-side*, where nothing rejects and no statement timeout applies.
- * Left unbounded it would hang past Prometheus' scrape deadline and lose the
- * whole response — the process and request metrics included — exactly when
- * saturation is the thing worth seeing. Two seconds sits well inside a default
- * 10s scrape timeout.
- */
-const POOL_PROBE_TIMEOUT_MS = 2000;
-
-/**
- * Resolve `promise`, or reject once `ms` have passed.
- *
- * The abandoned promise is left to settle on its own; it is a single trivial
- * query and its result is simply discarded.
- */
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-	let timer: ReturnType<typeof setTimeout> | undefined;
-
-	const deadline = new Promise<never>((_, reject) => {
-		timer = setTimeout(() => reject(new Error("timed out")), ms);
-	});
-
-	return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
-}
 
 /** What {@link handleMetrics} needs to answer a scrape. */
 export type MetricsDeps = {
@@ -70,10 +42,7 @@ export async function handleMetrics(
 	// on.
 	try {
 		deps.metrics.setPostgresConnections(
-			await withTimeout(
-				readConnectionCounts(deps.client, deps.applicationName),
-				POOL_PROBE_TIMEOUT_MS,
-			),
+			await readConnectionCountsBounded(deps.client, deps.applicationName),
 		);
 	} catch (err) {
 		deps.logger.warn({ err }, "could not read postgres connection counts");

--- a/apps/jobs-api/src/metrics/registry.ts
+++ b/apps/jobs-api/src/metrics/registry.ts
@@ -1,0 +1,106 @@
+import type { ConnectionCounts } from "@virtool/data/metrics/data";
+import {
+	Counter,
+	collectDefaultMetrics,
+	Gauge,
+	Histogram,
+	Registry,
+} from "prom-client";
+
+/** One handled request, as observed by the metrics middleware. */
+export type RequestSample = {
+	method: string;
+	/**
+	 * The route's registered path pattern — `/jobs/:jobId`, not `/jobs/1234`.
+	 *
+	 * The pattern is what keeps this label bounded. A real pathname carries ids,
+	 * and one time series per job would grow without limit.
+	 */
+	route: string;
+	/** The response status, or `"error"` when the handler threw instead. */
+	status: string;
+	durationSeconds: number;
+};
+
+/** The metrics surface this process exposes, as returned by {@link createMetrics}. */
+export type Metrics = {
+	recordHttpRequest: (sample: RequestSample) => void;
+	setPostgresConnections: (counts: ConnectionCounts) => void;
+	contentType: string;
+	render: () => Promise<string>;
+};
+
+/**
+ * Build this process's Prometheus registry and the handles that write to it.
+ *
+ * A factory rather than a module-scope singleton, so a test gets its own
+ * registry and cannot see what another suite happened to register. It is also
+ * why nothing here reads configuration: `poolMax` arrives as an argument, the
+ * way `@virtool/data` and `@virtool/storage` take theirs.
+ *
+ * This is a *separate registry from the web app's*, in a separate process. The
+ * series names deliberately match, so one dashboard works for both; the two are
+ * told apart by the scrape's target labels and by `application_name` in
+ * `pg_stat_activity`, not by renaming the metrics.
+ */
+export function createMetrics(poolMax: number): Metrics {
+	const registry = new Registry();
+
+	// Standard `process_*` and `nodejs_*` series: RSS, heap, CPU, GC, open
+	// handles, and event loop lag. Left unprefixed on purpose — off-the-shelf
+	// Node dashboards and alerting rules match these names exactly.
+	collectDefaultMetrics({ register: registry });
+
+	const httpRequests = new Counter({
+		name: "virtool_http_requests_total",
+		help: "HTTP requests handled, by route, method, and response status.",
+		labelNames: ["route", "method", "status"],
+		registers: [registry],
+	});
+
+	const httpDuration = new Histogram({
+		name: "virtool_http_request_duration_seconds",
+		help: "Time from request receipt to response headers, in seconds.",
+		labelNames: ["route", "method"],
+		buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+		registers: [registry],
+	});
+
+	const postgresConnections = new Gauge({
+		name: "virtool_postgres_connections",
+		help: "Open Postgres backends belonging to this process, by backend state.",
+		labelNames: ["state"],
+		registers: [registry],
+	});
+
+	// Static, but it is the denominator: pool saturation is only legible as
+	// `virtool_postgres_connections / virtool_postgres_pool_max`.
+	new Gauge({
+		name: "virtool_postgres_pool_max",
+		help: "Maximum size of this process's Postgres connection pool.",
+		registers: [registry],
+	}).set(poolMax);
+
+	return {
+		recordHttpRequest(sample) {
+			const { method, route } = sample;
+
+			httpRequests.inc({ route, method, status: sample.status });
+			httpDuration.observe({ route, method }, sample.durationSeconds);
+		},
+
+		setPostgresConnections(counts) {
+			postgresConnections.set({ state: "active" }, counts.active);
+			postgresConnections.set({ state: "idle" }, counts.idle);
+			postgresConnections.set(
+				{ state: "idle in transaction" },
+				counts.idleInTransaction,
+			);
+			postgresConnections.set({ state: "other" }, counts.other);
+		},
+
+		contentType: registry.contentType,
+
+		render: () => registry.metrics(),
+	};
+}

--- a/apps/web/src/instrument.server.ts
+++ b/apps/web/src/instrument.server.ts
@@ -7,7 +7,7 @@ import { getCommonOptions } from "@virtool/sentry";
 // (set in `getCommonOptions`) is what lets `@virtool/logger` forward records via
 // `Sentry.logger`. No DSN means no init, so dev and unconfigured deploys are
 // untouched.
-const options = getCommonOptions();
+const options = getCommonOptions("web");
 
 if (options.dsn) {
 	// Import the profiler lazily and only when configured. `@sentry/profiling-node`

--- a/apps/web/src/instrument.server.ts
+++ b/apps/web/src/instrument.server.ts
@@ -9,7 +9,19 @@ import { getCommonOptions } from "@virtool/sentry";
 // untouched.
 const options = getCommonOptions("web");
 
-if (options.dsn) {
+// The DSN comes from `config`, not from `options.dsn`. `getCommonOptions` reads
+// it with `readDsn`, which goes straight to `process.env` and so cannot see a
+// `VT_SENTRY_DSN_FILE` mount — a deployment following the `<KEY>_FILE`
+// convention would have had Sentry silently disabled. Imported dynamically for
+// the same reason `@server/logger` is below: a top-level import front-loads the
+// module graph before the SDK installs its hooks.
+//
+// The browser DSN is a separate value, baked in at build time by Vite from
+// `import.meta.env`, and cannot be file-backed at all.
+const { config } = await import("@server/config");
+const dsn = config.sentryDsn;
+
+if (dsn) {
 	// Import the profiler lazily and only when configured. `@sentry/profiling-node`
 	// pulls in a native CommonJS addon that the Vite/Nitro SSR transform can't
 	// process, so a top-level import breaks dev and tests where no DSN is set.
@@ -17,6 +29,7 @@ if (options.dsn) {
 	const { nodeProfilingIntegration } = await import("@sentry/profiling-node");
 	Sentry.init({
 		...options,
+		dsn,
 		integrations: [nodeProfilingIntegration()],
 		beforeSend: dropExpectedClientErrors,
 	});

--- a/apps/web/src/server/composition.ts
+++ b/apps/web/src/server/composition.ts
@@ -24,7 +24,7 @@ import { logger } from "./logger";
  */
 export const storage: StorageBackend = createStorageBackend(config.storage);
 
-const handles = createDb(config);
+const handles = createDb(config, "web");
 
 /** The postgres-js connection pool for this process. */
 export const client: PgClient = handles.client;

--- a/apps/web/src/server/config.ts
+++ b/apps/web/src/server/config.ts
@@ -10,6 +10,15 @@ export type ServerConfig = {
 	postgresUrl: string;
 	postgresPoolMax: number;
 	metricsToken: string | undefined;
+	/**
+	 * Server-side Sentry DSN.
+	 *
+	 * Parsed here rather than read by `@virtool/sentry`'s `readDsn`, which goes
+	 * straight to `process.env` and so would miss a `VT_SENTRY_DSN_FILE` mount.
+	 * The browser DSN is a separate value baked in at build time by Vite and
+	 * cannot be file-backed at all.
+	 */
+	sentryDsn: string | undefined;
 	storage: StorageConfig;
 };
 
@@ -26,6 +35,12 @@ const ServerEnv = z.object({
 	// tooling injects for a value it has nothing to put in — leaves `/metrics`
 	// returning 404, so upgrading never starts exposing internals by surprise.
 	VT_METRICS_TOKEN: z.preprocess(
+		(value) => (value === "" ? undefined : value),
+		z.string().optional(),
+	),
+	// Listed here so it picks up the `<KEY>_FILE` resolution every other key
+	// gets. Unset — or empty, which deployment tooling injects — disables Sentry.
+	VT_SENTRY_DSN: z.preprocess(
 		(value) => (value === "" ? undefined : value),
 		z.string().optional(),
 	),
@@ -47,6 +62,7 @@ const ServerEnvSchema = ServerEnv.transform((raw, ctx) => ({
 	postgresUrl: raw.VT_POSTGRES_URL,
 	postgresPoolMax: raw.VT_POSTGRES_POOL_MAX ?? DEFAULT_POSTGRES_POOL_MAX,
 	metricsToken: raw.VT_METRICS_TOKEN,
+	sentryDsn: raw.VT_SENTRY_DSN,
 	storage: buildStorage(raw, ctx),
 }));
 

--- a/apps/web/src/server/config.ts
+++ b/apps/web/src/server/config.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { resolveFileBacked } from "@virtool/contracts/env";
 import type { StorageConfig } from "@virtool/storage";
 import { z } from "zod";
 
@@ -143,44 +143,17 @@ function buildStorage(raw: StorageEnv, ctx: z.RefinementCtx): StorageConfig {
 	};
 }
 
-const FILE_SUFFIX = "_FILE";
-
 // Every key also accepts a `<KEY>_FILE` variant naming a file to read the value
-// from — the convention Prometheus and Docker use. A Kubernetes `Secret`
-// populated by the secrets-store CSI driver goes stale when a key is added to
-// the SecretProviderClass, so a pod can start with an env var the cluster
-// believes it has updated; the driver's file mount has no such staleness.
-//
-// The file wins over the plain variable deliberately. A rollout that moves to
-// the mount can still carry the stale env var from the `Secret` it replaces,
-// and failing on the overlap would crashloop the very rollout that fixes it.
-function resolveFileBacked(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-	const resolved = { ...env };
-
-	for (const key of Object.keys(ServerEnv.shape)) {
-		const path = env[`${key}${FILE_SUFFIX}`];
-
-		if (!path) {
-			continue;
-		}
-
-		try {
-			resolved[key] = readFileSync(path, "utf8").trim();
-		} catch (error) {
-			throw new Error(
-				`${key}${FILE_SUFFIX} points at ${path}, which could not be read`,
-				{ cause: error },
-			);
-		}
-	}
-
-	return resolved;
-}
-
+// from. The resolver is shared with `apps/jobs-api` through
+// `@virtool/contracts/env` rather than copied, so the precedence rule — the
+// file wins over a plain variable of the same name — cannot drift between the
+// two services.
 export function parseServerConfig(
 	env: NodeJS.ProcessEnv = process.env,
 ): ServerConfig {
-	return ServerEnvSchema.parse(resolveFileBacked(env));
+	return ServerEnvSchema.parse(
+		resolveFileBacked(Object.keys(ServerEnv.shape), env),
+	);
 }
 
 export const config: ServerConfig = parseServerConfig();

--- a/apps/web/src/server/metrics/__tests__/handler.test.ts
+++ b/apps/web/src/server/metrics/__tests__/handler.test.ts
@@ -1,12 +1,12 @@
 import type { ConnectionCounts } from "@virtool/data/metrics/data";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { configMock, readConnectionCounts } = vi.hoisted(() => ({
+const { configMock, readConnectionCountsBounded } = vi.hoisted(() => ({
 	configMock: {
 		metricsToken: undefined as string | undefined,
 		postgresPoolMax: 10,
 	},
-	readConnectionCounts: vi.fn(),
+	readConnectionCountsBounded: vi.fn(),
 }));
 
 vi.mock("../../config", () => ({ config: configMock }));
@@ -14,7 +14,7 @@ vi.mock("../../composition", () => ({
 	client: {},
 	applicationName: "virtool-ts@test",
 }));
-vi.mock("@virtool/data/metrics/data", () => ({ readConnectionCounts }));
+vi.mock("@virtool/data/metrics/data", () => ({ readConnectionCountsBounded }));
 vi.mock("../../logger", () => ({
 	logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
@@ -36,7 +36,7 @@ function scrape(headers: Record<string, string> = {}): Promise<Response> {
 
 beforeEach(() => {
 	configMock.metricsToken = TOKEN;
-	readConnectionCounts.mockReset().mockResolvedValue(COUNTS);
+	readConnectionCountsBounded.mockReset().mockResolvedValue(COUNTS);
 });
 
 describe("handleMetrics", () => {
@@ -47,7 +47,7 @@ describe("handleMetrics", () => {
 
 		expect(response.status).toBe(404);
 		// The endpoint must not do any work before refusing.
-		expect(readConnectionCounts).not.toHaveBeenCalled();
+		expect(readConnectionCountsBounded).not.toHaveBeenCalled();
 	});
 
 	it("rejects a request carrying no credentials", async () => {
@@ -55,7 +55,7 @@ describe("handleMetrics", () => {
 
 		expect(response.status).toBe(401);
 		expect(response.headers.get("www-authenticate")).toBe("Bearer");
-		expect(readConnectionCounts).not.toHaveBeenCalled();
+		expect(readConnectionCountsBounded).not.toHaveBeenCalled();
 	});
 
 	it.each([
@@ -68,7 +68,7 @@ describe("handleMetrics", () => {
 		const response = await scrape({ authorization });
 
 		expect(response.status).toBe(401);
-		expect(readConnectionCounts).not.toHaveBeenCalled();
+		expect(readConnectionCountsBounded).not.toHaveBeenCalled();
 	});
 
 	// RFC 9110 §11.1: the auth scheme is case-insensitive.
@@ -105,7 +105,9 @@ describe("handleMetrics", () => {
 	});
 
 	it("still serves process metrics when Postgres is unreachable", async () => {
-		readConnectionCounts.mockRejectedValue(new Error("connection refused"));
+		readConnectionCountsBounded.mockRejectedValue(
+			new Error("connection refused"),
+		);
 
 		const response = await scrape({ authorization: `Bearer ${TOKEN}` });
 
@@ -114,18 +116,14 @@ describe("handleMetrics", () => {
 	});
 
 	// A saturated pool queues the probe client-side, where nothing rejects, so
-	// the scrape has to abandon it rather than hang past Prometheus' deadline.
-	it("still serves process metrics when the pool probe never settles", async () => {
-		readConnectionCounts.mockReturnValue(new Promise(() => {}));
+	// the read abandons it and rejects. The deadline itself belongs to
+	// `readConnectionCountsBounded` and is tested in `@virtool/data`; what
+	// matters here is that the handler treats a timeout like any other probe
+	// failure and still serves the rest of the scrape.
+	it("still serves process metrics when the pool probe times out", async () => {
+		readConnectionCountsBounded.mockRejectedValue(new Error("timed out"));
 
-		vi.useFakeTimers();
-
-		const pending = scrape({ authorization: `Bearer ${TOKEN}` });
-
-		await vi.advanceTimersByTimeAsync(5000);
-		vi.useRealTimers();
-
-		const response = await pending;
+		const response = await scrape({ authorization: `Bearer ${TOKEN}` });
 
 		expect(response.status).toBe(200);
 		expect(await response.text()).toContain("process_resident_memory_bytes");

--- a/apps/web/src/server/metrics/handler.ts
+++ b/apps/web/src/server/metrics/handler.ts
@@ -1,5 +1,5 @@
 import { isBearerTokenValid } from "@virtool/contracts/bearer";
-import { readConnectionCounts } from "@virtool/data/metrics/data";
+import { readConnectionCountsBounded } from "@virtool/data/metrics/data";
 import { applicationName, client } from "../composition";
 import { config } from "../config";
 import { logger } from "../logger";
@@ -8,34 +8,6 @@ import {
 	renderMetrics,
 	setPostgresConnections,
 } from "./registry";
-
-/**
- * How long a scrape waits on the pool probe before abandoning it.
- *
- * The probe is a query on the very pool it measures, so a saturated pool queues
- * it *client-side*, where nothing rejects and no statement timeout applies. Left
- * unbounded it would hang past Prometheus' scrape deadline and lose the whole
- * response — the process and request metrics included — exactly when saturation
- * is the thing worth seeing. Two seconds sits well inside a default 10s scrape
- * timeout.
- */
-const POOL_PROBE_TIMEOUT_MS = 2000;
-
-/**
- * Resolve `promise`, or reject once `ms` have passed.
- *
- * The abandoned promise is left to settle on its own; it is a single trivial
- * query and its result is simply discarded.
- */
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-	let timer: ReturnType<typeof setTimeout> | undefined;
-
-	const deadline = new Promise<never>((_, reject) => {
-		timer = setTimeout(() => reject(new Error("timed out")), ms);
-	});
-
-	return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
-}
 
 /**
  * Serve the Prometheus scrape endpoint backing `GET /metrics`.
@@ -70,10 +42,7 @@ export async function handleMetrics(request: Request): Promise<Response> {
 	// metrics carry on.
 	try {
 		setPostgresConnections(
-			await withTimeout(
-				readConnectionCounts(client, applicationName),
-				POOL_PROBE_TIMEOUT_MS,
-			),
+			await readConnectionCountsBounded(client, applicationName),
 		);
 	} catch (err) {
 		logger.warn({ err }, "could not read postgres connection counts");

--- a/apps/web/src/server/metrics/handler.ts
+++ b/apps/web/src/server/metrics/handler.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from "node:crypto";
+import { isBearerTokenValid } from "@virtool/contracts/bearer";
 import { readConnectionCounts } from "@virtool/data/metrics/data";
 import { applicationName, client } from "../composition";
 import { config } from "../config";
@@ -8,8 +8,6 @@ import {
 	renderMetrics,
 	setPostgresConnections,
 } from "./registry";
-
-const BEARER_PREFIX = "bearer ";
 
 /**
  * How long a scrape waits on the pool probe before abandoning it.
@@ -40,35 +38,6 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
 }
 
 /**
- * Compare the presented bearer token to the configured one without leaking
- * where they first differ.
- *
- * `timingSafeEqual` throws on a length mismatch, so that case is screened
- * first. The screen reveals the configured token's length, which is not worth
- * defending: an attacker learns nothing that narrows the search meaningfully.
- *
- * The scheme is matched case-insensitively, as RFC 9110 §11.1 requires. The
- * credential after it is not — it is compared byte for byte, so a token that
- * differs only in case or surrounding whitespace is a different token.
- */
-function isAuthorized(request: Request, token: string): boolean {
-	const header = request.headers.get("authorization");
-
-	if (header?.slice(0, BEARER_PREFIX.length).toLowerCase() !== BEARER_PREFIX) {
-		return false;
-	}
-
-	const presented = Buffer.from(header.slice(BEARER_PREFIX.length));
-	const expected = Buffer.from(token);
-
-	if (presented.length !== expected.length) {
-		return false;
-	}
-
-	return timingSafeEqual(presented, expected);
-}
-
-/**
  * Serve the Prometheus scrape endpoint backing `GET /metrics`.
  *
  * A raw route rather than a server function, because Prometheus scrapes over
@@ -88,7 +57,7 @@ export async function handleMetrics(request: Request): Promise<Response> {
 		return new Response("Not Found", { status: 404 });
 	}
 
-	if (!isAuthorized(request, token)) {
+	if (!isBearerTokenValid(request.headers.get("authorization"), token)) {
 		return new Response("Unauthorized", {
 			status: 401,
 			headers: { "www-authenticate": "Bearer" },

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -133,13 +133,20 @@ Dockerfile stage and a CI matrix entry — the one deliberate exception.
 
 ## The apps
 
-- **`apps/jobs-api`** — `@virtool/jobs-api`, the jobs control plane. A
-  long-running HTTP service on port 9950, mirroring Python's
+- **`apps/jobs-api`** — `@virtool/jobs-api`, the jobs API: the control
+  plane workflow runners call to claim, run and finish jobs. It is called
+  "the jobs API" everywhere — directory, package, image, Kubernetes
+  service and prose — matching Python and the workflow runtime; "control
+  plane" is its role, not an alternate name. A long-running **Hono** app
+  on `@hono/node-server`, port 9950, mirroring Python's
   `virtool/jobs/main.py`, which serves as `api-jobs-service` behind a
-  ClusterIP with no ingress rule. Serves `/health/live` and
-  `/health/ready`; the readiness probe folds `checkPostgres` through
-  `summarizeReadiness`, the same pair `apps/web` uses. Image:
-  `ghcr.io/virtool/jobs-api`.
+  ClusterIP with no ingress rule. Hono because the handlers it will grow
+  are ported from raw-route handlers already written against Web
+  `Request`/`Response`, so they move across verbatim. Serves
+  `/health/live`, `/health/ready` and a token-gated `/metrics`; the
+  readiness probe folds `checkPostgres` through `summarizeReadiness`, the
+  same pair `apps/web` uses. `postgres` and `pino` are its externals.
+  Image: `ghcr.io/virtool/jobs-api`.
 - **`apps/create-subtraction`** — `@virtool/create-subtraction`, the first
   workflow executor. One-shot: the pod starts, does its work, exits. Only
   its object-storage half is wired; claiming a job arrives with the

--- a/docs/jobs-api.md
+++ b/docs/jobs-api.md
@@ -167,12 +167,18 @@ connects as `virtool-ts-jobs-api@<hostname>` and counts **only its own
 backends** — not the web app's, which share the database and, on a
 developer machine, the hostname too.
 
-The read is time-bounded at two seconds. The probe is a query on the very
+The handler calls `readConnectionCountsBounded`, which applies the shared
+`POOL_PROBE_TIMEOUT_MS` (two seconds). The probe is a query on the very
 pool it measures, so a saturated pool queues it *client-side*, where
 nothing rejects and no statement timeout applies; unbounded it would hang
 past the scrape deadline and cost the whole response — process and
 request metrics included — exactly when saturation is worth seeing. A
 failed or slow read logs a warning and drops only the pool gauges.
+
+The deadline lives in `@virtool/data` rather than beside each handler
+because both services expose pool gauges and both need the same bound for
+the same reason; a second copy is free to drift to a value that no longer
+fits inside the scrape timeout.
 
 ## Sentry
 
@@ -191,6 +197,15 @@ environment by the SDK helper. `readDsn` goes straight to `process.env`
 and would skip the `<KEY>_FILE` resolution that `config.ts` has already
 done. No DSN means no `init`, so dev and unconfigured deploys are
 untouched.
+
+**The process must be started with `node --import @sentry/node/preload`**,
+as the Dockerfile `CMD` and the `start` script both do. Because the DSN
+comes from file-backed config, `Sentry.init` cannot run until config has
+been read — by which point ESM has already evaluated every static import,
+including `@hono/node-server` and `postgres`. The preload hook installs
+the SDK's module hooks ahead of all of them, which is what makes that late
+init safe. Drop the flag and the service still reports errors while
+recording no HTTP or database spans, with nothing in the logs to say so.
 
 There is **no `beforeSend` filter**, and that asymmetry with `apps/web`
 is deliberate. The web app needs one because a server function signals an

--- a/docs/jobs-api.md
+++ b/docs/jobs-api.md
@@ -1,0 +1,281 @@
+# The jobs API
+
+`apps/jobs-api` is the service workflow runners call to claim, run and
+finish jobs. It is a plain Node process serving HTTP on port 9950,
+deployed as its own Deployment behind a ClusterIP service with **no
+ingress rule** — nothing outside the cluster can reach it.
+
+It is called "the jobs API" everywhere: the directory, the package
+(`@virtool/jobs-api`), the image (`ghcr.io/virtool/jobs-api`), the
+Kubernetes service, the Sentry `service` tag, the pino logger `name`,
+and the `application_name` it connects to Postgres under. "Control
+plane" describes its role; it is not a second name for it. Python and
+the workflow runtime already call it the jobs API, and a service with
+two names across two repositories is a service nobody can grep for.
+
+## Why it is a separate service
+
+It mirrors the topology Python already has — `virtool/jobs/main.py`, a
+separate aiohttp app served as `api-jobs-service` on 9950 — and the port
+matches so the two can be swapped behind the same ClusterIP.
+
+Two things follow from the split that do not follow from a shared
+process:
+
+- **A bug in the job-key guard is not remotely exploitable.** The
+  runner-facing surface is not reachable from the internet at all, so a
+  mistake in the credential check is a cluster-internal problem rather
+  than a public one.
+- **Workflow traffic and page-load traffic get separate pools and scale
+  independently.** A burst of runners claiming jobs cannot exhaust the
+  connection pool the SPA's page loads depend on, and neither side's
+  replica count is hostage to the other's load.
+
+## Layout
+
+| File | Responsibility |
+| --- | --- |
+| `src/index.ts` | Entry point: config, Sentry, pool, server, graceful shutdown |
+| `src/app.ts` | `createApp` — the Hono app, its middleware and its routes |
+| `src/config.ts` | Environment parsing, including every `<KEY>_FILE` variant |
+| `src/instrument.ts` | Sentry initialisation and the `SERVICE` constant |
+| `src/logger.ts` | The pino logger singleton |
+| `src/metrics/registry.ts` | `createMetrics` — this process's Prometheus registry |
+| `src/metrics/handler.ts` | Token check, pre-scrape pool read, response |
+| `src/__tests__/authorization.test.ts` | The route-enumerating authorization floor |
+
+Nothing is constructed at import time. `createApp` and `createMetrics`
+are factories taking their dependencies as arguments, the same rule
+`@virtool/data` and `@virtool/storage` follow — which is what lets the
+authorization test build a whole app over fakes without opening a pool.
+
+## Hono, and why
+
+The handlers this service grows are ported from raw-route handlers
+already written against Web `Request`/`Response`, so they move across
+verbatim. Hono is a thin router over exactly those types; Express and
+Fastify would each have meant rewriting every handler against a
+framework-specific request object for nothing.
+
+`@hono/node-server` adapts the app to `node:http`. `serve()` returns a
+Node server, which is what the `SIGTERM` handler closes.
+
+## It must never import from `apps/web`
+
+In either direction. A `biome.json` override over `apps/*/src/**`
+(excluding `apps/web/src/**`) bans every feature alias, `@server/**`,
+the `@/*` catch-all, and relative reaches into `apps/web`.
+
+This service is the likeliest offender, because it does work
+`apps/web/src/server` also does — so copying an import from there is an
+easy mistake. Shared code goes *down* into a package instead:
+`@virtool/data` for persistence and domain functions, `@virtool/storage`
+for object storage, `@virtool/contracts` for wire shapes and the two
+server helpers below, `@virtool/logger` and `@virtool/sentry` for
+observability.
+
+## The authorization floor
+
+`src/__tests__/authorization.test.ts` enumerates `app.routes` and
+requires **every route** either to refuse an unauthenticated request —
+401, 403, or 404 — or to be named in `PUBLIC_ROUTES` in `app.ts`, with a
+comment saying why.
+
+A route added without a floor therefore fails the build, by name, rather
+than shipping open. That test landed with the skeleton and before any
+endpoint, deliberately: a guard added after the endpoints it guards is a
+guard written to match whatever those endpoints already do.
+
+`PUBLIC_ROUTES` holds exactly two entries, both Kubernetes probes:
+
+- `/health/live`
+- `/health/ready`
+
+The kubelet presents no credential, and a readiness probe that could
+fail closed on an auth problem would take the pod out of service for the
+wrong reason. Neither reveals anything beyond whether Postgres answers.
+
+`/metrics` is deliberately **not** in that list. It enforces its own
+bearer token and is expected to refuse like everything else.
+
+The test also asserts the reverse: every `PUBLIC_ROUTES` entry names a
+route that actually exists. A stale exception is as much a bug as a
+missing one — it reads as a deliberate decision about a route that is no
+longer there.
+
+## Health
+
+| Route | Meaning |
+| --- | --- |
+| `GET /health/live` | The process is up. Always `200`, no I/O. |
+| `GET /health/ready` | `200` when Postgres answers, `503` when it does not. |
+
+Both fold `checkPostgres` through `summarizeReadiness` from
+`@virtool/data/health/data` — the same pair `apps/web` uses, so the two
+services' probes cannot drift. Neither requires the metrics token: a
+probe that needed a credential would be one more thing to get wrong
+during a rollout.
+
+## Metrics
+
+`GET /metrics` serves the Prometheus text exposition from this process's
+**own registry**, built by `createMetrics`. It is a separate registry in
+a separate process from the web app's; the series names deliberately
+match so one dashboard covers both, and the two are told apart by the
+scrape's target labels and by `application_name`, not by renaming the
+metrics.
+
+Prometheus needs a **second scrape job** for this service, and an
+authenticated one — the endpoint requires a bearer token.
+
+### The token
+
+`VT_METRICS_TOKEN` gates it:
+
+- **Unset or empty** — `404`. Metrics are off until a deployment opts
+  in, so upgrading never starts exposing internals by surprise.
+- **Set** — the request must carry `Authorization: Bearer <token>`.
+  Anything else gets `401` and a `WWW-Authenticate: Bearer` header.
+
+The service being unreachable from the internet does not make the token
+redundant: everything inside the cluster can reach a ClusterIP, and the
+endpoint shares a socket with the API itself.
+
+The comparison is `isBearerTokenValid` from `@virtool/contracts/bearer`,
+which is constant-time. It is shared with `apps/web` rather than copied,
+because two copies of a constant-time comparison are two chances to
+quietly regress one of them into `===`.
+
+### No label may be unbounded
+
+The request middleware labels each observation with the route's
+**registered path pattern**, via `routePath(c, -1)` from `hono/route` —
+`/jobs/:jobId`, never `/jobs/1234`. The label is then bounded by the
+number of routes rather than by the number of jobs. A request matching
+nothing falls to the middleware's own `/*`, which is bounded too.
+
+A handler that throws leaves no status behind, so those are counted as
+`status="error"` — a bounded sentinel that keeps the counter's total
+honest either way.
+
+### Pool occupancy
+
+`readConnectionCounts` (`@virtool/data/metrics/data`) filters
+`pg_stat_activity` on the `applicationName` that `createDb` set. This
+process passes `"jobs-api"` as `createDb`'s second argument, so it
+connects as `virtool-ts-jobs-api@<hostname>` and counts **only its own
+backends** — not the web app's, which share the database and, on a
+developer machine, the hostname too.
+
+The read is time-bounded at two seconds. The probe is a query on the very
+pool it measures, so a saturated pool queues it *client-side*, where
+nothing rejects and no statement timeout applies; unbounded it would hang
+past the scrape deadline and cost the whole response — process and
+request metrics included — exactly when saturation is worth seeing. A
+failed or slow read logs a warning and drops only the pool gauges.
+
+## Sentry
+
+Reports to the **same project** as `apps/web`, which is what makes one
+search across the whole backend possible. Two options from
+`getCommonOptions(service)` keep the two apart:
+
+- `initialScope.tags.service` — `jobs-api`, so an issue list, an alert
+  rule or a dashboard can narrow to one service.
+- `dist` — also `jobs-api`. Every image in this repo shares the release
+  version, so without it the two services' source maps collide under one
+  release and a stack trace resolves against whichever uploaded last.
+
+The DSN is passed to `initSentry` explicitly rather than read from the
+environment by the SDK helper. `readDsn` goes straight to `process.env`
+and would skip the `<KEY>_FILE` resolution that `config.ts` has already
+done. No DSN means no `init`, so dev and unconfigured deploys are
+untouched.
+
+There is **no `beforeSend` filter**, and that asymmetry with `apps/web`
+is deliberate. The web app needs one because a server function signals an
+expected 4xx by *throwing* `ClientError`, which would otherwise be
+reported as a false incident. This service has no such mechanism: a Hono
+handler returns a 4xx response rather than throwing, so nothing routine
+reaches Sentry to be filtered. Add a filter only if a route starts
+throwing for an expected outcome — and prefer not to.
+
+## Configuration
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `VT_POSTGRES_URL` | *required* | Connection string |
+| `VT_POSTGRES_POOL_MAX` | `10` | postgres-js pool size |
+| `VT_JOBS_API_HOST` | `0.0.0.0` | Listen address |
+| `VT_JOBS_API_PORT` | `9950` | Listen port, matching Python's jobs API |
+| `VT_METRICS_TOKEN` | unset | Bearer token for `/metrics`; unset means `404` |
+| `VT_SENTRY_DSN` | unset | Unset disables Sentry |
+
+Every one also accepts a `<KEY>_FILE` variant naming a file to read the
+value from, so a secret reaches a pod through the secrets-store CSI
+driver's file mount rather than a Kubernetes `Secret`. The file **wins**
+over a plain variable of the same name: a rollout moving to the mount can
+still carry the stale variable from the `Secret` it replaces, and erroring
+on the overlap would crashloop the very rollout that fixes it. An
+unreadable path throws at startup; an empty file is an unset value.
+
+That resolution is `resolveFileBacked` from `@virtool/contracts/env`,
+shared with `apps/web` rather than copied so the precedence rule cannot
+drift between the two services. It walks a list of keys the caller
+names — `KEYS` in `config.ts` — so a key left off that list silently
+loses its file variant. Add a key to both places.
+
+Both helpers this service takes from `@virtool/contracts` sit behind
+their own subpath exports (`/env`, `/bearer`) and are excluded from the
+package barrel, because they use `node:fs` and `node:crypto` and most of
+`@virtool/contracts` is imported by React components. The package
+typechecks as two projects for the same reason: `tsconfig.json` covers
+the browser-safe modules with no Node types at all, and
+`tsconfig.node.json` covers just those two.
+
+## The image
+
+`ghcr.io/virtool/jobs-api`, built from the repo-root `Dockerfile`'s
+`jobs-api` target and pushed by the release pipeline alongside the web
+image.
+
+The runtime base is **`node:24-alpine`**. This service copies nothing
+from `ghcr.io/virtool/tools` and needs no bioinformatics binaries, so it
+does not pay the Debian base the workflow images pay to satisfy those
+binaries. Do not move it to Debian for uniformity's sake.
+
+The app bundles to a single `dist/index.mjs` with tsdown, every
+`@virtool/*` inlined from TypeScript source. `postgres` and `pino` stay
+external and are materialised into the image by `pnpm deploy`; they are
+listed verbatim as strings in `tsdown.config.ts`'s `neverBundle`, which
+is also how knip sees them as used. `hono`, `@hono/node-server`,
+`@sentry/node` and `prom-client` are externalised by default and are
+imported directly by this app's source, so knip finds them without help.
+
+## Deployment
+
+The Kubernetes manifests live in a **different repository** — this one
+carries no `k8s/`, chart or kustomization. What that repository needs
+for this service:
+
+- A Deployment running the `ghcr.io/virtool/jobs-api` image, with the
+  liveness and readiness probes pointed at `/health/live` and
+  `/health/ready`.
+- A **ClusterIP** Service on 9950 and **no Ingress**. The absence of the
+  ingress rule is the security boundary this whole service is built
+  around.
+- The `virtool` ServiceAccount, which carries the object-storage access
+  the finalize endpoints will need to verify what a workflow wrote.
+- A second, **authenticated** Prometheus scrape job carrying the bearer
+  token, since the web app's scrape job cannot cover an endpoint on a
+  different service with a different credential.
+
+## What is not here yet
+
+Only health and metrics. Every runner-facing endpoint — claim, ping,
+step start, finish, and the three finalize routes — lands in its own
+issue, against the wire contract already written in
+`packages/contracts/src/jobsApi.ts`. `@virtool/storage` is deliberately
+**not** yet a dependency: nothing here writes or reads an object, and
+declaring it early would fail `pnpm knip` as an unused dependency. Add
+it with the first endpoint that needs it.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,7 +1,12 @@
 # Metrics
 
-The server exposes Prometheus metrics at `GET /metrics`, in the text
+The web app exposes Prometheus metrics at `GET /metrics`, in the text
 exposition format, from a single process-wide registry.
+
+This describes `apps/web`. The jobs API is a separate process with its
+own registry and its own `/metrics`, scraped as a second Prometheus
+target; the series names deliberately match so one dashboard covers
+both.
 
 ## Layout
 
@@ -182,7 +187,7 @@ So occupancy is read from Postgres' own view instead. `createDb`
 connection and hands it back alongside the pool:
 
 ```ts
-const applicationName = buildApplicationName(hostname());
+const applicationName = buildApplicationName(service, hostname());
 
 const client = postgres(config.postgresUrl, {
 	max: config.postgresPoolMax,
@@ -197,6 +202,14 @@ counts its own pool**. Without it every replica would report the same
 cluster-wide total, and summing the series in Grafana would multiply it
 by the replica count.
 
+The `service` — `"web"` or `"jobs-api"`, passed as `createDb`'s second
+argument — is the other part, and it is what keeps **two services'
+pools apart**. They share a database, and on a developer machine a
+hostname as well, so without it each would count the other's backends
+and both would report the sum. It is a separate argument rather than a
+config field because it is a fact about the process, not something read
+from the environment.
+
 ### The name has to survive the round trip
 
 `@virtool/data/db/applicationName` bounds the value at **63 bytes**. Postgres holds
@@ -205,13 +218,20 @@ longer *silently* — connections would then be opened under a clipped
 name while the filter still searched for the full one, and every pool
 gauge would read zero with nothing in the logs to say why.
 
-`virtool-ts@` leaves 52 bytes for the hostname, which a long deployment
-name can overflow. An overflowing hostname is replaced by a truncated
-SHA-256 digest of itself rather than clipped, because orchestrators put
-the part that distinguishes one replica from another — the pod's random
-suffix — at the *end*. Clipping would collapse a deployment's replicas
-onto one name and reintroduce the multiplication the hostname was there
-to prevent.
+The prefix is `virtool-ts-<service>@` — `virtool-ts-web@`,
+`virtool-ts-jobs-api@` — which leaves 48 and 43 bytes respectively for
+the hostname, and a long deployment name can overflow that. An
+overflowing hostname is replaced by a truncated SHA-256 digest of itself
+rather than clipped, because orchestrators put the part that
+distinguishes one replica from another — the pod's random suffix — at
+the *end*. Clipping would collapse a deployment's replicas onto one name
+and reintroduce the multiplication the hostname was there to prevent.
+
+The **service segment is never digested away**, only the hostname is. It
+is short, bounded by the number of services shipped, and it is the
+discriminator worth keeping legible — a digest that swallowed it would
+put the web app and the jobs API back in one bucket for exactly the
+long-hostname deployments most likely to have several replicas.
 
 ### Collection is bounded, and happens in the handler
 

--- a/docs/pathoscope-core.md
+++ b/docs/pathoscope-core.md
@@ -148,6 +148,17 @@ from the repo root. The crate is compiled in the same Dockerfile as its only
 consumer, so there is no second release stream to coordinate and no window in
 which the workflow and its core disagree.
 
+**CI builds this image but does not publish it, and that is deliberate.** The
+`Build / Pathoscope` job compiles the Dockerfile on every run — enough to catch
+a break — and there is no publish job to pair with it. `virtool/workflow-pathoscope`
+is still the repo that builds and releases the pathoscope workflow, so a second
+pipeline shipping the same workflow from here would leave two candidates for
+what the cluster runs. That repo publishes `ghcr.io/virtool/pathoscope` and this
+Dockerfile targets `ghcr.io/virtool/ts-pathoscope`, so nothing is being
+overwritten today; the point is that the port is unfinished, not that the names
+clash. Add a publish job when that repo is retired, and settle which image name
+the cluster pulls in the same change.
+
 **The base is Debian, and that is settled rather than a choice.** The runtime
 copies binaries from `ghcr.io/virtool/tools`, which are built against
 `python:3.13-bookworm`, so the Rust core has to be an ordinary glibc build and

--- a/packages/bio/src/fastqc.test.ts
+++ b/packages/bio/src/fastqc.test.ts
@@ -214,7 +214,7 @@ describe("parseFastqcData", () => {
 	});
 
 	/**
-	 * Why zeros beat reproducing Python's `nan`: the control plane validates
+	 * Why zeros beat reproducing Python's `nan`: the jobs API validates
 	 * this object at sample finalize and the schema rejects NaN, so a run that
 	 * hit an all-N cycle would fail to store its quality at all.
 	 */

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -5,17 +5,20 @@
 	"type": "module",
 	"sideEffects": false,
 	"exports": {
-		".": "./src/index.ts"
+		".": "./src/index.ts",
+		"./bearer": "./src/bearer.ts",
+		"./env": "./src/env.ts"
 	},
 	"scripts": {
 		"test": "vitest run",
 		"test:watch": "vitest",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsc -p tsconfig.json && tsc -p tsconfig.node.json"
 	},
 	"dependencies": {
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
+		"@types/node": "^26.1.2",
 		"vitest": "^4.1.10"
 	}
 }

--- a/packages/contracts/src/bearer.ts
+++ b/packages/contracts/src/bearer.ts
@@ -1,0 +1,40 @@
+import { timingSafeEqual } from "node:crypto";
+
+const BEARER_PREFIX = "bearer ";
+
+/**
+ * Check an `Authorization: Bearer <token>` header against the expected token
+ * without leaking where the two first differ.
+ *
+ * Reached through the `@virtool/contracts/bearer` subpath rather than the
+ * package barrel, so `node:crypto` never enters the browser graph.
+ *
+ * Shared by every service that gates a Prometheus scrape — `apps/web` and
+ * `apps/jobs-api` both call it — because two copies of a constant-time
+ * comparison are two chances to quietly regress one of them into `===`.
+ *
+ * `timingSafeEqual` throws on a length mismatch, so that case is screened
+ * first. The screen reveals the configured token's length, which is not worth
+ * defending: an attacker learns nothing that narrows the search meaningfully.
+ *
+ * The scheme is matched case-insensitively, as RFC 9110 §11.1 requires. The
+ * credential after it is not — it is compared byte for byte, so a token that
+ * differs only in case or surrounding whitespace is a different token.
+ */
+export function isBearerTokenValid(
+	header: string | null | undefined,
+	token: string,
+): boolean {
+	if (header?.slice(0, BEARER_PREFIX.length).toLowerCase() !== BEARER_PREFIX) {
+		return false;
+	}
+
+	const presented = Buffer.from(header.slice(BEARER_PREFIX.length));
+	const expected = Buffer.from(token);
+
+	if (presented.length !== expected.length) {
+		return false;
+	}
+
+	return timingSafeEqual(presented, expected);
+}

--- a/packages/contracts/src/env.test.ts
+++ b/packages/contracts/src/env.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { resolveFileBacked } from "./env";
+
+function writeSecret(contents: string): string {
+	const path = join(mkdtempSync(join(tmpdir(), "vt-env-")), "secret");
+	writeFileSync(path, contents);
+	return path;
+}
+
+describe("resolveFileBacked", () => {
+	it("leaves a plain variable alone", () => {
+		const resolved = resolveFileBacked(["VT_TOKEN"], { VT_TOKEN: "plain" });
+
+		expect(resolved.VT_TOKEN).toBe("plain");
+	});
+
+	it("reads the value from the file named by the _FILE variant", () => {
+		const resolved = resolveFileBacked(["VT_TOKEN"], {
+			VT_TOKEN_FILE: writeSecret("from-file"),
+		});
+
+		expect(resolved.VT_TOKEN).toBe("from-file");
+	});
+
+	// A rollout moving to a secrets-store mount can still carry the stale env var
+	// from the `Secret` it replaces. Erroring on the overlap would crashloop the
+	// very rollout that fixes it, so the file wins instead.
+	it("prefers the file over a plain variable of the same name", () => {
+		const resolved = resolveFileBacked(["VT_TOKEN"], {
+			VT_TOKEN: "stale",
+			VT_TOKEN_FILE: writeSecret("current"),
+		});
+
+		expect(resolved.VT_TOKEN).toBe("current");
+	});
+
+	// Kubernetes mounts routinely end in a newline; a token compared byte for
+	// byte would never match if it survived.
+	it("trims surrounding whitespace", () => {
+		const resolved = resolveFileBacked(["VT_TOKEN"], {
+			VT_TOKEN_FILE: writeSecret("  padded\n"),
+		});
+
+		expect(resolved.VT_TOKEN).toBe("padded");
+	});
+
+	it("treats an empty file as an unset value", () => {
+		const resolved = resolveFileBacked(["VT_TOKEN"], {
+			VT_TOKEN_FILE: writeSecret("   "),
+		});
+
+		expect(resolved.VT_TOKEN).toBe("");
+	});
+
+	// Failing at startup beats silently falling back to a plain variable that may
+	// not be there, which would surface later as an unrelated-looking error.
+	it("throws when the path cannot be read", () => {
+		expect(() =>
+			resolveFileBacked(["VT_TOKEN"], {
+				VT_TOKEN_FILE: "/nonexistent/secret",
+			}),
+		).toThrow(/VT_TOKEN_FILE points at \/nonexistent\/secret/);
+	});
+
+	// The caller names the keys, so a key left off the list keeps its plain value
+	// and silently loses the file variant.
+	it("ignores a _FILE variant for a key it was not given", () => {
+		const resolved = resolveFileBacked([], {
+			VT_TOKEN_FILE: writeSecret("ignored"),
+		});
+
+		expect(resolved.VT_TOKEN).toBeUndefined();
+	});
+
+	it("does not mutate the environment it was given", () => {
+		const env = { VT_TOKEN_FILE: writeSecret("from-file") };
+
+		resolveFileBacked(["VT_TOKEN"], env);
+
+		expect(env).not.toHaveProperty("VT_TOKEN");
+	});
+});

--- a/packages/contracts/src/env.ts
+++ b/packages/contracts/src/env.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * Suffix naming the file a value is read from.
+ *
+ * The convention Prometheus and Docker use, and the reason it is worth having:
+ * a Kubernetes `Secret` populated by the secrets-store CSI driver goes stale
+ * when a key is added to the `SecretProviderClass`, so a pod can start with an
+ * env var the cluster believes it has updated. The driver's file mount has no
+ * such staleness.
+ */
+const FILE_SUFFIX = "_FILE";
+
+/**
+ * Resolve every `<KEY>_FILE` variant in `env` into its plain `<KEY>`.
+ *
+ * Reached through the `@virtool/contracts/env` subpath rather than the package
+ * barrel, so `node:fs` never enters the browser graph. Every server that parses
+ * configuration shares this one implementation — `apps/web` over its zod
+ * schema's keys, `apps/jobs-api` over its own much smaller list — because a
+ * second copy is free to drift on the precedence rule below.
+ *
+ * **The file wins over a plain variable of the same name.** A rollout moving to
+ * the mount can still carry the stale env var from the `Secret` it replaces,
+ * and erroring on the overlap would crashloop the very rollout that fixes it.
+ *
+ * An unreadable path throws, so a misconfigured mount fails at startup rather
+ * than silently falling back. An empty file is an unset value: the trimmed
+ * empty string is what the caller's schema then sees.
+ */
+export function resolveFileBacked(
+	keys: Iterable<string>,
+	env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+	const resolved = { ...env };
+
+	for (const key of keys) {
+		const path = env[`${key}${FILE_SUFFIX}`];
+
+		if (!path) {
+			continue;
+		}
+
+		try {
+			resolved[key] = readFileSync(path, "utf8").trim();
+		} catch (error) {
+			throw new Error(
+				`${key}${FILE_SUFFIX} points at ${path}, which could not be read`,
+				{ cause: error },
+			);
+		}
+	}
+
+	return resolved;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9,7 +9,7 @@ export * from "./groups";
 export * from "./hmms";
 export * from "./indexes";
 export * from "./jobs";
-export * from "./jobsControlPlane";
+export * from "./jobsApi";
 export * from "./json";
 export * from "./labels";
 export * from "./nuvs";

--- a/packages/contracts/src/jobs.ts
+++ b/packages/contracts/src/jobs.ts
@@ -19,7 +19,7 @@ export type JobState = z.infer<typeof JobState>;
  * enum, `build_index` included. That workflow stays Python-owned — the TypeScript
  * runtime ports the other four — but `build_index` rows exist in the `jobs`
  * table today, so a narrower union would fail to parse a job that is perfectly
- * valid. The control plane instead refuses to hand out a `build_index` job at
+ * valid. The jobs API instead refuses to hand out a `build_index` job at
  * claim time, which is a rule about who may run what, not about what a row may
  * contain.
  *

--- a/packages/contracts/src/jobsApi.test.ts
+++ b/packages/contracts/src/jobsApi.test.ts
@@ -13,7 +13,7 @@ import {
 	StoredJobStep,
 	toStoredJobClaim,
 	toStoredJobStep,
-} from "./jobsControlPlane";
+} from "./jobsApi";
 
 const claim: JobClaim = {
 	runnerId: "runner-1",
@@ -210,7 +210,7 @@ describe("file manifest", () => {
 	});
 
 	it("drops a storage key a runner tries to name", () => {
-		// Keys are the control plane's to derive. A runner that sends one gets it
+		// Keys are the jobs API's to derive. A runner that sends one gets it
 		// stripped here rather than having it reach the data layer.
 		const manifest = JobFileManifest.parse({
 			kind: "sampleRead",

--- a/packages/contracts/src/jobsApi.ts
+++ b/packages/contracts/src/jobsApi.ts
@@ -1,5 +1,6 @@
-// The jobs control-plane wire contract, shared by the control-plane routes in
-// `apps/jobs-api` and the workflow runtime's HTTP client. Both sides import
+// The jobs API's wire contract, shared by the routes in `apps/jobs-api` — the
+// control plane for running jobs — and the workflow runtime's HTTP client,
+// which is the only thing that calls them. Both sides import
 // these schemas: the routes parse incoming bodies with the same shapes the
 // runtime uses to build them, so a contract change is a type error on both
 // sides in the same commit rather than a runtime 422 discovered in a lab.
@@ -25,7 +26,7 @@
 //
 // # Endpoint surface
 //
-// Paths carry no prefix. The control plane is its own app serving no SPA, so
+// Paths carry no prefix. The jobs API is its own app serving no SPA, so
 // nothing collides with the SPA's own `/jobs/{jobId}` route and these match
 // Python's byte for byte.
 //
@@ -76,7 +77,7 @@ export const JobStepDefinition = z.object({
 
 export type JobStepDefinition = z.infer<typeof JobStepDefinition>;
 
-/** A workflow step as the control plane returns it. Persisted with `started_at`. */
+/** A workflow step as the jobs API returns it. Persisted with `started_at`. */
 export const JobStep = z.object({
 	id: z.string(),
 	name: z.string(),
@@ -100,7 +101,7 @@ export type JobStepStarted = z.infer<typeof JobStepStarted>;
  * Body for `POST /jobs/{jobId}/steps/{stepId}/start`.
  *
  * Genuinely empty, and expected to stay that way: the step id comes from the
- * path and the start time is the control plane's to assign, not the runner's.
+ * path and the start time is the jobs API's to assign, not the runner's.
  */
 export const StartJobStepRequest = z.object({});
 
@@ -326,7 +327,7 @@ export type AnalysisFileManifest = z.infer<typeof AnalysisFileManifest>;
  * access and write the bytes themselves, so they declare what they wrote instead.
  *
  * **The manifest carries no storage key.** Keys are built by `@virtool/storage`
- * from ids the control plane already holds and must stay byte-for-byte identical
+ * from ids the jobs API already holds and must stay byte-for-byte identical
  * to Python's. Letting a runner name its own key would put key construction on
  * the untrusted side of the boundary and silently orphan objects; the control
  * plane derives the key and the manifest carries only `nameOnDisk`.

--- a/packages/contracts/src/samples.ts
+++ b/packages/contracts/src/samples.ts
@@ -59,7 +59,7 @@ export type Read = {
 /**
  * The FastQC quality charts associated with a sample.
  *
- * A schema rather than a plain type because the control plane validates an
+ * A schema rather than a plain type because the jobs API validates an
  * incoming quality blob at sample finalize; `@virtool/bio`'s FastQC parser is
  * what produces it.
  */

--- a/packages/contracts/src/subtractions.ts
+++ b/packages/contracts/src/subtractions.ts
@@ -20,7 +20,7 @@ export type SubtractionNested = {
  * percentages by mistake, which is the plausible unit error here; a per-nucleotide
  * `count / total` can never exceed 1, so it costs a correct payload nothing.
  *
- * A schema rather than a plain type because the control plane validates it at
+ * A schema rather than a plain type because the jobs API validates it at
  * subtraction finalize.
  */
 const nucleotideFraction = z.number().min(0).max(1);

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,4 +1,11 @@
 {
+	// The browser-safe half of the package, and the reason `types` stays empty:
+	// most of `@virtool/contracts` is imported by React components, and a Node
+	// global that typechecks here would reach the client bundle unremarked. The
+	// two server-only modules — `env.ts` and `bearer.ts`, each behind its own
+	// subpath export so no barrel import pulls them — are checked separately by
+	// `tsconfig.node.json`.
 	"extends": "../tsconfig.base.json",
-	"include": ["src"]
+	"include": ["src"],
+	"exclude": ["src/bearer.ts", "src/env.ts", "src/env.test.ts"]
 }

--- a/packages/contracts/tsconfig.node.json
+++ b/packages/contracts/tsconfig.node.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../tsconfig.base.json",
+	"compilerOptions": {
+		"types": ["node"]
+	},
+	"include": ["src/bearer.ts", "src/env.ts", "src/env.test.ts"]
+}

--- a/packages/data/src/db/applicationName.test.ts
+++ b/packages/data/src/db/applicationName.test.ts
@@ -6,13 +6,13 @@ const MAX_LENGTH = 63;
 
 describe("buildApplicationName", () => {
 	it("keeps a short hostname readable", () => {
-		expect(buildApplicationName("virtool-web-7d9f8b6c5d-x2ktp")).toBe(
-			"virtool-ts@virtool-web-7d9f8b6c5d-x2ktp",
+		expect(buildApplicationName("web", "virtool-web-7d9f8b6c5d-x2ktp")).toBe(
+			"virtool-ts-web@virtool-web-7d9f8b6c5d-x2ktp",
 		);
 	});
 
 	it("stays within the length Postgres stores", () => {
-		const name = buildApplicationName("h".repeat(200));
+		const name = buildApplicationName("jobs-api", "h".repeat(200));
 
 		expect(Buffer.byteLength(name)).toBeLessThanOrEqual(MAX_LENGTH);
 	});
@@ -20,14 +20,43 @@ describe("buildApplicationName", () => {
 	it("keeps replicas distinct when hostnames differ only in their suffix", () => {
 		const prefix = "virtool-web-with-a-very-long-deployment-name-7d9f8b6c5d-";
 
-		expect(buildApplicationName(`${prefix}x2ktp`)).not.toBe(
-			buildApplicationName(`${prefix}q7bnf`),
+		expect(buildApplicationName("web", `${prefix}x2ktp`)).not.toBe(
+			buildApplicationName("web", `${prefix}q7bnf`),
 		);
 	});
 
-	it("is stable for a given hostname", () => {
+	it("is stable for a given service and hostname", () => {
 		const host = "h".repeat(200);
 
-		expect(buildApplicationName(host)).toBe(buildApplicationName(host));
+		expect(buildApplicationName("web", host)).toBe(
+			buildApplicationName("web", host),
+		);
+	});
+
+	// The two services share a database, and on a developer machine they share a
+	// hostname too. Without a distinct name each would count the other's backends
+	// in `pg_stat_activity` and both would report the sum.
+	it("keeps two services on one host apart", () => {
+		const host = "localhost";
+
+		expect(buildApplicationName("web", host)).not.toBe(
+			buildApplicationName("jobs-api", host),
+		);
+	});
+
+	// The digest fallback replaces the hostname only. A long hostname must not
+	// collapse two services onto one name.
+	it("keeps two services apart when the hostname is digested", () => {
+		const host = "h".repeat(200);
+
+		expect(buildApplicationName("web", host)).not.toBe(
+			buildApplicationName("jobs-api", host),
+		);
+	});
+
+	it("keeps the service segment legible when the hostname is digested", () => {
+		expect(buildApplicationName("jobs-api", "h".repeat(200))).toMatch(
+			/^virtool-ts-jobs-api@/,
+		);
 	});
 });

--- a/packages/data/src/db/applicationName.ts
+++ b/packages/data/src/db/applicationName.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 
-const PREFIX = "virtool-ts@";
+const PREFIX = "virtool-ts";
 
 /**
  * Postgres stores `application_name` in a `NAMEDATALEN` buffer and silently
@@ -18,13 +18,21 @@ const DIGEST_LENGTH = 16;
  * truncates on the way in matches nothing on the way out, and the pool gauges
  * silently report zero.
  *
+ * `service` names the process — `web`, `jobs-api` — and is what keeps the two
+ * services' pools apart. They share a database, and on a developer machine they
+ * share a hostname too, so without it each would count the other's backends and
+ * both would report the sum.
+ *
  * A hostname long enough to overflow gets replaced by a digest rather than
  * clipped, because orchestrators put the part that distinguishes one replica
  * from another — the pod's random suffix — at the *end*. Truncating would
  * collapse every replica of a deployment onto one name and multiply its counts.
+ * The service segment is never digested away: it is short, bounded by the
+ * number of services we ship, and it is the discriminator worth keeping legible.
  */
-export function buildApplicationName(host: string): string {
-	const full = `${PREFIX}${host}`;
+export function buildApplicationName(service: string, host: string): string {
+	const prefix = `${PREFIX}-${service}@`;
+	const full = `${prefix}${host}`;
 
 	if (Buffer.byteLength(full) <= MAX_LENGTH) {
 		return full;
@@ -35,5 +43,5 @@ export function buildApplicationName(host: string): string {
 		.digest("hex")
 		.slice(0, DIGEST_LENGTH);
 
-	return `${PREFIX}${digest}`;
+	return `${prefix}${digest}`;
 }

--- a/packages/data/src/db/pg.ts
+++ b/packages/data/src/db/pg.ts
@@ -35,6 +35,10 @@ export type DbHandles = {
 	 * The hostname is part of it so each replica counts its own pool rather than
 	 * every Virtool process sharing the database. Without it, every replica would
 	 * report the same cluster-wide total and summing the series would multiply it.
+	 *
+	 * The `service` passed to {@link createDb} is the other part, and it is what
+	 * keeps the web app's pool separate from the jobs API's — the two share a
+	 * database, and on a developer machine a hostname as well.
 	 */
 	applicationName: string;
 };
@@ -45,9 +49,14 @@ export type DbHandles = {
  * Call this once, at a composition root. Nothing in this package opens a pool
  * at import time — that is what lets the jobs API and the workflow ports reuse
  * the data layer without inheriting the web app's configuration.
+ *
+ * `service` names the calling process — `"web"`, `"jobs-api"` — and reaches
+ * Postgres as part of `application_name`. It is a second argument rather than a
+ * {@link DbConfig} field because it is a fact about the process, not something
+ * read from the environment.
  */
-export function createDb(config: DbConfig): DbHandles {
-	const applicationName = buildApplicationName(hostname());
+export function createDb(config: DbConfig, service: string): DbHandles {
+	const applicationName = buildApplicationName(service, hostname());
 
 	const client = postgres(config.postgresUrl, {
 		max: config.postgresPoolMax,

--- a/packages/data/src/metrics/data.test.ts
+++ b/packages/data/src/metrics/data.test.ts
@@ -3,7 +3,11 @@ import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import type { PgClient } from "../db/pg";
-import { readConnectionCounts } from "./data";
+import {
+	POOL_PROBE_TIMEOUT_MS,
+	readConnectionCounts,
+	readConnectionCountsBounded,
+} from "./data";
 
 // `readConnectionCounts` reads `pg_stat_activity` and touches no application
 // table, so it needs a live connection rather than the schema `createTestDatabase`
@@ -76,5 +80,33 @@ describe("readConnectionCounts", () => {
 			idleInTransaction: 0,
 			other: 0,
 		});
+	});
+});
+
+describe("readConnectionCountsBounded", () => {
+	it("returns the counts when the probe answers in time", async () => {
+		const counts = await readConnectionCountsBounded(reader, applicationName);
+
+		expect(counts.active).toBe(1);
+	});
+
+	// A saturated pool queues the probe client-side, inside the postgres.js
+	// closure, where nothing rejects and no statement timeout applies. Without
+	// this deadline a scrape would hang past Prometheus' own timeout and lose the
+	// entire response — process and request metrics included — in exactly the
+	// situation the pool gauges exist to diagnose.
+	it("rejects rather than hanging when the probe never settles", async () => {
+		// postgres.js clients are called as a tagged template, so a function that
+		// returns a forever-pending promise stands in for a query queued behind a
+		// full pool.
+		const never = (() => new Promise(() => {})) as unknown as PgClient;
+
+		await expect(
+			readConnectionCountsBounded(never, applicationName, 10),
+		).rejects.toThrow("timed out");
+	});
+
+	it("defaults to the shared probe timeout", () => {
+		expect(POOL_PROBE_TIMEOUT_MS).toBe(2000);
 	});
 });

--- a/packages/data/src/metrics/data.ts
+++ b/packages/data/src/metrics/data.ts
@@ -30,6 +30,34 @@ function bucketFor(state: string | null): keyof ConnectionCounts {
 }
 
 /**
+ * How long a scrape waits on the pool probe before abandoning it.
+ *
+ * The probe is a query on the very pool it measures, so a saturated pool queues
+ * it *client-side*, where nothing rejects and no statement timeout applies. Left
+ * unbounded it would hang past Prometheus' scrape deadline and lose the whole
+ * response — the process and request metrics included — exactly when saturation
+ * is the thing worth seeing. Two seconds sits well inside a default 10s scrape
+ * timeout.
+ */
+export const POOL_PROBE_TIMEOUT_MS = 2000;
+
+/**
+ * Resolve `promise`, or reject once `ms` have passed.
+ *
+ * The abandoned promise is left to settle on its own; it is a single trivial
+ * query and its result is simply discarded.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	const deadline = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => reject(new Error("timed out")), ms);
+	});
+
+	return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
+}
+
+/**
  * Count this process's open Postgres backends by state.
  *
  * Postgres' own view of the connections is the only one available: postgres.js
@@ -66,4 +94,25 @@ export async function readConnectionCounts(
 	}
 
 	return counts;
+}
+
+/**
+ * {@link readConnectionCounts}, bounded by {@link POOL_PROBE_TIMEOUT_MS}.
+ *
+ * This is what a `/metrics` handler should call. Both services expose pool
+ * gauges and both need the same deadline for the same reason, so the timeout
+ * lives here rather than being spelled out again beside each handler — a second
+ * copy is free to drift to a value that no longer fits inside the scrape
+ * timeout.
+ *
+ * Still throws on timeout or query failure. A caller drops the pool gauges and
+ * logs, rather than failing the whole scrape: a Postgres outage is exactly when
+ * the process and request metrics matter most.
+ */
+export function readConnectionCountsBounded(
+	client: PgClient,
+	applicationName: string,
+	timeoutMs: number = POOL_PROBE_TIMEOUT_MS,
+): Promise<ConnectionCounts> {
+	return withTimeout(readConnectionCounts(client, applicationName), timeoutMs);
 }

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -9,6 +9,22 @@ export function readDsn(): string | undefined {
 export type CommonSentryOptions = {
 	dsn: string | undefined;
 	environment: string;
+	/**
+	 * Distinguishes one service's build artifacts from another's.
+	 *
+	 * Every image in this repo shares the release version, so without a `dist`
+	 * the web app's and the jobs API's source maps collide under one release and
+	 * a stack trace resolves against whichever uploaded last.
+	 */
+	dist: string;
+	/**
+	 * Tags every event with the service that reported it.
+	 *
+	 * Both services report to the same Sentry project, which is what makes one
+	 * search across the whole backend possible. The tag is what lets an issue
+	 * list, an alert rule, or a dashboard narrow back down to one of them.
+	 */
+	initialScope: { tags: { service: string } };
 	sendDefaultPii: boolean;
 	tracesSampleRate: number;
 	profileSessionSampleRate: number;
@@ -16,12 +32,21 @@ export type CommonSentryOptions = {
 	enableLogs: boolean;
 };
 
-export function getCommonOptions(): CommonSentryOptions {
+/**
+ * Build the Sentry options every server-side process shares.
+ *
+ * `service` names the process — `"web"`, `"jobs-api"` — and is required rather
+ * than defaulted, because an untagged event is indistinguishable from one whose
+ * tagging silently regressed.
+ */
+export function getCommonOptions(service: string): CommonSentryOptions {
 	const environment = process.env.NODE_ENV ?? "development";
 	const isProd = environment === "production";
 	return {
 		dsn: readDsn(),
 		environment,
+		dist: service,
+		initialScope: { tags: { service } },
 		sendDefaultPii: true,
 		tracesSampleRate: isProd ? 0.1 : 1.0,
 		// Decided once per `Sentry.init` — that is, once per server process, not

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,22 +61,43 @@ importers:
 
   apps/jobs-api:
     dependencies:
+      '@hono/node-server':
+        specifier: ^2.1.0
+        version: 2.1.0(hono@4.13.0)
+      '@sentry/node':
+        specifier: ^10.69.0
+        version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
+      '@virtool/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       '@virtool/data':
         specifier: workspace:*
         version: link:../../packages/data
       '@virtool/logger':
         specifier: workspace:*
         version: link:../../packages/logger
+      '@virtool/sentry':
+        specifier: workspace:*
+        version: link:../../packages/sentry
+      hono:
+        specifier: ^4.13.0
+        version: 4.13.0
       pino:
         specifier: ^10.1.0
         version: 10.3.1
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
     devDependencies:
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(oxc-resolver@11.24.2)(tsx@4.23.0)(typescript@7.0.2)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/site:
     dependencies:
@@ -152,13 +173,13 @@ importers:
         version: 5.5.7(@standard-schema/spec@1.1.0)(react-hook-form@7.83.0(react@19.2.8))(zod@4.4.3)
       '@sentry/profiling-node':
         specifier: 10.69.0
-        version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
+        version: 10.69.0
       '@sentry/replay':
         specifier: 10.69.0
         version: 10.69.0
       '@sentry/tanstackstart-react':
         specifier: ^10.69.0
-        version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(react@19.2.8)
+        version: 10.69.0(react@19.2.8)
       '@tanstack/react-query':
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
@@ -343,6 +364,9 @@ importers:
         specifier: ^4.3.6
         version: 4.4.3
     devDependencies:
+      '@types/node':
+        specifier: ^26.1.2
+        version: 26.1.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -1621,6 +1645,12 @@ packages:
     resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@hono/node-server@2.1.0':
+    resolution: {integrity: sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
 
   '@hookform/resolvers@5.5.7':
     resolution: {integrity: sha512-CyPCYV8/KlXfEXLWj8HHHhVsR/IZ6Ckm3b/a4fWtO/lRnRK1huqncb8LlAWrmpPRsse5glF5aVuDRMHEr3UGag==}
@@ -5870,6 +5900,10 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
+    engines: {node: '>=16.9.0'}
+
   hook-std@4.0.0:
     resolution: {integrity: sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ==}
     engines: {node: '>=20'}
@@ -9424,7 +9458,7 @@ snapshots:
       '@babel/parser': 8.0.4
       '@babel/template': 8.0.0
       '@babel/types': 8.0.4
-      obug: 2.1.3
+      obug: 2.1.4
 
   '@babel/types@7.29.0':
     dependencies:
@@ -9952,6 +9986,10 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.6.4
       yargs: 17.7.3
+
+  '@hono/node-server@2.1.0(hono@4.13.0)':
+    dependencies:
+      hono: 4.13.0
 
   '@hookform/resolvers@5.5.7(@standard-schema/spec@1.1.0)(react-hook-form@7.83.0(react@19.2.8))(zod@4.4.3)':
     dependencies:
@@ -11574,7 +11612,7 @@ snapshots:
       '@sentry/conventions': 0.16.0
       '@sentry/core': 10.69.0
 
-  '@sentry/profiling-node@10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))':
+  '@sentry/profiling-node@10.69.0':
     dependencies:
       '@sentry/core': 10.69.0
       '@sentry/node': 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
@@ -11611,7 +11649,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/tanstackstart-react@10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(react@19.2.8)':
+  '@sentry/tanstackstart-react@10.69.0(react@19.2.8)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@sentry/browser-utils': 10.69.0
@@ -14181,6 +14219,8 @@ snapshots:
       space-separated-tokens: 2.0.2
 
   highlight.js@10.7.3: {}
+
+  hono@4.13.0: {}
 
   hook-std@4.0.0: {}
 
@@ -17031,7 +17071,7 @@ snapshots:
       es-module-lexer: 2.3.1
       expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.5
       std-env: 4.2.0


### PR DESCRIPTION
## Summary

- Replaces the hand-rolled `node:http` server in `apps/jobs-api` with a Hono app on `@hono/node-server`, giving the service the observability (Sentry, metrics, structured logging) and authorization scaffolding the runner-facing endpoints will land on top of, matching the topology Python already runs (`api-jobs-service`, ClusterIP, no ingress).
- Settles naming across the codebase: the service is "the jobs API" everywhere — directory, package, image, Kubernetes service, Sentry tag, logger name — matching what Python and the workflow runtime already call it; "control plane" is demoted to a role description and `contracts/src/jobsControlPlane.ts` becomes `jobsApi.ts`.
- Moves `resolveFileBacked` and `isBearerTokenValid` down into `@virtool/contracts` (behind subpath exports, kept out of the browser graph) so the `<KEY>_FILE` precedence rule and the constant-time comparison can't drift between the web app and the jobs API, and gives `buildApplicationName` a service argument so the two services' Postgres pools are distinguishable in `pg_stat_activity`.

## Notes

- The web app's `application_name` changes from `virtool-ts@<host>` to `virtool-ts-web@<host>`. Both producer and consumer derive it from the same function, so the pool gauges stay correct.
- The Kubernetes manifests (Deployment, ClusterIP, no Ingress, `virtool` SA, second authenticated Prometheus scrape job) live in another repository. `docs/jobs-api.md` records what that repository needs.
- `@virtool/storage` is deliberately not yet a dependency — nothing here touches an object, and declaring it early fails `pnpm knip`. It arrives with the first finalize endpoint.