### PR TITLE
chore: mirror the caches table and serve cache lookup and registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ This is a **pnpm monorepo**:
   runners call to claim, run and finish jobs. A Hono app on port 9950,
   mirroring Python's `virtool/jobs/main.py` (`api-jobs-service`, ClusterIP,
   **no ingress** — that absence is the security boundary). Serves
-  `/health/live`, `/health/ready` and a token-gated `/metrics` today. Image:
+  `/health/live`, `/health/ready`, a token-gated `/metrics`, and the two
+  cache endpoints — `GET /caches/{key}` and `POST /caches` — today. Image:
   `ghcr.io/virtool/jobs-api`, Alpine. Three rules: it is **always "the jobs
   API"**, never "the control plane" — that names its role, not the service;
   **every route must refuse an unauthenticated caller or be named in

--- a/apps/jobs-api/package.json
+++ b/apps/jobs-api/package.json
@@ -19,6 +19,7 @@
 		"@virtool/data": "workspace:*",
 		"@virtool/logger": "workspace:*",
 		"@virtool/sentry": "workspace:*",
+		"@virtool/storage": "workspace:*",
 		"drizzle-orm": "^0.45.2",
 		"hono": "^4.13.0",
 		"pino": "^10.1.0",

--- a/apps/jobs-api/src/__tests__/authorization.test.ts
+++ b/apps/jobs-api/src/__tests__/authorization.test.ts
@@ -1,5 +1,6 @@
-import type { PgClient } from "@virtool/data/db/pg";
+import type { Db, PgClient } from "@virtool/data/db/pg";
 import type { Logger } from "@virtool/logger";
+import { MemoryStorage } from "@virtool/storage";
 import { describe, expect, it } from "vitest";
 import { type AppDeps, createApp, PUBLIC_ROUTES } from "../app";
 import { createMetrics } from "../metrics/registry";
@@ -26,6 +27,24 @@ function fakeClient(): PgClient {
 	return (() => Promise.resolve([])) as unknown as PgClient;
 }
 
+/**
+ * A Drizzle handle stand-in.
+ *
+ * Nothing here should reach it either: an unauthenticated request is turned
+ * away by the guard before it reads a job row, so a handler that queries
+ * through this throws rather than quietly passing the test.
+ */
+function fakeDb(): Db {
+	return new Proxy(
+		{},
+		{
+			get() {
+				throw new Error("a refused request must not query the database");
+			},
+		},
+	) as Db;
+}
+
 function fakeLogger(): Logger {
 	const noop = () => undefined;
 	return {
@@ -39,6 +58,8 @@ function fakeLogger(): Logger {
 function deps(overrides: Partial<AppDeps> = {}): AppDeps {
 	return {
 		client: fakeClient(),
+		db: fakeDb(),
+		storage: new MemoryStorage(),
 		logger: fakeLogger(),
 		metrics: createMetrics(10),
 		applicationName: "virtool-ts-jobs-api@test",

--- a/apps/jobs-api/src/app.ts
+++ b/apps/jobs-api/src/app.ts
@@ -1,8 +1,10 @@
-import type { PgClient } from "@virtool/data/db/pg";
+import type { Db, PgClient } from "@virtool/data/db/pg";
 import { checkPostgres, summarizeReadiness } from "@virtool/data/health/data";
 import type { Logger } from "@virtool/logger";
+import type { StorageBackend } from "@virtool/storage";
 import { Hono } from "hono";
 import { routePath } from "hono/route";
+import { handleGetCache, handleRegisterCache } from "./caches/handlers";
 import { handleMetrics } from "./metrics/handler";
 import type { Metrics } from "./metrics/registry";
 
@@ -28,6 +30,8 @@ export const PUBLIC_ROUTES = ["/health/live", "/health/ready"] as const;
 /** What {@link createApp} needs to serve. */
 export type AppDeps = {
 	client: PgClient;
+	db: Db;
+	storage: StorageBackend;
 	logger: Logger;
 	metrics: Metrics;
 	applicationName: string;
@@ -81,6 +85,15 @@ export function createApp(deps: AppDeps): Hono {
 			report.statusCode,
 		);
 	});
+
+	// Python serves these at the same paths, with no prefix — a separate app has
+	// no SPA to collide with. Each handler calls the job-auth guard itself;
+	// nothing here runs middleware on its behalf.
+	app.get("/caches/:key", (c) =>
+		handleGetCache(deps, c.req.raw, c.req.param("key")),
+	);
+
+	app.post("/caches", (c) => handleRegisterCache(deps, c.req.raw));
 
 	app.get("/metrics", (c) =>
 		handleMetrics(c, {

--- a/apps/jobs-api/src/caches/handlers.test.ts
+++ b/apps/jobs-api/src/caches/handlers.test.ts
@@ -223,6 +223,37 @@ describe("handleRegisterCache", () => {
 		await expect(storage.size(cacheKey(UUID_B))).rejects.toThrow();
 		expect(await db.select().from(caches)).toHaveLength(1);
 	});
+
+	// A lost response or an ordinary client retry re-sends the same uuid. That
+	// re-selects the caller's own row, so the object it names must survive — a
+	// row pointing at a deleted blob is unreadable and unrepairable.
+	it("leaves the object in place when a retry repeats the same uuid", async () => {
+		await storage.write(cacheKey(UUID_A), body("hello world!"));
+
+		const payload = {
+			key: "trimmed-reads:abc",
+			uuid: UUID_A,
+			params: {},
+		};
+
+		const first = await handleRegisterCache(deps, post(payload));
+		const retry = await handleRegisterCache(deps, post(payload));
+
+		expect(first.status).toBe(201);
+		expect(retry.status).toBe(200);
+		expect((await retry.json()).created).toBe(false);
+
+		// The whole point: the row the retry returned still resolves to bytes.
+		const lookup = await handleGetCache(
+			deps,
+			get("trimmed-reads:abc"),
+			"trimmed-reads:abc",
+		);
+
+		await expect(storage.size((await lookup.json()).storageKey)).resolves.toBe(
+			12,
+		);
+	});
 });
 
 describe("handleGetCache", () => {

--- a/apps/jobs-api/src/caches/handlers.test.ts
+++ b/apps/jobs-api/src/caches/handlers.test.ts
@@ -1,0 +1,297 @@
+import { seedUser } from "@virtool/data/auth/test/fixtures";
+import type { Db } from "@virtool/data/db/pg";
+import { caches } from "@virtool/data/db/schema/caches";
+import { jobs } from "@virtool/data/db/schema/jobs";
+import { users } from "@virtool/data/db/schema/users";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import { createLogger } from "@virtool/logger";
+import { cacheKey, MemoryStorage } from "@virtool/storage";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { seedJob } from "../auth/test/fixtures";
+import {
+	type CacheHandlerDeps,
+	handleGetCache,
+	handleRegisterCache,
+} from "./handlers";
+
+const UUID_A = "a".repeat(32);
+const UUID_B = "b".repeat(32);
+
+let database: TestDatabase;
+let db: Db;
+let storage: MemoryStorage;
+let deps: CacheHandlerDeps;
+let credential: string;
+
+const logger = createLogger({ name: "test", level: "silent" });
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(caches);
+	await db.delete(jobs);
+	await db.delete(users);
+
+	const job = await seedJob(db, await seedUser(db));
+
+	credential = Buffer.from(`job-${job.id}:${job.key}`).toString("base64");
+	storage = new MemoryStorage();
+	deps = { db, storage, logger };
+});
+
+async function* body(text: string): AsyncIterable<Uint8Array> {
+	yield new TextEncoder().encode(text);
+}
+
+function get(key: string, authenticated = true): Request {
+	return new Request(
+		`https://jobs.virtool.test/caches/${encodeURIComponent(key)}`,
+		{
+			headers: authenticated ? { authorization: `Basic ${credential}` } : {},
+		},
+	);
+}
+
+function post(payload: unknown, authenticated = true): Request {
+	return new Request("https://jobs.virtool.test/caches", {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+			...(authenticated ? { authorization: `Basic ${credential}` } : {}),
+		},
+		body: JSON.stringify(payload),
+	});
+}
+
+describe("handleRegisterCache", () => {
+	it("refuses an unauthenticated caller", async () => {
+		const response = await handleRegisterCache(
+			deps,
+			post({ key: "k", uuid: UUID_A, params: {} }, false),
+		);
+
+		expect(response.status).toBe(401);
+		expect(await db.select().from(caches)).toEqual([]);
+	});
+
+	it("registers a cache and answers 201 with camelCase fields", async () => {
+		await storage.write(cacheKey(UUID_A), body("hello world!"));
+
+		const response = await handleRegisterCache(
+			deps,
+			post({ key: "trimmed-reads:abc", uuid: UUID_A, params: { trim: true } }),
+		);
+
+		expect(response.status).toBe(201);
+		expect(await response.json()).toEqual({
+			id: expect.any(Number),
+			key: "trimmed-reads:abc",
+			storageKey: `caches/v1/${UUID_A}`,
+			size: 12,
+			params: { trim: true },
+			createdAt: expect.any(String),
+			lastAccessedAt: expect.any(String),
+			created: true,
+		});
+	});
+
+	// The declared size is not part of the contract at all, so a caller sending
+	// one gets the server's reading regardless — the extra field is ignored.
+	it("stores the size it read from storage, not one the caller sent", async () => {
+		await storage.write(cacheKey(UUID_A), body("hello world!"));
+
+		const response = await handleRegisterCache(
+			deps,
+			post({
+				key: "trimmed-reads:abc",
+				uuid: UUID_A,
+				params: {},
+				size: 999_999,
+			}),
+		);
+
+		expect((await response.json()).size).toBe(12);
+	});
+
+	it("rejects a uuid that is not 32 hex characters", async () => {
+		for (const uuid of ["", "not-a-uuid", "A".repeat(32), "a".repeat(31)]) {
+			const response = await handleRegisterCache(
+				deps,
+				post({ key: "trimmed-reads:abc", uuid, params: {} }),
+			);
+
+			expect(response.status).toBe(400);
+		}
+
+		expect(await db.select().from(caches)).toEqual([]);
+	});
+
+	// The wire carries no storage key, so the only lever a caller has on the
+	// object's location is the uuid — and a traversal-shaped one is not a uuid.
+	// Without this, a job-authenticated caller could point a cache row at a
+	// sample or index object, which Python's LRU eviction would then delete.
+	it("cannot produce a row pointing outside caches/v1/", async () => {
+		await storage.write("samples/1/reads_1.fq.gz", body("not a cache"));
+
+		const response = await handleRegisterCache(
+			deps,
+			post({
+				key: "trimmed-reads:abc",
+				uuid: "../../samples/1/reads_1.fq.gz",
+				params: {},
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		expect(await db.select().from(caches)).toEqual([]);
+	});
+
+	it("rejects a storage key sent in place of a uuid", async () => {
+		const response = await handleRegisterCache(
+			deps,
+			post({
+				key: "trimmed-reads:abc",
+				uuid: `caches/v1/${UUID_A}`,
+				params: {},
+			}),
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("answers 400 and writes no row when the uuid names no object", async () => {
+		const response = await handleRegisterCache(
+			deps,
+			post({ key: "trimmed-reads:abc", uuid: UUID_A, params: {} }),
+		);
+
+		expect(response.status).toBe(400);
+		expect(await db.select().from(caches)).toEqual([]);
+	});
+
+	it("answers 400 for a malformed body", async () => {
+		const request = new Request("https://jobs.virtool.test/caches", {
+			method: "POST",
+			headers: {
+				authorization: `Basic ${credential}`,
+				"content-type": "application/json",
+			},
+			body: "{",
+		});
+
+		expect((await handleRegisterCache(deps, request)).status).toBe(400);
+	});
+
+	// Both derived the same key and wrote the same bytes. The loser is pointed at
+	// the winner's blob and its own orphan is reclaimed, because an orphan has no
+	// row for Python's LRU eviction to walk.
+	it("answers 200 with the winner's row when the key already exists", async () => {
+		await storage.write(cacheKey(UUID_A), body("aaa"));
+		await storage.write(cacheKey(UUID_B), body("aaa"));
+
+		const first = await handleRegisterCache(
+			deps,
+			post({ key: "trimmed-reads:abc", uuid: UUID_A, params: {} }),
+		);
+		const second = await handleRegisterCache(
+			deps,
+			post({ key: "trimmed-reads:abc", uuid: UUID_B, params: {} }),
+		);
+
+		expect(first.status).toBe(201);
+		expect(second.status).toBe(200);
+
+		const winner = await first.json();
+		const loser = await second.json();
+
+		expect(loser.created).toBe(false);
+		expect(loser.id).toBe(winner.id);
+		expect(loser.storageKey).toBe(winner.storageKey);
+
+		await expect(storage.size(cacheKey(UUID_A))).resolves.toBe(3);
+		await expect(storage.size(cacheKey(UUID_B))).rejects.toThrow();
+		expect(await db.select().from(caches)).toHaveLength(1);
+	});
+});
+
+describe("handleGetCache", () => {
+	it("refuses an unauthenticated caller", async () => {
+		const response = await handleGetCache(
+			deps,
+			get("trimmed-reads:abc", false),
+			"trimmed-reads:abc",
+		);
+
+		expect(response.status).toBe(401);
+	});
+
+	it("answers 404 for a key with no row", async () => {
+		const response = await handleGetCache(
+			deps,
+			get("nothing-here"),
+			"nothing-here",
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	// The point of the lookup path: without it a workflow cannot reach a cached
+	// blob at all, because `storageKey` is a per-write uuid and is not derivable
+	// from the cache key.
+	it("resolves a registered key to the storage key and server-read size", async () => {
+		await storage.write(cacheKey(UUID_A), body("hello world!"));
+
+		await handleRegisterCache(
+			deps,
+			post({ key: "trimmed-reads:abc", uuid: UUID_A, params: { trim: true } }),
+		);
+
+		const response = await handleGetCache(
+			deps,
+			get("trimmed-reads:abc"),
+			"trimmed-reads:abc",
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			id: expect.any(Number),
+			key: "trimmed-reads:abc",
+			storageKey: `caches/v1/${UUID_A}`,
+			size: 12,
+			params: { trim: true },
+			createdAt: expect.any(String),
+			lastAccessedAt: expect.any(String),
+		});
+	});
+
+	// Metadata only. The workflow reads the bytes from the bucket itself, so a
+	// body here would put this service back on the data path Python was on.
+	it("relays no cache bytes", async () => {
+		await storage.write(cacheKey(UUID_A), body("hello world!"));
+
+		await handleRegisterCache(
+			deps,
+			post({ key: "trimmed-reads:abc", uuid: UUID_A, params: {} }),
+		);
+
+		const response = await handleGetCache(
+			deps,
+			get("trimmed-reads:abc"),
+			"trimmed-reads:abc",
+		);
+
+		expect(response.headers.get("content-type")).toContain("application/json");
+		expect(await response.text()).not.toContain("hello world!");
+	});
+});

--- a/apps/jobs-api/src/caches/handlers.ts
+++ b/apps/jobs-api/src/caches/handlers.ts
@@ -1,0 +1,135 @@
+import type { Cache, CacheRegistered } from "@virtool/contracts";
+import { RegisterCacheRequest } from "@virtool/contracts";
+import {
+	CacheNotFoundError,
+	CacheObjectMissingError,
+	getCache,
+	registerCache,
+} from "@virtool/data/caches/data";
+import type { Db } from "@virtool/data/db/pg";
+import type { CacheRow } from "@virtool/data/db/schema/caches";
+import type { Logger } from "@virtool/logger";
+import type { StorageBackend } from "@virtool/storage";
+import { requireJobRequest } from "../auth/guard";
+
+/** What the cache handlers need to serve a request. */
+export type CacheHandlerDeps = {
+	db: Db;
+	storage: StorageBackend;
+	logger: Logger;
+};
+
+/**
+ * Map a row to its wire shape.
+ *
+ * The mapping happens here, at the handler boundary, rather than inside
+ * `@virtool/data` — `apps/web`'s client feature modules read the same data
+ * functions, so renaming a field down there would break them at a distance.
+ */
+function toCache(row: CacheRow): Cache {
+	return {
+		id: row.id,
+		key: row.key,
+		storageKey: row.storage_key,
+		size: row.size,
+		params: row.params,
+		createdAt: row.created_at.toISOString(),
+		lastAccessedAt: row.last_accessed_at.toISOString(),
+	};
+}
+
+/**
+ * Resolve a logical cache key to the row that names the blob behind it.
+ *
+ * Metadata only. Workflows read object storage directly, so nothing here
+ * streams cache bytes — the caller takes `storageKey` to the bucket itself.
+ * This diverges from Python, which streamed the payload through its jobs API.
+ */
+export async function handleGetCache(
+	deps: CacheHandlerDeps,
+	request: Request,
+	key: string,
+): Promise<Response> {
+	const principal = await requireJobRequest(deps.db, request);
+
+	if (principal instanceof Response) {
+		return principal;
+	}
+
+	try {
+		return Response.json(toCache(await getCache(deps.db, key)));
+	} catch (err) {
+		if (err instanceof CacheNotFoundError) {
+			return Response.json({ message: "Cache not found" }, { status: 404 });
+		}
+
+		throw err;
+	}
+}
+
+/**
+ * Register a cache row for a blob the caller has already written.
+ *
+ * The body carries a uuid, never a storage key: the key is composed server-side
+ * with `cacheKey(uuid)`, so a job-authenticated caller cannot point a cache row
+ * at a sample, index or subtraction object — which Python's LRU eviction, which
+ * deletes by `storage_key`, would then destroy.
+ *
+ * 201 when this call created the row, 200 when an equivalent one already
+ * existed. Losing a race to another workflow deriving the same key is success,
+ * not an error, and the response carries the winner's row either way.
+ */
+export async function handleRegisterCache(
+	deps: CacheHandlerDeps,
+	request: Request,
+): Promise<Response> {
+	const principal = await requireJobRequest(deps.db, request);
+
+	if (principal instanceof Response) {
+		return principal;
+	}
+
+	let body: unknown;
+
+	try {
+		body = await request.json();
+	} catch {
+		return Response.json({ message: "Malformed body" }, { status: 400 });
+	}
+
+	const parsed = RegisterCacheRequest.safeParse(body);
+
+	if (!parsed.success) {
+		return Response.json(
+			{ message: "Invalid body", errors: parsed.error.issues },
+			{ status: 400 },
+		);
+	}
+
+	try {
+		const { row, created } = await registerCache(
+			deps.db,
+			deps.storage,
+			deps.logger,
+			parsed.data,
+		);
+
+		const registered: CacheRegistered = { ...toCache(row), created };
+
+		deps.logger.info(
+			{ jobId: principal.jobId, key: row.key, created },
+			"registered cache",
+		);
+
+		return Response.json(registered, { status: created ? 201 : 200 });
+	} catch (err) {
+		if (err instanceof CacheObjectMissingError) {
+			return Response.json(
+				{ message: "No object stored under that uuid" },
+				{ status: 400 },
+			);
+		}
+
+		throw err;
+	}
+}

--- a/apps/jobs-api/src/config.ts
+++ b/apps/jobs-api/src/config.ts
@@ -1,4 +1,5 @@
 import { resolveFileBacked } from "@virtool/contracts/env";
+import type { StorageConfig } from "@virtool/storage";
 
 /** Everything this process reads from the environment at startup. */
 export type Config = {
@@ -6,6 +7,12 @@ export type Config = {
 	port: number;
 	postgresUrl: string;
 	postgresPoolMax: number;
+	/**
+	 * The same bucket Python and `apps/web` use. Cache registration reads an
+	 * object's size from it before writing a row, so this service cannot start
+	 * without it.
+	 */
+	storage: StorageConfig;
 	/**
 	 * Gates the Prometheus scrape endpoint. Unset leaves `/metrics` reporting
 	 * 404, so a deployment never starts exposing internals on upgrade.
@@ -33,6 +40,16 @@ const KEYS = [
 	"VT_POSTGRES_POOL_MAX",
 	"VT_METRICS_TOKEN",
 	"VT_SENTRY_DSN",
+	"VT_STORAGE_BACKEND",
+	"VT_STORAGE_S3_BUCKET",
+	"VT_STORAGE_S3_REGION",
+	"VT_STORAGE_S3_ENDPOINT",
+	"VT_STORAGE_S3_ACCESS_KEY_ID",
+	"VT_STORAGE_S3_SECRET_ACCESS_KEY",
+	"VT_STORAGE_AZURE_ACCOUNT",
+	"VT_STORAGE_AZURE_CONTAINER",
+	"VT_STORAGE_AZURE_ACCESS_KEY",
+	"VT_STORAGE_AZURE_ENDPOINT",
 ] as const;
 
 // Deployment tooling routinely injects an empty string for a value it has
@@ -76,6 +93,56 @@ function readNumber(
 }
 
 /**
+ * Build the storage configuration this process hands to
+ * `createStorageBackend`.
+ *
+ * `@virtool/storage` owns the shape but reads no environment of its own, so
+ * each host application resolves it. This is a hand-rolled counterpart to the
+ * zod schema in `apps/web/src/server/config.ts` rather than a shared parser:
+ * this service deliberately carries no zod, and the two only have to agree on
+ * the variable names, which are the deployment's contract either way.
+ */
+function buildStorage(resolved: NodeJS.ProcessEnv): StorageConfig {
+	const backend = present(resolved.VT_STORAGE_BACKEND);
+
+	if (backend !== "s3" && backend !== "azure") {
+		throw new Error("VT_STORAGE_BACKEND must be one of: s3, azure");
+	}
+
+	if (backend === "s3") {
+		const accessKeyId = present(resolved.VT_STORAGE_S3_ACCESS_KEY_ID);
+		const secretAccessKey = present(resolved.VT_STORAGE_S3_SECRET_ACCESS_KEY);
+
+		// Both or neither. One alone is a half-configured deployment that would
+		// otherwise fall back to instance credentials and fail later, at the first
+		// request, rather than at startup.
+		if (Boolean(accessKeyId) !== Boolean(secretAccessKey)) {
+			throw new Error(
+				"VT_STORAGE_S3_ACCESS_KEY_ID and VT_STORAGE_S3_SECRET_ACCESS_KEY must be set together, or both left empty to use IAM role credentials",
+			);
+		}
+
+		return {
+			kind: "s3",
+			bucket: requireValue(resolved, "VT_STORAGE_S3_BUCKET"),
+			region: present(resolved.VT_STORAGE_S3_REGION),
+			// Left unset for real AWS, which the SDK resolves from the region.
+			endpoint: present(resolved.VT_STORAGE_S3_ENDPOINT),
+			accessKeyId,
+			secretAccessKey,
+		};
+	}
+
+	return {
+		kind: "azure",
+		account: requireValue(resolved, "VT_STORAGE_AZURE_ACCOUNT"),
+		container: requireValue(resolved, "VT_STORAGE_AZURE_CONTAINER"),
+		accessKey: present(resolved.VT_STORAGE_AZURE_ACCESS_KEY),
+		endpoint: present(resolved.VT_STORAGE_AZURE_ENDPOINT),
+	};
+}
+
+/**
  * Resolve configuration from the environment.
  *
  * Every key also accepts a `<KEY>_FILE` variant naming a file to read the value
@@ -94,6 +161,7 @@ export function parseConfig(env: NodeJS.ProcessEnv = process.env): Config {
 		port: readNumber(resolved, "VT_JOBS_API_PORT", 9950),
 		postgresUrl: requireValue(resolved, "VT_POSTGRES_URL"),
 		postgresPoolMax: readNumber(resolved, "VT_POSTGRES_POOL_MAX", 10),
+		storage: buildStorage(resolved),
 		metricsToken: present(resolved.VT_METRICS_TOKEN),
 		sentryDsn: present(resolved.VT_SENTRY_DSN),
 	};

--- a/apps/jobs-api/src/index.ts
+++ b/apps/jobs-api/src/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "@hono/node-server";
 import { createDb, logPostgresVersion } from "@virtool/data/db/pg";
+import { createStorageBackend } from "@virtool/storage";
 import { createApp } from "./app";
 import { parseConfig } from "./config";
 import { initSentry, SERVICE } from "./instrument";
@@ -12,10 +13,12 @@ const config = parseConfig();
 // auto-instrumentation can install its import hooks ahead of what it patches.
 initSentry(config.sentryDsn);
 
-const { client, applicationName } = createDb(config, SERVICE);
+const { client, db, applicationName } = createDb(config, SERVICE);
 
 const app = createApp({
 	client,
+	db,
+	storage: createStorageBackend(config.storage),
 	logger,
 	metrics: createMetrics(config.postgresPoolMax),
 	applicationName,

--- a/docs/database.md
+++ b/docs/database.md
@@ -86,6 +86,7 @@ states:
 | OTUs         | `legacy_otus`                                        | Built          |
 | Sequences    | `legacy_sequences`                                   | Built          |
 | History      | `legacy_history`, `legacy_history_diff`, `revisions` | Built          |
+| Caches       | `caches`                                             | Built          |
 
 The Postgres table(s) column lists the single mirrored table for the
 **partial mirror** rows and the principal Python-defined table(s) for
@@ -124,6 +125,15 @@ document, `data` included (`writeLegacyOtu`); `legacy_sequences.position` is
 load-bearing and a delete leaves a gap rather than renumbering; and the
 `otu_version` `NULL` that stands for `"removed"` is reversed at the boundary
 rather than stored. See `@virtool/data/otus/data` and `@virtool/data/history/data`.
+
+Caches are the one **Built** domain with no `functions.ts` in
+`apps/web`. Nothing in the SPA reads a cache — only workflows do — so
+the mirror and `packages/data/src/caches/data.ts` are served by
+`apps/jobs-api/src/caches/handlers.ts` instead. Its unique constraint on
+`key` is declared by its real name, `cache_key`, because
+`createTestDatabase()` derives its DDL from these mirrors: an undeclared
+constraint is simply absent from a test database, and the duplicate-key
+race the registration path is built around would never be exercised.
 
 The `subtractions` mirror is now full — the subtraction domain is
 served from this repo — but jobs still reaches it through the same reverse

--- a/docs/jobs-api.md
+++ b/docs/jobs-api.md
@@ -292,10 +292,17 @@ logical caches sharing one object.
 When the insert takes no row, the loser re-selects by `key` and returns
 the **winner's** row, so it reads the blob that actually survived. It
 then deletes its own orphan, after the write has committed, logging a
-failure rather than throwing. That is safe because `storage_key` is a
-per-write uuid — the winner's row points elsewhere — and necessary
-because an orphan has no row, so Python's LRU eviction, which walks
-rows, will never reclaim it.
+failure rather than throwing. That is necessary because an orphan has no
+row, so Python's LRU eviction, which walks rows, will never reclaim it.
+
+**The delete is guarded on the winner's `storage_key` differing from the
+one this call composed.** A retry — a lost response, an ordinary client
+retry — arrives with the *same* uuid, so it re-selects its own row and
+the object it would delete is the live one that row names. Deleting
+there leaves a row pointing at nothing: unreadable to every later
+lookup, and unrepairable by eviction, which walks rows and would find
+this one perfectly intact. The guard is what makes `POST /caches`
+idempotent rather than merely conflict-tolerant.
 
 This deliberately diverges from Python, which raises
 `CacheAlreadyExistsError` on the same race. The divergence is the reason
@@ -504,7 +511,8 @@ for this service:
 
 ## What is not here yet
 
-Health, metrics and the two cache endpoints. Every remaining
-runner-facing endpoint — claim, ping, step start, finish, and the three
-finalize routes — lands in its own issue, against the wire contract
-already written in `packages/contracts/src/jobsApi.ts`.
+This service serves health, metrics and the two cache endpoints, and
+nothing else yet. Every remaining runner-facing endpoint — claim, ping,
+step start, finish, and the three finalize routes — lands in its own
+issue, against the wire contract already written in
+`packages/contracts/src/jobsApi.ts`.

--- a/docs/jobs-api.md
+++ b/docs/jobs-api.md
@@ -43,6 +43,7 @@ process:
 | `src/auth/verify.ts` | `verifyJobRequest` — the job credential check |
 | `src/auth/guard.ts` | `requireJobRequest` — the guard every handler starts with |
 | `src/auth/test/fixtures.ts` | `seedJob` — a job row and the plaintext key for it |
+| `src/caches/handlers.ts` | Cache lookup and registration |
 | `src/metrics/registry.ts` | `createMetrics` — this process's Prometheus registry |
 | `src/metrics/handler.ts` | Token check, pre-scrape pool read, response |
 | `src/__tests__/authorization.test.ts` | The route-enumerating authorization floor |
@@ -221,6 +222,93 @@ services' probes cannot drift. Neither requires the metrics token: a
 probe that needed a credential would be one more thing to get wrong
 during a rollout.
 
+## Caches
+
+Workflows reuse expensive derived artifacts — trimmed reads, mapping
+indexes, collapsed references — through the `caches` table, which Python
+owns at `virtool/caches/pg.py` and `@virtool/data` mirrors read-only.
+
+| Route | Meaning |
+| --- | --- |
+| `GET /caches/{key}` | Resolve a logical key to its row. `404` on a miss. |
+| `POST /caches` | Register a row for a blob the caller has already written. |
+
+Both paths match Python's, with no prefix — a separate app has no SPA to
+collide with. Each handler calls `requireJobRequest` itself; nothing
+runs middleware on its behalf.
+
+**Neither endpoint carries cache bytes.** Workflows have direct
+object-storage access, so the writer puts its blob at `caches/v1/<uuid>`
+and then registers the row, and the reader takes `storageKey` to the
+bucket. Python streamed payloads through its jobs API; this does not.
+
+**Lookup is not optional garnish.** A row's `storageKey` is a per-write
+UUID and is not derivable from the cache key, so a workflow holding a
+derived key cannot read the blob at all until this server resolves one
+to the other. It is on the hot path of every workflow start, which is
+why `getCache` refreshes `last_accessed_at` only when it is older than
+five minutes — Python's `LAST_ACCESSED_REFRESH_INTERVAL`, and the same
+threshold on both sides because both read the same rows. An
+unconditional `UPDATE` would turn every read into a write.
+
+### The wire carries a UUID, never a storage key
+
+`POST /caches` takes `{ key, uuid, params }`, and the server composes
+the storage key with `cacheKey(uuid)` from `@virtool/storage`. The uuid
+is validated as 32 lowercase hex characters.
+
+This is not stylistic. A caller-supplied `storageKey` would let a
+job-authenticated caller register a cache row pointing at a sample,
+index or subtraction object — and Python's LRU eviction deletes by
+`storage_key`, so that is a route to having another domain's files
+destroyed. Composing the key from a validated uuid makes it
+unrepresentable.
+
+The uuid must also be **fresh per write attempt**, never derived from
+the cache key, so that the loser of a race can delete its own orphan
+without touching the winner's object.
+
+### Verify, then transact
+
+`registerCache` calls `storage.size(cacheKey(uuid))` **before** any
+database work, and stores the size it read. A caller declaring a blob it
+never wrote gets `400` and leaves no row behind; a caller sending a size
+is simply ignored — the field is not on the contract. No storage call
+happens inside a transaction.
+
+### Losing the race is success
+
+Two workflows can legitimately derive the same cache key at once, and
+both blobs hold the same bytes, so **"already existed" is a 2xx** — 201
+when the call created the row, 200 when it did not, plus a `created`
+flag in the body for logging.
+
+The insert uses `onConflictDoNothing({ target: caches.key })`, targeting
+the `cache_key` constraint **specifically**. A bare
+`onConflictDoNothing()` would also swallow a `storage_key` collision,
+which can only mean a reused uuid — a bug, and one that would leave two
+logical caches sharing one object.
+
+When the insert takes no row, the loser re-selects by `key` and returns
+the **winner's** row, so it reads the blob that actually survived. It
+then deletes its own orphan, after the write has committed, logging a
+failure rather than throwing. That is safe because `storage_key` is a
+per-write uuid — the winner's row points elsewhere — and necessary
+because an orphan has no row, so Python's LRU eviction, which walks
+rows, will never reclaim it.
+
+This deliberately diverges from Python, which raises
+`CacheAlreadyExistsError` on the same race. The divergence is the reason
+the loser path is handled explicitly rather than left to an error
+handler.
+
+### Eviction stays in Python
+
+No eviction, storage-budget accounting or scheduled cleanup lives here.
+`CACHE_EVICTION_GRACE_PERIOD`, `select_eviction_candidates` and the
+periodic task in `virtool/caches/` remain Python's. The only deletion
+this service performs is the loser's own orphan.
+
 ## Metrics
 
 `GET /metrics` serves the Prometheus text exposition from this process's
@@ -330,6 +418,26 @@ throwing for an expected outcome — and prefer not to.
 | `VT_JOBS_API_PORT` | `9950` | Listen port, matching Python's jobs API |
 | `VT_METRICS_TOKEN` | unset | Bearer token for `/metrics`; unset means `404` |
 | `VT_SENTRY_DSN` | unset | Unset disables Sentry |
+| `VT_STORAGE_BACKEND` | *required* | `s3` or `azure` |
+| `VT_STORAGE_S3_BUCKET` | *required for `s3`* | Bucket name |
+| `VT_STORAGE_S3_REGION` | unset | Region |
+| `VT_STORAGE_S3_ENDPOINT` | unset | Left unset for real AWS |
+| `VT_STORAGE_S3_ACCESS_KEY_ID` | unset | With the secret, or neither |
+| `VT_STORAGE_S3_SECRET_ACCESS_KEY` | unset | With the id, or neither |
+| `VT_STORAGE_AZURE_ACCOUNT` | *required for `azure`* | Storage account |
+| `VT_STORAGE_AZURE_CONTAINER` | *required for `azure`* | Container name |
+| `VT_STORAGE_AZURE_ACCESS_KEY` | unset | Unset uses the pod's identity |
+| `VT_STORAGE_AZURE_ENDPOINT` | unset | Left unset for real Azure |
+
+The storage variables are the **same bucket** `apps/web` and Python use,
+and the same variable names. `@virtool/storage` owns the config shape but
+reads no environment itself, so each host application resolves it — this
+service with a hand-rolled parser in `config.ts` rather than the zod
+schema `apps/web` uses, because it deliberately carries no zod. The two
+only have to agree on the variable names, which are the deployment's
+contract either way. The S3 credential pair is **both or neither**: one
+alone is a half-configured deployment that would otherwise fall back to
+instance credentials and fail at the first request instead of at startup.
 
 Every one also accepts a `<KEY>_FILE` variant naming a file to read the
 value from, so a secret reaches a pod through the secrets-store CSI
@@ -372,6 +480,9 @@ is also how knip sees them as used. `hono`, `@hono/node-server`,
 `@sentry/node` and `prom-client` are externalised by default and are
 imported directly by this app's source, so knip finds them without help.
 
+`@virtool/storage`'s S3 and Azure SDKs ride along inlined, like every
+other `@virtool/*` dependency.
+
 ## Deployment
 
 The Kubernetes manifests live in a **different repository** — this one
@@ -385,17 +496,15 @@ for this service:
   ingress rule is the security boundary this whole service is built
   around.
 - The `virtool` ServiceAccount, which carries the object-storage access
-  the finalize endpoints will need to verify what a workflow wrote.
+  cache registration uses to verify what a workflow wrote, and which the
+  finalize endpoints will need for the same reason.
 - A second, **authenticated** Prometheus scrape job carrying the bearer
   token, since the web app's scrape job cannot cover an endpoint on a
   different service with a different credential.
 
 ## What is not here yet
 
-Only health and metrics. Every runner-facing endpoint — claim, ping,
-step start, finish, and the three finalize routes — lands in its own
-issue, against the wire contract already written in
-`packages/contracts/src/jobsApi.ts`. `@virtool/storage` is deliberately
-**not** yet a dependency: nothing here writes or reads an object, and
-declaring it early would fail `pnpm knip` as an unused dependency. Add
-it with the first endpoint that needs it.
+Health, metrics and the two cache endpoints. Every remaining
+runner-facing endpoint — claim, ping, step start, finish, and the three
+finalize routes — lands in its own issue, against the wire contract
+already written in `packages/contracts/src/jobsApi.ts`.

--- a/packages/contracts/src/caches.ts
+++ b/packages/contracts/src/caches.ts
@@ -1,0 +1,77 @@
+// The cache endpoints' wire contract, shared by the handlers in `apps/jobs-api`
+// and the workflow runtime that calls them.
+//
+//   GET  /caches/{key}  -                    -> Cache           (200 | 404)
+//   POST /caches        RegisterCacheRequest -> CacheRegistered (201 created | 200 existed)
+//
+// Workflows reuse expensive derived artifacts — trimmed reads, mapping indexes,
+// collapsed references — by deriving a logical cache key and asking for it.
+// **Lookup is what makes the cache usable at all**: a row's `storageKey` is a
+// per-write UUID and cannot be recomputed from the cache key, so a workflow
+// cannot read a cached blob until this server has resolved one to the other.
+//
+// **No endpoint carries cache bytes.** Workflows have direct object-storage
+// access: the writer puts the blob at `caches/v1/<uuid>` itself and then
+// registers the row, and the reader takes `storageKey` to the bucket. This
+// diverges from Python, which streamed payloads through its jobs API.
+
+import { z } from "zod";
+import { JsonObject } from "./json";
+
+/**
+ * The UUID a writer minted for its own blob, as `uuid4().hex` — 32 lowercase
+ * hex characters, matching what Python writes.
+ *
+ * The wire carries this rather than a storage key, and the server composes the
+ * key with `cacheKey(uuid)`. A caller-supplied key would let a job-authenticated
+ * caller register a cache row pointing at a sample, index or subtraction
+ * object — and Python's LRU eviction deletes by `storage_key`, so that is a
+ * route to having another domain's files destroyed. Validating a uuid and
+ * composing the key server-side makes that unrepresentable.
+ */
+export const CacheUuid = z.string().regex(/^[0-9a-f]{32}$/);
+
+/** Body for `POST /caches` — what a workflow declares after writing its blob. */
+export const RegisterCacheRequest = z.object({
+	key: z.string().min(1),
+	uuid: CacheUuid,
+
+	/** Diagnostic metadata persisted with the row. Not used for lookup. */
+	params: JsonObject,
+});
+
+export type RegisterCacheRequest = z.infer<typeof RegisterCacheRequest>;
+
+/**
+ * A cache row as the endpoints return it.
+ *
+ * camelCase, like everything else on this wire; the Drizzle mirror keeps
+ * Python's snake_case column names because those are row content. `size` is the
+ * size the server read from storage, never one the caller sent.
+ */
+export const Cache = z.object({
+	id: z.number().int(),
+	key: z.string(),
+	storageKey: z.string(),
+	size: z.number().int().nonnegative(),
+	params: JsonObject,
+	createdAt: z.string(),
+	lastAccessedAt: z.string(),
+});
+
+export type Cache = z.infer<typeof Cache>;
+
+/**
+ * Response to `POST /caches`.
+ *
+ * Two workflows can legitimately derive the same cache key at once, and both
+ * blobs hold the same bytes, so **"already existed" is success**. The loser
+ * receives the winner's row — its `id`, `storageKey` and `size` — so it reads
+ * the blob that actually survived. `created` distinguishes the two only for
+ * logging.
+ */
+export const CacheRegistered = Cache.extend({
+	created: z.boolean(),
+});
+
+export type CacheRegistered = z.infer<typeof CacheRegistered>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -4,6 +4,7 @@ export * from "./apiKeys";
 export * from "./artifacts";
 export * from "./auth";
 export * from "./banners";
+export * from "./caches";
 export * from "./errors";
 export * from "./groups";
 export * from "./hmms";

--- a/packages/contracts/src/jobsApi.ts
+++ b/packages/contracts/src/jobsApi.ts
@@ -38,6 +38,12 @@
 //   PATCH  /samples/{id}                       FinalizeSampleRequest      -> Sample
 //   PATCH  /subtractions/{id}                  FinalizeSubtractionRequest -> Subtraction
 //   PATCH  /analyses/{id}                      FinalizeAnalysisRequest    -> Analysis
+//   GET    /caches/{key}                       -                     -> Cache           (200 | 404)
+//   POST   /caches                             RegisterCacheRequest  -> CacheRegistered (201 | 200)
+//
+// The cache shapes live in `./caches` rather than here, because they are the one
+// part of this surface a workflow reaches on its own behalf rather than on
+// behalf of a job it is finishing.
 //
 // The workflow to claim is a query parameter on `POST /jobs/claim`, not a body
 // field, matching Python's `ClaimJobView`.

--- a/packages/data/src/caches/data.test.ts
+++ b/packages/data/src/caches/data.test.ts
@@ -1,0 +1,256 @@
+import { cacheKey, MemoryStorage } from "@virtool/storage";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Db } from "../db/pg";
+import { caches } from "../db/schema/caches";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { testLogger } from "../test/logger";
+import {
+	CacheNotFoundError,
+	CacheObjectMissingError,
+	getCache,
+	registerCache,
+} from "./data";
+
+let database: TestDatabase;
+let db: Db;
+const queries: string[] = [];
+
+beforeAll(async () => {
+	database = await createTestDatabase({
+		onQuery: (query) => queries.push(query),
+	});
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(caches);
+	queries.length = 0;
+});
+
+const UUID_A = "0".repeat(32);
+const UUID_B = "1".repeat(32);
+
+async function* body(text: string): AsyncIterable<Uint8Array> {
+	yield new TextEncoder().encode(text);
+}
+
+async function storageWith(
+	entries: Record<string, string>,
+): Promise<MemoryStorage> {
+	const storage = new MemoryStorage();
+
+	for (const [uuid, contents] of Object.entries(entries)) {
+		await storage.write(cacheKey(uuid), body(contents));
+	}
+
+	return storage;
+}
+
+async function seedCache(overrides: Partial<typeof caches.$inferInsert> = {}) {
+	const now = new Date();
+
+	const [row] = await db
+		.insert(caches)
+		.values({
+			key: "trimmed-reads:abc",
+			storage_key: cacheKey(UUID_A),
+			params: { sample_id: 1 },
+			size: 12,
+			created_at: now,
+			last_accessed_at: now,
+			...overrides,
+		})
+		.returning();
+
+	if (!row) {
+		throw new Error("failed to seed cache");
+	}
+
+	return row;
+}
+
+describe("getCache", () => {
+	it("returns the row for a known key", async () => {
+		const seeded = await seedCache();
+
+		const row = await getCache(db, "trimmed-reads:abc");
+
+		expect(row.id).toBe(seeded.id);
+		expect(row.storage_key).toBe(cacheKey(UUID_A));
+		expect(row.size).toBe(12);
+		expect(row.params).toEqual({ sample_id: 1 });
+	});
+
+	it("throws CacheNotFoundError for an unknown key", async () => {
+		await expect(getCache(db, "nothing-here")).rejects.toThrow(
+			CacheNotFoundError,
+		);
+	});
+
+	// Lookup is on the hot path of every workflow start, so a fresh row must not
+	// cost a write.
+	it("issues no update when last_accessed_at is fresh", async () => {
+		await seedCache({
+			last_accessed_at: new Date(Date.now() - 60 * 1000),
+		});
+
+		queries.length = 0;
+		await getCache(db, "trimmed-reads:abc");
+
+		expect(queries.some((query) => /update/i.test(query))).toBe(false);
+	});
+
+	it("refreshes last_accessed_at once it is older than five minutes", async () => {
+		const stale = new Date(Date.now() - 6 * 60 * 1000);
+		const seeded = await seedCache({ last_accessed_at: stale });
+
+		const row = await getCache(db, "trimmed-reads:abc");
+
+		expect(row.last_accessed_at.getTime()).toBeGreaterThan(stale.getTime());
+
+		const [stored] = await db
+			.select()
+			.from(caches)
+			.where(eq(caches.id, seeded.id));
+
+		expect(stored?.last_accessed_at.getTime()).toBeGreaterThan(stale.getTime());
+	});
+});
+
+describe("registerCache", () => {
+	it("inserts a row keyed on the uuid the caller wrote under", async () => {
+		const storage = await storageWith({ [UUID_A]: "hello world!" });
+
+		const { row, created } = await registerCache(db, storage, testLogger, {
+			key: "trimmed-reads:abc",
+			uuid: UUID_A,
+			params: { trim: true },
+		});
+
+		expect(created).toBe(true);
+		expect(row.key).toBe("trimmed-reads:abc");
+		expect(row.storage_key).toBe(cacheKey(UUID_A));
+		expect(row.params).toEqual({ trim: true });
+	});
+
+	// The size on the row is what this side measured, so a caller cannot inflate
+	// its own footprint or hide from Python's storage-budget accounting.
+	it("stores the size read from storage", async () => {
+		const storage = await storageWith({ [UUID_A]: "hello world!" });
+
+		const { row } = await registerCache(db, storage, testLogger, {
+			key: "trimmed-reads:abc",
+			uuid: UUID_A,
+			params: {},
+		});
+
+		expect(row.size).toBe(12);
+	});
+
+	it("writes no row when the uuid names no object", async () => {
+		const storage = new MemoryStorage();
+
+		await expect(
+			registerCache(db, storage, testLogger, {
+				key: "trimmed-reads:abc",
+				uuid: UUID_A,
+				params: {},
+			}),
+		).rejects.toThrow(CacheObjectMissingError);
+
+		expect(await db.select().from(caches)).toEqual([]);
+	});
+
+	// Both workflows derived the same key and wrote the same bytes, so the loser
+	// has nothing to report but success — pointed at the winner's blob.
+	it("returns the winner's row to the loser of a key race", async () => {
+		const storage = await storageWith({ [UUID_A]: "aaa", [UUID_B]: "aaa" });
+
+		const winner = await registerCache(db, storage, testLogger, {
+			key: "trimmed-reads:abc",
+			uuid: UUID_A,
+			params: { first: true },
+		});
+
+		const loser = await registerCache(db, storage, testLogger, {
+			key: "trimmed-reads:abc",
+			uuid: UUID_B,
+			params: { second: true },
+		});
+
+		expect(loser.created).toBe(false);
+		expect(loser.row.id).toBe(winner.row.id);
+		expect(loser.row.storage_key).toBe(cacheKey(UUID_A));
+		expect(loser.row.params).toEqual({ first: true });
+
+		expect(await db.select().from(caches)).toHaveLength(1);
+	});
+
+	// An orphan has no row, so Python's LRU eviction — which walks rows — would
+	// never reclaim it.
+	it("deletes the loser's orphan and leaves the winner's object intact", async () => {
+		const storage = await storageWith({ [UUID_A]: "aaa", [UUID_B]: "aaa" });
+
+		await registerCache(db, storage, testLogger, {
+			key: "trimmed-reads:abc",
+			uuid: UUID_A,
+			params: {},
+		});
+
+		await registerCache(db, storage, testLogger, {
+			key: "trimmed-reads:abc",
+			uuid: UUID_B,
+			params: {},
+		});
+
+		await expect(storage.size(cacheKey(UUID_A))).resolves.toBe(3);
+		await expect(storage.size(cacheKey(UUID_B))).rejects.toThrow();
+	});
+
+	it("both writers succeed when they register concurrently", async () => {
+		const storage = await storageWith({ [UUID_A]: "aaa", [UUID_B]: "aaa" });
+
+		const results = await Promise.all([
+			registerCache(db, storage, testLogger, {
+				key: "trimmed-reads:abc",
+				uuid: UUID_A,
+				params: {},
+			}),
+			registerCache(db, storage, testLogger, {
+				key: "trimmed-reads:abc",
+				uuid: UUID_B,
+				params: {},
+			}),
+		]);
+
+		expect(results.filter((result) => result.created)).toHaveLength(1);
+		expect(new Set(results.map((result) => result.row.id)).size).toBe(1);
+		expect(await db.select().from(caches)).toHaveLength(1);
+	});
+
+	// `onConflictDoNothing` is targeted at `cache_key` specifically. A
+	// `storage_key` collision can only mean a reused uuid, which is a bug, and
+	// swallowing it would leave two logical caches sharing one object.
+	it("raises on a storage_key collision rather than swallowing it", async () => {
+		const storage = await storageWith({ [UUID_A]: "aaa" });
+
+		await registerCache(db, storage, testLogger, {
+			key: "trimmed-reads:abc",
+			uuid: UUID_A,
+			params: {},
+		});
+
+		await expect(
+			registerCache(db, storage, testLogger, {
+				key: "mapping-index:def",
+				uuid: UUID_A,
+				params: {},
+			}),
+		).rejects.toThrow(/storage_key/);
+	});
+});

--- a/packages/data/src/caches/data.test.ts
+++ b/packages/data/src/caches/data.test.ts
@@ -233,6 +233,32 @@ describe("registerCache", () => {
 		expect(await db.select().from(caches)).toHaveLength(1);
 	});
 
+	// A retry re-selects the caller's *own* row, so the object it names is the
+	// live one. Deleting it as if it were an orphan would strand the row on
+	// nothing — a state no lookup can detect and no eviction repairs, since
+	// eviction walks rows and this row still exists.
+	it("keeps the object when a retry sends the same key and uuid", async () => {
+		const storage = await storageWith({ [UUID_A]: "aaa" });
+
+		const first = await registerCache(db, storage, testLogger, {
+			key: "trimmed-reads:abc",
+			uuid: UUID_A,
+			params: {},
+		});
+
+		const retry = await registerCache(db, storage, testLogger, {
+			key: "trimmed-reads:abc",
+			uuid: UUID_A,
+			params: {},
+		});
+
+		expect(retry.created).toBe(false);
+		expect(retry.row.id).toBe(first.row.id);
+		expect(retry.row.storage_key).toBe(cacheKey(UUID_A));
+
+		await expect(storage.size(cacheKey(UUID_A))).resolves.toBe(3);
+	});
+
 	// `onConflictDoNothing` is targeted at `cache_key` specifically. A
 	// `storage_key` collision can only mean a reused uuid, which is a bug, and
 	// swallowing it would leave two logical caches sharing one object.

--- a/packages/data/src/caches/data.ts
+++ b/packages/data/src/caches/data.ts
@@ -100,10 +100,13 @@ export async function getCache(db: Db, key: string): Promise<CacheRow> {
  * swallowed. This deliberately diverges from Python, which raises
  * `CacheAlreadyExistsError` on the same race.
  *
- * The loser then deletes its own orphan. That is safe because `storage_key` is a
- * per-write uuid — the winner's row points somewhere else — and it is necessary
- * because an orphan has no row, so Python's LRU eviction, which walks rows, will
- * never reclaim it. It happens after the write has committed, so a storage
+ * The loser then deletes its own orphan — but **only once it has established
+ * the winner is somebody else**. A retry of a call that already succeeded
+ * arrives with the same uuid and so re-selects its own row, and deleting there
+ * would leave a live row pointing at nothing. Otherwise the delete is safe,
+ * because `storage_key` is a per-write uuid and the winner's row points
+ * elsewhere, and it is necessary, because an orphan has no row and Python's LRU
+ * eviction walks rows. It happens after the write has committed, so a storage
  * failure only leaks bytes and is logged rather than thrown.
  */
 export async function registerCache(
@@ -157,13 +160,18 @@ export async function registerCache(
 		throw new Error(`cache row for ${values.key} vanished mid-registration`);
 	}
 
-	try {
-		await storage.delete(storageKey);
-	} catch (err) {
-		logger.warn(
-			{ err, key: values.key, storageKey },
-			"cache orphan cleanup failed; object orphaned",
-		);
+	// Same uuid means this is a retry of a call that already inserted, so the
+	// object is the one the winning row names. Deleting it would strand a live
+	// row on nothing, which no later lookup could detect and no eviction fix.
+	if (winner.storage_key !== storageKey) {
+		try {
+			await storage.delete(storageKey);
+		} catch (err) {
+			logger.warn(
+				{ err, key: values.key, storageKey },
+				"cache orphan cleanup failed; object orphaned",
+			);
+		}
 	}
 
 	return { row: winner, created: false };

--- a/packages/data/src/caches/data.ts
+++ b/packages/data/src/caches/data.ts
@@ -1,0 +1,170 @@
+import type { JsonObject } from "@virtool/contracts";
+import type { Logger } from "@virtool/logger";
+import type { StorageBackend } from "@virtool/storage";
+import { cacheKey, StorageKeyNotFoundError } from "@virtool/storage";
+import { eq } from "drizzle-orm";
+import type { Db } from "../db/pg";
+import { type CacheRow, caches } from "../db/schema/caches";
+import { AppError } from "../errors";
+
+/**
+ * How stale `last_accessed_at` must be before a lookup refreshes it.
+ *
+ * Python's `LAST_ACCESSED_REFRESH_INTERVAL` (`virtool/caches/data.py`), and the
+ * threshold has to stay the same on both sides because both services read the
+ * same rows. Refreshing unconditionally would turn every cache lookup — which
+ * is on the hot path of every workflow start — into a write.
+ */
+const LAST_ACCESSED_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Thrown when no cache row matches the requested key. */
+export class CacheNotFoundError extends AppError {}
+
+/** Thrown when a registration names a uuid with no object behind it. */
+export class CacheObjectMissingError extends AppError {}
+
+/** Fields needed to register a cache whose blob the caller has already written. */
+export type CacheRegisterValues = {
+	key: string;
+
+	/**
+	 * The uuid the writer minted for its own blob, already validated as 32 hex
+	 * characters at the boundary. The storage key is composed from it here and
+	 * never accepted from a caller.
+	 */
+	uuid: string;
+
+	params: JsonObject;
+};
+
+/** A registered cache row, and whether this call is what created it. */
+export type CacheRegistration = {
+	row: CacheRow;
+	created: boolean;
+};
+
+async function findCacheByKey(db: Db, key: string): Promise<CacheRow | null> {
+	const [row] = await db
+		.select()
+		.from(caches)
+		.where(eq(caches.key, key))
+		.limit(1);
+
+	return row ?? null;
+}
+
+/**
+ * Resolve a logical cache key to its row, refreshing `last_accessed_at` only
+ * when it has gone stale.
+ *
+ * The row's `storage_key` is the point of this call: it is a per-write uuid, so
+ * a workflow holding a derived cache key cannot reach the blob without asking.
+ */
+export async function getCache(db: Db, key: string): Promise<CacheRow> {
+	const row = await findCacheByKey(db, key);
+
+	if (row === null) {
+		throw new CacheNotFoundError();
+	}
+
+	const now = new Date();
+
+	if (
+		now.getTime() - row.last_accessed_at.getTime() <
+		LAST_ACCESSED_REFRESH_INTERVAL_MS
+	) {
+		return row;
+	}
+
+	await db
+		.update(caches)
+		.set({ last_accessed_at: now })
+		.where(eq(caches.id, row.id));
+
+	return { ...row, last_accessed_at: now };
+}
+
+/**
+ * Register a cache row for a blob the caller has already written to
+ * `caches/v1/<uuid>`.
+ *
+ * Storage is read **before** any database work, and the size stored is the one
+ * this side measured — a caller that declares a blob it did not write gets a
+ * `CacheObjectMissingError` and leaves no row behind, and a caller that lies
+ * about the size is simply ignored.
+ *
+ * Two workflows can legitimately derive the same cache key at once, and both
+ * blobs hold the same bytes, so **losing that race is success**. The insert
+ * targets the `cache_key` constraint specifically: a `storage_key` collision can
+ * only mean a reused uuid, which is a bug, and must still raise rather than be
+ * swallowed. This deliberately diverges from Python, which raises
+ * `CacheAlreadyExistsError` on the same race.
+ *
+ * The loser then deletes its own orphan. That is safe because `storage_key` is a
+ * per-write uuid — the winner's row points somewhere else — and it is necessary
+ * because an orphan has no row, so Python's LRU eviction, which walks rows, will
+ * never reclaim it. It happens after the write has committed, so a storage
+ * failure only leaks bytes and is logged rather than thrown.
+ */
+export async function registerCache(
+	db: Db,
+	storage: StorageBackend,
+	logger: Logger,
+	values: CacheRegisterValues,
+): Promise<CacheRegistration> {
+	const storageKey = cacheKey(values.uuid);
+
+	let size: number;
+
+	try {
+		size = await storage.size(storageKey);
+	} catch (err) {
+		if (err instanceof StorageKeyNotFoundError) {
+			throw new CacheObjectMissingError();
+		}
+
+		throw err;
+	}
+
+	const now = new Date();
+
+	// A single statement, so it needs no transaction of its own: it either
+	// inserts or takes no row, and a concurrent inserter blocks it only until
+	// that inserter commits.
+	const [inserted] = await db
+		.insert(caches)
+		.values({
+			key: values.key,
+			storage_key: storageKey,
+			params: values.params,
+			size,
+			created_at: now,
+			last_accessed_at: now,
+		})
+		.onConflictDoNothing({ target: caches.key })
+		.returning();
+
+	if (inserted) {
+		return { row: inserted, created: true };
+	}
+
+	const winner = await findCacheByKey(db, values.key);
+
+	if (winner === null) {
+		// The conflicting row was deleted between the insert and this read —
+		// eviction is the only thing that does that. Genuinely unexpected, and not
+		// something the caller can act on, so it is not an AppError.
+		throw new Error(`cache row for ${values.key} vanished mid-registration`);
+	}
+
+	try {
+		await storage.delete(storageKey);
+	} catch (err) {
+		logger.warn(
+			{ err, key: values.key, storageKey },
+			"cache orphan cleanup failed; object orphaned",
+		);
+	}
+
+	return { row: winner, created: false };
+}

--- a/packages/data/src/db/schema/caches.ts
+++ b/packages/data/src/db/schema/caches.ts
@@ -1,0 +1,42 @@
+// Read-only mirror of the `caches` table managed by the upstream Python service
+// via Alembic. Do not generate or push migrations from this side. Keep the
+// columns in sync with `../../../../../../virtool/virtool/caches/pg.py`.
+
+import type { JsonObject } from "@virtool/contracts";
+import {
+	bigint,
+	integer,
+	jsonb,
+	pgTable,
+	text,
+	timestamp,
+	unique,
+} from "drizzle-orm/pg-core";
+
+export const caches = pgTable(
+	"caches",
+	{
+		id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
+		key: text("key").notNull(),
+		// A per-write UUID under `caches/v1/`, stored verbatim rather than derived
+		// from the row id, so two writers racing on the same `key` never target the
+		// same object and the loser can delete its own orphan.
+		storage_key: text("storage_key").unique().notNull(),
+		params: jsonb("params").$type<JsonObject>().notNull(),
+		// Cache payloads routinely exceed 2 GiB, past the range of a 32-bit
+		// integer, so this mirrors Python's BigInteger — the same reasoning as
+		// `uploads.size`. `mode: "number"` is safe up to 2^53.
+		size: bigint("size", { mode: "number" }).notNull(),
+		created_at: timestamp("created_at").notNull(),
+		last_accessed_at: timestamp("last_accessed_at").notNull(),
+	},
+	// Named, not inferred. Python pins `cache_key` in three places so the
+	// expected duplicate-key race is distinguishable from any other integrity
+	// violation. It also has to exist here for tests to exercise the conflict
+	// path at all: `createTestDatabase()` derives its DDL from these mirrors, so
+	// an undeclared constraint is simply absent from a test database.
+	(table) => [unique("cache_key").on(table.key)],
+);
+
+/** A row from the `caches` table. */
+export type CacheRow = typeof caches.$inferSelect;

--- a/packages/data/src/db/schema/index.ts
+++ b/packages/data/src/db/schema/index.ts
@@ -5,6 +5,7 @@
 // the `export *` list as it lands.
 export * from "./analyses";
 export * from "./apiKeys";
+export * from "./caches";
 export * from "./groups";
 export * from "./history";
 export * from "./hmms";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@virtool/sentry':
         specifier: workspace:*
         version: link:../../packages/sentry
+      '@virtool/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(postgres@3.4.9)


### PR DESCRIPTION
## Summary

- Add the Drizzle mirror for the `caches` table — the last table this server had no mirror for — plus `getCache` and `registerCache` in `@virtool/data`.
- Serve `GET /caches/{key}` and `POST /caches` on the jobs API, so a workflow can resolve a logical cache key to the blob behind it and register a newly derived one. The wire carries a uuid, never a storage key: the server composes the key with `cacheKey(uuid)`, so a job-authenticated caller cannot point a cache row at a sample, index or subtraction object.
- Treat losing a registration race as success — the loser re-selects the winner's row and deletes its own orphan, rather than raising like Python's `CacheAlreadyExistsError`. The jobs API gains its storage configuration here, since registration reads an object's size before writing a row.