### PR TITLE
fix: read stored file locations off the owning row, not derived keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -670,13 +670,13 @@ Constraints these handlers carry, each of which has been a bug:
   the response on the way out. `request.formData()` puts a multi-gigabyte read
   file in the Node heap. For the same reason the upload must not become a server
   function: the RPC client uses `fetch`, which cannot report progress.
-- **Compose a storage key only from a row already matched.** A `$filename` param
-  is looked up first — against `subtraction_files`, or a whitelist of the names
-  an index build produces — and the key is then built from that row's own `name`
-  and `storage_key`. Never from the URL param, which is how a param traverses
-  out of the prefix, and never from the row id.
-- **`Content-Disposition` carries the row's `name`**, never the UUID-prefixed
-  `name_on_disk` that keys the object.
+- **Take a storage key off a row already matched.** A `$filename` param selects
+  a row first — against `subtraction_files`, or a whitelist of the names an index
+  build produces — and the key is then read from that row's `storage_key`. Never
+  compose one from the URL param, which is how a param traverses out of a prefix,
+  and never from the row id.
+- **`Content-Disposition` carries the row's `name`**, never `name_on_disk` and
+  never the key.
 - **A download gets its own URL.** The FASTA routes end in a literal `fasta`
   segment rather than a `.fa` suffix on the resource URL — sniffing a suffix
   inside a read handler is what puts two representations on one path.
@@ -866,14 +866,15 @@ analyses read path. Renormalizing is a Python-side migration.
 
 **An index build is started here and finished by Python.**
 `createIndex` (`@virtool/data/indexes/data`) inserts the pending `indexes` row,
-mints its `storage_key`, stamps every unbuilt `legacy_history` row with
-it, and creates the `create_index` task the Python runner claims — that
-task writes the artifact and flips `ready`. The insert runs under
+stamps every unbuilt `legacy_history` row with it, and creates the
+`create_index` task the Python runner claims — that task writes the
+artifact, records each file's `storage_key`, and flips `ready`. The
+insert runs under
 `pg_try_advisory_xact_lock(hashtext('index_build:{referenceId}'))`, the
 same key Python takes, so a build started from either service excludes
-one started from the other. Don't drop the lock, and don't derive
-`storage_key` from the row id — a migrated index keys on its old Mongo
-id instead.
+one started from the other. Don't drop the lock. `indexes.storage_key`
+is dead — it is still `NOT NULL`, so the insert fills it, but nothing
+composes a key from it any more.
 
 See [docs/database.md](docs/database.md) for which domains the TS
 server can reach today, why the OTU tables keep their legacy shape and
@@ -886,17 +887,32 @@ Uploads, reads, analysis results, indexes, subtractions, HMM profiles,
 and caches live in S3 or Azure Blob — **the same bucket Python uses**.
 `@virtool/storage` exposes a five-method streaming interface
 (`read`, `write`, `delete`, `list`, `size`); there are no paths, file
-handles, or presigned URLs. Keys are built by `@virtool/storage/keys` and
-must stay byte-for-byte identical to Python's — a divergence silently
-reads nothing and orphans what it writes. There is no filesystem backend.
+handles, or presigned URLs. There is no filesystem backend.
+
+**A key is recorded, not derived.** Every row naming a stored object
+carries its complete key in a `storage_key` column, and every read path
+reads that column — nothing recomposes a key from a row id, a legacy id,
+or a filename. New keys come from `mintStorageKey(domain, parentId)` and
+`mintRootStorageKey(domain)` in `@virtool/storage/keys`, whose UUID leaf
+must stay hyphenless to match Python's `uuid4().hex`. The `parentId`
+segment is for human inspection only; keys in the bucket are
+heterogeneous by design, because a migrated row keeps whatever prefix it
+was written under.
 
 `StorageError` and `StorageKeyNotFoundError` come from
 `@virtool/storage/errors` and extend plain `Error`, not the data layer's
 `AppError`, so the storage package carries no dependency on the data layer.
 
 The backend is built once at startup and **passed into `data.ts`
-functions as an argument, the way `db` is**. `deletePrefix` never
-throws; it returns failures, and callers must log them.
+functions as an argument, the way `db` is**. `deleteKeys` never throws;
+it returns failures, and callers must log them.
+
+**Cleanup enumerates recorded keys; there is no prefix sweep.** Read a
+row's key *before* deleting the row, and where a cascade takes child rows
+with it — a sample's analyses take their `analysis_files`, an index takes
+its `index_files` — collect the children's keys in the parent's delete.
+An object written before keys were recorded is named by no row, survives
+the delete, and is left for an orphan sweep that does not exist yet.
 
 Client code must never reference the whole `import.meta.env` object.
 Vite would serialize every `VT_`-prefixed variable — including

--- a/apps/create-subtraction/src/storage.ts
+++ b/apps/create-subtraction/src/storage.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "@virtool/logger";
-import { type StorageBackend, subtractionPrefix } from "@virtool/storage";
+import type { StorageBackend } from "@virtool/storage";
 
 /**
  * Confirm the pod can actually reach the bucket, before it does any work.
@@ -9,15 +9,19 @@ import { type StorageBackend, subtractionPrefix } from "@virtool/storage";
  * already been downloaded and an aligner has run for an hour. Listing a prefix
  * is the cheapest call that exercises credentials, endpoint and bucket name
  * together, so it is worth paying at startup. It reads a single entry and stops:
- * a real subtraction prefix holds a full Bowtie2 index, and draining the listing
- * would cost a page of requests to learn nothing more.
+ * draining the listing would cost a page of requests to learn nothing more.
+ *
+ * The prefix is only a plausible place to look. Keys are recorded on rows rather
+ * than derived, so a subtraction's objects are not guaranteed to live under it —
+ * an empty listing still proves the bucket is reachable, which is all this
+ * checks.
  */
 export async function checkStorageAccess(
 	storage: StorageBackend,
 	logger: Logger,
 	subtractionId: string,
 ): Promise<void> {
-	const prefix = subtractionPrefix(subtractionId);
+	const prefix = `subtractions/${subtractionId}/`;
 
 	for await (const object of storage.list(prefix)) {
 		logger.info({ prefix, key: object.key }, "reached object storage");

--- a/apps/web/src/server/indexes/download.test.ts
+++ b/apps/web/src/server/indexes/download.test.ts
@@ -1,5 +1,4 @@
 import type { Db } from "@virtool/data/db/pg";
-import { takeFirstOrThrow } from "@virtool/data/db/rows";
 import { apiKeys } from "@virtool/data/db/schema/apiKeys";
 import { groups, userGroups } from "@virtool/data/db/schema/groups";
 import { legacyHistory } from "@virtool/data/db/schema/history";
@@ -17,7 +16,7 @@ import {
 	createTestDatabase,
 	type TestDatabase,
 } from "@virtool/data/db/test/fixtures";
-import { MemoryStorage } from "@virtool/storage";
+import { MemoryStorage, mintStorageKey } from "@virtool/storage";
 import { eq } from "drizzle-orm";
 import {
 	afterAll,
@@ -95,27 +94,22 @@ beforeEach(async () => {
 	ownerId = await seedUser(db, { handle: "alice" });
 });
 
+// Returns the key the row records, which is what a test writes its bytes under.
 async function seedFile(
 	indexId: number,
 	name = "reference.fa.gz",
-): Promise<void> {
+): Promise<string> {
+	const storageKey = mintStorageKey("indexes", indexId);
+
 	await db.insert(indexFiles).values({
 		name,
 		index_id: indexId,
 		size: 5,
+		storage_key: storageKey,
 		type: "fasta",
 	});
-}
 
-// `storage_key` is minted by the seeder and cannot be derived from the row id,
-// so the key a test writes under has to be read back.
-async function storageKey(indexId: number): Promise<string> {
-	return takeFirstOrThrow(
-		await db
-			.select({ storageKey: indexes.storage_key })
-			.from(indexes)
-			.where(eq(indexes.id, indexId)),
-	).storageKey;
+	return storageKey;
 }
 
 async function write(key: string, contents: string): Promise<void> {
@@ -140,7 +134,11 @@ async function request(userId: number | null): Promise<Request> {
 }
 
 /** Seed a reference owned by `ownerId` with one finished build and its file. */
-async function seedBuild(): Promise<{ referenceId: number; indexId: number }> {
+async function seedBuild(): Promise<{
+	referenceId: number;
+	indexId: number;
+	storageKey: string;
+}> {
 	const referenceId = await seedReference(db, ownerId);
 	const indexId = await seedIndex(db, {
 		referenceId,
@@ -148,14 +146,14 @@ async function seedBuild(): Promise<{ referenceId: number; indexId: number }> {
 		version: 0,
 	});
 
-	await seedFile(indexId);
-	await write(`indexes/${await storageKey(indexId)}/reference.fa.gz`, "hello");
+	const storageKey = await seedFile(indexId);
+	await write(storageKey, "hello");
 
-	return { referenceId, indexId };
+	return { referenceId, indexId, storageKey };
 }
 
 describe("handleIndexFile", () => {
-	it("streams a build's file from its storage-key prefix", async () => {
+	it("streams a build's file from the key its row records", async () => {
 		const { indexId } = await seedBuild();
 
 		const response = await handleIndexFile(
@@ -178,15 +176,12 @@ describe("handleIndexFile", () => {
 	// `index_files.size` records what the build task wrote and is nullable, so the
 	// header has to come from the object or the client truncates.
 	it("sizes the response from storage, not the row", async () => {
-		const { indexId } = await seedBuild();
+		const { indexId, storageKey } = await seedBuild();
 		await db
 			.update(indexFiles)
 			.set({ size: null })
 			.where(eq(indexFiles.index_id, indexId));
-		await write(
-			`indexes/${await storageKey(indexId)}/reference.fa.gz`,
-			"considerably longer than five bytes",
-		);
+		await write(storageKey, "considerably longer than five bytes");
 
 		const response = await handleIndexFile(
 			await request(ownerId),
@@ -303,8 +298,7 @@ describe("handleIndexFile", () => {
 	// row exists for them.
 	it("returns a 404 for a file the whitelist does not name", async () => {
 		const { indexId } = await seedBuild();
-		await seedFile(indexId, "secret.txt");
-		await write(`indexes/${await storageKey(indexId)}/secret.txt`, "hello");
+		await write(await seedFile(indexId, "secret.txt"), "hello");
 
 		const response = await handleIndexFile(
 			await request(ownerId),
@@ -315,8 +309,8 @@ describe("handleIndexFile", () => {
 		expect(response.status).toBe(404);
 	});
 
-	// The filename only ever reaches a key after it has matched a registered
-	// file, so it cannot escape the index's prefix.
+	// The filename only ever selects a row; the key comes off that row, so a
+	// filename carrying path segments names no object.
 	it("returns a 404 for a filename the index has no row for", async () => {
 		const { indexId } = await seedBuild();
 

--- a/apps/web/src/server/samples/download.test.ts
+++ b/apps/web/src/server/samples/download.test.ts
@@ -17,7 +17,7 @@ import {
 	createTestDatabase,
 	type TestDatabase,
 } from "@virtool/data/db/test/fixtures";
-import { MemoryStorage } from "@virtool/storage";
+import { MemoryStorage, mintStorageKey } from "@virtool/storage";
 import {
 	afterAll,
 	beforeAll,
@@ -110,23 +110,34 @@ async function seedSample(
 	).id;
 }
 
-// `sample_reads.sample` is the storage prefix the file was written under, which
-// is the legacy id for a migrated sample and the integer id otherwise.
+// `sample_reads.sample` is the legacy text id the row is matched by, which is
+// the legacy id for a migrated sample and the integer id otherwise. It no longer
+// has anything to do with where the object lives — `storage_key` records that,
+// and the seeder returns it so a test can write its bytes there.
 async function seedRead(
 	sampleId: number,
 	{
 		name = "reads_1.fq.gz",
 		nameOnDisk = name,
 		sample = String(sampleId),
-	}: { name?: string; nameOnDisk?: string; sample?: string } = {},
-): Promise<void> {
+		storageKey = mintStorageKey("samples", sampleId),
+	}: {
+		name?: string;
+		nameOnDisk?: string;
+		sample?: string;
+		storageKey?: string;
+	} = {},
+): Promise<string> {
 	await db.insert(sampleReads).values({
 		name,
 		name_on_disk: nameOnDisk,
 		sample,
 		sample_id: sampleId,
 		size: 5,
+		storage_key: storageKey,
 	});
+
+	return storageKey;
 }
 
 async function write(key: string, contents: string): Promise<void> {
@@ -151,10 +162,9 @@ async function request(userId: number | null): Promise<Request> {
 }
 
 describe("handleSampleReads", () => {
-	it("streams a Postgres-native sample's read from its integer prefix", async () => {
+	it("streams a read from the key its row records", async () => {
 		const sampleId = await seedSample();
-		await seedRead(sampleId);
-		await write(`samples/${sampleId}/reads_1.fq.gz`, "hello");
+		await write(await seedRead(sampleId), "hello");
 
 		const response = await handleSampleReads(
 			await request(ownerId),
@@ -171,11 +181,14 @@ describe("handleSampleReads", () => {
 		expect(await response.text()).toBe("hello");
 	});
 
-	// A sample migrated out of Mongo keeps its legacy id as the storage prefix,
-	// even though it is addressed by its integer id.
-	it("reads a migrated sample's read from its legacy prefix", async () => {
+	// A migrated sample's reads keep the legacy key they were backfilled with,
+	// even though the sample is addressed by its integer id.
+	it("reads a migrated sample's read from its backfilled key", async () => {
 		const sampleId = await seedSample({ legacy_id: "abc123" });
-		await seedRead(sampleId, { sample: "abc123" });
+		await seedRead(sampleId, {
+			sample: "abc123",
+			storageKey: "samples/abc123/reads_1.fq.gz",
+		});
 		await write("samples/abc123/reads_1.fq.gz", "hello");
 
 		const response = await handleSampleReads(
@@ -188,14 +201,12 @@ describe("handleSampleReads", () => {
 		expect(await response.text()).toBe("hello");
 	});
 
-	// `upload_reads` sets `name` and `name_on_disk` from the same argument, so
-	// the two agree on every row today. The URL still carries `name`, so the
-	// match and the key have to come from different columns for that to stay an
-	// implementation detail rather than something the route depends on.
-	it("matches on name but keys the object on name_on_disk", async () => {
+	// The URL carries `name`, which selects the row. Nothing about the object's
+	// location is derived from either name column.
+	it("matches on name and takes the key off the matched row", async () => {
 		const sampleId = await seedSample();
-		await seedRead(sampleId, { nameOnDisk: "stored_1.fq.gz" });
-		await write(`samples/${sampleId}/stored_1.fq.gz`, "hello");
+		const key = await seedRead(sampleId, { nameOnDisk: "stored_1.fq.gz" });
+		await write(key, "hello");
 
 		const response = await handleSampleReads(
 			await request(ownerId),
@@ -215,12 +226,9 @@ describe("handleSampleReads", () => {
 	// the header has to come from the object or the client truncates.
 	it("sizes the response from storage, not the row", async () => {
 		const sampleId = await seedSample();
-		await seedRead(sampleId);
+		const key = await seedRead(sampleId);
 		await db.update(sampleReads).set({ size: null });
-		await write(
-			`samples/${sampleId}/reads_1.fq.gz`,
-			"considerably longer than five bytes",
-		);
+		await write(key, "considerably longer than five bytes");
 
 		const response = await handleSampleReads(
 			await request(ownerId),
@@ -249,8 +257,7 @@ describe("handleSampleReads", () => {
 	it("accepts an api key", async () => {
 		const key = await seedApiKey(db, ownerId, {});
 		const sampleId = await seedSample();
-		await seedRead(sampleId);
-		await write(`samples/${sampleId}/reads_1.fq.gz`, "hello");
+		await write(await seedRead(sampleId), "hello");
 
 		const response = await handleSampleReads(
 			new Request("https://virtool.test/samples/1/reads/x", {
@@ -267,8 +274,7 @@ describe("handleSampleReads", () => {
 	// signed-in caller download the reads of a sample they could not see.
 	it("rejects a user without the read right with a 403", async () => {
 		const sampleId = await seedSample();
-		await seedRead(sampleId);
-		await write(`samples/${sampleId}/reads_1.fq.gz`, "hello");
+		await write(await seedRead(sampleId), "hello");
 
 		const strangerId = await seedUser(db, { handle: "bob" });
 
@@ -284,8 +290,7 @@ describe("handleSampleReads", () => {
 	it("serves a member of the sample's group when it grants group read", async () => {
 		const groupId = await seedGroup(db, { name: "lab" });
 		const sampleId = await seedSample({ group_id: groupId, group_read: true });
-		await seedRead(sampleId);
-		await write(`samples/${sampleId}/reads_1.fq.gz`, "hello");
+		await write(await seedRead(sampleId), "hello");
 
 		const memberId = await seedUser(db, { handle: "bob" });
 		await addToGroup(db, memberId, groupId);
@@ -319,8 +324,8 @@ describe("handleSampleReads", () => {
 		expect(response.status).toBe(404);
 	});
 
-	// The filename only ever reaches a key after it has matched a registered
-	// read, so it cannot escape the sample's prefix.
+	// The filename only ever selects a row; the key comes off that row, so a
+	// filename carrying path segments names no object.
 	it("returns a 404 for a filename the sample has no row for", async () => {
 		const sampleId = await seedSample();
 		await seedRead(sampleId);

--- a/apps/web/src/server/subtraction/download.test.ts
+++ b/apps/web/src/server/subtraction/download.test.ts
@@ -11,7 +11,7 @@ import {
 	createTestDatabase,
 	type TestDatabase,
 } from "@virtool/data/db/test/fixtures";
-import { MemoryStorage } from "@virtool/storage";
+import { MemoryStorage, mintStorageKey } from "@virtool/storage";
 import { eq } from "drizzle-orm";
 import {
 	afterAll,
@@ -96,16 +96,23 @@ async function seedSubtraction(
 	).id;
 }
 
+// Returns the key the row records, which is what a test writes its bytes under.
 async function seedFile(
 	subtractionId: number,
-	name = "subtraction.fa.gz",
-): Promise<void> {
+	{
+		name = "subtraction.fa.gz",
+		storageKey = mintStorageKey("subtractions", subtractionId),
+	}: { name?: string; storageKey?: string } = {},
+): Promise<string> {
 	await db.insert(subtractionFiles).values({
 		name,
 		subtraction_id: subtractionId,
 		size: 5,
+		storage_key: storageKey,
 		type: "fasta",
 	});
+
+	return storageKey;
 }
 
 async function write(key: string, contents: string): Promise<void> {
@@ -132,10 +139,9 @@ async function request(userId: number | null): Promise<Request> {
 }
 
 describe("handleSubtractionFile", () => {
-	it("streams a Postgres-native subtraction's file from its integer prefix", async () => {
+	it("streams a subtraction's file from the key its row records", async () => {
 		const subtractionId = await seedSubtraction();
-		await seedFile(subtractionId);
-		await write(`subtractions/${subtractionId}/subtraction.fa.gz`, "hello");
+		await write(await seedFile(subtractionId), "hello");
 
 		const response = await handleSubtractionFile(
 			await request(userId),
@@ -154,11 +160,14 @@ describe("handleSubtractionFile", () => {
 		expect(await response.text()).toBe("hello");
 	});
 
-	// A subtraction migrated out of Mongo keeps its legacy slug as the storage
-	// prefix, even though it is addressed by its integer id.
-	it("reads a migrated subtraction's file from its legacy prefix", async () => {
+	// A migrated subtraction's files keep the legacy key they were backfilled
+	// with, spaces already substituted, even though the subtraction is addressed
+	// by its integer id.
+	it("reads a migrated subtraction's file from its backfilled key", async () => {
 		const subtractionId = await seedSubtraction({ legacy_id: "arabidopsis 1" });
-		await seedFile(subtractionId);
+		await seedFile(subtractionId, {
+			storageKey: "subtractions/arabidopsis_1/subtraction.fa.gz",
+		});
 		await write("subtractions/arabidopsis_1/subtraction.fa.gz", "hello");
 
 		const response = await handleSubtractionFile(
@@ -175,15 +184,12 @@ describe("handleSubtractionFile", () => {
 	// so the header has to come from the object or the client truncates.
 	it("sizes the response from storage, not the row", async () => {
 		const subtractionId = await seedSubtraction();
-		await seedFile(subtractionId);
+		const key = await seedFile(subtractionId);
 		await db
 			.update(subtractionFiles)
 			.set({ size: null })
 			.where(eq(subtractionFiles.subtraction_id, subtractionId));
-		await write(
-			`subtractions/${subtractionId}/subtraction.fa.gz`,
-			"considerably longer than five bytes",
-		);
+		await write(key, "considerably longer than five bytes");
 
 		const response = await handleSubtractionFile(
 			await request(userId),
@@ -212,8 +218,7 @@ describe("handleSubtractionFile", () => {
 	it("accepts an api key", async () => {
 		const key = await seedApiKey(db, userId, {});
 		const subtractionId = await seedSubtraction();
-		await seedFile(subtractionId);
-		await write(`subtractions/${subtractionId}/subtraction.fa.gz`, "hello");
+		await write(await seedFile(subtractionId), "hello");
 
 		const response = await handleSubtractionFile(
 			new Request("https://virtool.test/subtractions/1/files/x", {
@@ -248,8 +253,7 @@ describe("handleSubtractionFile", () => {
 
 	it("returns a 404 when the subtraction is deleted", async () => {
 		const subtractionId = await seedSubtraction({ deleted: true });
-		await seedFile(subtractionId);
-		await write(`subtractions/${subtractionId}/subtraction.fa.gz`, "hello");
+		await write(await seedFile(subtractionId), "hello");
 
 		const response = await handleSubtractionFile(
 			await request(userId),
@@ -260,8 +264,8 @@ describe("handleSubtractionFile", () => {
 		expect(response.status).toBe(404);
 	});
 
-	// The filename only ever reaches a key after it has matched a registered
-	// file, so it cannot escape the subtraction's prefix.
+	// The filename only ever selects a row; the key comes off that row, so a
+	// filename carrying path segments names no object.
 	it("returns a 404 for a filename the subtraction has no row for", async () => {
 		const subtractionId = await seedSubtraction();
 		await seedFile(subtractionId);

--- a/apps/web/src/server/uploads/download.test.ts
+++ b/apps/web/src/server/uploads/download.test.ts
@@ -87,6 +87,7 @@ async function seedUpload(
 				removed: false,
 				reserved: false,
 				size: 5,
+				storageKey: "uploads/abc",
 				type: "reads",
 				uploadedAt: new Date(),
 				userId,
@@ -118,9 +119,9 @@ async function request(userId: number | null): Promise<Request> {
 }
 
 describe("handleUploadDownload", () => {
-	it("streams the upload from its name_on_disk key", async () => {
+	it("streams the upload from the key its row records", async () => {
 		const uploadId = await seedUpload();
-		await write("files/abc-reads.fq.gz", "hello");
+		await write("uploads/abc", "hello");
 
 		const response = await handleUploadDownload(
 			await request(userId),
@@ -138,14 +139,15 @@ describe("handleUploadDownload", () => {
 		expect(await response.text()).toBe("hello");
 	});
 
-	// The object is keyed by the UUID-prefixed `name_on_disk`, but the download
+	// The object's key says nothing about what the file is called; the download
 	// is named after what the user chose.
 	it("names the download after the upload's name, not its key", async () => {
 		const uploadId = await seedUpload({
 			name: "my reads.fq.gz",
 			nameOnDisk: "f0e1-my reads.fq.gz",
+			storageKey: "uploads/f0e1",
 		});
-		await write("files/f0e1-my reads.fq.gz", "hello");
+		await write("uploads/f0e1", "hello");
 
 		const response = await handleUploadDownload(
 			await request(userId),
@@ -162,7 +164,7 @@ describe("handleUploadDownload", () => {
 	// the client truncates.
 	it("sizes the response from storage, not the row", async () => {
 		const uploadId = await seedUpload({ size: null });
-		await write("files/abc-reads.fq.gz", "considerably longer than five bytes");
+		await write("uploads/abc", "considerably longer than five bytes");
 
 		const response = await handleUploadDownload(
 			await request(userId),
@@ -176,7 +178,7 @@ describe("handleUploadDownload", () => {
 
 	it("rejects an anonymous caller with a 401", async () => {
 		const uploadId = await seedUpload();
-		await write("files/abc-reads.fq.gz", "hello");
+		await write("uploads/abc", "hello");
 
 		const response = await handleUploadDownload(
 			await request(null),
@@ -189,7 +191,7 @@ describe("handleUploadDownload", () => {
 	it("accepts an api key", async () => {
 		const key = await seedApiKey(db, userId, {});
 		const uploadId = await seedUpload();
-		await write("files/abc-reads.fq.gz", "hello");
+		await write("uploads/abc", "hello");
 
 		const response = await handleUploadDownload(
 			new Request("https://virtool.test/uploads/1", {
@@ -221,7 +223,7 @@ describe("handleUploadDownload", () => {
 
 	it("returns a 404 when the upload is removed", async () => {
 		const uploadId = await seedUpload({ removed: true, removedAt: new Date() });
-		await write("files/abc-reads.fq.gz", "hello");
+		await write("uploads/abc", "hello");
 
 		const response = await handleUploadDownload(
 			await request(userId),
@@ -231,8 +233,9 @@ describe("handleUploadDownload", () => {
 		expect(response.status).toBe(404);
 	});
 
-	it("returns a 404 when the row has no name_on_disk", async () => {
-		const uploadId = await seedUpload({ nameOnDisk: null });
+	// A row predating recorded keys names no object we can locate.
+	it("returns a 404 when the row has no storage_key", async () => {
+		const uploadId = await seedUpload({ storageKey: null });
 
 		const response = await handleUploadDownload(
 			await request(userId),
@@ -243,7 +246,7 @@ describe("handleUploadDownload", () => {
 	});
 
 	it("returns a 404 when the row exists but its bytes do not", async () => {
-		const uploadId = await seedUpload({ nameOnDisk: "missing-reads.fq.gz" });
+		const uploadId = await seedUpload({ storageKey: "uploads/missing" });
 
 		const response = await handleUploadDownload(
 			await request(userId),

--- a/docs/database.md
+++ b/docs/database.md
@@ -196,13 +196,13 @@ Starting an index build is the one write that takes a Postgres advisory
 lock, and the reason is that Python still performs the second half of it.
 
 `createIndex` (`@virtool/data/indexes/data`) inserts the pending `indexes` row,
-mints its `storage_key`, stamps every `legacy_history` row whose
-`index_id` is `NULL` with the new build, and creates a `create_index`
-task. The Python task runner claims that task, patches every OTU in the
-manifest back to the version the build was pinned to, gzips the artifact
-into `indexes/{storage_key}/reference-v2.json.gz`, records the
-`index_files` row, promotes `legacy_otus.last_indexed_version`, and only
-then sets `ready = true`. Nothing on this side finishes a build.
+stamps every `legacy_history` row whose `index_id` is `NULL` with the new
+build, and creates a `create_index` task. The Python task runner claims
+that task, patches every OTU in the manifest back to the version the
+build was pinned to, gzips the artifact into a freshly minted key,
+records the `index_files` row **with that key on it**, promotes
+`legacy_otus.last_indexed_version`, and only then sets `ready = true`.
+Nothing on this side finishes a build.
 
 Two builds of one reference would each stamp the other's changes and then
 collide on the `(reference_id, version)` unique constraint, so the insert
@@ -225,16 +225,20 @@ cheap rejection that avoids reading the manifest, and once inside it,
 which is the one that is actually race-free. Both raise the same error,
 so a caller cannot tell which fired.
 
-Two columns are load-bearing for the handoff:
+Two columns matter for the handoff:
 
-- **`storage_key`** is `NOT NULL`, unique, and **not derivable from the
-  row id** — an index migrated from Mongo keys its files on the old
-  string id, and one created here on a minted UUID. Writing the row
-  without it fails; deriving it from `id` orphans the files the Python
-  task writes.
 - **`manifest`** is `{otuId: otuVersion}` captured at the moment the
   build starts. It is what pins the artifact to a point in time, so it is
   read before the lock is taken rather than inside the transaction.
+- **`indexes.storage_key`** is dead. Keys were once composed as
+  `indexes/{storage_key}/{file name}`; each `index_files` row now records
+  its own complete key instead. The column is still `NOT NULL`, so the
+  insert has to fill it — Python retains it until a cleanup revision, so
+  a rolling deploy never has readers of a dropped column — but nothing
+  reads it. `indexes.otus_json_storage_key` is the one key still held on
+  the index itself: the compressed OTU JSON is materialized on demand and
+  deliberately has no `index_files` row, because one would publish it in
+  the index's file listing.
 
 `indexes` carries a `num_nonnulls(job_id, task_id) <= 1` check upstream:
 a build is backed by at most one of a legacy workflow job or a task. A

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -25,7 +25,7 @@ type StorageBackend = {
 };
 ```
 
-- Keys are `/`-delimited with no leading slash: `samples/abc123/reads_1.fq.gz`.
+- Keys are `/`-delimited with no leading slash: `samples/12/9f2c…`.
 - `read` and `write` stream. Sequencing files are far too large to buffer.
 - `write` creates or overwrites and returns the number of bytes written.
 - `delete` is idempotent — deleting a key that was never there is not an error.
@@ -43,55 +43,72 @@ or rely on it for ordering.
 
 ### Cleanup
 
-`deletePrefix(storage, prefix)` deletes everything under a prefix and **never
-throws**. Callers reach it having already committed the database write that
-orphaned the objects, so failing the whole operation because one delete failed
-would abandon the rest of the cleanup and report failure for work that mostly
-succeeded. It returns `{ key, error }` pairs instead. **Log them** — that is
-the only thing keeping the orphans observable. If the listing itself fails, the
-prefix comes back in place of a key.
+`deleteKeys(storage, keys)` deletes every object named and **never throws**.
+Callers reach it having already committed the database write that orphaned the
+objects, so failing the whole operation because one delete failed would abandon
+the rest of the cleanup and report failure for work that mostly succeeded. It
+returns `{ key, error }` pairs instead. **Log them** — that is the only thing
+keeping the orphans observable.
+
+The keys passed in are the ones the rows being deleted recorded, so they have to
+be read **before** those rows go. Where a cascade removes child rows — a
+sample's analyses take their `analysis_files` with them, an index takes its
+`index_files` — the parent's delete collects the children's keys first.
+
+There is no prefix sweep, in either service. Only an object some row names can
+be reached, so anything written before keys were recorded — a migrated
+analysis's result blobs, above all — survives a delete and is left for a
+separate orphan sweep. That sweep does not exist yet.
 
 ## Keys
 
-Key builders live in `@virtool/storage/keys` and must stay byte-for-byte identical to
-Python's. A divergence does not fail loudly: it silently reads nothing and
-orphans whatever it writes.
+**A key is recorded, not derived.** Every row that names a stored object carries
+its complete key in a `storage_key` column, and every read path reads that
+column. Nothing recomposes a key from a row id, a legacy id, or a filename, so
+changing how keys are chosen cannot force a single object to move.
 
-| Builder | Key |
+The columns, all `UNIQUE`:
+
+| Table | Column | Null? |
+| --- | --- | --- |
+| `sample_reads` | `storage_key` | no |
+| `index_files` | `storage_key` | no |
+| `sample_artifacts` | `storage_key` | yes |
+| `subtraction_files` | `storage_key` | yes |
+| `analysis_files` | `storage_key` | yes |
+| `uploads` | `storage_key` | yes |
+| `indexes` | `otus_json_storage_key` | yes |
+
+A column is nullable exactly where the value it was backfilled from is: the
+backfill derived each key from whatever the old read path composed, and where
+that source column is nullable a row can exist naming no retrievable object. A
+NULL key states that faithfully rather than fabricating one. `indexes` carries
+its OTU JSON key directly because that object is materialized on demand and
+deliberately has no `index_files` row — one would publish it in the index's file
+listing.
+
+New keys come from `@virtool/storage/keys`, and must stay byte-for-byte
+compatible with Python's — the leaf is `uuid4().hex`, so **no hyphens**:
+
+| Minter | Key |
 | --- | --- |
-| `uploadFileKey(nameOnDisk)` | `files/{nameOnDisk}` |
-| `analysisFileKey(nameOnDisk)` | `analyses/{nameOnDisk}` |
-| `sampleFileKey(storageId, filename)` | `samples/{storageId}/{filename}` |
-| `samplePrefix(storageId)` | `samples/{storageId}/` |
-| `analysisPrefix(sampleStorageId, analysisLegacyId)` | `samples/{sampleStorageId}/analysis/{analysisLegacyId}/` |
-| `subtractionFileKey(storageId, filename)` | `subtractions/{storageId}/{filename}` |
-| `subtractionPrefix(storageId)` | `subtractions/{storageId}/` |
-| `indexFileKey(storageKey, filename)` | `indexes/{storageKey}/{filename}` |
-| `indexPrefix(storageKey)` | `indexes/{storageKey}/` |
+| `mintStorageKey(domain, parentId)` | `{domain}/{parentId}/{uuid}` |
+| `mintRootStorageKey(domain)` | `{domain}/{uuid}` |
 | `cacheKey(uuid)` | `caches/v1/{uuid}` |
 | `HMM_PROFILES_KEY` | `hmm/profiles.hmm` |
 | `HMM_ANNOTATIONS_KEY` | `hmm/annotations.json.gz` |
 
-Two subtleties are load-bearing:
+The `{parentId}` segment groups an owning resource's objects for human
+inspection and means nothing to any read path. Uploads have no owning resource —
+they are the resource — so they use `mintRootStorageKey`, which also makes the
+key available before the row exists: the object is written first, and no
+database transaction is held open for the length of the upload stream.
 
-- **A sample's storage id is not always its primary key.** Use
-  `sampleStorageId(sampleId, legacyId)`, which returns the legacy Mongo id when
-  the sample has one and the integer primary key otherwise. A sample keeps one
-  prefix for life.
-- **Neither is a subtraction's.** `subtractionStorageId(subtractionId,
-  legacyId)` follows the same rule, and mirrors Python's
-  `_resolve_storage_id`. A subtraction is addressed by its integer id
-  everywhere else, so it is easy to reach for `String(id)` and silently orphan
-  every migrated subtraction's files.
-- **An index's prefix is neither.** It is the `indexes.storage_key` column,
-  persisted because it cannot be derived from the row id at all — a migrated
-  index keys on its old Mongo id and a natively-created one on a minted UUID.
-  Read the column; never pass the index id.
-- **Subtraction ids may contain spaces**, and Python substitutes underscores
-  when composing the key. `subtractionFileKey` and `subtractionPrefix` do the
-  same. Never build a subtraction key by hand.
+**Keys in the bucket are heterogeneous by design.** A migrated row keeps the
+Mongo slug or integer id it was written under; only rows created since get a
+UUID. Never infer a key's shape from another key.
 
-A cache's key is persisted on its row. Read it from there rather than
+A cache's key is persisted on its row too. Read it from there rather than
 recomputing it.
 
 ## Configuration

--- a/packages/data/src/analyses/data.test.ts
+++ b/packages/data/src/analyses/data.test.ts
@@ -699,7 +699,7 @@ describe("deleteAnalysis", () => {
 		).toHaveLength(1);
 	});
 
-	it("touches storage not at all for a Postgres-native analysis", async () => {
+	it("deletes the objects its file rows name", async () => {
 		const storage = new MemoryStorage();
 		const sampleId = await seedSample();
 
@@ -709,31 +709,35 @@ describe("deleteAnalysis", () => {
 			legacy_id: null,
 		});
 
-		// A Postgres-native analysis keeps its results in the `results` column and
-		// wrote nothing to storage. The first key is the prefix a delete that fell
-		// back to the row id instead of the legacy id would clear.
-		const keys = [
-			`samples/${sampleId}/analysis/${analysisId}/results.json`,
-			`samples/${sampleId}/analysis/other/results.json`,
-		];
+		await db.insert(analysisFiles).values([
+			{ analysis_id: analysisId, name: "a.fa", storage_key: "analyses/a" },
+			{ analysis_id: analysisId, name: "b.fa", storage_key: "analyses/b" },
+		]);
 
-		for (const key of keys) {
+		for (const key of ["analyses/a", "analyses/b", "analyses/other"]) {
 			await storage.write(key, oneChunk());
 		}
 
 		await deleteAnalysis(db, storage, testLogger, analysisId);
 
-		expect(await storedKeys(storage)).toEqual(new Set(keys));
+		expect(await storedKeys(storage)).toEqual(new Set(["analyses/other"]));
 	});
 
-	it("deletes a Mongo-migrated analysis's objects under its own prefix", async () => {
+	// A migrated analysis's result blobs were written before keys were recorded,
+	// so no row names them and nothing here can reach them. They are the orphan
+	// sweep's problem, not this delete's.
+	it("leaves a migrated analysis's unrecorded objects", async () => {
 		const storage = new MemoryStorage();
 		const sampleId = await seedSample({ legacy_id: "smpl" });
 
-		await storage.write("samples/smpl/analysis/abc/results.json", oneChunk());
-		await storage.write("samples/smpl/analysis/abc/nuvs.fa", oneChunk());
-		await storage.write("samples/smpl/analysis/other/results.json", oneChunk());
-		await storage.write("samples/smpl/reads_1.fq.gz", oneChunk());
+		const keys = [
+			"samples/smpl/analysis/abc/results.json",
+			"samples/smpl/analysis/abc/nuvs.fa",
+		];
+
+		for (const key of keys) {
+			await storage.write(key, oneChunk());
+		}
 
 		const analysisId = await seedAnalysis({
 			sample_id: sampleId,
@@ -743,12 +747,7 @@ describe("deleteAnalysis", () => {
 
 		await deleteAnalysis(db, storage, testLogger, analysisId);
 
-		expect(await storedKeys(storage)).toEqual(
-			new Set([
-				"samples/smpl/analysis/other/results.json",
-				"samples/smpl/reads_1.fq.gz",
-			]),
-		);
+		expect(await storedKeys(storage)).toEqual(new Set(keys));
 	});
 });
 

--- a/packages/data/src/analyses/data.ts
+++ b/packages/data/src/analyses/data.ts
@@ -11,12 +11,7 @@ import type {
 	UserNested,
 } from "@virtool/contracts";
 import type { Logger } from "@virtool/logger";
-import {
-	analysisPrefix,
-	deletePrefix,
-	type StorageBackend,
-	sampleStorageId,
-} from "@virtool/storage";
+import { deleteKeys, type StorageBackend } from "@virtool/storage";
 import { and, asc, count, desc, eq, inArray, type SQL } from "drizzle-orm";
 import type { Db, DbOrTx } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
@@ -34,7 +29,11 @@ import { users } from "../db/schema/users";
 import { AppError } from "../errors";
 import { emit } from "../events/emit";
 import { createJob, getJobs } from "../jobs/data";
-import { type SampleActor, sampleReadableFilter } from "../samples/data";
+import {
+	type SampleActor,
+	sampleReadableFilter,
+	sampleStorageId,
+} from "../samples/data";
 import { formatAnalysis } from "./format";
 
 /** Filters and pagination accepted by {@link findAnalyses}. */
@@ -630,9 +629,7 @@ export async function deleteAnalysis(
 	const [row] = await db
 		.select({
 			id: analyses.id,
-			legacy_id: analyses.legacy_id,
 			ready: analyses.ready,
-			sample: analyses.sample,
 			sample_id: analyses.sample_id,
 		})
 		.from(analyses)
@@ -650,6 +647,12 @@ export async function deleteAnalysis(
 	// Capture the full analysis for the return value before its rows are removed.
 	const analysis = await getAnalysis(db, analysisId);
 
+	// Read before the delete: `analysis_files` cascades on `analyses.id`.
+	const fileRows = await db
+		.select({ key: analysisFiles.storage_key })
+		.from(analysisFiles)
+		.where(eq(analysisFiles.analysis_id, analysisId));
+
 	const deleted = await db
 		.delete(analyses)
 		.where(eq(analyses.id, analysisId))
@@ -659,19 +662,17 @@ export async function deleteAnalysis(
 		throw new AnalysisNotFoundError();
 	}
 
-	// Only analyses migrated from Mongo have a legacy id and slug-prefixed objects
-	// to clean up. Postgres-native analyses keep their results in the `results`
-	// column and wrote nothing to storage.
-	if (row.legacy_id !== null) {
-		for (const failure of await deletePrefix(
-			storage,
-			analysisPrefix(row.sample, row.legacy_id),
-		)) {
-			logger.error(
-				{ analysisId, key: failure.key, err: failure.error },
-				"storage cleanup failed; file orphaned",
-			);
-		}
+	// Only objects a row named are removed. A migrated analysis's result blobs
+	// have no row and are left for the orphan sweep.
+	const storageKeys = fileRows
+		.map(({ key }) => key)
+		.filter((key) => key !== null);
+
+	for (const failure of await deleteKeys(storage, storageKeys)) {
+		logger.error(
+			{ analysisId, key: failure.key, err: failure.error },
+			"storage cleanup failed; file orphaned",
+		);
 	}
 
 	await emit("analyses", analysisId, "delete");

--- a/packages/data/src/db/schema/analyses.ts
+++ b/packages/data/src/db/schema/analyses.ts
@@ -60,6 +60,10 @@ export const analysisFiles = pgTable("analysis_files", {
 	name: text("name"),
 	name_on_disk: text("name_on_disk").unique(),
 	size: bigint("size", { mode: "number" }),
+	// The file's complete object-storage key. Nullable because it was backfilled
+	// from `name_on_disk`, which is itself nullable: a row without one names no
+	// retrievable object.
+	storage_key: text("storage_key").unique(),
 	uploaded_at: timestamp("uploaded_at"),
 });
 

--- a/packages/data/src/db/schema/indexes.ts
+++ b/packages/data/src/db/schema/indexes.ts
@@ -30,10 +30,17 @@ export const indexes = pgTable("indexes", {
 	ready: boolean("ready")
 		.$defaultFn(() => false)
 		.notNull(),
-	// The object-storage prefix the build's files live under. A migrated index
-	// keys on its Mongo id and a natively-created one on a minted UUID, so this
-	// cannot be derived from `id` and must be persisted.
+	// Dead. Keys were once composed as `indexes/{storage_key}/{file name}`; each
+	// file now records its own complete key. Python retains the column until a
+	// later cleanup revision so a rolling deploy never has readers of a dropped
+	// column, and still requires it on insert.
 	storage_key: text("storage_key").unique().notNull(),
+	// The exception to files recording their own keys. The compressed OTU JSON is
+	// materialized on demand and deliberately has no `index_files` row, because
+	// such a row would publish it in the index's file listing. Nullable: an index
+	// that has never been asked for its OTU JSON has not written one, and the key
+	// is minted on first write.
+	otus_json_storage_key: text("otus_json_storage_key").unique(),
 	reference_id: bigint("reference_id", { mode: "number" }).notNull(),
 	user_id: integer("user_id").notNull(),
 	// A build is backed by at most one of these: `job_id` for a legacy
@@ -51,6 +58,9 @@ export const indexFiles = pgTable("index_files", {
 	index_id: bigint("index_id", { mode: "number" }).notNull(),
 	type: indexType("type"),
 	size: bigint("size", { mode: "number" }),
+	// The file's complete object-storage key, superseding the per-index
+	// `indexes.storage_key` slug keys were previously composed from.
+	storage_key: text("storage_key").unique().notNull(),
 });
 
 /** A row from the `indexes` table. */

--- a/packages/data/src/db/schema/samples.ts
+++ b/packages/data/src/db/schema/samples.ts
@@ -100,6 +100,10 @@ export const sampleArtifacts = pgTable("sample_artifacts", {
 	name: text("name").notNull(),
 	name_on_disk: text("name_on_disk"),
 	size: bigint("size", { mode: "number" }),
+	// The artifact's complete object-storage key. Nullable because it was
+	// backfilled from `name_on_disk`, which is itself nullable: a row without one
+	// names no retrievable object.
+	storage_key: text("storage_key").unique(),
 	type: text("type").notNull(),
 	uploaded_at: timestamp("uploaded_at"),
 });
@@ -112,6 +116,8 @@ export const sampleReads = pgTable("sample_reads", {
 	name: text("name").notNull(),
 	name_on_disk: text("name_on_disk").notNull(),
 	size: bigint("size", { mode: "number" }),
+	// The reads file's complete object-storage key.
+	storage_key: text("storage_key").unique().notNull(),
 	upload: integer("upload"),
 	uploaded_at: timestamp("uploaded_at"),
 });

--- a/packages/data/src/db/schema/subtractions.ts
+++ b/packages/data/src/db/schema/subtractions.ts
@@ -4,8 +4,8 @@
 // `../../../../../../virtool/virtool/subtractions/pg.py`.
 //
 // `legacy_id` (the Mongo `_id`) is null for Postgres-native subtractions. Every
-// endpoint addresses a subtraction by its integer id, but its files live under
-// the legacy id when it has one — see `subtractionStorageId`.
+// endpoint addresses a subtraction by its integer id. Nothing derives a storage
+// key from either: each file records its own in `subtraction_files.storage_key`.
 
 import {
 	bigint,
@@ -60,6 +60,10 @@ export const subtractionFiles = pgTable("subtraction_files", {
 	// Files routinely exceed 2 GiB, past the range of a 32-bit integer, so this
 	// mirrors Python's BigInteger. `mode: "number"` is safe up to 2^53.
 	size: bigint("size", { mode: "number" }),
+	// The file's complete object-storage key. Nullable because it was backfilled
+	// from `name`, which is itself nullable: a row without one names no
+	// retrievable object.
+	storage_key: text("storage_key").unique(),
 });
 
 /** A row from the `subtractions` table. */

--- a/packages/data/src/db/schema/uploads.ts
+++ b/packages/data/src/db/schema/uploads.ts
@@ -30,6 +30,10 @@ export const uploads = pgTable("uploads", {
 	// Read sizes routinely exceed 2 GiB, past the range of a 32-bit integer, so
 	// this mirrors Python's BigInteger. `mode: "number"` is safe up to 2^53.
 	size: bigint("size", { mode: "number" }),
+	// The upload's complete object-storage key. Nullable because it was
+	// backfilled from `name_on_disk`, which is itself nullable: a row without one
+	// names no retrievable object.
+	storageKey: text("storage_key").unique(),
 	type: text("type"),
 	uploadedAt: timestamp("uploaded_at"),
 	userId: integer("user_id")

--- a/packages/data/src/indexes/data.test.ts
+++ b/packages/data/src/indexes/data.test.ts
@@ -251,6 +251,7 @@ describe("getIndex", () => {
 			index_id: indexId,
 			name: "reference.fa.gz",
 			size: 2048,
+			storage_key: `indexes/${indexId}/reference`,
 			type: "fasta",
 		});
 

--- a/packages/data/src/indexes/data.ts
+++ b/packages/data/src/indexes/data.ts
@@ -15,7 +15,6 @@ import type {
 	IndexOtu,
 	IndexSearchResult,
 } from "@virtool/contracts";
-import { indexFileKey } from "@virtool/storage";
 import {
 	and,
 	asc,
@@ -432,8 +431,9 @@ export async function getIndexReferenceId(
  * The storage key of one of a build's files, or `null` when the build has no
  * such file.
  *
- * The key is composed from the row's own `name`, never the caller's, so a
- * filename carrying path segments cannot traverse out of the index's prefix.
+ * The key is read off the row the name matched, never composed from the
+ * caller's input. The `INDEX_FILE_NAMES` guard is kept as a cheap rejection of
+ * anything a build never produces.
  */
 export async function getIndexFileKey(
 	db: DbOrTx,
@@ -445,17 +445,12 @@ export async function getIndexFileKey(
 	}
 
 	const [row] = await db
-		.select({ name: indexFiles.name, storageKey: indexes.storage_key })
+		.select({ storageKey: indexFiles.storage_key })
 		.from(indexFiles)
-		.innerJoin(indexes, eq(indexes.id, indexFiles.index_id))
 		.where(and(eq(indexFiles.index_id, indexId), eq(indexFiles.name, filename)))
 		.limit(1);
 
-	if (!row) {
-		return null;
-	}
-
-	return indexFileKey(row.storageKey, row.name);
+	return row?.storageKey ?? null;
 }
 
 // Whether the reference has a build that has not finished.
@@ -588,9 +583,9 @@ export async function createIndex(
 					// Filled in below, once this build owns its changes.
 					manifest: {},
 					ready: false,
-					// The storage prefix the build's files land under. Python mints a
-					// UUID here rather than deriving it from the id, because a migrated
-					// index keys on its old Mongo id instead.
+					// Dead, but still `NOT NULL` until Python's cleanup revision drops
+					// it. Each of the build's files records its own complete key; this
+					// is no longer a prefix anything is composed from.
 					storage_key: randomUUID().replaceAll("-", ""),
 					reference_id: referenceId,
 					user_id: userId,

--- a/packages/data/src/samples/data.test.ts
+++ b/packages/data/src/samples/data.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { seedUser } from "../auth/test/fixtures";
 import type { Db } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
-import { analyses } from "../db/schema/analyses";
+import { analyses, analysisFiles } from "../db/schema/analyses";
 import { groups, userGroups } from "../db/schema/groups";
 import { jobs } from "../db/schema/jobs";
 import { labels } from "../db/schema/labels";
@@ -410,12 +410,14 @@ describe("getSample", () => {
 				sample_id: sampleId,
 				name: "reads_1.fq.gz",
 				name_on_disk: "reads_1.fq.gz",
+				storage_key: `samples/${sampleId}/reads_1`,
 			},
 			{
 				sample: String(sampleId),
 				sample_id: sampleId,
 				name: "reads_2.fq.gz",
 				name_on_disk: "reads_2.fq.gz",
+				storage_key: `samples/${sampleId}/reads_2`,
 			},
 		]);
 
@@ -440,6 +442,8 @@ describe("getSample", () => {
 			sample_id: null,
 			name: "reads_1.fq.gz",
 			name_on_disk: "reads_1.fq.gz",
+			// Backfilled with the key the row's object already lived under.
+			storage_key: "samples/abc123/reads_1.fq.gz",
 		});
 		await db.insert(sampleArtifacts).values({
 			sample: "abc123",
@@ -664,12 +668,14 @@ describe("deleteSample", () => {
 			sample_id: sampleId,
 			name: "reads_1.fq.gz",
 			name_on_disk: "reads_1.fq.gz",
+			storage_key: `samples/${sampleId}/reads_1`,
 		});
 		await db.insert(sampleArtifacts).values({
 			sample: String(sampleId),
 			sample_id: sampleId,
 			name: "a.json",
 			type: "json",
+			storage_key: `samples/${sampleId}/artifact`,
 		});
 		await seedAnalysis({ sample_id: sampleId, workflow: "nuvs", ready: true });
 
@@ -714,6 +720,65 @@ describe("deleteSample", () => {
 			.from(uploads)
 			.where(eq(uploads.id, uploadId));
 		expect(upload?.reserved).toBe(false);
+	});
+
+	// Analysis files are reached through the sample's analyses, whose rows go in
+	// the same transaction, so their keys have to be collected before the delete
+	// or nothing is left to name them.
+	it("deletes the objects its rows name, analysis files included", async () => {
+		const storage = new MemoryStorage();
+		const sampleId = await seedSample({ name: "Doomed" });
+
+		await db.insert(sampleReads).values({
+			sample: String(sampleId),
+			sample_id: sampleId,
+			name: "reads_1.fq.gz",
+			name_on_disk: "reads_1.fq.gz",
+			storage_key: "samples/reads",
+		});
+		await db.insert(sampleArtifacts).values({
+			sample: String(sampleId),
+			sample_id: sampleId,
+			name: "a.json",
+			type: "json",
+			storage_key: "samples/artifact",
+		});
+
+		const analysisId = await seedAnalysis({
+			sample_id: sampleId,
+			workflow: "nuvs",
+			ready: true,
+		});
+
+		await db.insert(analysisFiles).values({
+			analysis_id: analysisId,
+			name: "nuvs.fa",
+			storage_key: "analyses/nuvs",
+		});
+
+		for (const key of [
+			"samples/reads",
+			"samples/artifact",
+			"analyses/nuvs",
+			"samples/unrecorded",
+		]) {
+			await storage.write(
+				key,
+				(async function* () {
+					yield new TextEncoder().encode("x");
+				})(),
+			);
+		}
+
+		await deleteSample(db, storage, testLogger, sampleId);
+
+		const remaining = [];
+		for await (const object of storage.list("")) {
+			remaining.push(object.key);
+		}
+
+		// Only the object no row named survives.
+		expect(remaining).toEqual(["samples/unrecorded"]);
 	});
 
 	it("throws when the sample does not exist", async () => {

--- a/packages/data/src/samples/data.ts
+++ b/packages/data/src/samples/data.ts
@@ -19,13 +19,7 @@ import type {
 } from "@virtool/contracts";
 import { AnalysisWorkflow } from "@virtool/contracts";
 import type { Logger } from "@virtool/logger";
-import {
-	deletePrefix,
-	type StorageBackend,
-	sampleFileKey,
-	samplePrefix,
-	sampleStorageId,
-} from "@virtool/storage";
+import { deleteKeys, type StorageBackend } from "@virtool/storage";
 import {
 	and,
 	asc,
@@ -42,7 +36,7 @@ import {
 } from "drizzle-orm";
 import type { Db, DbOrTx } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
-import { analyses } from "../db/schema/analyses";
+import { analyses, analysisFiles } from "../db/schema/analyses";
 import { groups, userGroups } from "../db/schema/groups";
 import { labels } from "../db/schema/labels";
 import {
@@ -123,6 +117,22 @@ export class SampleFileDuplicateError extends AppError {}
  * outcome — reading one surfaces it rather than degrading to a blank owner.
  */
 export class SampleOwnerlessError extends AppError {}
+
+/**
+ * The value a sample's child rows carry in their legacy `sample` text column:
+ * the Mongo `_id` for anything migrated out of Mongo, the integer primary key
+ * for everything since.
+ *
+ * This is row matching, not a storage key. `sample_id` is nullable on rows old
+ * enough to predate it, so a query for a sample's artifacts, reads or uploads
+ * has to accept either column.
+ */
+export function sampleStorageId(
+	sampleId: number,
+	legacyId: string | null,
+): string {
+	return legacyId || String(sampleId);
+}
 
 const WORKFLOW_CONDITIONS = ["none", "pending", "ready"] as const;
 
@@ -789,16 +799,9 @@ export async function checkSampleRight(
  * The storage key of one of a sample's read files, or `null` when the sample
  * has no read by that name.
  *
- * The row is matched on `name`, which is what the URL carries, but the key is
- * composed from `name_on_disk`, which is what the object was written under.
- * `upload_reads` sets the two from the same argument, so they agree on every
- * row today; keying on the column that means "the name on disk" is what keeps
- * that an implementation detail rather than a load-bearing assumption.
- *
- * Neither comes from the caller, so a filename carrying path segments cannot
- * traverse out of the sample's prefix. `sample` is the prefix the file was
- * written under, which for a Mongo-migrated sample is its legacy id rather than
- * its integer one.
+ * The row is matched on `name`, which is what the URL carries, and the key is
+ * then read off that row. Nothing is composed from the caller's input, so a
+ * filename carrying path segments names no object.
  */
 export async function getSampleReadsFileKey(
 	db: DbOrTx,
@@ -818,10 +821,7 @@ export async function getSampleReadsFileKey(
 	const storageId = sampleStorageId(sampleId, sample.legacy_id);
 
 	const [read] = await db
-		.select({
-			nameOnDisk: sampleReads.name_on_disk,
-			sample: sampleReads.sample,
-		})
+		.select({ storageKey: sampleReads.storage_key })
 		.from(sampleReads)
 		.where(
 			and(
@@ -834,11 +834,7 @@ export async function getSampleReadsFileKey(
 		)
 		.limit(1);
 
-	if (!read) {
-		return null;
-	}
-
-	return sampleFileKey(read.sample, read.nameOnDisk);
+	return read?.storageKey ?? null;
 }
 
 async function checkNameInUse(
@@ -1240,7 +1236,41 @@ export async function deleteSample(
 	// The FK cascade only covers two of these relationships, so every table is
 	// deleted explicitly. Rows may be keyed by the integer id or the legacy
 	// storage string depending on when the sample was created.
-	await db.transaction(async (tx) => {
+	const storageKeys = await db.transaction(async (tx) => {
+		// Every key has to be read before its row goes. Analysis files are reached
+		// through the sample's analyses, whose rows cascade them away, so they are
+		// collected here rather than by `deleteAnalysis`.
+		const keyRows = await Promise.all([
+			tx
+				.select({ key: sampleArtifacts.storage_key })
+				.from(sampleArtifacts)
+				.where(
+					or(
+						eq(sampleArtifacts.sample_id, sampleId),
+						eq(sampleArtifacts.sample, storageId),
+					),
+				),
+			tx
+				.select({ key: sampleReads.storage_key })
+				.from(sampleReads)
+				.where(
+					or(
+						eq(sampleReads.sample_id, sampleId),
+						eq(sampleReads.sample, storageId),
+					),
+				),
+			tx
+				.select({ key: analysisFiles.storage_key })
+				.from(analysisFiles)
+				.innerJoin(analyses, eq(analyses.id, analysisFiles.analysis_id))
+				.where(eq(analyses.sample_id, sampleId)),
+		]);
+
+		const keys = keyRows
+			.flat()
+			.map(({ key }) => key)
+			.filter((key) => key !== null);
+
 		if (uploadIds.length > 0) {
 			await tx
 				.update(uploads)
@@ -1282,9 +1312,14 @@ export async function deleteSample(
 		if (deleted.length === 0) {
 			throw new SampleNotFoundError();
 		}
+
+		return keys;
 	});
 
-	for (const failure of await deletePrefix(storage, samplePrefix(storageId))) {
+	// Only objects a row named are removed. Anything written before keys were
+	// recorded — a migrated analysis's result blobs, above all — is unreachable
+	// from here and is left for the orphan sweep.
+	for (const failure of await deleteKeys(storage, storageKeys)) {
 		logger.error(
 			{ sampleId, key: failure.key, err: failure.error },
 			"storage cleanup failed; file orphaned",

--- a/packages/data/src/subtraction/data.test.ts
+++ b/packages/data/src/subtraction/data.test.ts
@@ -219,6 +219,7 @@ describe("getSubtraction", () => {
 		await db.insert(subtractionFiles).values({
 			name: "subtraction.fa.gz",
 			subtraction_id: subtractionId,
+			storage_key: `subtractions/${subtractionId}/fasta`,
 			type: "fasta",
 			size: 100,
 		});
@@ -363,11 +364,19 @@ describe("deleteSubtraction", () => {
 		expect(await db.select().from(legacySampleSubtractions)).toHaveLength(0);
 	});
 
-	// A subtraction migrated out of Mongo keeps its legacy slug as its storage
-	// prefix, so cleaning up under the integer id would orphan every byte.
-	it("clears storage under a migrated subtraction's legacy prefix", async () => {
+	// Cleanup enumerates the keys the file rows record. A migrated subtraction's
+	// rows carry the legacy key they were backfilled with, which no longer bears
+	// any relation to the id the subtraction is addressed by.
+	it("deletes the objects its file rows name", async () => {
 		const storage = new MemoryStorage();
 		const subtractionId = await seedSubtraction({ legacy_id: "arabidopsis 1" });
+
+		await db.insert(subtractionFiles).values({
+			name: "subtraction.fa.gz",
+			subtraction_id: subtractionId,
+			storage_key: "subtractions/arabidopsis_1/subtraction.fa.gz",
+			type: "fasta",
+		});
 
 		await storage.write(
 			"subtractions/arabidopsis_1/subtraction.fa.gz",
@@ -383,6 +392,30 @@ describe("deleteSubtraction", () => {
 			remaining.push(object.key);
 		}
 		expect(remaining).toEqual([]);
+	});
+
+	// Objects written before keys were recorded are not named by any row, so
+	// nothing can reach them here. They are the orphan sweep's problem.
+	it("leaves an object no file row names", async () => {
+		const storage = new MemoryStorage();
+		const subtractionId = await seedSubtraction();
+
+		await storage.write(
+			`subtractions/${subtractionId}/subtraction.fa.gz`,
+			(async function* () {
+				yield new TextEncoder().encode("hello");
+			})(),
+		);
+
+		await deleteSubtraction(db, storage, testLogger, subtractionId);
+
+		const remaining = [];
+		for await (const object of storage.list("subtractions/")) {
+			remaining.push(object.key);
+		}
+		expect(remaining).toEqual([
+			`subtractions/${subtractionId}/subtraction.fa.gz`,
+		]);
 	});
 
 	it("throws when the subtraction is already deleted", async () => {

--- a/packages/data/src/subtraction/data.ts
+++ b/packages/data/src/subtraction/data.ts
@@ -12,12 +12,7 @@ import type {
 } from "@virtool/contracts";
 import type { Logger } from "@virtool/logger";
 import type { StorageBackend } from "@virtool/storage";
-import {
-	deletePrefix,
-	subtractionFileKey,
-	subtractionPrefix,
-	subtractionStorageId,
-} from "@virtool/storage";
+import { deleteKeys } from "@virtool/storage";
 import { and, asc, count, eq, ilike, or } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import type { Db, DbOrTx } from "../db/pg";
@@ -296,23 +291,20 @@ export async function getSubtraction(
 	};
 }
 
-// A subtraction's files live under the prefix its storage id names, which is
-// the legacy Mongo id for anything migrated out of Mongo and the integer
-// primary key for everything created since. Mirrors Python's
-// `_resolve_storage_id`.
-async function resolveSubtractionStorageId(
+// Whether a live subtraction has this id. Mirrors Python's `_check_exists`.
+async function checkSubtractionExists(
 	db: DbOrTx,
 	subtractionId: number,
-): Promise<string | null> {
+): Promise<boolean> {
 	const [row] = await db
-		.select({ id: subtractions.id, legacy_id: subtractions.legacy_id })
+		.select({ id: subtractions.id })
 		.from(subtractions)
 		.where(
 			and(eq(subtractions.id, subtractionId), eq(subtractions.deleted, false)),
 		)
 		.limit(1);
 
-	return row ? subtractionStorageId(row.id, row.legacy_id) : null;
+	return row !== undefined;
 }
 
 /**
@@ -320,8 +312,9 @@ async function resolveSubtractionStorageId(
  * under.
  *
  * Returns null when the subtraction, or a file of that name on it, does not
- * exist. The key is composed only from a name that matched a row, so a filename
- * taken from a URL can never traverse out of the subtraction's prefix.
+ * exist, or when the file predates keys being recorded. The key is read off the
+ * matched row rather than composed, so a filename taken from a URL names no
+ * object.
  *
  * The row's `size` is deliberately not returned. It is nullable, and it records
  * what the create job wrote rather than what the bucket currently holds — a
@@ -332,10 +325,10 @@ export async function getSubtractionFileKey(
 	subtractionId: number,
 	filename: string,
 ): Promise<string | null> {
-	const [storageId, [file]] = await Promise.all([
-		resolveSubtractionStorageId(db, subtractionId),
+	const [exists, [file]] = await Promise.all([
+		checkSubtractionExists(db, subtractionId),
 		db
-			.select({ name: subtractionFiles.name })
+			.select({ storageKey: subtractionFiles.storage_key })
 			.from(subtractionFiles)
 			.where(
 				and(
@@ -346,11 +339,11 @@ export async function getSubtractionFileKey(
 			.limit(1),
 	]);
 
-	if (storageId === null || !file?.name) {
+	if (!exists) {
 		return null;
 	}
 
-	return subtractionFileKey(storageId, file.name);
+	return file?.storageKey ?? null;
 }
 
 export async function createSubtraction(
@@ -432,14 +425,17 @@ export async function deleteSubtraction(
 	logger: Logger,
 	subtractionId: number,
 ): Promise<void> {
-	const storageId = await db.transaction(async (tx) => {
-		// Doubles as the existence check: the resolver filters out deleted rows and
-		// returns null when nothing matches.
-		const resolved = await resolveSubtractionStorageId(tx, subtractionId);
-
-		if (resolved === null) {
+	const storageKeys = await db.transaction(async (tx) => {
+		// The check filters out already-deleted rows, so this doubles as the
+		// existence check.
+		if (!(await checkSubtractionExists(tx, subtractionId))) {
 			return null;
 		}
+
+		const fileRows = await tx
+			.select({ key: subtractionFiles.storage_key })
+			.from(subtractionFiles)
+			.where(eq(subtractionFiles.subtraction_id, subtractionId));
 
 		// Soft delete: the row stays so historical analyses that reference it still
 		// resolve. Unlink it from any samples that held it as a default subtraction.
@@ -452,16 +448,18 @@ export async function deleteSubtraction(
 			.delete(legacySampleSubtractions)
 			.where(eq(legacySampleSubtractions.subtraction_id, subtractionId));
 
-		return resolved;
+		return fileRows.map(({ key }) => key).filter((key) => key !== null);
 	});
 
-	if (storageId === null) {
+	if (storageKeys === null) {
 		throw new SubtractionNotFoundError();
 	}
 
 	// The database write has committed, so a storage failure only orphans bytes
 	// rather than failing the delete. Log the orphans so they stay observable.
-	const failures = await deletePrefix(storage, subtractionPrefix(storageId));
+	// Only objects a file row names are removed; anything written before keys
+	// were recorded is left for the orphan sweep.
+	const failures = await deleteKeys(storage, storageKeys);
 
 	for (const failure of failures) {
 		logger.warn(

--- a/packages/data/src/uploads/data.test.ts
+++ b/packages/data/src/uploads/data.test.ts
@@ -1,5 +1,5 @@
 import type { UploadType } from "@virtool/contracts";
-import { MemoryStorage, uploadFileKey } from "@virtool/storage";
+import { MemoryStorage } from "@virtool/storage";
 import { eq } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { seedUser } from "../auth/test/fixtures";
@@ -53,6 +53,7 @@ async function seedUpload(
 			removed: false,
 			reserved: false,
 			size: 10,
+			storageKey: `uploads/${Math.random()}`,
 			type: "reads",
 			uploadedAt: new Date(),
 			userId,
@@ -90,7 +91,8 @@ describe("createUpload", () => {
 			.where(eq(uploadsTable.id, upload.id));
 
 		expect(row?.ready).toBe(true);
-		expect(await storage.size(uploadFileKey(row?.nameOnDisk ?? ""))).toBe(5);
+		expect(row?.storageKey).toMatch(/^uploads\/[0-9a-f]{32}$/);
+		expect(await storage.size(row?.storageKey ?? "")).toBe(5);
 	});
 
 	it("never exposes name_on_disk", async () => {
@@ -173,7 +175,7 @@ describe("deleteUpload", () => {
 			.select()
 			.from(uploadsTable)
 			.where(eq(uploadsTable.id, upload.id));
-		const key = uploadFileKey(before?.nameOnDisk ?? "");
+		const key = before?.storageKey ?? "";
 
 		await deleteUpload(db, storage, testLogger, upload.id);
 

--- a/packages/data/src/uploads/data.ts
+++ b/packages/data/src/uploads/data.ts
@@ -6,7 +6,7 @@ import type {
 } from "@virtool/contracts";
 import type { Logger } from "@virtool/logger";
 import type { StorageBackend } from "@virtool/storage";
-import { uploadFileKey } from "@virtool/storage";
+import { mintRootStorageKey } from "@virtool/storage";
 import { and, count, desc, eq, inArray } from "drizzle-orm";
 import type { DbOrTx } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
@@ -126,7 +126,12 @@ export async function createUpload(
 	const now = new Date();
 	const nameOnDisk = `${crypto.randomUUID()}-${values.name}`;
 
-	const size = await storage.write(uploadFileKey(nameOnDisk), values.body);
+	// Minted before the write, so the bytes land under a key the row then records
+	// verbatim. `name_on_disk` no longer locates anything; Python still reads it
+	// to identify the upload a reference-import task was queued against.
+	const storageKey = mintRootStorageKey("uploads");
+
+	const size = await storage.write(storageKey, values.body);
 
 	const row = takeFirstOrThrow(
 		await db
@@ -139,6 +144,7 @@ export async function createUpload(
 				removed: false,
 				reserved: false,
 				size,
+				storageKey,
 				type: values.type,
 				uploadedAt: now,
 				userId: values.userId,
@@ -161,10 +167,9 @@ export type UploadFile = {
  * Resolve an upload to the storage key holding its bytes and the name it was
  * uploaded under, or `null` if there is nothing to download.
  *
- * `name_on_disk` is what the object is keyed by — a UUID-prefixed name that
- * keeps two uploads of `reads.fq.gz` apart — while `name` is what the user
- * chose and what the download is named. Both columns are nullable at the
- * database level, so a row missing either has no downloadable file.
+ * `storage_key` locates the object and `name` is what the user chose and what
+ * the download is named. Both columns are nullable at the database level, so a
+ * row missing either has no downloadable file.
  *
  * A removed upload is excluded, matching Python. `ready` is deliberately not
  * filtered on: Python does not either, and an upload created from this side is
@@ -175,16 +180,16 @@ export async function getUploadFile(
 	uploadId: number,
 ): Promise<UploadFile | null> {
 	const [row] = await db
-		.select({ name: uploadsTable.name, nameOnDisk: uploadsTable.nameOnDisk })
+		.select({ name: uploadsTable.name, storageKey: uploadsTable.storageKey })
 		.from(uploadsTable)
 		.where(and(eq(uploadsTable.id, uploadId), eq(uploadsTable.removed, false)))
 		.limit(1);
 
-	if (!row?.name || !row.nameOnDisk) {
+	if (!row?.name || !row.storageKey) {
 		return null;
 	}
 
-	return { key: uploadFileKey(row.nameOnDisk), name: row.name };
+	return { key: row.storageKey, name: row.name };
 }
 
 /**
@@ -267,13 +272,13 @@ export async function deleteUpload(
 		.set({ removed: true, removedAt: new Date() })
 		.where(eq(uploadsTable.id, uploadId));
 
-	// `name_on_disk` is nullable at the database level. A row that somehow lacks
-	// one has no bytes we can locate, so skip the storage delete rather than
-	// deleting the empty `files/` key, which could point at an unintended object.
-	if (row.nameOnDisk) {
-		await storage.delete(uploadFileKey(row.nameOnDisk));
+	// `storage_key` is nullable at the database level. A row that lacks one names
+	// no object we can locate — it predates keys being recorded — so leave its
+	// bytes to the orphan sweep rather than guessing at a key.
+	if (row.storageKey) {
+		await storage.delete(row.storageKey);
 	} else {
-		logger.warn({ uploadId }, "removed upload has no name_on_disk to delete");
+		logger.warn({ uploadId }, "removed upload has no storage_key to delete");
 	}
 
 	await emit("uploads", uploadId, "delete");

--- a/packages/storage/src/cleanup.test.ts
+++ b/packages/storage/src/cleanup.test.ts
@@ -1,17 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { deletePrefix } from "./cleanup";
+import { deleteKeys } from "./cleanup";
 import { MemoryStorage } from "./memory";
 import { failingStorage, listAll, streamOf } from "./test/fixtures";
 
-describe("deletePrefix", () => {
-	it("deletes every object under the prefix and leaves the rest", async () => {
+describe("deleteKeys", () => {
+	it("deletes every named object and leaves the rest", async () => {
 		const storage = new MemoryStorage();
 
 		await storage.write("samples/1/reads.fq", streamOf("aaa"));
 		await storage.write("samples/1/quality.json", streamOf("bb"));
 		await storage.write("samples/2/reads.fq", streamOf("c"));
 
-		expect(await deletePrefix(storage, "samples/1/")).toEqual([]);
+		expect(
+			await deleteKeys(storage, [
+				"samples/1/reads.fq",
+				"samples/1/quality.json",
+			]),
+		).toEqual([]);
 
 		const remaining = await listAll(storage, "samples/");
 
@@ -20,10 +25,10 @@ describe("deletePrefix", () => {
 		]);
 	});
 
-	it("is idempotent when the prefix holds nothing", async () => {
+	it("is idempotent when there are no keys", async () => {
 		const storage = new MemoryStorage();
 
-		expect(await deletePrefix(storage, "samples/1/")).toEqual([]);
+		expect(await deleteKeys(storage, [])).toEqual([]);
 	});
 
 	it("reports the failures instead of throwing", async () => {
@@ -34,28 +39,19 @@ describe("deletePrefix", () => {
 
 		const error = new Error("delete failed");
 
-		const failures = await deletePrefix(
+		const failures = await deleteKeys(
 			failingStorage({
-				list: storage.list.bind(storage),
 				delete: (key: string) =>
 					key.endsWith("reads.fq")
 						? Promise.reject(error)
 						: storage.delete(key),
 			}),
-			"samples/1/",
+			["samples/1/reads.fq", "samples/1/quality.json"],
 		);
 
 		expect(failures).toEqual([{ key: "samples/1/reads.fq", error }]);
 
 		// The failure of one delete must not abandon the others.
 		expect(await listAll(storage, "samples/1/")).toHaveLength(1);
-	});
-
-	it("reports the prefix itself when the listing fails", async () => {
-		const failures = await deletePrefix(failingStorage(), "samples/1/");
-
-		expect(failures).toEqual([
-			{ key: "samples/1/", error: new Error("list failed") },
-		]);
 	});
 });

--- a/packages/storage/src/cleanup.ts
+++ b/packages/storage/src/cleanup.ts
@@ -7,7 +7,7 @@ export type DeleteFailure = {
 };
 
 /**
- * Best-effort delete of every object under `prefix`.
+ * Best-effort delete of every object named by `keys`.
  *
  * Never throws. Callers reach this having already committed the database write
  * that orphaned these objects, so propagating one failure would abandon the
@@ -15,25 +15,17 @@ export type DeleteFailure = {
  * Failures come back instead, and callers are expected to log them so the
  * orphans stay observable.
  *
- * If the listing itself fails, no per-object keys are known, so the prefix is
- * reported in place of a key.
+ * Callers pass the keys recorded on the rows they are deleting, which must be
+ * read before those rows go, so only objects a row names are removed. Objects
+ * written before keys were recorded are unreachable this way and are left for a
+ * separate sweep.
  */
-export async function deletePrefix(
+export async function deleteKeys(
 	storage: StorageBackend,
-	prefix: string,
+	keys: Iterable<string>,
 ): Promise<DeleteFailure[]> {
-	const keys: string[] = [];
-
-	try {
-		for await (const object of storage.list(prefix)) {
-			keys.push(object.key);
-		}
-	} catch (error) {
-		return [{ key: prefix, error }];
-	}
-
 	const results = await Promise.all(
-		keys.map(async (key) => {
+		[...keys].map(async (key) => {
 			try {
 				await storage.delete(key);
 				return null;

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,4 +1,4 @@
-export { type DeleteFailure, deletePrefix } from "./cleanup";
+export { type DeleteFailure, deleteKeys } from "./cleanup";
 export type { StorageConfig } from "./config";
 export { StorageError, StorageKeyNotFoundError } from "./errors";
 export { createStorageBackend } from "./factory";

--- a/packages/storage/src/integration.test.ts
+++ b/packages/storage/src/integration.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { deletePrefix } from "./cleanup";
+import { deleteKeys } from "./cleanup";
 import type { StorageConfig } from "./config";
 import { StorageKeyNotFoundError } from "./errors";
 import { createStorageBackend } from "./factory";
@@ -49,6 +49,20 @@ function testPrefix(name: string): string {
 	return `test/${worker}/${name.replaceAll(/[^a-zA-Z0-9]+/g, "_")}/`;
 }
 
+// Sweeping a prefix is a test affordance only. No production path does it: rows
+// record their keys, and cleanup enumerates those.
+async function clearPrefix(
+	storage: StorageBackend,
+	prefix: string,
+): Promise<void> {
+	const objects = await listAll(storage, prefix);
+
+	await deleteKeys(
+		storage,
+		objects.map((object) => object.key),
+	);
+}
+
 describe.each(BACKENDS)("$name storage", ({ config }) => {
 	let storage: StorageBackend;
 	let prefix: string;
@@ -57,10 +71,10 @@ describe.each(BACKENDS)("$name storage", ({ config }) => {
 		storage = createStorageBackend(config);
 		prefix = testPrefix(ctx.task.name);
 
-		await deletePrefix(storage, prefix);
+		await clearPrefix(storage, prefix);
 
 		return async () => {
-			await deletePrefix(storage, prefix);
+			await clearPrefix(storage, prefix);
 		};
 	});
 

--- a/packages/storage/src/keys.test.ts
+++ b/packages/storage/src/keys.test.ts
@@ -1,50 +1,25 @@
 import { describe, expect, it } from "vitest";
 import {
-	analysisFileKey,
 	cacheKey,
 	HMM_ANNOTATIONS_KEY,
 	HMM_PROFILES_KEY,
-	indexFileKey,
-	indexPrefix,
-	sampleFileKey,
-	samplePrefix,
-	sampleStorageId,
-	subtractionFileKey,
-	subtractionPrefix,
-	uploadFileKey,
+	mintRootStorageKey,
+	mintStorageKey,
 } from "./keys";
 
 describe("storage keys", () => {
-	it("composes upload and analysis keys", () => {
-		expect(uploadFileKey("1-reads.fq.gz")).toBe("files/1-reads.fq.gz");
-		expect(analysisFileKey("nuvs.json")).toBe("analyses/nuvs.json");
+	it("mints a key under its parent", () => {
+		expect(mintStorageKey("samples", 7)).toMatch(/^samples\/7\/[0-9a-f]{32}$/);
 	});
 
-	it("composes sample keys and prefixes", () => {
-		expect(sampleFileKey("abc123", "reads_1.fq.gz")).toBe(
-			"samples/abc123/reads_1.fq.gz",
-		);
-		expect(samplePrefix("abc123")).toBe("samples/abc123/");
+	it("mints a key with no parent segment", () => {
+		expect(mintRootStorageKey("uploads")).toMatch(/^uploads\/[0-9a-f]{32}$/);
 	});
 
-	it("keeps the legacy id as a sample's storage id when it has one", () => {
-		expect(sampleStorageId(7, "abc123")).toBe("abc123");
-		expect(sampleStorageId(7, null)).toBe("7");
-	});
-
-	it("composes index keys and prefixes", () => {
-		expect(indexFileKey("idx1", "otus.json.gz")).toBe(
-			"indexes/idx1/otus.json.gz",
-		);
-		expect(indexPrefix("idx1")).toBe("indexes/idx1/");
-	});
-
-	it("substitutes underscores for spaces in subtraction ids", () => {
-		expect(subtractionFileKey("Homo sapiens", "subtraction.fa.gz")).toBe(
-			"subtractions/Homo_sapiens/subtraction.fa.gz",
-		);
-		expect(subtractionPrefix("Homo sapiens")).toBe(
-			"subtractions/Homo_sapiens/",
+	it("mints a distinct key every time", () => {
+		expect(mintStorageKey("samples", 7)).not.toBe(mintStorageKey("samples", 7));
+		expect(mintRootStorageKey("uploads")).not.toBe(
+			mintRootStorageKey("uploads"),
 		);
 	});
 

--- a/packages/storage/src/keys.ts
+++ b/packages/storage/src/keys.ts
@@ -1,102 +1,50 @@
 /**
- * Storage keys, which must stay byte-for-byte identical to the ones Python
- * builds. Both processes read and write the same bucket, so a divergence here
- * does not fail loudly — it silently reads nothing and orphans what it writes.
- */
-
-/** Key for an uploaded file. */
-export function uploadFileKey(nameOnDisk: string): string {
-	return `files/${nameOnDisk}`;
-}
-
-/** Key for an analysis file. */
-export function analysisFileKey(nameOnDisk: string): string {
-	return `analyses/${nameOnDisk}`;
-}
-
-/**
- * The prefix segment a sample's files live under, fixed for the sample's life.
- * Mongo-migrated samples keep their legacy id; Postgres-native ones use the
- * integer primary key.
- */
-export function sampleStorageId(
-	sampleId: number,
-	legacyId: string | null,
-): string {
-	return legacyId || String(sampleId);
-}
-
-/** Key for a sample file. */
-export function sampleFileKey(storageId: string, filename: string): string {
-	return `samples/${storageId}/${filename}`;
-}
-
-/** Prefix holding every file for a sample. */
-export function samplePrefix(storageId: string): string {
-	return `samples/${storageId}/`;
-}
-
-/**
- * Prefix holding the stored result objects of a Mongo-migrated analysis, nested
- * under its parent sample. Only analyses migrated from Mongo have one:
- * Postgres-native analyses keep their results in the `results` column and write
- * nothing to storage.
- */
-export function analysisPrefix(
-	sampleStorageId: string,
-	analysisLegacyId: string,
-): string {
-	return `samples/${sampleStorageId}/analysis/${analysisLegacyId}/`;
-}
-
-// Subtraction ids may contain spaces. Python substitutes underscores when
-// composing the key, so the same subtraction resolves to the same key here.
-function normalizeSubtractionId(subtractionId: string): string {
-	return subtractionId.replaceAll(" ", "_");
-}
-
-/**
- * The prefix segment a subtraction's files live under, fixed for its life.
- * Mongo-migrated subtractions keep their legacy id; Postgres-native ones use
- * the integer primary key.
- */
-export function subtractionStorageId(
-	subtractionId: number,
-	legacyId: string | null,
-): string {
-	return legacyId || String(subtractionId);
-}
-
-/** Key for a subtraction file. */
-export function subtractionFileKey(
-	subtractionId: string,
-	filename: string,
-): string {
-	return `subtractions/${normalizeSubtractionId(subtractionId)}/${filename}`;
-}
-
-/** Prefix holding every file for a subtraction. */
-export function subtractionPrefix(subtractionId: string): string {
-	return `subtractions/${normalizeSubtractionId(subtractionId)}/`;
-}
-
-/**
- * Key for an index file.
+ * Minting of object-storage keys, which must stay byte-for-byte compatible with
+ * the ones Python mints. Both processes read and write the same bucket, so a
+ * divergence here does not fail loudly — it silently reads nothing and orphans
+ * what it writes.
  *
- * The segment is the index's `storage_key` column, not its row id — a migrated
- * index keys on its old Mongo id and a natively-created one on a minted UUID,
- * so neither can be derived from the id.
+ * Keys are not derived from database identity. Every row that names a stored
+ * object records its complete key verbatim, so no read path recomposes one and
+ * no change to how keys are chosen can force objects to move. Objects written
+ * before keys were recorded keep whatever prefix they were stored under, so the
+ * keys in the bucket are heterogeneous by design.
  */
-export function indexFileKey(storageKey: string, filename: string): string {
-	return `indexes/${storageKey}/${filename}`;
+
+import { randomUUID } from "node:crypto";
+
+// Python mints the leaf with `uuid4().hex`, which carries no hyphens.
+function uuidHex(): string {
+	return randomUUID().replaceAll("-", "");
 }
 
-/** Prefix holding every file for an index. */
-export function indexPrefix(storageKey: string): string {
-	return `indexes/${storageKey}/`;
+/**
+ * Mint a fresh key for a file belonging to `parentId`.
+ *
+ * The `parentId` segment groups an owning resource's objects for human
+ * inspection and has no meaning to any read path — the row records the whole
+ * key.
+ */
+export function mintStorageKey(domain: string, parentId: number): string {
+	return `${domain}/${parentId}/${uuidHex()}`;
 }
 
-/** Key for a cache. Persisted on the cache row rather than recomputed. */
+/**
+ * Mint a fresh key for a resource that has no owner.
+ *
+ * Uploads are not files belonging to some other resource — they are the
+ * resource — so there is no parent id to group them under.
+ *
+ * Minting without a parent id also means the key is available before the row
+ * exists, so the object can be written first and the row created afterwards.
+ * That keeps a database transaction from being held open for the length of the
+ * upload stream.
+ */
+export function mintRootStorageKey(domain: string): string {
+	return `${domain}/${uuidHex()}`;
+}
+
+/** Key for a cache. Persisted on the cache row rather than recomposed. */
 export function cacheKey(uuid: string): string {
 	return `caches/v1/${uuid}`;
 }


### PR DESCRIPTION
## Summary
- Storage keys were derived at read time from database identity — a sample's legacy id, an index's `storage_key` slug, an upload's `name_on_disk`. Each row that names a stored object now records its complete key verbatim, and new keys are minted `{domain}/{parent_id}/{uuid}`. Mirrors virtool/virtool#3766, which owns the migration and the backfill; this side only mirrors the columns it added.
- Closes a read-path bug this repo already had: reads resolved on `name_on_disk` while Python's `get_reads_file` keys on `name`, so a migrated row whose two columns disagreed was unreadable from here. Reading the recorded key removes the class of bug rather than the instance.
- Cleanup enumerates recorded keys instead of sweeping a prefix, so a delete reads its rows' keys before those rows go — including the `analysis_files` a sample's analyses cascade away. Objects written before keys were recorded are named by no row and are deliberately left for a separate orphan sweep, which does not exist yet.

**Deploy ordering:** the Alembic revision has to land first. Drizzle selecting a column that does not exist fails at query time, not build time. The reverse is safe — the backfill preserves every current key, so the pre-merge code keeps working against the migrated database.