### PR TITLE
chore: stand up the tasks app with a shared bootstrap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,9 @@ jobs:
                     - image: jobs-api
                       target: jobs-api
                       workspace: apps/jobs-api
+                    - image: tasks
+                      target: tasks
+                      workspace: apps/tasks
                     - image: ts-create-subtraction
                       target: create-subtraction
                       workspace: apps/create-subtraction
@@ -179,10 +182,10 @@ jobs:
                   node-version: ${{ env.NODE_VERSION }}
                   pnpm-version: ${{ env.PNPM_VERSION }}
             # Exclusions rather than an inclusion list, so a new workspace that
-            # declares `test` is covered without editing this job. The four
+            # declares `test` is covered without editing this job. The five
             # excluded here have their own jobs.
             - name: Test
-              run: pnpm -r --filter "!@virtool/web" --filter "!@virtool/data" --filter "!@virtool/storage" --filter "!@virtool/jobs-api" test
+              run: pnpm -r --filter "!@virtool/web" --filter "!@virtool/data" --filter "!@virtool/storage" --filter "!@virtool/jobs-api" --filter "!@virtool/tasks" test
     test-jobs-api:
         name: Test / Jobs API
         runs-on: ubuntu-24.04
@@ -201,6 +204,26 @@ jobs:
             # the fast package loop.
             - name: Test
               run: pnpm --filter @virtool/jobs-api test
+              env:
+                  TZ: UTC
+    test-tasks:
+        name: Test / Tasks
+        runs-on: ubuntu-24.04
+        timeout-minutes: 15
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+            - name: Setup
+              uses: ./.github/actions/setup
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  pnpm-version: ${{ env.PNPM_VERSION }}
+            # Its own job rather than part of Test / Packages, for the same
+            # reason as Test / Data: the probes are tested against a real
+            # Postgres testcontainer, and pulling that image does not belong in
+            # the fast package loop.
+            - name: Test
+              run: pnpm --filter @virtool/tasks test
               env:
                   TZ: UTC
     test-data:
@@ -322,6 +345,7 @@ jobs:
                 test-packages,
                 test-data,
                 test-jobs-api,
+                test-tasks,
                 test-rust,
                 test-storage,
                 test-web,
@@ -367,6 +391,9 @@ jobs:
                     - image: jobs-api
                       target: jobs-api
                       workspace: apps/jobs-api
+                    - image: tasks
+                      target: tasks
+                      workspace: apps/tasks
                     - image: ts-create-subtraction
                       target: create-subtraction
                       workspace: apps/create-subtraction

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,17 @@ This is a **pnpm monorepo**:
   cookie fallback; this service has no session model. Reaching a terminal
   state (`cancelled`, `failed`, `succeeded`) is the only thing that revokes
   a job key. See [docs/jobs-api.md](docs/jobs-api.md).
+- `apps/tasks/` — `@virtool/tasks`, the task service: **one** long-lived
+  process carrying both halves of Virtool's task system, the periodic
+  spawner and the runner that claims and executes what it spawns. Image:
+  `ghcr.io/virtool/tasks`, Alpine, no ingress and **no Service** — its HTTP
+  listener serves only `/health/live`, `/health/ready` and a token-gated
+  `/metrics` on `VT_TASKS_PROBE_PORT` (9900). The two halves are turned off
+  independently with `VT_TASKS_SPAWN_ENABLED` and `VT_TASKS_CLAIM_ENABLED`
+  — both default `true` — which is what decouples their rollouts without a
+  second image. Everything is built inside `bootstrap()`; this app has no
+  module-scope singleton of any kind, not config, not the pool, not the
+  registry. See [docs/tasks.md](docs/tasks.md).
 - `apps/create-subtraction/` — `@virtool/create-subtraction`, the first workflow
   executor: a one-shot process that starts, works, exits. Only its object
   storage half is wired so far. Image: `ghcr.io/virtool/ts-create-subtraction`,
@@ -806,14 +817,15 @@ Prometheus scrapes `GET /metrics`, gated by a bearer token
 (`VT_METRICS_TOKEN`). With the variable unset the route reports 404, so
 metrics are off until a deployment opts in.
 
-**There are two scrape targets, not one** — `apps/web` and `apps/jobs-api`
-are separate processes with separate registries, each needing its own
-Prometheus job. Series names deliberately match so one dashboard covers
-both; they are told apart by the scrape's target labels and by
-`application_name`, **never by renaming a metric**. Both gate the endpoint
-with `isBearerTokenValid` (`@virtool/contracts/bearer`) — constant-time, so
-don't reimplement it or reduce it to `===`. The rest of this section is
-`apps/web`; see [docs/jobs-api.md](docs/jobs-api.md) for the other.
+**There are three scrape targets, not one** — `apps/web`, `apps/jobs-api`
+and `apps/tasks` are separate processes with separate registries, each
+needing its own Prometheus job. Series names deliberately match so one
+dashboard covers them all; they are told apart by the scrape's target
+labels and by `application_name`, **never by renaming a metric**. All three
+gate the endpoint with `isBearerTokenValid` (`@virtool/contracts/bearer`) —
+constant-time, so don't reimplement it or reduce it to `===`. The rest of
+this section is `apps/web`; see [docs/jobs-api.md](docs/jobs-api.md) and
+[docs/tasks.md](docs/tasks.md) for the others.
 
 `server/metrics/registry.ts` owns the one process-wide `Registry`.
 Default process metrics keep prom-client's standard unprefixed names
@@ -853,6 +865,49 @@ into the client graph.
 See [docs/metrics.md](docs/metrics.md) for the exported series, the
 token check, cardinality rules, and what deeper instrumentation would
 take.
+
+### Tasks
+
+`apps/tasks` is **one** process carrying both halves of the task system.
+The periodic spawner inserts scheduled tasks; the runner claims and
+executes them. Each is disabled independently — `VT_TASKS_SPAWN_ENABLED`
+and `VT_TASKS_CLAIM_ENABLED`, both defaulting to `true`, so an omitted key
+fails toward a working fleet rather than a pod that starts, passes every
+probe and does nothing. That is what decouples the two rollouts: the
+cutover from Python is one deployment started with claiming off, then one
+flag flip. Don't reintroduce a second binary to get the same effect.
+
+**Nothing in this app happens at import time.** `bootstrap()`
+(`src/bootstrap.ts`) is the composition root and builds all of it — config,
+logger, pool, emitter, storage, registry, listener — returning an
+`AppContext`. There is no config singleton, no module-scope pool, and no
+`SHOW server_version` fired by an import. A module of this app can be
+imported to read a type without opening anything.
+
+Four rules it carries:
+
+- **Config is the app's own zod schema**, parsed by `parseTasksConfig`,
+  and every key keeps the `<KEY>_FILE` behaviour through the shared
+  `resolveFileBacked`. A boolean is spelled out rather than left to
+  `z.coerce.boolean()`, which reads `"false"` as `true`.
+- **Liveness must never depend on Postgres.** `GET /health/live` is
+  static. A database blip that failed it would restart the whole fleet
+  and kill every task in flight. Readiness still probes Postgres, and
+  reports 503 from the moment shutdown begins.
+- **The version is passed into `bootstrap` explicitly**, from a JSON
+  import of the app's own manifest. `__APP_VERSION__` is a Vite `define`
+  and does not exist here; reading it would render `virtool_app_info`
+  with an empty label and nothing would fail.
+- **Never call `process.exit()`.** Registering a SIGTERM handler removes
+  Node's default exit behaviour, so shutdown is the app's job from that
+  moment: readiness flips, hooks run LIFO, the listener closes, the pool
+  drains, Sentry **flushes** (never `close()`), and `process.exitCode` is
+  set for a natural drain. The backstop timer is `.unref()`'d and its
+  budget must stay under `terminationGracePeriodSeconds`.
+
+See [docs/tasks.md](docs/tasks.md) for the full config table, the
+`AppContext` contract, the shutdown ordering and its guarantees, and the
+probe and metrics surface.
 
 ## Data
 
@@ -1158,18 +1213,19 @@ naming, comments, and concurrency rules with examples.
 - **Projects (`@virtool/storage`):** `unit` covers everything testable
   against `MemoryStorage`; `integration` runs the S3 and Azure backends
   against real Garage and Azurite containers and has its own CI job.
-- **`@virtool/data`** and **`@virtool/jobs-api`** each run one node
-  project against a Postgres testcontainer, and each has its own CI job
-  for the same reason storage does — a container pull does not belong in
-  the fast package loop. Both are excluded from `Test / Packages`.
+- **`@virtool/data`**, **`@virtool/jobs-api`** and **`@virtool/tasks`**
+  each run one node project against a Postgres testcontainer, and each
+  has its own CI job for the same reason storage does — a container pull
+  does not belong in the fast package loop. All three are excluded from
+  `Test / Packages`.
 - **The Postgres container is described once**, in
   `packages/data/src/db/test/globalSetup.ts`. The `@virtool/data`
-  project, the web app's `server` project and `@virtool/jobs-api` all
-  name that module as their `globalSetup` — the latter two through the
-  `@virtool/data/db/test/globalSetup` subpath — so the options cannot
-  drift and `withReuse()` boots one container for the three suites
-  locally. There is no teardown; `docker rm -f` it when done. Don't add
-  a second copy of the container options.
+  project, the web app's `server` project, `@virtool/jobs-api` and
+  `@virtool/tasks` all name that module as their `globalSetup` — the
+  latter three through the `@virtool/data/db/test/globalSetup` subpath —
+  so the options cannot drift and `withReuse()` boots one container for
+  every suite locally. There is no teardown; `docker rm -f` it when done.
+  Don't add a second copy of the container options.
 - **Test location:** `__tests__/` directories alongside source files
   (web), or sibling `*.test.ts` files (packages).
 - **Test files:** `ComponentName.test.tsx` or `functionName.test.ts`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,30 @@ ENV VT_JOBS_API_PORT="9950"
 # earlier than that; the preload hook is what makes late init safe.
 CMD ["node", "--import", "@sentry/node/preload", "dist/index.mjs"]
 
+FROM base AS build-tasks
+COPY apps/tasks ./apps/tasks
+RUN pnpm --filter @virtool/tasks build \
+    && pnpm deploy --filter @virtool/tasks --prod /prod/tasks
+
+# One binary carries both halves of the task system. The spawner and the runner
+# are turned off independently with VT_TASKS_SPAWN_ENABLED and
+# VT_TASKS_CLAIM_ENABLED, so a staged cutover is a flag on one Deployment rather
+# than a second image. Like the jobs API, this needs no bioinformatics tools and
+# stays on Alpine.
+FROM node:24-alpine AS tasks
+WORKDIR /tasks
+COPY --from=build-tasks /prod/tasks ./
+EXPOSE 9900
+ENV VT_TASKS_PROBE_PORT="9900"
+# Exec form, and `node` directly rather than `npm start`: npm does not forward
+# signals to the process it spawns (npm/rfcs#829, still open), so SIGTERM would
+# never reach the shutdown sequence and every rollout would end in SIGKILL with
+# claims still held. The `--import @sentry/node/preload` flag installs Sentry's
+# module hooks before any application import is evaluated — the DSN comes from
+# `<KEY>_FILE`-backed config and cannot be read any earlier, so late init is
+# safe only because of this.
+CMD ["node", "--import", "@sentry/node/preload", "dist/index.mjs"]
+
 FROM base AS build-create-subtraction
 COPY apps/create-subtraction ./apps/create-subtraction
 RUN pnpm --filter @virtool/create-subtraction build \

--- a/apps/tasks/package.json
+++ b/apps/tasks/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "@virtool/tasks",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsdown",
+		"start": "node --import @sentry/node/preload dist/index.mjs",
+		"test": "vitest run",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@sentry/node": "^10.69.0",
+		"@virtool/contracts": "workspace:*",
+		"@virtool/data": "workspace:*",
+		"@virtool/logger": "workspace:*",
+		"@virtool/sentry": "workspace:*",
+		"@virtool/storage": "workspace:*",
+		"pino": "^10.1.0",
+		"postgres": "^3.4.9",
+		"prom-client": "^15.1.3",
+		"zod": "^4.3.5"
+	},
+	"devDependencies": {
+		"tsdown": "^0.22.14",
+		"vitest": "^4.1.10"
+	}
+}

--- a/apps/tasks/src/bootstrap.ts
+++ b/apps/tasks/src/bootstrap.ts
@@ -1,0 +1,161 @@
+import type { Server } from "node:http";
+import * as Sentry from "@sentry/node";
+import {
+	createDb,
+	type Db,
+	logPostgresVersion,
+	type PgClient,
+} from "@virtool/data/db/pg";
+import { createEmitter } from "@virtool/data/events/emit";
+import { createLogger, type Logger } from "@virtool/logger";
+import { createStorageBackend, type StorageBackend } from "@virtool/storage";
+import { parseTasksConfig, type TasksConfig } from "./config";
+import { initSentry, SERVICE } from "./instrument";
+import { createMetrics } from "./metrics/registry";
+import { createProbeServer } from "./probes";
+import { createShutdownController } from "./shutdown";
+
+/** How long Sentry may spend flushing buffered envelopes, in milliseconds. */
+const SENTRY_FLUSH_TIMEOUT = 2_000;
+
+/** Everything a tasks process needs, built once at startup. */
+export type AppContext = {
+	config: TasksConfig;
+	logger: Logger;
+	db: Db;
+	client: PgClient;
+	storage: StorageBackend;
+	/**
+	 * Register a callback to run on SIGTERM or SIGINT.
+	 *
+	 * Guarantees a caller can rely on: hooks run **after** readiness has already
+	 * flipped to unavailable; hooks run **before** the database pool closes, so a
+	 * hook may still write — releasing a task claim, for instance; hooks run in
+	 * reverse registration order; each is awaited; a throwing hook does not
+	 * prevent the others from running; and the whole sequence is bounded by the
+	 * backstop, so a hook must not assume unlimited time.
+	 */
+	onShutdown: (name: string, hook: () => Promise<void>) => void;
+	/** Flip readiness independently of shutdown — e.g. while draining. */
+	setReady: (ready: boolean) => void;
+};
+
+/** What {@link bootstrap} needs that it cannot read from the environment. */
+export type BootstrapOptions = {
+	/**
+	 * This build's version, for `virtool_app_info`.
+	 *
+	 * Passed explicitly because there is no `__APP_VERSION__` outside Vite: an
+	 * ambient global would resolve to `undefined` here and render an empty label
+	 * with nothing failing to say so.
+	 */
+	version: string;
+};
+
+function listen(server: Server, port: number): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(port, () => {
+			server.removeListener("error", reject);
+			resolve();
+		});
+	});
+}
+
+function close(server: Server): Promise<void> {
+	return new Promise((resolve) => {
+		server.close(() => resolve());
+		// `close` stops the listener accepting new connections but waits on the
+		// open ones, and the kubelet's probes are keep-alive. Idle sockets are
+		// dropped so the wait is bounded by a probe in flight rather than by the
+		// next one the kubelet would have sent.
+		server.closeIdleConnections();
+	});
+}
+
+/**
+ * Build everything this process runs on, and return it.
+ *
+ * Nothing in this app happens at import time — no environment parse, no pool,
+ * no storage backend, no registry, no `SHOW server_version`. It all happens
+ * here, in order, so that importing any module of this app to test it or to
+ * read a type costs nothing.
+ *
+ * The order is load-bearing at three points. Sentry initialises **first**, so
+ * a failure anywhere below is reported. The client-event emitter is installed
+ * as soon as the pool exists, because `emit` inside `@virtool/data` throws
+ * without it and the task frames would never publish. And the probe listener
+ * starts **last**, so nothing it reports on is still being built when the
+ * kubelet's first probe arrives.
+ */
+export async function bootstrap(
+	options: BootstrapOptions,
+): Promise<AppContext> {
+	const config = parseTasksConfig();
+
+	const sentry = initSentry(config.sentryDsn);
+
+	const logger = createLogger({ name: SERVICE });
+
+	logger.info(
+		{ environment: sentry.environment, foundSentryDsn: sentry.enabled },
+		sentry.enabled ? "sentry initialised" : "sentry disabled",
+	);
+
+	const { client, db } = createDb(config, SERVICE);
+
+	createEmitter({ client, logger });
+
+	logPostgresVersion(client, logger);
+
+	const storage = createStorageBackend(config.storage);
+
+	let ready = true;
+
+	function setReady(value: boolean): void {
+		ready = value;
+	}
+
+	const server = createProbeServer({
+		client,
+		logger,
+		metrics: createMetrics(options.version),
+		metricsToken: config.metricsToken,
+		isReady: () => ready,
+	});
+
+	const shutdown = createShutdownController({
+		logger,
+		setReady,
+		closeListener: () => close(server),
+		closeDatabase: () => client.end(),
+		flushSentry: async () => {
+			await Sentry.flush(SENTRY_FLUSH_TIMEOUT);
+		},
+		timeout: config.shutdownTimeout,
+	});
+
+	shutdown.listen();
+
+	await listen(server, config.probePort);
+
+	logger.info(
+		{
+			port: config.probePort,
+			version: options.version,
+			claimEnabled: config.claimEnabled,
+			spawnEnabled: config.spawnEnabled,
+		},
+		"listening",
+	);
+
+	return {
+		config,
+		logger,
+		db,
+		client,
+		storage,
+		onShutdown: shutdown.onShutdown,
+		setReady,
+	};
+}

--- a/apps/tasks/src/bootstrap.ts
+++ b/apps/tasks/src/bootstrap.ts
@@ -32,8 +32,9 @@ export type AppContext = {
 	 * flipped to unavailable; hooks run **before** the database pool closes, so a
 	 * hook may still write — releasing a task claim, for instance; hooks run in
 	 * reverse registration order; each is awaited; a throwing hook does not
-	 * prevent the others from running; and the whole sequence is bounded by the
-	 * backstop, so a hook must not assume unlimited time.
+	 * prevent the others from running, though it does make the process exit
+	 * non-zero; and the whole sequence is bounded by the backstop, so a hook must
+	 * not assume unlimited time.
 	 */
 	onShutdown: (name: string, hook: () => Promise<void>) => void;
 	/** Flip readiness independently of shutdown — e.g. while draining. */
@@ -137,7 +138,22 @@ export async function bootstrap(
 
 	shutdown.listen();
 
-	await listen(server, config.probePort);
+	try {
+		await listen(server, config.probePort);
+	} catch (err) {
+		// The pool is open by now, and registering the signal handlers above has
+		// already displaced Node's default exit behaviour — so a port that will not
+		// bind would otherwise leave a container running forever with no listener
+		// for the kubelet to fail, which is the one state Kubernetes cannot restart
+		// its way out of. Release what was built before the failure propagates.
+		await close(server);
+
+		await client.end().catch((endErr) => {
+			logger.error({ err: endErr }, "failed to close the database pool");
+		});
+
+		throw err;
+	}
 
 	logger.info(
 		{

--- a/apps/tasks/src/config.test.ts
+++ b/apps/tasks/src/config.test.ts
@@ -1,0 +1,221 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { parseTasksConfig, TASKS_ENV_KEYS } from "./config";
+
+let directory: string;
+
+beforeAll(() => {
+	directory = mkdtempSync(join(tmpdir(), "virtool-tasks-config-"));
+});
+
+afterAll(() => {
+	rmSync(directory, { recursive: true, force: true });
+});
+
+/** Write `content` to a file in the temp directory and return its path. */
+function writeSecret(name: string, content: string): string {
+	const path = join(directory, name);
+	writeFileSync(path, content, "utf8");
+	return path;
+}
+
+/** The smallest environment that parses, for a test to add one key to. */
+function baseEnv(): NodeJS.ProcessEnv {
+	return {
+		VT_POSTGRES_URL: "postgres://virtool:virtool@localhost:5432/virtool",
+		VT_STORAGE_BACKEND: "s3",
+		VT_STORAGE_S3_BUCKET: "virtool",
+	};
+}
+
+describe("parseTasksConfig", () => {
+	it("prefixes every key it reads with VT_", () => {
+		expect(TASKS_ENV_KEYS.length).toBeGreaterThan(0);
+
+		for (const key of TASKS_ENV_KEYS) {
+			expect(key.startsWith("VT_")).toBe(true);
+		}
+	});
+
+	it("parses a minimal environment", () => {
+		const config = parseTasksConfig(baseEnv());
+
+		expect(config.postgresUrl).toBe(
+			"postgres://virtool:virtool@localhost:5432/virtool",
+		);
+		expect(config.storage).toEqual({
+			kind: "s3",
+			bucket: "virtool",
+			region: undefined,
+			endpoint: undefined,
+			accessKeyId: undefined,
+			secretAccessKey: undefined,
+		});
+	});
+
+	it("applies defaults for every omitted optional key", () => {
+		const config = parseTasksConfig(baseEnv());
+
+		expect(config.postgresPoolMax).toBe(10);
+		expect(config.probePort).toBe(9900);
+		expect(config.shutdownTimeout).toBe(30);
+		expect(config.metricsToken).toBeUndefined();
+		expect(config.sentryDsn).toBeUndefined();
+	});
+
+	it("throws when a required key is missing", () => {
+		expect(() => parseTasksConfig({ VT_STORAGE_BACKEND: "s3" })).toThrowError();
+	});
+
+	describe("claim and spawn flags", () => {
+		// An omitted flag has to fail toward a working fleet. A default of `false`
+		// would make a deployment that never set it a silent no-op — a pod that
+		// starts, passes every probe, and does nothing at all.
+		it("defaults both to enabled", () => {
+			const config = parseTasksConfig(baseEnv());
+
+			expect(config.claimEnabled).toBe(true);
+			expect(config.spawnEnabled).toBe(true);
+		});
+
+		it("reads false, which is the value a rollout actually writes", () => {
+			const config = parseTasksConfig({
+				...baseEnv(),
+				VT_TASKS_CLAIM_ENABLED: "false",
+				VT_TASKS_SPAWN_ENABLED: "0",
+			});
+
+			expect(config.claimEnabled).toBe(false);
+			expect(config.spawnEnabled).toBe(false);
+		});
+
+		it("reads true", () => {
+			const config = parseTasksConfig({
+				...baseEnv(),
+				VT_TASKS_CLAIM_ENABLED: "true",
+				VT_TASKS_SPAWN_ENABLED: "1",
+			});
+
+			expect(config.claimEnabled).toBe(true);
+			expect(config.spawnEnabled).toBe(true);
+		});
+
+		it("rejects a value that is neither", () => {
+			expect(() =>
+				parseTasksConfig({ ...baseEnv(), VT_TASKS_CLAIM_ENABLED: "yes" }),
+			).toThrowError();
+		});
+
+		it("treats an injected empty string as unset", () => {
+			const config = parseTasksConfig({
+				...baseEnv(),
+				VT_TASKS_CLAIM_ENABLED: "",
+			});
+
+			expect(config.claimEnabled).toBe(true);
+		});
+	});
+
+	describe("<KEY>_FILE resolution", () => {
+		it("reads the value from the named file", () => {
+			const config = parseTasksConfig({
+				...baseEnv(),
+				VT_METRICS_TOKEN_FILE: writeSecret("token", "a-metrics-token"),
+			});
+
+			expect(config.metricsToken).toBe("a-metrics-token");
+		});
+
+		// The CSI driver's file mount carries whatever the secret store had,
+		// trailing newline included. An untrimmed token never matches.
+		it("trims the file's contents", () => {
+			const config = parseTasksConfig({
+				...baseEnv(),
+				VT_METRICS_TOKEN_FILE: writeSecret("padded", "  a-metrics-token\n"),
+			});
+
+			expect(config.metricsToken).toBe("a-metrics-token");
+		});
+
+		// A rollout moving to the mount can still carry the stale env var from the
+		// Secret it replaces. Erroring on the overlap would crashloop the very
+		// rollout that fixes it.
+		it("lets the file win over a plain variable of the same name", () => {
+			const config = parseTasksConfig({
+				...baseEnv(),
+				VT_METRICS_TOKEN: "stale-from-the-secret",
+				VT_METRICS_TOKEN_FILE: writeSecret("fresh", "from-the-mount"),
+			});
+
+			expect(config.metricsToken).toBe("from-the-mount");
+		});
+
+		it("throws when the path cannot be read", () => {
+			expect(() =>
+				parseTasksConfig({
+					...baseEnv(),
+					VT_METRICS_TOKEN_FILE: join(directory, "does-not-exist"),
+				}),
+			).toThrowError(/could not be read/);
+		});
+
+		it("reads an empty file as an unset value", () => {
+			const config = parseTasksConfig({
+				...baseEnv(),
+				VT_METRICS_TOKEN_FILE: writeSecret("empty", "\n"),
+			});
+
+			expect(config.metricsToken).toBeUndefined();
+		});
+
+		it("applies to a required key as well", () => {
+			const config = parseTasksConfig({
+				VT_POSTGRES_URL_FILE: writeSecret(
+					"url",
+					"postgres://virtool@db:5432/virtool\n",
+				),
+				VT_STORAGE_BACKEND: "s3",
+				VT_STORAGE_S3_BUCKET: "virtool",
+			});
+
+			expect(config.postgresUrl).toBe("postgres://virtool@db:5432/virtool");
+		});
+	});
+
+	describe("storage", () => {
+		it("rejects an S3 access key id without its secret", () => {
+			expect(() =>
+				parseTasksConfig({
+					...baseEnv(),
+					VT_STORAGE_S3_ACCESS_KEY_ID: "an-id",
+				}),
+			).toThrowError(/must be set together/);
+		});
+
+		it("accepts both S3 credentials together", () => {
+			const config = parseTasksConfig({
+				...baseEnv(),
+				VT_STORAGE_S3_ACCESS_KEY_ID: "an-id",
+				VT_STORAGE_S3_SECRET_ACCESS_KEY: "a-secret",
+			});
+
+			expect(config.storage).toMatchObject({
+				kind: "s3",
+				accessKeyId: "an-id",
+				secretAccessKey: "a-secret",
+			});
+		});
+
+		it("requires the azure container when the backend is azure", () => {
+			expect(() =>
+				parseTasksConfig({
+					VT_POSTGRES_URL: "postgres://virtool@db:5432/virtool",
+					VT_STORAGE_BACKEND: "azure",
+					VT_STORAGE_AZURE_ACCOUNT: "an-account",
+				}),
+			).toThrowError(/VT_STORAGE_AZURE_CONTAINER/);
+		});
+	});
+});

--- a/apps/tasks/src/config.ts
+++ b/apps/tasks/src/config.ts
@@ -1,0 +1,261 @@
+import { resolveFileBacked } from "@virtool/contracts/env";
+import type { StorageConfig } from "@virtool/storage";
+import { z } from "zod";
+
+/** postgres-js pool size when `VT_POSTGRES_POOL_MAX` is unset. */
+const DEFAULT_POSTGRES_POOL_MAX = 10;
+
+/**
+ * Port the probe and metrics listener binds when `VT_TASKS_PROBE_PORT` is
+ * unset.
+ *
+ * The value is arbitrary — this process serves no traffic and has no Service —
+ * but it is hardcoded in the deployment manifests, so it is fixed here and
+ * documented rather than left to drift.
+ */
+const DEFAULT_PROBE_PORT = 9900;
+
+/**
+ * Seconds the shutdown sequence may take before the backstop gives up, when
+ * `VT_TASKS_SHUTDOWN_TIMEOUT` is unset.
+ *
+ * It must sit strictly under `terminationGracePeriodSeconds`, which covers
+ * `preStop` and shutdown combined. The manifests use a 60 s grace period behind
+ * a 10 s `preStop` sleep, leaving 50 s; 30 s is comfortably inside that, so an
+ * overrun is reported by this process rather than cut short by SIGKILL.
+ */
+const DEFAULT_SHUTDOWN_TIMEOUT = 30;
+
+/** Everything this process reads from the environment at startup. */
+export type TasksConfig = {
+	postgresUrl: string;
+	postgresPoolMax: number;
+	probePort: number;
+	/** Seconds the shutdown sequence may run before the backstop gives up. */
+	shutdownTimeout: number;
+	/**
+	 * Whether this process claims and runs tasks.
+	 *
+	 * Set to `false` to deploy the spawner half alone, which is how the
+	 * TypeScript runner reaches production ahead of the cutover from Python: one
+	 * deployment spawns periodic tasks while Python still runs them, and flipping
+	 * this to `true` is the cutover. Defaults to `true`, so an omitted key fails
+	 * toward a working fleet rather than a silent no-op one.
+	 */
+	claimEnabled: boolean;
+	/**
+	 * Whether this process spawns periodic tasks.
+	 *
+	 * Every replica carries the spawner, so this exists to turn it off — during
+	 * the cutover window, when Python is still spawning the same periodic tasks
+	 * and two spawners would duplicate them.
+	 */
+	spawnEnabled: boolean;
+	/**
+	 * Gates the Prometheus scrape endpoint. Unset leaves `/metrics` reporting
+	 * 404, so a deployment never starts exposing internals on upgrade.
+	 */
+	metricsToken: string | undefined;
+	/** Unset disables Sentry entirely, which is what dev and CI want. */
+	sentryDsn: string | undefined;
+	storage: StorageConfig;
+};
+
+// Deployment tooling routinely injects an empty string for a value it has
+// nothing to put in. Treat that as unset everywhere, so a default applies
+// rather than an empty credential being sent as a literal.
+function optional() {
+	return z.preprocess(
+		(value) => (value === "" ? undefined : value),
+		z.string().optional(),
+	);
+}
+
+/**
+ * Read a `VT_`-prefixed boolean.
+ *
+ * Spelled out rather than deferring to `z.coerce.boolean()`, which is a plain
+ * truthiness cast: it reads the string `"false"` as `true`, so the one value a
+ * deployment is most likely to write in order to turn something off would turn
+ * it on instead.
+ */
+function boolish(fallback: boolean) {
+	return z.preprocess(
+		(value) => (value === "" || value === undefined ? undefined : value),
+		z
+			.enum(["true", "false", "1", "0"])
+			.optional()
+			.transform((value) =>
+				value === undefined ? fallback : value === "true" || value === "1",
+			),
+	);
+}
+
+const TasksEnv = z.object({
+	VT_POSTGRES_URL: z.string().url(),
+	// Deployment tooling routinely injects an empty string for a value it has
+	// nothing to put in; treat that as unset so the default applies rather than
+	// coercing "" to 0 and failing the `.positive()` check at startup.
+	VT_POSTGRES_POOL_MAX: z.preprocess(
+		(value) => (value === "" ? undefined : value),
+		z.coerce.number().int().positive().optional(),
+	),
+	VT_TASKS_PROBE_PORT: z.preprocess(
+		(value) => (value === "" ? undefined : value),
+		z.coerce.number().int().positive().optional(),
+	),
+	VT_TASKS_SHUTDOWN_TIMEOUT: z.preprocess(
+		(value) => (value === "" ? undefined : value),
+		z.coerce.number().int().positive().optional(),
+	),
+	VT_TASKS_CLAIM_ENABLED: boolish(true),
+	VT_TASKS_SPAWN_ENABLED: boolish(true),
+	VT_METRICS_TOKEN: optional(),
+	// Listed here so it picks up the `<KEY>_FILE` resolution every other key
+	// gets. `@virtool/sentry`'s `readDsn` goes straight to `process.env` and
+	// would miss a `VT_SENTRY_DSN_FILE` mount, so the DSN is resolved here and
+	// passed to `Sentry.init` explicitly instead.
+	VT_SENTRY_DSN: optional(),
+	VT_STORAGE_BACKEND: z.enum(["s3", "azure"]),
+	VT_STORAGE_S3_BUCKET: optional(),
+	VT_STORAGE_S3_REGION: optional(),
+	VT_STORAGE_S3_ENDPOINT: optional(),
+	VT_STORAGE_S3_ACCESS_KEY_ID: optional(),
+	VT_STORAGE_S3_SECRET_ACCESS_KEY: optional(),
+	VT_STORAGE_AZURE_ACCOUNT: optional(),
+	VT_STORAGE_AZURE_CONTAINER: optional(),
+	VT_STORAGE_AZURE_ACCESS_KEY: optional(),
+	VT_STORAGE_AZURE_ENDPOINT: optional(),
+});
+
+type TasksEnvValues = z.infer<typeof TasksEnv>;
+
+function requirePresent(
+	ctx: z.RefinementCtx,
+	key: keyof TasksEnvValues,
+	value: string | undefined,
+	backend: string,
+): boolean {
+	if (value) {
+		return true;
+	}
+
+	ctx.addIssue({
+		code: "custom",
+		path: [key],
+		message: `${key} is required when VT_STORAGE_BACKEND=${backend}`,
+	});
+
+	return false;
+}
+
+function buildStorage(
+	raw: TasksEnvValues,
+	ctx: z.RefinementCtx,
+): StorageConfig {
+	if (raw.VT_STORAGE_BACKEND === "s3") {
+		const accessKeyId = raw.VT_STORAGE_S3_ACCESS_KEY_ID;
+		const secretAccessKey = raw.VT_STORAGE_S3_SECRET_ACCESS_KEY;
+
+		let ok = requirePresent(
+			ctx,
+			"VT_STORAGE_S3_BUCKET",
+			raw.VT_STORAGE_S3_BUCKET,
+			"s3",
+		);
+
+		// Both empty means the AWS credential chain supplies an IAM role. Exactly
+		// one set is always a mistake, and silently ignoring the odd one out would
+		// send the process to production authenticating as the wrong principal.
+		if (Boolean(accessKeyId) !== Boolean(secretAccessKey)) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["VT_STORAGE_S3_ACCESS_KEY_ID"],
+				message:
+					"VT_STORAGE_S3_ACCESS_KEY_ID and VT_STORAGE_S3_SECRET_ACCESS_KEY must be set together, or both left empty to use IAM role credentials",
+			});
+			ok = false;
+		}
+
+		if (!ok) {
+			return z.NEVER;
+		}
+
+		return {
+			kind: "s3",
+			bucket: raw.VT_STORAGE_S3_BUCKET as string,
+			region: raw.VT_STORAGE_S3_REGION,
+			// Left unset for real AWS, which the SDK resolves from the region.
+			endpoint: raw.VT_STORAGE_S3_ENDPOINT,
+			accessKeyId,
+			secretAccessKey,
+		};
+	}
+
+	const account = requirePresent(
+		ctx,
+		"VT_STORAGE_AZURE_ACCOUNT",
+		raw.VT_STORAGE_AZURE_ACCOUNT,
+		"azure",
+	);
+	const container = requirePresent(
+		ctx,
+		"VT_STORAGE_AZURE_CONTAINER",
+		raw.VT_STORAGE_AZURE_CONTAINER,
+		"azure",
+	);
+
+	if (!account || !container) {
+		return z.NEVER;
+	}
+
+	return {
+		kind: "azure",
+		account: raw.VT_STORAGE_AZURE_ACCOUNT as string,
+		container: raw.VT_STORAGE_AZURE_CONTAINER as string,
+		accessKey: raw.VT_STORAGE_AZURE_ACCESS_KEY,
+		endpoint: raw.VT_STORAGE_AZURE_ENDPOINT,
+	};
+}
+
+const TasksEnvSchema = TasksEnv.transform((raw, ctx) => ({
+	postgresUrl: raw.VT_POSTGRES_URL,
+	postgresPoolMax: raw.VT_POSTGRES_POOL_MAX ?? DEFAULT_POSTGRES_POOL_MAX,
+	probePort: raw.VT_TASKS_PROBE_PORT ?? DEFAULT_PROBE_PORT,
+	shutdownTimeout: raw.VT_TASKS_SHUTDOWN_TIMEOUT ?? DEFAULT_SHUTDOWN_TIMEOUT,
+	claimEnabled: raw.VT_TASKS_CLAIM_ENABLED,
+	spawnEnabled: raw.VT_TASKS_SPAWN_ENABLED,
+	metricsToken: raw.VT_METRICS_TOKEN,
+	sentryDsn: raw.VT_SENTRY_DSN,
+	storage: buildStorage(raw, ctx),
+}));
+
+/**
+ * Every environment key this process reads.
+ *
+ * Derived from the schema rather than listed by hand, because the `<KEY>_FILE`
+ * resolution below walks it: a key missing from this list silently loses its
+ * file variant and reads only the plain environment. `config.test.ts` asserts
+ * every entry carries the `VT_` prefix.
+ */
+export const TASKS_ENV_KEYS: string[] = Object.keys(TasksEnv.shape);
+
+/**
+ * Resolve this process's configuration from the environment.
+ *
+ * A function rather than a module-scope constant, and the whole reason this app
+ * has no configuration singleton: `bootstrap` calls it, everything downstream
+ * receives the result as an argument. Importing any module in this app must not
+ * force an environment parse.
+ *
+ * Every key also accepts a `<KEY>_FILE` variant naming a file to read the value
+ * from, via the resolver shared with `apps/web` and `apps/jobs-api` in
+ * `@virtool/contracts/env`. It is imported rather than copied so the precedence
+ * rule — the file wins over a plain variable of the same name — cannot drift
+ * between the three services.
+ */
+export function parseTasksConfig(
+	env: NodeJS.ProcessEnv = process.env,
+): TasksConfig {
+	return TasksEnvSchema.parse(resolveFileBacked(TASKS_ENV_KEYS, env));
+}

--- a/apps/tasks/src/config.ts
+++ b/apps/tasks/src/config.ts
@@ -192,20 +192,20 @@ function buildStorage(
 		};
 	}
 
-	const account = requirePresent(
+	const hasAccount = requirePresent(
 		ctx,
 		"VT_STORAGE_AZURE_ACCOUNT",
 		raw.VT_STORAGE_AZURE_ACCOUNT,
 		"azure",
 	);
-	const container = requirePresent(
+	const hasContainer = requirePresent(
 		ctx,
 		"VT_STORAGE_AZURE_CONTAINER",
 		raw.VT_STORAGE_AZURE_CONTAINER,
 		"azure",
 	);
 
-	if (!account || !container) {
+	if (!hasAccount || !hasContainer) {
 		return z.NEVER;
 	}
 

--- a/apps/tasks/src/index.ts
+++ b/apps/tasks/src/index.ts
@@ -1,0 +1,41 @@
+import { createLogger } from "@virtool/logger";
+import { bootstrap } from "./bootstrap";
+import { SERVICE } from "./instrument";
+import { APP_VERSION } from "./version";
+
+/**
+ * The tasks process.
+ *
+ * One binary carries both halves of Virtool's task system: the periodic
+ * spawner, which inserts the scheduled tasks, and the runner, which claims and
+ * executes them. Each is turned off independently — `VT_TASKS_SPAWN_ENABLED`
+ * and `VT_TASKS_CLAIM_ENABLED`, both defaulting to `true` — which is what
+ * decouples their rollouts without needing two images. The cutover from Python
+ * is one deployment that starts with claiming off, and one flag flip.
+ *
+ * Both halves are placeholders here. This build starts, serves its probes and
+ * shuts down cleanly; the spawn schedule and the claim loop land with the
+ * issues that own them.
+ */
+async function main(): Promise<void> {
+	const context = await bootstrap({ version: APP_VERSION });
+
+	if (context.config.spawnEnabled) {
+		context.logger.info("periodic task spawning is enabled");
+	}
+
+	if (context.config.claimEnabled) {
+		context.logger.info("task claiming is enabled");
+	}
+}
+
+try {
+	await main();
+} catch (err) {
+	// The logger `bootstrap` builds may not exist yet — a bad `VT_POSTGRES_URL`
+	// fails the config parse before anything else is constructed — so this
+	// reports through one of its own. `process.exitCode` rather than
+	// `process.exit()`, so the line above actually reaches stdout.
+	createLogger({ name: SERVICE }).fatal({ err }, "failed to start");
+	process.exitCode = 1;
+}

--- a/apps/tasks/src/instrument.ts
+++ b/apps/tasks/src/instrument.ts
@@ -1,0 +1,59 @@
+import * as Sentry from "@sentry/node";
+import { getCommonOptions } from "@virtool/sentry";
+
+/** The name this service reports under, in Sentry and in `application_name`. */
+export const SERVICE = "tasks";
+
+/** What {@link initSentry} did, for the caller to log once it has a logger. */
+export type SentryStatus = {
+	enabled: boolean;
+	environment: string;
+};
+
+/**
+ * Initialise Sentry for this process.
+ *
+ * **This runs after `postgres` and the rest of the module graph have already
+ * been imported, and that is fine only because the process is started with
+ * `node --import @sentry/node/preload`.** ESM evaluates every static import
+ * before any top-level statement, and the bundle makes that concrete — the
+ * externals land at the top of `dist/index.mjs` while this call sits thousands
+ * of lines below. Without the preload flag the SDK's module hooks would install
+ * too late to patch anything, and the service would report errors while
+ * silently recording no database spans.
+ *
+ * Init cannot simply move earlier: the DSN comes from `<KEY>_FILE`-backed
+ * config, which has to be read first. That is exactly the case Sentry's "late
+ * initialization" guidance covers, and the preload hook is its answer. If the
+ * flag is ever dropped from the Dockerfile or the `start` script, tracing goes
+ * quiet with nothing in the logs to say so.
+ *
+ * Reports to the same project as `apps/web` and `apps/jobs-api`, tagged
+ * `service: tasks` and carrying its own `dist` so the images' source maps do
+ * not collide under the shared release version. Both come from
+ * `getCommonOptions`.
+ *
+ * The status is returned rather than logged. Nothing in this app builds a
+ * logger at module scope, and `bootstrap` initialises Sentry *before* the
+ * logger so that anything the logger's own construction reports is already
+ * captured — so there is no logger to call at this point.
+ *
+ * There is deliberately no pino destination forwarding records to Sentry, as
+ * `apps/web` has. That stream is written against
+ * `@sentry/tanstackstart-react`, so bringing it here means a third copy of it
+ * rather than a shared one, and the SDK's own uncaught-exception and
+ * unhandled-rejection integrations already report what a crash needs. A task
+ * body that wants a handled failure in Sentry calls `Sentry.captureException`
+ * explicitly. Lift the stream into `@virtool/sentry` before copying it.
+ */
+export function initSentry(dsn: string | undefined): SentryStatus {
+	const options = getCommonOptions(SERVICE);
+
+	if (!dsn) {
+		return { enabled: false, environment: options.environment };
+	}
+
+	Sentry.init({ ...options, dsn });
+
+	return { enabled: true, environment: options.environment };
+}

--- a/apps/tasks/src/metrics/handler.ts
+++ b/apps/tasks/src/metrics/handler.ts
@@ -1,0 +1,52 @@
+import { isBearerTokenValid } from "@virtool/contracts/bearer";
+import type { ProbeResponse } from "../probes";
+import type { Metrics } from "./registry";
+
+/** What {@link handleMetrics} needs to answer a scrape. */
+export type MetricsDeps = {
+	metrics: Metrics;
+	/** The request's `Authorization` header, verbatim. */
+	authorization: string | undefined;
+	token: string | undefined;
+};
+
+/**
+ * Answer a Prometheus scrape at `GET /metrics`.
+ *
+ * This process has no Service and is unreachable from outside the cluster, but
+ * the token is not redundant: the listener answers anything that can route to
+ * the pod IP. With no token configured it reports **404** rather than serving
+ * openly, so an existing deployment does not start exposing internals on
+ * upgrade; with a token configured and a wrong one presented it reports
+ * **401**.
+ *
+ * `isBearerTokenValid` is shared with `apps/web` and `apps/jobs-api` rather
+ * than reimplemented. It screens the length before `timingSafeEqual`, which
+ * throws on a length mismatch — reducing the comparison to `===` reintroduces
+ * the timing leak the shared helper exists to close.
+ *
+ * How these pods actually get scraped is unsettled. A `prometheus.io/scrape`
+ * annotation needs no Service and yields genuine per-pod series, but cannot
+ * carry a bearer token — under the semantics here that means no metrics at all
+ * rather than open metrics. If that is the route taken, this handler needs a
+ * deliberate third state; do not reach it by quietly dropping the gate.
+ */
+export async function handleMetrics(deps: MetricsDeps): Promise<ProbeResponse> {
+	if (!deps.token) {
+		return { status: 404, body: "Not Found", headers: {} };
+	}
+
+	if (!isBearerTokenValid(deps.authorization, deps.token)) {
+		return {
+			status: 401,
+			body: "Unauthorized",
+			headers: { "www-authenticate": "Bearer" },
+		};
+	}
+
+	return {
+		status: 200,
+		body: await deps.metrics.render(),
+		headers: { "content-type": deps.metrics.contentType },
+	};
+}

--- a/apps/tasks/src/metrics/registry.ts
+++ b/apps/tasks/src/metrics/registry.ts
@@ -1,0 +1,51 @@
+import { collectDefaultMetrics, Gauge, Registry } from "prom-client";
+
+/** The metrics surface this process exposes, as returned by {@link createMetrics}. */
+export type Metrics = {
+	contentType: string;
+	render: () => Promise<string>;
+};
+
+/**
+ * Build this process's Prometheus registry.
+ *
+ * A factory rather than a module-scope singleton, so a test gets its own
+ * registry and cannot see what another suite happened to register — and so
+ * importing this module does no work. `version` arrives as an argument for the
+ * same reason nothing here reads configuration.
+ *
+ * This is a *separate registry from the web app's and the jobs API's*, in a
+ * separate process. Series names deliberately match where they overlap, so one
+ * dashboard works across all three; the processes are told apart by the
+ * scrape's target labels, not by renaming a metric.
+ *
+ * Only the process defaults and `virtool_app_info` are registered. The
+ * `virtool_http_*` series are web-specific — their buckets top out at 10 s, and
+ * this process serves nothing but probes — and the task and queue series belong
+ * to the issues that add the claim and spawn loops.
+ */
+export function createMetrics(version: string): Metrics {
+	const registry = new Registry();
+
+	// Standard `process_*` and `nodejs_*` series: RSS, heap, CPU, GC, open
+	// handles, and event loop lag. Left unprefixed on purpose — off-the-shelf
+	// Node dashboards and alerting rules match these names exactly. Event loop
+	// lag is the one that matters most here: a CPU-bound task body starves the
+	// loop, and that is invisible in every other series.
+	collectDefaultMetrics({ register: registry });
+
+	// The conventional `_info` shape: a gauge pinned at 1 whose labels carry the
+	// facts. Joining it onto other series in a query is what correlates a change
+	// in behaviour with the deploy that caused it.
+	new Gauge({
+		name: "virtool_app_info",
+		help: "Build information for the running process, always set to 1.",
+		labelNames: ["version"],
+		registers: [registry],
+	}).set({ version }, 1);
+
+	return {
+		contentType: registry.contentType,
+		render: () => registry.metrics(),
+	};
+}

--- a/apps/tasks/src/probes.test.ts
+++ b/apps/tasks/src/probes.test.ts
@@ -1,0 +1,283 @@
+import type { AddressInfo } from "node:net";
+import { createDb, type PgClient } from "@virtool/data/db/pg";
+import { createLogger, type Logger } from "@virtool/logger";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createMetrics } from "./metrics/registry";
+import { createProbeServer, type ProbeDeps } from "./probes";
+
+const METRICS_TOKEN = "a-metrics-token";
+
+const logger: Logger = createLogger({ name: "test", level: "silent" });
+
+let client: PgClient;
+
+beforeAll(async () => {
+	// `VT_POSTGRES_URL` comes from the shared testcontainer named as this
+	// project's `globalSetup`. A real pool is what makes the readiness assertions
+	// below mean anything: a fake that resolves would pass whether or not the
+	// handler ever queries.
+	client = createDb(
+		{ postgresUrl: process.env.VT_POSTGRES_URL as string, postgresPoolMax: 2 },
+		"tasks-test",
+	).client;
+}, 60_000);
+
+afterAll(async () => {
+	await client.end();
+});
+
+/**
+ * A postgres.js client that cannot reach a database.
+ *
+ * The real thing is called as a tagged template, so a function rejecting is
+ * enough to stand in for an unreachable server.
+ */
+function unreachableClient(): PgClient {
+	return (() =>
+		Promise.reject(new Error("ECONNREFUSED"))) as unknown as PgClient;
+}
+
+/** Start a probe listener on an ephemeral port and return a `fetch` for it. */
+async function serve(overrides: Partial<ProbeDeps> = {}): Promise<{
+	get: (path: string, headers?: HeadersInit) => Promise<Response>;
+	close: () => Promise<void>;
+}> {
+	const server = createProbeServer({
+		client,
+		logger,
+		metrics: createMetrics("1.2.3"),
+		metricsToken: METRICS_TOKEN,
+		isReady: () => true,
+		...overrides,
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+
+	const { port } = server.address() as AddressInfo;
+
+	return {
+		get: (path, headers) =>
+			fetch(`http://127.0.0.1:${port}${path}`, { headers }),
+		close: () =>
+			new Promise<void>((resolve) => {
+				server.close(() => resolve());
+				server.closeAllConnections();
+			}),
+	};
+}
+
+describe("GET /health/live", () => {
+	// The D14 constraint, made executable. A liveness probe that depends on
+	// Postgres restarts the whole fleet on a database blip, killing every task in
+	// flight to fix nothing.
+	it("answers 200 with the database unreachable", async () => {
+		const probe = await serve({ client: unreachableClient() });
+
+		try {
+			const response = await probe.get("/health/live");
+
+			expect(response.status).toBe(200);
+			await expect(response.json()).resolves.toEqual({ status: "alive" });
+		} finally {
+			await probe.close();
+		}
+	});
+
+	it("answers 200 while shutting down", async () => {
+		const probe = await serve({
+			client: unreachableClient(),
+			isReady: () => false,
+		});
+
+		try {
+			expect((await probe.get("/health/live")).status).toBe(200);
+		} finally {
+			await probe.close();
+		}
+	});
+});
+
+describe("GET /health/ready", () => {
+	it("answers 200 when Postgres is up", async () => {
+		const probe = await serve();
+
+		try {
+			const response = await probe.get("/health/ready");
+
+			expect(response.status).toBe(200);
+			await expect(response.json()).resolves.toEqual({
+				status: "ready",
+				checks: { postgres: { ok: true } },
+			});
+		} finally {
+			await probe.close();
+		}
+	});
+
+	it("answers 503 when Postgres is unreachable", async () => {
+		const probe = await serve({ client: unreachableClient() });
+
+		try {
+			const response = await probe.get("/health/ready");
+
+			expect(response.status).toBe(503);
+			await expect(response.json()).resolves.toMatchObject({
+				status: "unavailable",
+			});
+		} finally {
+			await probe.close();
+		}
+	});
+
+	// The listener stays up through shutdown precisely so the kubelet gets this
+	// answer rather than a connection refused.
+	it("answers 503 once shutdown has begun, without querying", async () => {
+		const probe = await serve({
+			client: (() => {
+				throw new Error("a draining process must not query the database");
+			}) as unknown as PgClient,
+			isReady: () => false,
+		});
+
+		try {
+			expect((await probe.get("/health/ready")).status).toBe(503);
+		} finally {
+			await probe.close();
+		}
+	});
+});
+
+describe("GET /metrics", () => {
+	// Withholding even the fact that the endpoint exists, so an existing
+	// deployment does not start exposing internals on upgrade.
+	it("answers 404 when no token is configured", async () => {
+		const probe = await serve({ metricsToken: undefined });
+
+		try {
+			const response = await probe.get("/metrics", {
+				authorization: `Bearer ${METRICS_TOKEN}`,
+			});
+
+			expect(response.status).toBe(404);
+		} finally {
+			await probe.close();
+		}
+	});
+
+	it("answers 401 with no credential", async () => {
+		const probe = await serve();
+
+		try {
+			expect((await probe.get("/metrics")).status).toBe(401);
+		} finally {
+			await probe.close();
+		}
+	});
+
+	// A *different length* on purpose: `timingSafeEqual` throws rather than
+	// returning false when the buffers differ in size, so the shared helper
+	// screens the length first. A 500 here means that screen was lost.
+	it("answers 401 to a token of a different length", async () => {
+		const probe = await serve();
+
+		try {
+			const response = await probe.get("/metrics", {
+				authorization: "Bearer short",
+			});
+
+			expect(response.status).toBe(401);
+		} finally {
+			await probe.close();
+		}
+	});
+
+	it("answers 401 to a same-length token that differs", async () => {
+		const probe = await serve();
+
+		try {
+			const wrong = `${"b".repeat(METRICS_TOKEN.length - 1)}c`;
+			const response = await probe.get("/metrics", {
+				authorization: `Bearer ${wrong}`,
+			});
+
+			expect(response.status).toBe(401);
+		} finally {
+			await probe.close();
+		}
+	});
+
+	it("answers 401 to a malformed authorization header", async () => {
+		const probe = await serve();
+
+		try {
+			const response = await probe.get("/metrics", {
+				authorization: METRICS_TOKEN,
+			});
+
+			expect(response.status).toBe(401);
+		} finally {
+			await probe.close();
+		}
+	});
+
+	it("renders the registry with the right token", async () => {
+		const probe = await serve();
+
+		try {
+			const response = await probe.get("/metrics", {
+				authorization: `Bearer ${METRICS_TOKEN}`,
+			});
+
+			expect(response.status).toBe(200);
+
+			const body = await response.text();
+
+			// Left unprefixed on purpose, so off-the-shelf Node dashboards match.
+			expect(body).toContain("process_cpu_seconds_total");
+		} finally {
+			await probe.close();
+		}
+	});
+
+	// The `__APP_VERSION__` trap: that global is a Vite `define` and does not
+	// exist in a bundled Node app, so a version read from ambient scope renders
+	// as an empty label with nothing failing to say so.
+	it("renders virtool_app_info with a non-empty version", async () => {
+		const probe = await serve();
+
+		try {
+			const body = await (
+				await probe.get("/metrics", {
+					authorization: `Bearer ${METRICS_TOKEN}`,
+				})
+			).text();
+
+			const line = body
+				.split("\n")
+				.find((candidate) => candidate.startsWith("virtool_app_info{"));
+
+			expect(line).toBeDefined();
+
+			const version = /version="([^"]*)"/.exec(line as string)?.[1];
+
+			expect(version).toBe("1.2.3");
+			expect(version).not.toBe("");
+			expect(version).not.toBe("undefined");
+		} finally {
+			await probe.close();
+		}
+	});
+});
+
+describe("anything else", () => {
+	it("answers 404", async () => {
+		const probe = await serve();
+
+		try {
+			expect((await probe.get("/")).status).toBe(404);
+			expect((await probe.get("/health")).status).toBe(404);
+		} finally {
+			await probe.close();
+		}
+	});
+});

--- a/apps/tasks/src/probes.ts
+++ b/apps/tasks/src/probes.ts
@@ -1,0 +1,133 @@
+import { createServer, type Server } from "node:http";
+import type { PgClient } from "@virtool/data/db/pg";
+import { checkPostgres, summarizeReadiness } from "@virtool/data/health/data";
+import type { Logger } from "@virtool/logger";
+import { handleMetrics } from "./metrics/handler";
+import type { Metrics } from "./metrics/registry";
+
+/** A response the probe listener writes out verbatim. */
+export type ProbeResponse = {
+	status: number;
+	body: string;
+	headers: Record<string, string>;
+};
+
+/** What {@link createProbeServer} needs to answer a probe. */
+export type ProbeDeps = {
+	client: PgClient;
+	logger: Logger;
+	metrics: Metrics;
+	metricsToken: string | undefined;
+	/** Whether this process is currently accepting work. */
+	isReady: () => boolean;
+};
+
+function json(status: number, value: unknown): ProbeResponse {
+	return {
+		status,
+		body: JSON.stringify(value),
+		headers: { "content-type": "application/json" },
+	};
+}
+
+/**
+ * Answer `GET /health/live`.
+ *
+ * **Static, with no dependency of any kind — above all not Postgres.** A
+ * liveness probe that queries the database restarts the entire fleet on a
+ * twenty-second database blip, killing every task in flight to fix nothing.
+ * The same reasoning is why a CPU-bound task body must not be able to fail this
+ * either. Adding a check here is not an improvement; it is the failure mode.
+ */
+function handleLive(): ProbeResponse {
+	return json(200, { status: "alive" });
+}
+
+/**
+ * Answer `GET /health/ready`.
+ *
+ * Readiness earns its place where liveness does not: it drives a Deployment's
+ * `availableReplicas` and so its rollout progress, `minReadySeconds`, and PDB
+ * counting — all of which matter even though this process has no Service.
+ * Without it, a pod is Ready the moment the container starts, and against
+ * `maxUnavailable: 0` that is the difference between a safe rollout and a blind
+ * one.
+ *
+ * It reports 503 from the moment shutdown begins, before any hook has run, so
+ * the kubelet learns the pod is going away while the listener is still up to
+ * say so.
+ */
+async function handleReady(deps: ProbeDeps): Promise<ProbeResponse> {
+	if (!deps.isReady()) {
+		return json(503, { status: "unavailable", checks: {} });
+	}
+
+	const report = summarizeReadiness(
+		await checkPostgres(deps.client, deps.logger),
+	);
+
+	return json(report.statusCode, {
+		status: report.status,
+		checks: report.checks,
+	});
+}
+
+async function route(
+	deps: ProbeDeps,
+	method: string | undefined,
+	url: string | undefined,
+	authorization: string | undefined,
+): Promise<ProbeResponse> {
+	// Query strings and trailing junk are not part of any probe's contract, and
+	// the kubelet sends neither. Match the path alone.
+	const path = (url ?? "").split("?")[0];
+
+	if (method !== "GET") {
+		return { status: 404, body: "Not Found", headers: {} };
+	}
+
+	if (path === "/health/live") {
+		return handleLive();
+	}
+
+	if (path === "/health/ready") {
+		return handleReady(deps);
+	}
+
+	if (path === "/metrics") {
+		return handleMetrics({
+			metrics: deps.metrics,
+			authorization,
+			token: deps.metricsToken,
+		});
+	}
+
+	return { status: 404, body: "Not Found", headers: {} };
+}
+
+/**
+ * Build the probe and metrics listener.
+ *
+ * A plain `node:http` server rather than a framework: three routes and a 404
+ * do not earn a dependency, and this process serves no traffic. It is created
+ * unstarted so the caller decides when to listen — `bootstrap` starts it last,
+ * after everything it reports on already exists.
+ */
+export function createProbeServer(deps: ProbeDeps): Server {
+	return createServer((req, res) => {
+		route(deps, req.method, req.url, req.headers.authorization).then(
+			(response) => {
+				res.writeHead(response.status, response.headers);
+				res.end(response.body);
+			},
+			(err) => {
+				// A probe handler that throws must still answer. A socket left hanging
+				// reads to the kubelet as a timeout, which for liveness means a
+				// restart — the outcome the static handler above exists to avoid.
+				deps.logger.error({ err, url: req.url }, "probe handler failed");
+				res.writeHead(500, {});
+				res.end("Internal Server Error");
+			},
+		);
+	});
+}

--- a/apps/tasks/src/shutdown.test.ts
+++ b/apps/tasks/src/shutdown.test.ts
@@ -174,6 +174,52 @@ describe("createShutdownController", () => {
 		expect(unref).toHaveBeenCalled();
 	});
 
+	// A failed step that exited 0 would be indistinguishable from a clean
+	// shutdown, so an undrained pool or an unflushed Sentry buffer would pass
+	// unnoticed through every rollout.
+	it("reports a non-zero exit code when a step throws", async () => {
+		const controller = createShutdownController(
+			deps([], {
+				closeListener: async () => {
+					throw new Error("listener failed");
+				},
+			}),
+		);
+
+		await controller.shutdown("SIGTERM");
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("reports a non-zero exit code when a hook throws", async () => {
+		const controller = createShutdownController(deps([]));
+
+		controller.onShutdown("thrower", async () => {
+			throw new Error("hook failed");
+		});
+
+		await controller.shutdown("SIGTERM");
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	// The pool still has to drain and Sentry still has to flush, whatever the
+	// listener did.
+	it("runs the steps after one that throws", async () => {
+		const order: string[] = [];
+		const controller = createShutdownController(
+			deps(order, {
+				closeListener: async () => {
+					throw new Error("listener failed");
+				},
+			}),
+		);
+
+		await controller.shutdown("SIGTERM");
+
+		expect(order).toEqual(["setReady:false", "closeDatabase", "flushSentry"]);
+	});
+
 	it("reports a non-zero exit code when the sequence overruns", async () => {
 		const controller = createShutdownController(
 			deps([], {

--- a/apps/tasks/src/shutdown.test.ts
+++ b/apps/tasks/src/shutdown.test.ts
@@ -1,0 +1,190 @@
+import { createLogger, type Logger } from "@virtool/logger";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createShutdownController, type ShutdownDeps } from "./shutdown";
+
+const logger: Logger = createLogger({ name: "test", level: "silent" });
+
+const previousExitCode = process.exitCode;
+
+afterEach(() => {
+	// The controller sets `process.exitCode` — that is the behaviour under test —
+	// and leaving it set would decide this suite's own exit status.
+	process.exitCode = previousExitCode;
+	vi.restoreAllMocks();
+});
+
+/** Build deps that append each step's name to `order` as it runs. */
+function deps(
+	order: string[],
+	overrides: Partial<ShutdownDeps> = {},
+): ShutdownDeps {
+	return {
+		logger,
+		setReady: (ready) => {
+			order.push(`setReady:${ready}`);
+		},
+		closeListener: async () => {
+			order.push("closeListener");
+		},
+		closeDatabase: async () => {
+			order.push("closeDatabase");
+		},
+		flushSentry: async () => {
+			order.push("flushSentry");
+		},
+		timeout: 30,
+		...overrides,
+	};
+}
+
+describe("createShutdownController", () => {
+	it("flips readiness before anything else and closes the pool last", async () => {
+		const order: string[] = [];
+		const controller = createShutdownController(deps(order));
+
+		controller.onShutdown("a-hook", async () => {
+			order.push("a-hook");
+		});
+
+		await controller.shutdown("SIGTERM");
+
+		expect(order).toEqual([
+			"setReady:false",
+			"a-hook",
+			"closeListener",
+			"closeDatabase",
+			"flushSentry",
+		]);
+	});
+
+	// A hook registered later may depend on what an earlier one set up, so it has
+	// to come down first.
+	it("runs hooks in reverse registration order", async () => {
+		const order: string[] = [];
+		const controller = createShutdownController(deps(order));
+
+		controller.onShutdown("first", async () => {
+			order.push("first");
+		});
+		controller.onShutdown("second", async () => {
+			order.push("second");
+		});
+		controller.onShutdown("third", async () => {
+			order.push("third");
+		});
+
+		await controller.shutdown("SIGTERM");
+
+		expect(order.slice(1, 4)).toEqual(["third", "second", "first"]);
+	});
+
+	it("awaits each hook rather than starting them together", async () => {
+		const order: string[] = [];
+		const controller = createShutdownController(deps(order));
+
+		controller.onShutdown("slow", async () => {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			order.push("slow");
+		});
+		controller.onShutdown("fast", async () => {
+			order.push("fast");
+		});
+
+		await controller.shutdown("SIGTERM");
+
+		expect(order.slice(1, 3)).toEqual(["fast", "slow"]);
+	});
+
+	// Whatever went wrong in one hook, the pool still has to drain and the
+	// remaining hooks still have claims to release.
+	it("keeps going when a hook throws", async () => {
+		const order: string[] = [];
+		const controller = createShutdownController(deps(order));
+
+		controller.onShutdown("survivor", async () => {
+			order.push("survivor");
+		});
+		controller.onShutdown("thrower", async () => {
+			throw new Error("hook failed");
+		});
+
+		await controller.shutdown("SIGTERM");
+
+		expect(order).toEqual([
+			"setReady:false",
+			"survivor",
+			"closeListener",
+			"closeDatabase",
+			"flushSentry",
+		]);
+	});
+
+	// Hooks would otherwise run twice and the pool would be closed out from under
+	// the first pass.
+	it("ignores a second signal rather than re-entering", async () => {
+		const order: string[] = [];
+		const controller = createShutdownController(deps(order));
+
+		controller.onShutdown("a-hook", async () => {
+			order.push("a-hook");
+		});
+
+		await controller.shutdown("SIGTERM");
+		await controller.shutdown("SIGTERM");
+
+		expect(order.filter((step) => step === "a-hook")).toHaveLength(1);
+		expect(order.filter((step) => step === "closeDatabase")).toHaveLength(1);
+	});
+
+	it("sets a zero exit code without calling process.exit", async () => {
+		const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new Error("process.exit must never be called");
+		}) as never);
+
+		await createShutdownController(deps([])).shutdown("SIGTERM");
+
+		expect(exit).not.toHaveBeenCalled();
+		expect(process.exitCode).toBe(0);
+	});
+
+	// The backstop must not itself be the reason the process lingers: a clean
+	// shutdown that finishes in milliseconds would otherwise sit out the whole
+	// budget before the loop could drain.
+	it("unrefs the backstop timer", async () => {
+		const unref = vi.fn();
+		const original = globalThis.setTimeout;
+
+		vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+			handler: Parameters<typeof original>[0],
+			ms?: number,
+		) => {
+			const handle = original(handler, ms);
+			const real = handle.unref.bind(handle);
+
+			handle.unref = () => {
+				unref();
+				return real();
+			};
+
+			return handle;
+		}) as typeof original);
+
+		await createShutdownController(deps([])).shutdown("SIGTERM");
+
+		expect(unref).toHaveBeenCalled();
+	});
+
+	it("reports a non-zero exit code when the sequence overruns", async () => {
+		const controller = createShutdownController(
+			deps([], {
+				// The hook never settles, so only the backstop can end the sequence.
+				closeDatabase: () => new Promise<void>(() => undefined),
+				timeout: 0.02,
+			}),
+		);
+
+		await controller.shutdown("SIGTERM");
+
+		expect(process.exitCode).toBe(1);
+	});
+});

--- a/apps/tasks/src/shutdown.ts
+++ b/apps/tasks/src/shutdown.ts
@@ -1,0 +1,163 @@
+import type { Logger } from "@virtool/logger";
+
+/** Exit code set when the shutdown sequence completes within its budget. */
+const EXIT_CLEAN = 0;
+
+/** Exit code set when the backstop fires before the sequence finishes. */
+const EXIT_OVERRAN = 1;
+
+/** One registered shutdown callback and the name it is logged under. */
+type Hook = {
+	name: string;
+	run: () => Promise<void>;
+};
+
+/** What {@link createShutdownController} needs to wind the process down. */
+export type ShutdownDeps = {
+	logger: Logger;
+	/** Flip readiness. Called with `false` before any hook runs. */
+	setReady: (ready: boolean) => void;
+	/** Stop accepting probes. Runs after every hook. */
+	closeListener: () => Promise<void>;
+	/** Drain the Postgres pool. Runs last, so a hook may still write. */
+	closeDatabase: () => Promise<void>;
+	/** Flush buffered Sentry envelopes. Never `close()` — see below. */
+	flushSentry: () => Promise<void>;
+	/** Seconds the whole sequence may take before the backstop gives up. */
+	timeout: number;
+};
+
+/** The shutdown surface {@link createShutdownController} returns. */
+export type ShutdownController = {
+	onShutdown: (name: string, hook: () => Promise<void>) => void;
+	/** Run the sequence. Safe to call more than once; later calls are ignored. */
+	shutdown: (signal: string) => Promise<void>;
+	/** Register SIGTERM and SIGINT handlers. */
+	listen: () => void;
+};
+
+/** Run `promise`, or resolve `false` once `ms` milliseconds have passed. */
+function withBackstop(promise: Promise<void>, ms: number): Promise<boolean> {
+	return new Promise<boolean>((resolve) => {
+		const timer = setTimeout(() => resolve(false), ms);
+
+		// Without this the timer holds the event loop open for its full duration
+		// on an otherwise clean shutdown, so a process that finished winding down
+		// in 200 ms would still sit there for the whole budget before exiting.
+		timer.unref();
+
+		promise.then(
+			() => {
+				clearTimeout(timer);
+				resolve(true);
+			},
+			() => {
+				clearTimeout(timer);
+				resolve(true);
+			},
+		);
+	});
+}
+
+/**
+ * Build this process's shutdown sequence.
+ *
+ * **Registering a SIGTERM listener removes Node's default exit behaviour**, so
+ * from that moment exiting is entirely this module's responsibility.
+ *
+ * It discharges that with `process.exitCode` and a natural drain, never
+ * `process.exit()`. Node's own documentation is explicit that `exit()` forces
+ * the process down "even if there are still asynchronous operations pending",
+ * writes to `process.stdout` included — which here means a dropped pino line,
+ * an unsent Sentry envelope, and an uncommitted transaction.
+ *
+ * The ordering is fixed, and each step is awaited before the next:
+ *
+ * 1. Readiness flips to unavailable. The listener stays up, so the kubelet
+ *    still gets an answer rather than a connection refused.
+ * 2. Registered hooks run in **reverse registration order**, each awaited. A
+ *    hook that throws is logged and does not abort the ones after it.
+ * 3. The probe listener closes.
+ * 4. The database pool drains — after the hooks, so a hook may still write.
+ *    Releasing a task claim is exactly that.
+ * 5. Sentry flushes. `flush()`, never `close()`: `close()` flushes *and*
+ *    disables, so anything raised later in shutdown goes unreported.
+ *
+ * The whole sequence is bounded by the backstop, which means a hook cannot
+ * assume unlimited time. The budget must stay strictly under
+ * `terminationGracePeriodSeconds` — which covers `preStop` and shutdown
+ * together — or SIGKILL lands first and the process gets neither a clean
+ * shutdown nor a controlled failure.
+ */
+export function createShutdownController(
+	deps: ShutdownDeps,
+): ShutdownController {
+	const hooks: Hook[] = [];
+	let started = false;
+
+	async function runHooks(): Promise<void> {
+		// Reverse registration order: a hook registered later may depend on what an
+		// earlier one set up, so it has to come down first.
+		for (const hook of [...hooks].reverse()) {
+			try {
+				await hook.run();
+				deps.logger.debug({ hook: hook.name }, "ran shutdown hook");
+			} catch (err) {
+				deps.logger.error({ err, hook: hook.name }, "shutdown hook failed");
+			}
+		}
+	}
+
+	async function sequence(): Promise<void> {
+		deps.setReady(false);
+
+		await runHooks();
+		await deps.closeListener();
+		await deps.closeDatabase();
+		await deps.flushSentry();
+	}
+
+	async function shutdown(signal: string): Promise<void> {
+		if (started) {
+			// A second signal must not re-enter the sequence: hooks would run twice
+			// and the pool would be closed out from under the first pass.
+			deps.logger.warn({ signal }, "already shutting down");
+			return;
+		}
+
+		started = true;
+
+		deps.logger.info({ signal }, "shutting down");
+
+		const finished = await withBackstop(sequence(), deps.timeout * 1000);
+
+		if (finished) {
+			deps.logger.info("shutdown complete");
+			process.exitCode = EXIT_CLEAN;
+			return;
+		}
+
+		deps.logger.error(
+			{ timeout: deps.timeout },
+			"shutdown did not finish within its budget",
+		);
+
+		process.exitCode = EXIT_OVERRAN;
+	}
+
+	return {
+		onShutdown(name, run) {
+			hooks.push({ name, run });
+		},
+
+		shutdown,
+
+		listen() {
+			for (const signal of ["SIGINT", "SIGTERM"] as const) {
+				process.on(signal, () => {
+					void shutdown(signal);
+				});
+			}
+		},
+	};
+}

--- a/apps/tasks/src/shutdown.ts
+++ b/apps/tasks/src/shutdown.ts
@@ -1,10 +1,13 @@
 import type { Logger } from "@virtool/logger";
 
-/** Exit code set when the shutdown sequence completes within its budget. */
+/** Exit code set when every step of the sequence ran within its budget. */
 const EXIT_CLEAN = 0;
 
-/** Exit code set when the backstop fires before the sequence finishes. */
-const EXIT_OVERRAN = 1;
+/** Exit code set when a step failed, or the backstop fired before the end. */
+const EXIT_UNCLEAN = 1;
+
+/** How the shutdown sequence ended. */
+type Outcome = "clean" | "failed" | "overran";
 
 /** One registered shutdown callback and the name it is logged under. */
 type Hook = {
@@ -36,10 +39,16 @@ export type ShutdownController = {
 	listen: () => void;
 };
 
-/** Run `promise`, or resolve `false` once `ms` milliseconds have passed. */
-function withBackstop(promise: Promise<void>, ms: number): Promise<boolean> {
-	return new Promise<boolean>((resolve) => {
-		const timer = setTimeout(() => resolve(false), ms);
+/**
+ * Resolve what `promise` reports, or `"overran"` once `ms` have passed.
+ *
+ * `promise` settling `false` is a sequence that ran to the end with at least
+ * one failed step, and a rejection is one that could not — neither is a clean
+ * shutdown, and neither may be reported as one.
+ */
+function withBackstop(promise: Promise<boolean>, ms: number): Promise<Outcome> {
+	return new Promise<Outcome>((resolve) => {
+		const timer = setTimeout(() => resolve("overran"), ms);
 
 		// Without this the timer holds the event loop open for its full duration
 		// on an otherwise clean shutdown, so a process that finished winding down
@@ -47,13 +56,13 @@ function withBackstop(promise: Promise<void>, ms: number): Promise<boolean> {
 		timer.unref();
 
 		promise.then(
-			() => {
+			(ok) => {
 				clearTimeout(timer);
-				resolve(true);
+				resolve(ok ? "clean" : "failed");
 			},
 			() => {
 				clearTimeout(timer);
-				resolve(true);
+				resolve("failed");
 			},
 		);
 	});
@@ -83,6 +92,12 @@ function withBackstop(promise: Promise<void>, ms: number): Promise<boolean> {
  * 5. Sentry flushes. `flush()`, never `close()`: `close()` flushes *and*
  *    disables, so anything raised later in shutdown goes unreported.
  *
+ * **No step can abort the ones after it, and none can pass unreported.** Each
+ * is caught and logged on its own, so a listener that will not close still
+ * leaves the pool to drain; and any failure — a hook's included — is what the
+ * process exits `1` on, so a shutdown that failed is never indistinguishable
+ * from one that did not.
+ *
  * The whole sequence is bounded by the backstop, which means a hook cannot
  * assume unlimited time. The budget must stay strictly under
  * `terminationGracePeriodSeconds` — which covers `preStop` and shutdown
@@ -95,26 +110,53 @@ export function createShutdownController(
 	const hooks: Hook[] = [];
 	let started = false;
 
-	async function runHooks(): Promise<void> {
+	async function runHooks(): Promise<boolean> {
+		const results: boolean[] = [];
+
 		// Reverse registration order: a hook registered later may depend on what an
 		// earlier one set up, so it has to come down first.
 		for (const hook of [...hooks].reverse()) {
 			try {
 				await hook.run();
 				deps.logger.debug({ hook: hook.name }, "ran shutdown hook");
+				results.push(true);
 			} catch (err) {
 				deps.logger.error({ err, hook: hook.name }, "shutdown hook failed");
+				results.push(false);
 			}
+		}
+
+		return results.every((ok) => ok);
+	}
+
+	async function runStep(
+		step: string,
+		run: () => Promise<void>,
+	): Promise<boolean> {
+		try {
+			await run();
+			return true;
+		} catch (err) {
+			deps.logger.error({ err, step }, "shutdown step failed");
+			return false;
 		}
 	}
 
-	async function sequence(): Promise<void> {
+	async function sequence(): Promise<boolean> {
 		deps.setReady(false);
 
-		await runHooks();
-		await deps.closeListener();
-		await deps.closeDatabase();
-		await deps.flushSentry();
+		// Every step runs and every result is collected, rather than the first
+		// failure aborting the rest: a listener that would not close is no reason
+		// to leave the pool undrained or the Sentry buffer unflushed. The collected
+		// results are what stop a failed shutdown reporting itself as a clean one.
+		const results = [
+			await runHooks(),
+			await runStep("closeListener", deps.closeListener),
+			await runStep("closeDatabase", deps.closeDatabase),
+			await runStep("flushSentry", deps.flushSentry),
+		];
+
+		return results.every((ok) => ok);
 	}
 
 	async function shutdown(signal: string): Promise<void> {
@@ -129,11 +171,17 @@ export function createShutdownController(
 
 		deps.logger.info({ signal }, "shutting down");
 
-		const finished = await withBackstop(sequence(), deps.timeout * 1000);
+		const outcome = await withBackstop(sequence(), deps.timeout * 1000);
 
-		if (finished) {
+		if (outcome === "clean") {
 			deps.logger.info("shutdown complete");
 			process.exitCode = EXIT_CLEAN;
+			return;
+		}
+
+		if (outcome === "failed") {
+			deps.logger.error("shutdown finished with failed steps");
+			process.exitCode = EXIT_UNCLEAN;
 			return;
 		}
 
@@ -142,7 +190,7 @@ export function createShutdownController(
 			"shutdown did not finish within its budget",
 		);
 
-		process.exitCode = EXIT_OVERRAN;
+		process.exitCode = EXIT_UNCLEAN;
 	}
 
 	return {

--- a/apps/tasks/src/version.ts
+++ b/apps/tasks/src/version.ts
@@ -1,0 +1,19 @@
+import pkg from "../package.json" with { type: "json" };
+
+/**
+ * This build's version, as it reaches the `virtool_app_info` gauge.
+ *
+ * Read from the app's own manifest rather than from a build-time global.
+ * `apps/web` uses `__APP_VERSION__`, which is a **Vite** `define` and simply
+ * does not exist in a bundled Node app — the gauge label would render
+ * `undefined` with nothing failing to say so. A JSON import is a real module
+ * value: the bundler inlines it, `vitest` resolves it, and the version is then
+ * passed explicitly into `bootstrap` rather than read from ambient scope.
+ *
+ * It is only *correct* in a released image because CI's `publish-ghcr` job runs
+ * `pnpm -C ${{ matrix.workspace }} version` before the Docker build. That step
+ * is driven by the publish matrix, so this app is covered by its matrix entry —
+ * remove the entry and every image still builds while this silently reverts to
+ * `0.0.0`.
+ */
+export const APP_VERSION: string = pkg.version;

--- a/apps/tasks/tsconfig.json
+++ b/apps/tasks/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../tsconfig.node.json",
+	"compilerOptions": {
+		// `src/version.ts` reads this app's own `package.json`, which is how the
+		// version reaches `virtool_app_info` without a bundler-injected global.
+		"resolveJsonModule": true
+	},
+	"include": ["src", "tsdown.config.ts"]
+}

--- a/apps/tasks/tsdown.config.ts
+++ b/apps/tasks/tsdown.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: { index: "src/index.ts" },
+	format: ["esm"],
+	platform: "node",
+	target: "node24",
+	outDir: "dist",
+	sourcemap: true,
+	dts: false,
+	deps: {
+		// Workspace packages ship unbuilt TypeScript, so they must be inlined —
+		// that is the whole reason an app bundles. tsdown externalises everything
+		// in `dependencies` by default, which would otherwise leave a `.ts` import
+		// in the output that `node` cannot load.
+		alwaysBundle: [/^@virtool\//],
+		// Externals must appear verbatim as strings: knip's tsdown plugin reads
+		// them as declared dependencies, which is what keeps them out of the
+		// unused-dependency report without a knip.json entry.
+		neverBundle: ["pino", "postgres"],
+	},
+});

--- a/apps/tasks/vitest.config.ts
+++ b/apps/tasks/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		name: "tasks",
+		environment: "node",
+		// The Postgres container is described once, in the package that owns the
+		// schema, and `@virtool/data`'s own project, `apps/web`'s `server` project
+		// and `apps/jobs-api` all name that same module. One definition means one
+		// `withReuse()` hash, so a local run of every database-backed suite boots a
+		// single Postgres between them.
+		globalSetup: ["@virtool/data/db/test/globalSetup"],
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,320 @@
+# Tasks
+
+`apps/tasks` (`@virtool/tasks`) is Virtool's task service: a long-lived Node
+process that spawns periodic tasks and runs them. It is the TypeScript port of
+Python's `task_runner`, and it ships as `ghcr.io/virtool/tasks` on Alpine.
+
+It is deliberately small in surface. It serves no API, has no Service and no
+ingress, and the only HTTP it speaks is three routes on a probe listener. Its
+work reaches the outside world through Postgres and object storage.
+
+## One process, two halves
+
+The spawner and the runner are **one binary**, not two.
+
+The spawner inserts the scheduled tasks; the runner claims and executes them.
+Each is turned off independently:
+
+| Variable | Default | Effect when `false` |
+| --- | --- | --- |
+| `VT_TASKS_SPAWN_ENABLED` | `true` | The process spawns no periodic tasks. |
+| `VT_TASKS_CLAIM_ENABLED` | `true` | The process claims and runs nothing. |
+
+Both default to `true` because an omitted flag has to fail toward a working
+fleet. A default of `false` would make a deployment that never set the key a
+silent no-op — a pod that starts, passes every probe, and does nothing at all.
+
+The two flags are what decouple the halves' rollouts, which is the whole reason
+separate binaries were ever considered. The cutover from Python is:
+
+1. Deploy with `VT_TASKS_CLAIM_ENABLED=false`. The TypeScript spawner runs in
+   production while Python still executes what it spawns.
+2. Stop Python's spawner and runner.
+3. Flip `VT_TASKS_CLAIM_ENABLED` to `true`.
+
+One image and one Deployment carry that whole sequence. Don't reintroduce a
+second binary to get the same effect — a mode flag on one artifact is the same
+decoupling with half the pipeline.
+
+## Nothing happens at import time
+
+`bootstrap()` in `src/bootstrap.ts` is this app's composition root, and it is
+the *only* place anything is constructed. There is no config singleton, no
+module-scope pool, no module-scope registry, and no `SHOW server_version` fired
+as an import side effect. Importing any module of this app to read a type or to
+test a function costs nothing.
+
+That is a deliberate departure from `apps/web/src/server`, where `config`,
+`db` and `storage` are module-scope constants: importing anything downstream of
+those forces an environment parse and opens a pool. A process with a bootstrap
+function and a test suite cannot afford that.
+
+`bootstrap` runs this sequence, and three points in it are load-bearing:
+
+1. **Parse config.** `parseTasksConfig()` — see below.
+2. **Initialise Sentry.** *First*, so a failure anywhere below is reported.
+3. **Create the logger.** After Sentry, so the "sentry initialised" line the
+   status produces is the first thing written.
+4. **Open the pool.** `createDb(config, "tasks")`.
+5. **Install the client-event emitter.** `createEmitter({ client, logger })` —
+   without it every `emit()` inside `@virtool/data` throws, and the `tasks`
+   frames the framework publishes never reach the SPA.
+6. **Build storage.** `createStorageBackend(config.storage)`.
+7. **Register signal handlers**, then **start the probe listener** — *last*, so
+   nothing it reports on is still being built when the kubelet's first probe
+   arrives.
+
+A failure anywhere in that sequence propagates to `src/index.ts`, which logs
+through a logger of its own — `bootstrap`'s may not exist yet — and sets
+`process.exitCode = 1` without the listener ever starting.
+
+### `AppContext`
+
+What `bootstrap` returns, and the contract the spawn and claim loops build on:
+
+```ts
+type AppContext = {
+	config: TasksConfig;
+	logger: Logger;
+	db: Db;
+	client: PgClient;
+	storage: StorageBackend;
+	onShutdown: (name: string, hook: () => Promise<void>) => void;
+	setReady: (ready: boolean) => void;
+};
+```
+
+`db`, `client` and `storage` are passed into `@virtool/data` and
+`@virtool/storage` functions as arguments, exactly as they are in `apps/web`.
+Nothing imports a module-scope handle, because there is none to import.
+
+## Configuration
+
+Every key is `VT_`-prefixed, and every key also accepts a `<KEY>_FILE` variant
+naming a file to read the value from. That resolution is
+`resolveFileBacked` from `@virtool/contracts/env` — shared with `apps/web` and
+`apps/jobs-api` rather than copied, so its precedence rule cannot drift between
+the three services.
+
+Three of its behaviours are load-bearing and directly tested:
+
+- **The file wins over a plain variable of the same name.** A rollout moving to
+  a secrets-store CSI mount can still carry the stale env var from the
+  `Secret` it replaces, and erroring on the overlap would crashloop the very
+  rollout that fixes it.
+- **An unreadable path throws at startup**, so a misconfigured mount fails
+  loudly rather than silently falling back.
+- **An empty file is an unset value**, and the contents are trimmed — the mount
+  carries whatever the secret store had, trailing newline included.
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `VT_POSTGRES_URL` | — | Required. |
+| `VT_POSTGRES_POOL_MAX` | `10` | |
+| `VT_TASKS_PROBE_PORT` | `9900` | Hardcoded in the manifests; fixed, not arbitrary in practice. |
+| `VT_TASKS_SHUTDOWN_TIMEOUT` | `30` | **Seconds.** Must stay under the grace period — see below. |
+| `VT_TASKS_CLAIM_ENABLED` | `true` | |
+| `VT_TASKS_SPAWN_ENABLED` | `true` | |
+| `VT_METRICS_TOKEN` | unset | Unset leaves `/metrics` reporting 404. |
+| `VT_SENTRY_DSN` | unset | Unset disables Sentry. |
+| `VT_STORAGE_BACKEND` | — | Required, `s3` or `azure`. |
+| `VT_STORAGE_S3_*` / `VT_STORAGE_AZURE_*` | — | Same names and rules as `apps/web`. |
+
+The schema is zod, in `src/config.ts`, and `TASKS_ENV_KEYS` is derived from it
+rather than listed by hand — a key missing from that list would silently lose
+its file variant.
+
+Booleans are spelled out as an enum of `true` / `false` / `1` / `0` rather than
+left to `z.coerce.boolean()`, which is a plain truthiness cast: it reads the
+string `"false"` as `true`, so the one value a deployment is most likely to
+write in order to turn something off would turn it on instead. An injected
+empty string reads as unset everywhere, which is what deployment tooling emits
+for a value it has nothing to put in.
+
+## Probes and metrics
+
+A plain `node:http` listener on `VT_TASKS_PROBE_PORT`. Three routes; everything
+else, and every non-`GET`, is a 404.
+
+### `GET /health/live`
+
+Static `{"status":"alive"}`, with **no dependency of any kind — above all not
+Postgres.**
+
+A liveness probe that queries the database restarts the entire fleet on a
+twenty-second database blip, killing every task in flight to fix nothing. A
+CPU-bound task body starving the shared event loop is a second way to get a
+working pod killed. Adding a check here is not an improvement; it is the
+failure mode. A test asserts this route answers 200 with the database
+unreachable.
+
+For calibration: Python's `task_runner` has no probes at all today. Everything
+here is net new.
+
+### `GET /health/ready`
+
+`checkPostgres` and `summarizeReadiness` from `@virtool/data/health/data`,
+reporting 200 or 503. It answers 503 from the moment shutdown begins — before
+any hook has run, and without querying — while the listener stays up so the
+kubelet gets an answer rather than a connection refused.
+
+Readiness earns its place where liveness does not, even though this process has
+no Service: it drives a Deployment's `availableReplicas` and so its rollout
+progress, `minReadySeconds`, and PDB counting. Without it a pod is Ready the
+moment the container starts, and against `maxUnavailable: 0` that is the
+difference between a safe rollout and a blind one.
+
+### `GET /metrics`
+
+A private `prom-client` `Registry` holding `collectDefaultMetrics` — left
+unprefixed so off-the-shelf Node dashboards match — plus `virtool_app_info`.
+Nothing else yet. The `virtool_http_*` series are web-specific: their buckets
+top out at 10 s, and this process serves nothing but probes. Task and queue
+series belong to the issues that add the loops.
+
+The gate is `isBearerTokenValid` from `@virtool/contracts/bearer`, shared with
+the other two services. It screens the length before `timingSafeEqual`, which
+*throws* rather than returning false when the buffers differ in size; reducing
+the comparison to `===` reintroduces the timing leak the helper exists to
+close. Unset token means **404**, not open metrics, so an existing deployment
+does not start exposing internals on upgrade.
+
+How these pods get scraped is unsettled. A `prometheus.io/scrape` annotation
+needs no Service and yields genuine per-pod series, but cannot carry a bearer
+token — under the semantics above that means no metrics at all. If that is the
+route taken, the handler needs a deliberate third state. Do not reach it by
+quietly dropping the gate.
+
+### The version label
+
+`virtool_app_info{version}` comes from a JSON import of the app's own
+`package.json`, passed explicitly into `bootstrap`.
+
+`apps/web` reads `__APP_VERSION__`, which is a **Vite** `define` and simply
+does not exist in a bundled Node app: the label would render `undefined` with
+nothing failing to say so. A JSON import is a real module value — the bundler
+inlines it, `vitest` resolves it, and no ambient global is involved. It is only
+*correct* in a released image because CI's `publish-ghcr` job runs
+`pnpm -C ${{ matrix.workspace }} version` before the Docker build, which this
+app is covered by through its publish-matrix entry.
+
+## Shutdown
+
+Registering a SIGTERM listener **removes Node's default exit behaviour**. From
+that moment, exiting is entirely this app's responsibility.
+
+`src/shutdown.ts` discharges that with `process.exitCode` and a natural drain,
+**never `process.exit()`**. Node's own documentation is explicit that `exit()`
+forces the process down "even if there are still asynchronous operations
+pending", writes to `process.stdout` included — which here means a dropped pino
+line, an unsent Sentry envelope, and an uncommitted transaction.
+
+On the first SIGTERM or SIGINT, each step awaited before the next:
+
+1. **Readiness flips to unavailable.** The listener stays up.
+2. **Registered hooks run in reverse registration order (LIFO)**, each awaited.
+   A hook that throws is logged and does not abort the ones after it.
+3. **The probe listener closes.** Idle keep-alive sockets are dropped so the
+   wait is bounded by a probe in flight rather than the next one.
+4. **The database pool drains** — after the hooks, so a hook may still write.
+   Releasing a task claim is exactly that.
+5. **Sentry flushes.** `flush()`, never `close()`: `close()` flushes *and*
+   disables, so anything raised later in shutdown would go unreported.
+
+Then `process.exitCode` is set — `0` on completion, `1` if the backstop fired
+first — and the loop drains.
+
+A **second signal is logged and ignored.** Re-entering would run every hook
+twice and close the pool out from under the first pass.
+
+The backstop is `.unref()`'d. Without that it holds the event loop open for its
+full budget on an otherwise clean shutdown, so a process that finished winding
+down in 200 ms would still sit there for thirty seconds.
+
+`VT_TASKS_SHUTDOWN_TIMEOUT` must stay strictly under
+`terminationGracePeriodSeconds`, which covers `preStop` *and* shutdown
+combined. The manifests use a 60 s grace period behind a 10 s `preStop` sleep,
+leaving 50 s; the 30 s default is comfortably inside it. Set it too high and
+SIGKILL lands before the backstop fires, and the process gets neither a clean
+shutdown nor a controlled failure.
+
+### The image must not use `npm start`
+
+`CMD ["npm", "start"]` **does not forward signals** — npm/rfcs#829 is still
+open, with no fix in npm 10 or 11 — so SIGTERM would never reach the handler
+and every rollout would end in SIGKILL with claims still held. The image's
+command is exec-form `node`:
+
+```
+CMD ["node", "--import", "@sentry/node/preload", "dist/index.mjs"]
+```
+
+The PID-1 kernel special case only drops signals with *no* handler, so
+registering `process.on("SIGTERM")` covers the rest. `tini` and `dumb-init`
+matter only for zombie reaping, which is irrelevant until a task body spawns
+children.
+
+## Sentry
+
+`--import @sentry/node/preload` is not optional. ESM evaluates every static
+import before any top-level statement, and the bundle makes that concrete: the
+externals land at the top of `dist/index.mjs` while `Sentry.init` sits
+thousands of lines below in the bootstrap body. Without the preload flag the
+SDK's module hooks install too late to patch anything, and the service reports
+errors while silently recording no database spans.
+
+Init cannot simply move earlier: the DSN comes from `<KEY>_FILE`-backed config,
+which has to be read first. That is exactly the "late initialization" case the
+preload hook exists for. If the flag is dropped from the Dockerfile or the
+`start` script, tracing goes quiet with nothing in the logs to say so.
+
+The DSN is passed to `initSentry` explicitly rather than read by
+`@virtool/sentry`'s `readDsn`, which goes straight to `process.env` and would
+miss a `VT_SENTRY_DSN_FILE` mount. Events are tagged `service: tasks` and carry
+their own `dist`, both from `getCommonOptions`, so this image's source maps do
+not collide with the others' under the shared release version.
+
+There is deliberately **no pino destination forwarding log records to Sentry**,
+as `apps/web` has. That stream is written against `@sentry/tanstackstart-react`,
+so bringing it here means a third copy rather than a shared one, and the SDK's
+own uncaught-exception and unhandled-rejection integrations already report what
+a crash needs. Code wanting a *handled* failure in Sentry calls
+`Sentry.captureException` explicitly. Lift the stream into `@virtool/sentry`
+before copying it.
+
+## Testing
+
+`apps/tasks` has its own Vitest project and its own CI job (`Test / Tasks`),
+for the same reason `@virtool/data` and `@virtool/jobs-api` do: it runs against
+a real Postgres testcontainer, and pulling that image does not belong in the
+fast package loop. It is excluded from `Test / Packages` accordingly.
+
+The container is **not described here**. `globalSetup` names
+`@virtool/data/db/test/globalSetup`, the single definition every database-backed
+suite in the repo shares, so the options cannot drift and `withReuse()` boots
+one Postgres across all of them locally.
+
+## The framework and the loops
+
+`bootstrap` is the floor. The task framework, the claim/lease/reclaim data
+layer, and the dispatch loops land on top of it, and each fills in its section
+here in its own commit:
+
+- **Framework** — `defineTask`, the step model, the percent/fraction progress
+  seam, and event emission. Lives in `apps/tasks/src/framework/`: it is an
+  execution shell rather than persistence, only this process ever runs a task,
+  and it needs zod, which `@virtool/data` does not depend on and should not
+  start to.
+- **Claim, lease and reclaim** — `acquireTask`, `renewLeases`, `completeTask`,
+  `failTask`, `releaseTask`, `releaseRunnerClaims`, `reclaimExpiredLeases`.
+  These are pure persistence over a table both halves write, so they belong in
+  `packages/data/src/tasks/data.ts`, extending the module already there.
+- **The task bodies** — `apps/tasks/src/tasks/<type>.ts`, registered with the
+  runner's registry. The shell lives with its runtime, the way `functions.ts`
+  lives with the web app.
+
+Note there is **no `service.ts` tier available to a task body.** `service.ts` is
+the web app's orchestration layer and stays in `apps/web/src/server/<feature>/`,
+unreachable from here. A body's cross-`data` orchestration goes either into
+`@virtool/data` — when it is persistence plus injected external IO — or into
+the handler module itself. Do not add a `service.ts` under `packages/data/`.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -68,6 +68,12 @@ A failure anywhere in that sequence propagates to `src/index.ts`, which logs
 through a logger of its own — `bootstrap`'s may not exist yet — and sets
 `process.exitCode = 1` without the listener ever starting.
 
+**A listener that fails to bind closes the pool on the way out.** By step 7 the
+pool is open and the signal handlers have already displaced Node's default exit
+behaviour, so an occupied `VT_TASKS_PROBE_PORT` would otherwise leave a
+container running forever on referenced sockets with no listener for the
+kubelet to fail — the one state Kubernetes cannot restart its way out of.
+
 ### `AppContext`
 
 What `bootstrap` returns, and the contract the spawn and claim loops build on:
@@ -213,7 +219,8 @@ On the first SIGTERM or SIGINT, each step awaited before the next:
 
 1. **Readiness flips to unavailable.** The listener stays up.
 2. **Registered hooks run in reverse registration order (LIFO)**, each awaited.
-   A hook that throws is logged and does not abort the ones after it.
+   A hook that throws is logged and does not abort the ones after it, but the
+   process still exits non-zero.
 3. **The probe listener closes.** Idle keep-alive sockets are dropped so the
    wait is bounded by a probe in flight rather than the next one.
 4. **The database pool drains** — after the hooks, so a hook may still write.
@@ -221,8 +228,14 @@ On the first SIGTERM or SIGINT, each step awaited before the next:
 5. **Sentry flushes.** `flush()`, never `close()`: `close()` flushes *and*
    disables, so anything raised later in shutdown would go unreported.
 
-Then `process.exitCode` is set — `0` on completion, `1` if the backstop fired
-first — and the loop drains.
+**No step aborts the ones after it, and none passes unreported.** Each is
+caught and logged on its own, so a listener that will not close still leaves
+the pool to drain and Sentry to flush.
+
+Then `process.exitCode` is set — `0` only when every step ran, `1` if any of
+them failed or the backstop fired first — and the loop drains. A failed
+shutdown that exited `0` would be indistinguishable from a clean one, and an
+undrained pool would pass unnoticed through every rollout.
 
 A **second signal is logged and ignored.** Re-entering would run every hook
 twice and close the pool out from under the first pass.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,46 @@ importers:
         specifier: ^4.88.0
         version: 4.113.0(@types/node@26.1.2)
 
+  apps/tasks:
+    dependencies:
+      '@sentry/node':
+        specifier: ^10.69.0
+        version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
+      '@virtool/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
+      '@virtool/data':
+        specifier: workspace:*
+        version: link:../../packages/data
+      '@virtool/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
+      '@virtool/sentry':
+        specifier: workspace:*
+        version: link:../../packages/sentry
+      '@virtool/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
+      pino:
+        specifier: ^10.1.0
+        version: 10.3.1
+      postgres:
+        specifier: ^3.4.9
+        version: 3.4.9
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
+      zod:
+        specifier: ^4.3.5
+        version: 4.4.3
+    devDependencies:
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(oxc-resolver@11.24.2)(tsx@4.23.0)(typescript@7.0.2)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+
   apps/web:
     dependencies:
       '@dnd-kit/core':


### PR DESCRIPTION
## Summary

- Adds `apps/tasks` (`@virtool/tasks`), a new Node workspace holding **one** binary for both halves of the task system — the periodic spawner and the runner that claims and executes what it spawns. Each is disabled independently with `VT_TASKS_SPAWN_ENABLED` / `VT_TASKS_CLAIM_ENABLED`, both defaulting to `true`, so the cutover from Python is one deployment started with claiming off and then one flag flip, rather than a second image.
- Lands the floor the two loops build on, both of which are placeholders here: `bootstrap()` as the composition root, a zod config schema keeping the `<KEY>_FILE` behaviour through the shared resolver, a `node:http` probe and metrics listener, and a shutdown sequence that flips readiness, runs hooks LIFO, drains the pool and flushes Sentry without ever calling `process.exit()`. Nothing in the app runs at import time, so a module can be imported to read a type without opening a config parse, a pool or a registry.
- Ships as `ghcr.io/virtool/tasks` with its own Dockerfile stage, CI build and publish matrix entries and a `Test / Tasks` job, plus an `AGENTS.md` section and `docs/tasks.md`.