### PR TITLE
chore: authenticate workflow jobs with a dedicated request guard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,10 +179,30 @@ jobs:
                   node-version: ${{ env.NODE_VERSION }}
                   pnpm-version: ${{ env.PNPM_VERSION }}
             # Exclusions rather than an inclusion list, so a new workspace that
-            # declares `test` is covered without editing this job. The three
+            # declares `test` is covered without editing this job. The four
             # excluded here have their own jobs.
             - name: Test
-              run: pnpm -r --filter "!@virtool/web" --filter "!@virtool/data" --filter "!@virtool/storage" test
+              run: pnpm -r --filter "!@virtool/web" --filter "!@virtool/data" --filter "!@virtool/storage" --filter "!@virtool/jobs-api" test
+    test-jobs-api:
+        name: Test / Jobs API
+        runs-on: ubuntu-24.04
+        timeout-minutes: 15
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+            - name: Setup
+              uses: ./.github/actions/setup
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  pnpm-version: ${{ env.PNPM_VERSION }}
+            # Its own job rather than part of Test / Packages, for the same
+            # reason as Test / Data: the job guard is tested against a real
+            # Postgres testcontainer, and pulling that image does not belong in
+            # the fast package loop.
+            - name: Test
+              run: pnpm --filter @virtool/jobs-api test
+              env:
+                  TZ: UTC
     test-data:
         name: Test / Data
         runs-on: ubuntu-24.04
@@ -301,6 +321,7 @@ jobs:
                 check-typescript,
                 test-packages,
                 test-data,
+                test-jobs-api,
                 test-rust,
                 test-storage,
                 test-web,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,17 @@ This is a **pnpm monorepo**:
   mirroring Python's `virtool/jobs/main.py` (`api-jobs-service`, ClusterIP,
   **no ingress** — that absence is the security boundary). Serves
   `/health/live`, `/health/ready` and a token-gated `/metrics` today. Image:
-  `ghcr.io/virtool/jobs-api`, Alpine. Two rules: it is **always "the jobs
+  `ghcr.io/virtool/jobs-api`, Alpine. Three rules: it is **always "the jobs
   API"**, never "the control plane" — that names its role, not the service;
-  and **every route must refuse an unauthenticated caller or be named in
-  `PUBLIC_ROUTES`**, which `src/__tests__/authorization.test.ts` enforces.
-  See [docs/jobs-api.md](docs/jobs-api.md).
+  **every route must refuse an unauthenticated caller or be named in
+  `PUBLIC_ROUTES`**, which `src/__tests__/authorization.test.ts` enforces;
+  and a handler's floor is `requireJobRequest` (`src/auth/guard.ts`), which
+  authenticates a workflow pod as `job-{id}:{key}` over HTTP Basic and
+  **returns** an opaque 401 rather than throwing one. It resolves to a
+  `JobPrincipal` of `{ jobId }` — no user, no permissions — and there is no
+  cookie fallback; this service has no session model. Reaching a terminal
+  state (`cancelled`, `failed`, `succeeded`) is the only thing that revokes
+  a job key. See [docs/jobs-api.md](docs/jobs-api.md).
 - `apps/create-subtraction/` — `@virtool/create-subtraction`, the first workflow
   executor: a one-shot process that starts, works, exits. Only its object
   storage half is wired so far. Image: `ghcr.io/virtool/ts-create-subtraction`,
@@ -988,15 +994,16 @@ naming, comments, and concurrency rules with examples.
 - **Projects (`@virtool/storage`):** `unit` covers everything testable
   against `MemoryStorage`; `integration` runs the S3 and Azure backends
   against real Garage and Azurite containers and has its own CI job.
-- **`@virtool/data`** runs one node project against a Postgres
-  testcontainer, with its own CI job for the same reason storage has
-  one — a container pull does not belong in the fast package loop.
+- **`@virtool/data`** and **`@virtool/jobs-api`** each run one node
+  project against a Postgres testcontainer, and each has its own CI job
+  for the same reason storage does — a container pull does not belong in
+  the fast package loop. Both are excluded from `Test / Packages`.
 - **The Postgres container is described once**, in
-  `packages/data/src/db/test/globalSetup.ts`. Both the `@virtool/data`
-  project and the web app's `server` project name that module as their
-  `globalSetup` — the web app through the
+  `packages/data/src/db/test/globalSetup.ts`. The `@virtool/data`
+  project, the web app's `server` project and `@virtool/jobs-api` all
+  name that module as their `globalSetup` — the latter two through the
   `@virtool/data/db/test/globalSetup` subpath — so the options cannot
-  drift and `withReuse()` boots one container for the two suites
+  drift and `withReuse()` boots one container for the three suites
   locally. There is no teardown; `docker rm -f` it when done. Don't add
   a second copy of the container options.
 - **Test location:** `__tests__/` directories alongside source files

--- a/apps/jobs-api/package.json
+++ b/apps/jobs-api/package.json
@@ -19,6 +19,7 @@
 		"@virtool/data": "workspace:*",
 		"@virtool/logger": "workspace:*",
 		"@virtool/sentry": "workspace:*",
+		"drizzle-orm": "^0.45.2",
 		"hono": "^4.13.0",
 		"pino": "^10.1.0",
 		"postgres": "^3.4.9",

--- a/apps/jobs-api/src/auth/guard.test.ts
+++ b/apps/jobs-api/src/auth/guard.test.ts
@@ -1,0 +1,93 @@
+import { seedUser } from "@virtool/data/auth/test/fixtures";
+import type { Db } from "@virtool/data/db/pg";
+import { jobs } from "@virtool/data/db/schema/jobs";
+import { users } from "@virtool/data/db/schema/users";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { requireJobRequest } from "./guard";
+import { seedJob } from "./test/fixtures";
+
+let database: TestDatabase;
+let db: Db;
+let userId: number;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(jobs);
+	await db.delete(users);
+
+	userId = await seedUser(db);
+});
+
+function request(login: string, key: string): Request {
+	return new Request("https://jobs.virtool.test/jobs/1/ping", {
+		headers: {
+			authorization: `Basic ${Buffer.from(`${login}:${key}`).toString("base64")}`,
+		},
+	});
+}
+
+describe("requireJobRequest", () => {
+	it("returns the principal for a valid credential", async () => {
+		const job = await seedJob(db, userId);
+
+		expect(
+			await requireJobRequest(db, request(`job-${job.id}`, job.key)),
+		).toEqual({ jobId: job.id });
+	});
+
+	it("returns a 401 response rather than throwing", async () => {
+		const bare = new Request("https://jobs.virtool.test/jobs/1/ping");
+
+		const result = await requireJobRequest(db, bare);
+
+		expect(result).toBeInstanceOf(Response);
+		expect((result as Response).status).toBe(401);
+	});
+
+	// The header makes a browser prompt for credentials, and nothing that
+	// reaches this service is a browser. A runner's key is minted once, at claim
+	// time, so there is nothing for an interactive retry to supply.
+	it("sends no WWW-Authenticate header", async () => {
+		const bare = new Request("https://jobs.virtool.test/jobs/1/ping");
+
+		const result = (await requireJobRequest(db, bare)) as Response;
+
+		expect(result.headers.get("www-authenticate")).toBeNull();
+	});
+
+	// Every rejection has to look identical from outside. A body or status that
+	// varied would tell a caller which of the checks turned it away, and the
+	// most useful thing to learn that way is whether a given job id exists.
+	it("refuses every failure identically", async () => {
+		const job = await seedJob(db, userId, { state: "succeeded" });
+
+		const responses = await Promise.all(
+			[
+				new Request("https://jobs.virtool.test/jobs/1/ping"),
+				request("job-1", "not-the-key"),
+				request("job-99999999", "not-the-key"),
+				request("alice", job.key),
+				request(`job-${job.id}`, job.key),
+			].map((each) => requireJobRequest(db, each)),
+		);
+
+		for (const response of responses) {
+			expect(response).toBeInstanceOf(Response);
+			expect((response as Response).status).toBe(401);
+			expect(await (response as Response).text()).toBe("Unauthorized");
+		}
+	});
+});

--- a/apps/jobs-api/src/auth/guard.ts
+++ b/apps/jobs-api/src/auth/guard.ts
@@ -1,0 +1,45 @@
+import type { Db } from "@virtool/data/db/pg";
+import { type JobPrincipal, verifyJobRequest } from "./verify";
+
+/**
+ * Resolve the job behind a request, or the response to refuse it with.
+ *
+ * The floor every handler in this service starts with. A handler calls it
+ * first, returns the value straight back if it is a `Response`, and otherwise
+ * carries on with the principal:
+ *
+ * ```ts
+ * const principal = await requireJobRequest(db, request);
+ *
+ * if (principal instanceof Response) {
+ * 	return principal;
+ * }
+ * ```
+ *
+ * The refusal is **returned, not thrown**. A thrown one would have to be caught
+ * somewhere, and the somewhere that catches it is also the somewhere that
+ * catches a genuine bug — so a handler that crashed halfway through would
+ * answer 401 and read, to the runner and to Sentry alike, as a credential
+ * problem.
+ *
+ * The 401 carries no `WWW-Authenticate` header. That header exists to make a
+ * browser prompt for credentials, and nothing that reaches this service is a
+ * browser. Sending it would only invite an interactive retry loop against a
+ * service where the credential is minted once, at claim time.
+ *
+ * The body is a fixed string for the same reason {@link verifyJobRequest}
+ * returns a bare `null`: a runner learns that it may not proceed, and nothing
+ * about which of the checks turned it away.
+ */
+export async function requireJobRequest(
+	db: Db,
+	request: Request,
+): Promise<JobPrincipal | Response> {
+	const principal = await verifyJobRequest(db, request);
+
+	if (!principal) {
+		return new Response("Unauthorized", { status: 401 });
+	}
+
+	return principal;
+}

--- a/apps/jobs-api/src/auth/test/fixtures.ts
+++ b/apps/jobs-api/src/auth/test/fixtures.ts
@@ -1,0 +1,65 @@
+import { randomBytes } from "node:crypto";
+
+import { hashToken } from "@virtool/data/auth/tokens";
+import type { Db } from "@virtool/data/db/pg";
+import { jobs } from "@virtool/data/db/schema/jobs";
+
+/** What {@link seedJob} accepts. */
+export type SeedJobOptions = {
+	/** One of the job lifecycle states. `running` unless a test needs another. */
+	state?: string;
+	/** Leave `key` null, as it is on a job nobody has claimed. */
+	withKey?: boolean;
+	workflow?: string;
+};
+
+/** A seeded job and the plaintext key that authenticates as it. */
+export type SeededJob = {
+	id: number;
+	key: string;
+};
+
+/**
+ * Insert a job owned by `userId` and return its id with the plaintext key.
+ *
+ * Only the key's SHA-256 is stored, so the plaintext is returned — it is the
+ * only way a test can build a credential for the job afterwards, exactly as a
+ * runner only ever sees it in the claim response.
+ *
+ * The hashing here goes through `@virtool/data`'s `hashToken` rather than this
+ * app's local copy, deliberately. Seeding with the copy under test would make
+ * the verifier agree with itself no matter what either did; going through the
+ * shared one means a test that authenticates successfully has also shown that
+ * the two implementations produce the same digest.
+ *
+ * `withKey: false` leaves the column null, which is the state of a job that has
+ * been created but never claimed.
+ */
+export async function seedJob(
+	db: Db,
+	userId: number,
+	{
+		state = "running",
+		withKey = true,
+		workflow = "pathoscope",
+	}: SeedJobOptions = {},
+): Promise<SeededJob> {
+	const key = randomBytes(32).toString("hex");
+
+	const [job] = await db
+		.insert(jobs)
+		.values({
+			created_at: new Date(),
+			key: withKey ? hashToken(key) : null,
+			state,
+			user_id: userId,
+			workflow,
+		})
+		.returning({ id: jobs.id });
+
+	if (!job) {
+		throw new Error("failed to seed job");
+	}
+
+	return { id: job.id, key };
+}

--- a/apps/jobs-api/src/auth/verify.test.ts
+++ b/apps/jobs-api/src/auth/verify.test.ts
@@ -1,0 +1,261 @@
+import { seedUser } from "@virtool/data/auth/test/fixtures";
+import type { Db } from "@virtool/data/db/pg";
+import { jobs } from "@virtool/data/db/schema/jobs";
+import { users } from "@virtool/data/db/schema/users";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { seedJob } from "./test/fixtures";
+import { hashToken, parseBasicAuthHeader, verifyJobRequest } from "./verify";
+
+let database: TestDatabase;
+let db: Db;
+let userId: number;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(jobs);
+	await db.delete(users);
+
+	userId = await seedUser(db);
+});
+
+/** Build the request a runner sends, with `job-{id}:{key}` Basic credentials. */
+function request(login: string, key: string): Request {
+	return new Request("https://jobs.virtool.test/jobs/1/ping", {
+		headers: {
+			authorization: `Basic ${Buffer.from(`${login}:${key}`).toString("base64")}`,
+		},
+	});
+}
+
+// Fixed vectors, not a comparison against `@virtool/data`'s copy or Python's.
+// This digest is what `jobs.key` holds, and Python writes that column — so the
+// three implementations must agree forever. A test that ran the two TypeScript
+// copies against each other would pass just as happily if both drifted away
+// from Python together, which is the only drift that actually matters.
+describe("hashToken", () => {
+	it.each([
+		["", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"],
+		[
+			"virtool",
+			"59361c0bb629b66b9b7a82c139fbf8658c0c137b3ae4c728bef20e1fca24c276",
+		],
+	])("hashes %j to its pinned digest", (input, digest) => {
+		expect(hashToken(input)).toBe(digest);
+	});
+});
+
+describe("parseBasicAuthHeader", () => {
+	it("reads the login and key out of a well-formed header", () => {
+		const encoded = Buffer.from("job-7:secret").toString("base64");
+
+		expect(parseBasicAuthHeader(`Basic ${encoded}`)).toEqual({
+			login: "job-7",
+			key: "secret",
+		});
+	});
+
+	// RFC 7235 makes the scheme case-insensitive, and clients do send `basic`.
+	it("accepts the scheme in any case", () => {
+		const encoded = Buffer.from("job-7:secret").toString("base64");
+
+		expect(parseBasicAuthHeader(`basic ${encoded}`)?.login).toBe("job-7");
+		expect(parseBasicAuthHeader(`BASIC ${encoded}`)?.login).toBe("job-7");
+	});
+
+	// The RFC allows one *or more* spaces between the scheme and the credentials.
+	it("accepts extra whitespace around the scheme", () => {
+		const encoded = Buffer.from("job-7:secret").toString("base64");
+
+		expect(parseBasicAuthHeader(`  Basic   ${encoded}  `)?.login).toBe("job-7");
+	});
+
+	// A key is free to contain colons; only the first one separates.
+	it("splits on the first colon only", () => {
+		const encoded = Buffer.from("job-7:a:b:c").toString("base64");
+
+		expect(parseBasicAuthHeader(`Basic ${encoded}`)?.key).toBe("a:b:c");
+	});
+
+	it.each([
+		["a bearer token", "Bearer abcdef"],
+		["a scheme with no credentials", "Basic"],
+		["credentials with no scheme", Buffer.from("job-7:s").toString("base64")],
+		["trailing junk", `Basic ${Buffer.from("job-7:s").toString("base64")} x`],
+		["no separator", `Basic ${Buffer.from("job-7").toString("base64")}`],
+		["an empty login", `Basic ${Buffer.from(":secret").toString("base64")}`],
+		["an empty header", ""],
+	])("rejects %s", (_, header) => {
+		expect(parseBasicAuthHeader(header)).toBeNull();
+	});
+});
+
+describe("verifyJobRequest", () => {
+	it("resolves the job behind a well-formed credential", async () => {
+		const job = await seedJob(db, userId);
+
+		expect(
+			await verifyJobRequest(db, request(`job-${job.id}`, job.key)),
+		).toEqual({ jobId: job.id });
+	});
+
+	it("rejects a request carrying no authorization header", async () => {
+		await seedJob(db, userId);
+
+		const bare = new Request("https://jobs.virtool.test/jobs/1/ping");
+
+		expect(await verifyJobRequest(db, bare)).toBeNull();
+	});
+
+	// The header format is shared with the user-facing API, so a cookie is the
+	// obvious thing to reach for next. This service has no session model at all.
+	it("never falls back to a session cookie", async () => {
+		const job = await seedJob(db, userId);
+
+		const withCookie = new Request("https://jobs.virtool.test/jobs/1/ping", {
+			headers: { cookie: `session_id=anything; session_token=${job.key}` },
+		});
+
+		expect(await verifyJobRequest(db, withCookie)).toBeNull();
+	});
+
+	it("rejects a malformed authorization header", async () => {
+		const job = await seedJob(db, userId);
+
+		const bearer = new Request("https://jobs.virtool.test/jobs/1/ping", {
+			headers: { authorization: `Bearer ${job.key}` },
+		});
+
+		expect(await verifyJobRequest(db, bearer)).toBeNull();
+	});
+
+	it("rejects the right key under the wrong job's id", async () => {
+		const first = await seedJob(db, userId);
+		const second = await seedJob(db, userId);
+
+		expect(
+			await verifyJobRequest(db, request(`job-${second.id}`, first.key)),
+		).toBeNull();
+	});
+
+	it("rejects a wrong key", async () => {
+		const job = await seedJob(db, userId);
+
+		expect(
+			await verifyJobRequest(db, request(`job-${job.id}`, "not-the-key")),
+		).toBeNull();
+	});
+
+	// The stored value is the digest, so a caller who somehow read the column
+	// must not be able to present it back as the secret.
+	it("rejects the stored digest presented as the key", async () => {
+		const job = await seedJob(db, userId);
+
+		expect(
+			await verifyJobRequest(db, request(`job-${job.id}`, hashToken(job.key))),
+		).toBeNull();
+	});
+
+	it("rejects a job that has never been claimed", async () => {
+		const job = await seedJob(db, userId, { withKey: false });
+
+		expect(
+			await verifyJobRequest(db, request(`job-${job.id}`, job.key)),
+		).toBeNull();
+	});
+
+	it("rejects a job that does not exist", async () => {
+		const job = await seedJob(db, userId);
+		await db.delete(jobs);
+
+		expect(
+			await verifyJobRequest(db, request(`job-${job.id}`, job.key)),
+		).toBeNull();
+	});
+
+	// Reaching a terminal state is the only thing that stops a key working —
+	// there is no expiry and no revocation — so this is the whole of key
+	// invalidation, and it has to hold for every one of the three states.
+	it.each(["cancelled", "failed", "succeeded"])(
+		"rejects a valid key for a job that has %s",
+		async (state) => {
+			const job = await seedJob(db, userId, { state });
+
+			expect(
+				await verifyJobRequest(db, request(`job-${job.id}`, job.key)),
+			).toBeNull();
+		},
+	);
+
+	it("accepts a valid key for a job that is still pending", async () => {
+		const job = await seedJob(db, userId, { state: "pending" });
+
+		expect(
+			await verifyJobRequest(db, request(`job-${job.id}`, job.key)),
+		).toEqual({ jobId: job.id });
+	});
+
+	// `apps/web` folds a handle before refusing a `job` prefix, because it
+	// matches handles case-insensitively. Nothing here is a handle, so the
+	// prefix is matched literally and a folded spelling is simply not a login.
+	it.each(["JOB", "Job", "jOb"])(
+		"rejects a %s-prefixed login",
+		async (prefix) => {
+			const job = await seedJob(db, userId);
+
+			expect(
+				await verifyJobRequest(db, request(`${prefix}-${job.id}`, job.key)),
+			).toBeNull();
+		},
+	);
+
+	// Python splits the login on "-" and checks only the first part, so the
+	// anchored pattern here is the stricter of the two. Each of these would
+	// otherwise reach the database as a job id.
+	it.each([
+		"job",
+		"job-",
+		"-1",
+		"job_1",
+		"job-1-2",
+		"job-1x",
+		"xjob-1",
+		"job-+1",
+		"job-1.0",
+		"job- 1",
+		"job-0x1",
+	])("rejects %j as a login", async (login) => {
+		const job = await seedJob(db, userId);
+
+		expect(await verifyJobRequest(db, request(login, job.key))).toBeNull();
+	});
+
+	// `jobs.id` is a Postgres integer. Without the range screen this reaches the
+	// driver and comes back as a range error — a 500, and a Sentry frame, for
+	// what is only a bad credential.
+	it("rejects an id too large for the column without erroring", async () => {
+		await seedJob(db, userId);
+
+		expect(
+			await verifyJobRequest(db, request("job-99999999999999999999", "k")),
+		).toBeNull();
+	});
+
+	it("rejects a zero id", async () => {
+		await seedJob(db, userId);
+
+		expect(await verifyJobRequest(db, request("job-0", "k"))).toBeNull();
+	});
+});

--- a/apps/jobs-api/src/auth/verify.ts
+++ b/apps/jobs-api/src/auth/verify.ts
@@ -1,0 +1,188 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+import type { Db } from "@virtool/data/db/pg";
+import { jobs } from "@virtool/data/db/schema/jobs";
+import { eq } from "drizzle-orm";
+
+/**
+ * The states a job never leaves.
+ *
+ * Mirrors Python's `TERMINAL_JOB_STATES` in `virtool/jobs/models.py`.
+ *
+ * Reaching one of these is the **only** thing that stops a job key
+ * authenticating. There is no expiry, no revocation list, no rotation, and no
+ * way to invalidate a key while its job is still running — the column holds one
+ * digest for the life of the row. So the state has to be re-read on every
+ * request rather than trusted at claim time: a runner pod that outlives the job
+ * it claimed still holds a syntactically valid credential, and this check is
+ * what stops it being accepted.
+ */
+const TERMINAL_STATES = new Set(["cancelled", "failed", "succeeded"]);
+
+/**
+ * The `job-{id}` login carried by the Basic credentials.
+ *
+ * Anchored and case-sensitive. `apps/web` refuses any handle beginning with
+ * `job` case-insensitively, because it matches handles that way and `JOB-1`
+ * would otherwise resolve the very row `job-1` is refused. Nothing here is
+ * case-folded — the login is not a handle, it is a literal prefix and an id —
+ * so `JOB-1` is simply not a job login and gets the same 401 as anything else.
+ */
+const JOB_LOGIN = /^job-(\d+)$/;
+
+/**
+ * The largest value `jobs.id` can hold — it is a Postgres `integer`.
+ *
+ * `\d+` matches arbitrarily many digits, so without this an unauthenticated
+ * caller could send `job-99999999999` and get a range error out of the driver:
+ * a 500, and a stack frame in Sentry, for what is only a bad credential.
+ */
+const MAX_JOB_ID = 2_147_483_647;
+
+/**
+ * SHA-256 hex digest.
+ *
+ * A local copy of `hashToken` in `@virtool/data/auth/tokens`, which is itself a
+ * copy of Python's `hash_key` at `virtool/utils.py:98-99`. All three have to
+ * produce the same digest for the same input forever — `jobs.key` is written by
+ * Python and read here — so this one is pinned against fixed vectors in
+ * `verify.test.ts` rather than against either counterpart. A test that compared
+ * the two implementations would pass just as happily if both drifted together.
+ */
+export function hashToken(token: string): string {
+	return createHash("sha256").update(token).digest("hex");
+}
+
+/** The login and password carried by an HTTP Basic `Authorization` header. */
+export type BasicCredentials = {
+	login: string;
+	key: string;
+};
+
+/**
+ * Parse an HTTP Basic `Authorization` header into its login and password.
+ * Returns `null` for anything malformed — a non-Basic scheme, undecodable
+ * base64, a missing separator, or an empty login.
+ *
+ * A local copy of the function of the same name in
+ * `apps/web/src/server/auth/verify.ts`. It cannot be imported: this service
+ * must not reach into `apps/web`, and the shape is small enough that pushing it
+ * down into a package would couple the job credential's parsing to the user
+ * credential's for no gain. Both are pinned by their own fixed-vector tests.
+ */
+export function parseBasicAuthHeader(header: string): BasicCredentials | null {
+	// RFC 7235 allows one *or more* spaces between the scheme and the
+	// credentials, so split on runs of whitespace rather than a single space.
+	// Requiring exactly two parts still rejects a header with trailing junk —
+	// base64 contains no whitespace, so a third part means the header is broken.
+	const parts = header.trim().split(/\s+/);
+
+	if (parts.length !== 2) {
+		return null;
+	}
+
+	const [scheme, encoded] = parts;
+
+	if (scheme?.toLowerCase() !== "basic" || !encoded) {
+		return null;
+	}
+
+	const decoded = Buffer.from(encoded, "base64").toString("utf8");
+	const idx = decoded.indexOf(":");
+
+	if (idx < 1) {
+		return null;
+	}
+
+	return { login: decoded.slice(0, idx), key: decoded.slice(idx + 1) };
+}
+
+/**
+ * The identity behind an authenticated request to this service.
+ *
+ * A job, and nothing else. There is deliberately no `userId` and no permission
+ * set: a workflow pod acts as the job it claimed, not as the user who created
+ * it, and every rule this service enforces is a rule about which job may touch
+ * which row. Carrying the owner here would invite a handler to authorize
+ * against them instead.
+ */
+export type JobPrincipal = {
+	jobId: number;
+};
+
+/**
+ * Resolve the job behind a request from its HTTP Basic `Authorization` header,
+ * which a runner sends as `job-{id}:{key}`.
+ *
+ * Returns `null` for every failure — no header, a malformed one, a login that
+ * is not a job, an unknown or keyless job, a wrong key, or a job that has
+ * finished — so the caller answers one opaque 401 without saying which check
+ * failed. There is **no cookie fallback**: this service has no session model
+ * and nothing that reaches it holds a browser session.
+ *
+ * Mirrors Python's `virtool/jobs/auth.py` middleware, with two deliberate
+ * differences. The login is matched against an anchored pattern rather than
+ * `split("-")`, so `job-1-2` is refused rather than raising past the prefix
+ * check by accident; and the key comparison is timing-safe, where Python's is a
+ * plain `!=`.
+ */
+export async function verifyJobRequest(
+	db: Db,
+	request: Request,
+): Promise<JobPrincipal | null> {
+	const header = request.headers.get("authorization");
+
+	if (!header) {
+		return null;
+	}
+
+	const credentials = parseBasicAuthHeader(header);
+
+	if (!credentials) {
+		return null;
+	}
+
+	const digits = JOB_LOGIN.exec(credentials.login)?.[1];
+
+	if (!digits) {
+		return null;
+	}
+
+	const jobId = Number(digits);
+
+	if (jobId < 1 || jobId > MAX_JOB_ID) {
+		return null;
+	}
+
+	const [row] = await db
+		.select({ key: jobs.key, state: jobs.state })
+		.from(jobs)
+		.where(eq(jobs.id, jobId))
+		.limit(1);
+
+	// A job that has no key was never claimed, so nothing can be authenticating
+	// as it. Guarding here also keeps the comparison below off a null.
+	if (!row?.key) {
+		return null;
+	}
+
+	const expected = Buffer.from(row.key, "utf8");
+	const provided = Buffer.from(hashToken(credentials.key), "utf8");
+
+	// timingSafeEqual throws on a length mismatch, so the lengths are screened
+	// first. Both sides are hex digests of a fixed-width hash, so a differing
+	// length means the stored value is not one of ours and the screen leaks
+	// nothing about the key itself.
+	if (
+		expected.length !== provided.length ||
+		!timingSafeEqual(expected, provided)
+	) {
+		return null;
+	}
+
+	if (TERMINAL_STATES.has(row.state)) {
+		return null;
+	}
+
+	return { jobId };
+}

--- a/apps/jobs-api/vitest.config.ts
+++ b/apps/jobs-api/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		name: "jobs-api",
+		environment: "node",
+		// The Postgres container is described once, in the package that owns the
+		// schema, and `@virtool/data`'s own project and `apps/web`'s `server`
+		// project both name that same module. One definition means one
+		// `withReuse()` hash, so a local run of all three suites boots a single
+		// Postgres between them.
+		globalSetup: ["@virtool/data/db/test/globalSetup"],
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/docs/jobs-api.md
+++ b/docs/jobs-api.md
@@ -40,6 +40,9 @@ process:
 | `src/config.ts` | Environment parsing, including every `<KEY>_FILE` variant |
 | `src/instrument.ts` | Sentry initialisation and the `SERVICE` constant |
 | `src/logger.ts` | The pino logger singleton |
+| `src/auth/verify.ts` | `verifyJobRequest` — the job credential check |
+| `src/auth/guard.ts` | `requireJobRequest` — the guard every handler starts with |
+| `src/auth/test/fixtures.ts` | `seedJob` — a job row and the plaintext key for it |
 | `src/metrics/registry.ts` | `createMetrics` — this process's Prometheus registry |
 | `src/metrics/handler.ts` | Token check, pre-scrape pool read, response |
 | `src/__tests__/authorization.test.ts` | The route-enumerating authorization floor |
@@ -102,6 +105,108 @@ The test also asserts the reverse: every `PUBLIC_ROUTES` entry names a
 route that actually exists. A stale exception is as much a bug as a
 missing one — it reads as a deliberate decision about a route that is no
 longer there.
+
+## The job credential
+
+A workflow pod authenticates as the job it claimed, over HTTP Basic:
+
+```
+Authorization: Basic base64(job-{jobId}:{key})
+```
+
+`verifyJobRequest` (`src/auth/verify.ts`) resolves that to a
+`JobPrincipal` — `{ jobId }`, and nothing else. There is deliberately no
+`userId` and no permission set on it. A pod acts as its job, not as the
+user who created the job, and every rule this service enforces is a rule
+about which job may touch which row; carrying the owner would invite a
+handler to authorize against them instead.
+
+The sequence, in order:
+
+1. Read the `Authorization` header. Missing is a failure.
+2. Parse it as Basic. A non-Basic scheme, undecodable base64, a missing
+   `:`, or an empty login is a failure.
+3. Match the login against `/^job-(\d+)$/` — **anchored and
+   case-sensitive**.
+4. Screen the id: at least 1, and no larger than a Postgres `integer`.
+5. Read `key` and `state` for that id, in **one** query.
+6. Fail if `key` is null — that job was never claimed.
+7. Compare `hashToken(key)` to the stored digest with `timingSafeEqual`,
+   behind a length screen.
+8. Fail if `state` is terminal.
+
+**There is no cookie fallback, ever.** This service has no session
+model, and nothing that reaches it holds a browser session.
+
+`requireJobRequest` (`src/auth/guard.ts`) wraps it and is what a handler
+calls. On failure it **returns** `401 Unauthorized` rather than throwing
+— a thrown refusal would have to be caught somewhere, and that somewhere
+also catches genuine bugs, so a handler crashing halfway through would
+answer 401 and read as a credential problem to the runner and to Sentry
+alike. The 401 carries **no `WWW-Authenticate` header**: that header
+exists to make a browser prompt, and a runner's key is minted once, at
+claim time, so there is nothing an interactive retry could supply.
+
+Every failure returns an identical, opaque 401. Nothing distinguishes an
+unknown job from a wrong key from a finished one — the most useful thing
+a caller could otherwise learn is which job ids exist.
+
+### Terminal state is the whole of key revocation
+
+A key has no expiry, no revocation list and no rotation: `jobs.key` holds
+one digest for the life of the row. Reaching `cancelled`, `failed` or
+`succeeded` is the **only** thing that stops it authenticating, which is
+why the state is re-read on every request rather than trusted at claim
+time. A runner pod that outlives the job it claimed still holds a
+syntactically valid credential, and that check is what stops it being
+accepted.
+
+### The two local copies
+
+`hashToken` and `parseBasicAuthHeader` are reimplemented in
+`src/auth/verify.ts` rather than shared, each with a comment naming its
+counterpart, and each pinned by fixed-vector tests.
+
+`parseBasicAuthHeader` has no choice: its counterpart is in
+`apps/web/src/server/auth/verify.ts`, which this service must not reach
+into. `hashToken`'s counterpart is `@virtool/data/auth/tokens`, and both
+mirror Python's `hash_key` at `virtool/utils.py:98-99`. All three must
+produce the same digest forever — Python writes the column this side
+reads — so the test pins fixed digests rather than comparing the two
+TypeScript copies, which would pass just as happily if both drifted away
+from Python together.
+
+The `seedJob` fixture hashes with **`@virtool/data`'s** `hashToken`,
+deliberately. Seeding with the copy under test would make the verifier
+agree with itself no matter what either did; going through the shared one
+means a test that authenticates successfully has also shown the two agree.
+
+### Differences from Python
+
+`virtool/jobs/auth.py` is the counterpart middleware. Two deliberate
+divergences, both stricter:
+
+- The login is matched against an anchored pattern rather than
+  `holder_id.split("-")`, which checks only the first part. `job-1-2`
+  reaches Python's `int()` and raises; here it is simply not a login.
+- The key comparison is timing-safe. Python's is a plain `!=`.
+
+Python also answers 403 when the authenticated job id does not match a
+`job_id` path parameter. That is a per-route rule, not a property of the
+credential, so it belongs in the handlers rather than here — which is
+what `JobPrincipal` carrying `jobId` is for.
+
+### Tests need Postgres
+
+`verify.test.ts` and `guard.test.ts` run against `createTestDatabase()`,
+so `apps/jobs-api/vitest.config.ts` names
+`@virtool/data/db/test/globalSetup` — the same module `@virtool/data`'s
+project and `apps/web`'s `server` project name, so one `withReuse()` hash
+covers all three and a local run of them boots a single container.
+
+That is also why this workspace has its own `Test / Jobs API` CI job and
+is excluded from `Test / Packages`: pulling a Postgres image does not
+belong in the fast package loop.
 
 ## Health
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@virtool/sentry':
         specifier: workspace:*
         version: link:../../packages/sentry
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(postgres@3.4.9)
       hono:
         specifier: ^4.13.0
         version: 4.13.0
@@ -16931,7 +16934,7 @@ snapshots:
       es-module-lexer: 2.3.1
       expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.5
       std-env: 4.2.0


### PR DESCRIPTION
## Summary

- Workflow pods now authenticate to the jobs API as `job-{id}:{key}` over HTTP Basic. `verifyJobRequest` resolves that to a `JobPrincipal` of `{ jobId }` — no user, no permissions, since a pod acts as its job rather than as the user who created it — and `requireJobRequest` is the floor every handler will start with, *returning* an opaque 401 rather than throwing one. There is no cookie fallback; this service has no session model. Reaching a terminal state is the only thing that revokes a job key, so the state is re-read on every request rather than trusted at claim time.
- `hashToken` and `parseBasicAuthHeader` are local copies rather than imports, each naming its counterpart and Python's `virtool/utils.py:98-99`, and each pinned by fixed vectors — comparing the two TypeScript copies would pass just as happily if both drifted away from Python together. The `seedJob` fixture hashes with `@virtool/data`'s `hashToken` instead, so a test that authenticates successfully has also shown the two agree.
- The verifier is tested against a real Postgres via the shared `globalSetup`, so `@virtool/jobs-api` gets its own CI job and leaves the fast package loop, matching what `@virtool/data` and `@virtool/storage` already do.

Closes VIR-2837.

### Two deviations from the issue

The `**/handlers.ts` glob authorization test is deliberately **not** here. VIR-2840's route-enumerating `authorization.test.ts` already covers that ground and covers it better — it catches a guard that exists but was never mounted, which a per-function test cannot. The issue's `handle*(request, params)` convention also contradicts the `handleMetrics(c, deps)` signature that shipped, and there is nothing to enumerate until the lifecycle handlers land. If the handler-level test is still wanted, it belongs with VIR-2839, where `handleClaimJob` gives the exception list something to name.

`MAX_JOB_ID` is an addition beyond the spec. `\d+` matches arbitrarily many digits and `jobs.id` is a Postgres `integer`, so without the screen `job-99999999999` from an unauthenticated caller reaches the driver and comes back a 500 with a Sentry frame instead of a 401.