### PR TITLE
fix: let users delete an analysis whose job failed

### DIFF
--- a/apps/web/src/analyses/components/AnalysisItem.tsx
+++ b/apps/web/src/analyses/components/AnalysisItem.tsx
@@ -8,7 +8,7 @@ import ProgressCircle from "@base/ProgressCircle";
 import SlashList from "@base/SlashList";
 import { useFetchJob } from "@jobs/queries";
 import { toServerJobNested } from "@jobs/utils";
-import type { AnalysisMinimal } from "@virtool/contracts";
+import { type AnalysisMinimal, isJobStateTerminal } from "@virtool/contracts";
 import { Equal, EqualNot } from "lucide-react";
 import { useRemoveAnalysis } from "../queries";
 import { checkSupportedWorkflow } from "../utils";
@@ -59,6 +59,13 @@ export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 		analysis.job ? toServerJobNested(analysis.job) : undefined,
 	);
 
+	// Mirrors the server's delete guard. An unready analysis is not necessarily
+	// in flight: a workflow pod that is OOM-killed or evicted leaves the row
+	// unready forever, and gating the trash on `ready` alone left the user
+	// staring at a failed analysis with no way to remove it.
+	const state = job?.state ?? analysis.job?.state;
+	const canDelete = ready || state === undefined || isJobStateTerminal(state);
+
 	return (
 		<Box as="li" className="text-gray-600 mb-2.5">
 			<div className="grid grid-cols-5 items-center text-base font-medium [&_a]:font-medium">
@@ -68,16 +75,17 @@ export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 					user={user.handle}
 					time={createdAt}
 				/>
-				<div className="flex justify-end">
-					{ready ? (
-						<AnalysisItemRightIcon
-							canModify={canModify ?? false}
-							onRemove={onRemove}
-						/>
-					) : (
+				<div className="flex justify-end items-center gap-2">
+					{!ready && (
 						<ProgressCircle
 							progress={job?.progress ?? 0}
 							state={job?.state ?? "pending"}
+						/>
+					)}
+					{canDelete && (
+						<AnalysisItemRightIcon
+							canModify={canModify ?? false}
+							onRemove={onRemove}
 						/>
 					)}
 				</div>

--- a/apps/web/src/analyses/components/AnalysisItem.tsx
+++ b/apps/web/src/analyses/components/AnalysisItem.tsx
@@ -59,12 +59,13 @@ export default function AnalysisItem({ analysis }: AnalysisItemProps) {
 		analysis.job ? toServerJobNested(analysis.job) : undefined,
 	);
 
-	// Mirrors the server's delete guard. An unready analysis is not necessarily
-	// in flight: a workflow pod that is OOM-killed or evicted leaves the row
-	// unready forever, and gating the trash on `ready` alone left the user
-	// staring at a failed analysis with no way to remove it.
+	// The same predicate `deleteAnalysis` applies, and deliberately not `ready`.
+	// It reads both ways: an unready analysis whose pod was OOM-killed or evicted
+	// stays removable rather than stranding the user, and a finished analysis
+	// whose job has not been marked terminal yet does not advertise a button the
+	// server would answer with a 409.
 	const state = job?.state ?? analysis.job?.state;
-	const canDelete = ready || state === undefined || isJobStateTerminal(state);
+	const canDelete = state === undefined || isJobStateTerminal(state);
 
 	return (
 		<Box as="li" className="text-gray-600 mb-2.5">

--- a/apps/web/src/analyses/components/__tests__/AnalysisItem.test.tsx
+++ b/apps/web/src/analyses/components/__tests__/AnalysisItem.test.tsx
@@ -20,14 +20,25 @@ describe("<AnalysisItem />", () => {
 		);
 	}
 
-	function unreadyWith(state: JobState): Partial<AnalysisMinimal> {
+	function withJob(state: JobState, ready: boolean): Partial<AnalysisMinimal> {
 		const { job } = createFakeAnalysisMinimal();
 
-		return { ready: false, job: job && { ...job, state } };
+		return { ready, job: job && { ...job, state } };
+	}
+
+	/**
+	 * The remove button only ever appears once the account query resolves, so
+	 * its absence means nothing until that has had a chance to happen. Waiting
+	 * for the find to time out is what makes these assertions non-vacuous.
+	 */
+	async function expectNoRemoveButton() {
+		await expect(
+			screen.findByRole("button", { name: "remove" }),
+		).rejects.toThrow();
 	}
 
 	it("offers removal for a finished analysis", async () => {
-		renderItem({ ready: true });
+		renderItem(withJob("succeeded", true));
 
 		expect(
 			await screen.findByRole("button", { name: "remove" }),
@@ -37,22 +48,27 @@ describe("<AnalysisItem />", () => {
 	it.each<JobState>(["pending", "running"])(
 		"withholds removal while the job is %s",
 		async (state) => {
-			renderItem(unreadyWith(state));
+			renderItem(withJob(state, false));
 
-			// The account query has to settle before the absence means anything.
 			expect(await screen.findByRole("progressbar")).toBeInTheDocument();
-			expect(
-				screen.queryByRole("button", { name: "remove" }),
-			).not.toBeInTheDocument();
+			await expectNoRemoveButton();
 		},
 	);
+
+	// The workflow writes its analysis result before the job is marked terminal,
+	// so `ready` alone would advertise a button the server answers with a 409.
+	it("withholds removal from a ready analysis whose job is still running", async () => {
+		renderItem(withJob("running", true));
+
+		await expectNoRemoveButton();
+	});
 
 	// An OOM-killed or evicted pod leaves the analysis unready forever. It has to
 	// stay removable, or the user is stuck looking at it.
 	it.each<JobState>(["cancelled", "failed", "succeeded"])(
 		"offers removal for an unready analysis whose job is %s",
 		async (state) => {
-			renderItem(unreadyWith(state));
+			renderItem(withJob(state, false));
 
 			expect(
 				await screen.findByRole("button", { name: "remove" }),

--- a/apps/web/src/analyses/components/__tests__/AnalysisItem.test.tsx
+++ b/apps/web/src/analyses/components/__tests__/AnalysisItem.test.tsx
@@ -1,0 +1,72 @@
+import AnalysisItem from "@analyses/components/AnalysisItem";
+import { screen } from "@testing-library/react";
+import { createFakeAccount } from "@tests/fake/account";
+import { createFakeAnalysisMinimal } from "@tests/fake/analyses";
+import { mockGetAccount } from "@tests/server-fn/users";
+import { MemoryRouter, renderWithProviders } from "@tests/setup";
+import type { AnalysisMinimal, JobState } from "@virtool/contracts";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("<AnalysisItem />", () => {
+	beforeEach(() => {
+		mockGetAccount(createFakeAccount({ administrator_role: "full" }));
+	});
+
+	function renderItem(overrides: Partial<AnalysisMinimal>) {
+		renderWithProviders(
+			<MemoryRouter>
+				<AnalysisItem analysis={createFakeAnalysisMinimal(overrides)} />
+			</MemoryRouter>,
+		);
+	}
+
+	function unreadyWith(state: JobState): Partial<AnalysisMinimal> {
+		const { job } = createFakeAnalysisMinimal();
+
+		return { ready: false, job: job && { ...job, state } };
+	}
+
+	it("offers removal for a finished analysis", async () => {
+		renderItem({ ready: true });
+
+		expect(
+			await screen.findByRole("button", { name: "remove" }),
+		).toBeInTheDocument();
+	});
+
+	it.each<JobState>(["pending", "running"])(
+		"withholds removal while the job is %s",
+		async (state) => {
+			renderItem(unreadyWith(state));
+
+			// The account query has to settle before the absence means anything.
+			expect(await screen.findByRole("progressbar")).toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: "remove" }),
+			).not.toBeInTheDocument();
+		},
+	);
+
+	// An OOM-killed or evicted pod leaves the analysis unready forever. It has to
+	// stay removable, or the user is stuck looking at it.
+	it.each<JobState>(["cancelled", "failed", "succeeded"])(
+		"offers removal for an unready analysis whose job is %s",
+		async (state) => {
+			renderItem(unreadyWith(state));
+
+			expect(
+				await screen.findByRole("button", { name: "remove" }),
+			).toBeInTheDocument();
+			// The failure itself stays on screen alongside the remove button.
+			expect(screen.getByRole("progressbar")).toBeInTheDocument();
+		},
+	);
+
+	it("offers removal for an unready analysis with no job", async () => {
+		renderItem({ ready: false, job: null });
+
+		expect(
+			await screen.findByRole("button", { name: "remove" }),
+		).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/analyses/components/__tests__/AnalysisItemRightIcon.test.tsx
+++ b/apps/web/src/analyses/components/__tests__/AnalysisItemRightIcon.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { AnalysisItemRightIcon } from "../AnalysisItemRightIcon";
 
 describe("<AnalysisItemRightIcon />", () => {
-	it("should render remove icon when [ready=true] and [canModify=true]", async () => {
+	it("should render remove icon when [canModify=true]", async () => {
 		const onRemove = vi.fn();
 
 		const { rerender } = renderWithProviders(

--- a/apps/web/src/server/analyses/functions.test.ts
+++ b/apps/web/src/server/analyses/functions.test.ts
@@ -187,6 +187,24 @@ async function seedAnalysis(
 	).id;
 }
 
+async function seedJob(
+	overrides: Partial<typeof jobs.$inferInsert> = {},
+): Promise<number> {
+	return takeFirstOrThrow(
+		await db
+			.insert(jobs)
+			.values({
+				acquired: false,
+				created_at: new Date(),
+				state: "pending",
+				user_id: ownerId,
+				workflow: "nuvs",
+				...overrides,
+			})
+			.returning({ id: jobs.id }),
+	).id;
+}
+
 /** An analysis on a sample the caller may read but not write. */
 async function seedReadOnlyAnalysis(
 	overrides: Partial<typeof analyses.$inferInsert> = {},
@@ -379,12 +397,13 @@ describe("deleteAnalysis", () => {
 		expect(await db.select().from(analyses)).toHaveLength(1);
 	});
 
-	it("returns 409 for an analysis that is still running", async () => {
+	it("returns 409 for an analysis whose job is still running", async () => {
 		const userId = await signInAsNewUser();
 		const sampleId = await seedSample({ user_id: userId });
 		const analysisId = await seedAnalysis({
 			sample_id: sampleId,
 			ready: false,
+			job_id: await seedJob({ state: "running", user_id: userId }),
 		});
 
 		await expect(
@@ -396,6 +415,19 @@ describe("deleteAnalysis", () => {
 		expect(
 			await db.select().from(analyses).where(eq(analyses.id, analysisId)),
 		).toHaveLength(1);
+	});
+
+	it("deletes an unready analysis whose job failed", async () => {
+		const userId = await signInAsNewUser();
+		const sampleId = await seedSample({ user_id: userId });
+		const analysisId = await seedAnalysis({
+			sample_id: sampleId,
+			ready: false,
+			job_id: await seedJob({ state: "failed", user_id: userId }),
+		});
+
+		await expect(call("deleteAnalysisFn", { analysisId })).resolves.toBeNull();
+		expect(await db.select().from(analyses)).toHaveLength(0);
 	});
 
 	it("deletes the analysis for a caller with write rights", async () => {

--- a/packages/contracts/src/jobs.ts
+++ b/packages/contracts/src/jobs.ts
@@ -13,6 +13,18 @@ export const JobState = z.enum([
 export type JobState = z.infer<typeof JobState>;
 
 /**
+ * Whether a state is one a job never leaves.
+ *
+ * Mirrors Python's `TERMINAL_JOB_STATES`. Takes a plain `string` because
+ * `jobs.state` is a `text` column, not an enum — a row written by a future
+ * Python release can hold a state this union has never heard of, and such a
+ * state is not terminal until it is named here.
+ */
+export function isJobStateTerminal(state: string): boolean {
+	return state === "cancelled" || state === "failed" || state === "succeeded";
+}
+
+/**
  * A workflow a job can run.
  *
  * This is the job *read* path and carries every member of Python's `Workflow`

--- a/packages/data/src/analyses/data.test.ts
+++ b/packages/data/src/analyses/data.test.ts
@@ -687,16 +687,54 @@ describe("deleteAnalysis", () => {
 		).rejects.toBeInstanceOf(AnalysisNotFoundError);
 	});
 
-	it("refuses an analysis that is still running", async () => {
-		const analysisId = await seedAnalysisOnNewSample({ ready: false });
+	it.each(["pending", "running"])(
+		"refuses an analysis whose job is %s",
+		async (state) => {
+			const analysisId = await seedAnalysisOnNewSample({
+				ready: false,
+				job_id: await seedJob({ state }),
+			});
 
-		await expect(
-			deleteAnalysis(db, new MemoryStorage(), testLogger, analysisId),
-		).rejects.toBeInstanceOf(AnalysisRunningError);
+			await expect(
+				deleteAnalysis(db, new MemoryStorage(), testLogger, analysisId),
+			).rejects.toBeInstanceOf(AnalysisRunningError);
+
+			expect(
+				await db.select().from(analyses).where(eq(analyses.id, analysisId)),
+			).toHaveLength(1);
+		},
+	);
+
+	// A workflow pod that is OOM-killed or evicted never finalizes its analysis,
+	// so the row stays unready forever. Deletion has to follow the job, not
+	// `ready`, or nothing can ever clean these up.
+	it.each(["cancelled", "failed", "succeeded"])(
+		"deletes an unready analysis whose job is %s",
+		async (state) => {
+			const analysisId = await seedAnalysisOnNewSample({
+				ready: false,
+				job_id: await seedJob({ state }),
+			});
+
+			await deleteAnalysis(db, new MemoryStorage(), testLogger, analysisId);
+
+			expect(
+				await db.select().from(analyses).where(eq(analyses.id, analysisId)),
+			).toHaveLength(0);
+		},
+	);
+
+	it("deletes an unready analysis with no job row", async () => {
+		const analysisId = await seedAnalysisOnNewSample({
+			ready: false,
+			job_id: null,
+		});
+
+		await deleteAnalysis(db, new MemoryStorage(), testLogger, analysisId);
 
 		expect(
 			await db.select().from(analyses).where(eq(analyses.id, analysisId)),
-		).toHaveLength(1);
+		).toHaveLength(0);
 	});
 
 	it("touches storage not at all for a Postgres-native analysis", async () => {

--- a/packages/data/src/analyses/data.ts
+++ b/packages/data/src/analyses/data.ts
@@ -10,6 +10,7 @@ import type {
 	SubtractionNested,
 	UserNested,
 } from "@virtool/contracts";
+import { isJobStateTerminal } from "@virtool/contracts";
 import type { Logger } from "@virtool/logger";
 import {
 	analysisPrefix,
@@ -27,6 +28,7 @@ import {
 	nuvsBlast,
 } from "../db/schema/analyses";
 import { indexes } from "../db/schema/indexes";
+import { jobs } from "../db/schema/jobs";
 import { legacyReferences } from "../db/schema/references";
 import { legacySamples } from "../db/schema/samples";
 import { subtractions } from "../db/schema/subtractions";
@@ -631,11 +633,12 @@ export async function deleteAnalysis(
 		.select({
 			id: analyses.id,
 			legacy_id: analyses.legacy_id,
-			ready: analyses.ready,
 			sample: analyses.sample,
 			sample_id: analyses.sample_id,
+			jobState: jobs.state,
 		})
 		.from(analyses)
+		.leftJoin(jobs, eq(jobs.id, analyses.job_id))
 		.where(eq(analyses.id, analysisId))
 		.limit(1);
 
@@ -643,7 +646,13 @@ export async function deleteAnalysis(
 		throw new AnalysisNotFoundError();
 	}
 
-	if (!row.ready) {
+	// The guard asks whether a job is actually working on this analysis, not
+	// whether the analysis finished. `ready` cannot tell "still running" from
+	// "failed and never will be": a workflow pod that is OOM-killed or evicted
+	// leaves the row unready forever, and refusing on `ready` alone made that
+	// analysis undeletable by anyone. A job that reached a terminal state, or an
+	// analysis with no job row at all, cannot be in flight.
+	if (row.jobState !== null && !isJobStateTerminal(row.jobState)) {
 		throw new AnalysisRunningError("Analysis is still running");
 	}
 

--- a/packages/data/src/jobs/data.ts
+++ b/packages/data/src/jobs/data.ts
@@ -1,4 +1,4 @@
-import type { SearchResult } from "@virtool/contracts";
+import { isJobStateTerminal, type SearchResult } from "@virtool/contracts";
 import { count, desc, eq, inArray } from "drizzle-orm";
 import type { Db, DbOrTx } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
@@ -67,7 +67,7 @@ export class JobNotFoundError extends AppError {}
 // running job is the fraction of its steps that have started, everything else
 // is 0%.
 function computeProgress(state: string, steps: JobStep[] | null): number {
-	if (state === "succeeded" || state === "failed" || state === "cancelled") {
+	if (isJobStateTerminal(state)) {
 		return 100;
 	}
 


### PR DESCRIPTION
## Summary

- An analysis left unready by an OOM-killed or evicted workflow pod could never be deleted by anyone. The guard checked `ready`, which cannot tell "still running" from "failed and never will be", and the only thing cleaning one up was an in-process `on_failure` hook that a hard kill skips.
- `deleteAnalysis` now asks whether a job is actually working on the analysis: a job in a terminal state, or no job row at all, cannot be in flight. `AnalysisRunningError` and its 409 are unchanged — only the condition that raises it. The trash icon in the analysis list follows the same rule, so the fix is reachable from the app.
- `isJobStateTerminal` moved into `@virtool/contracts` because both sides need it; `computeProgress` was spelling the same three states out and now calls it.

Closes VIR-2926.