### PR TITLE
chore: serve workflow metadata reads from the jobs api

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,14 +21,19 @@ This is a **pnpm monorepo**:
   mirroring Python's `virtool/jobs/main.py` (`api-jobs-service`, ClusterIP,
   **no ingress** — that absence is the security boundary). Serves
   `/health/live`, `/health/ready`, a token-gated `/metrics`, the two
-  cache endpoints — `GET /caches/{key}` and `POST /caches` — and the three
+  cache endpoints — `GET /caches/{key}` and `POST /caches` — the three
   finalize routes — `PATCH /subtractions/{id}`, `PATCH /samples/{id}`,
-  `PATCH /analyses/{id}` — today. Image:
-  `ghcr.io/virtool/jobs-api`, Alpine. Three rules: it is **always "the jobs
+  `PATCH /analyses/{id}` — and the six metadata reads —
+  `GET /samples/{id}`, `/subtractions/{id}`, `/indexes/{id}`,
+  `/analyses/{id}`, `/refs/{id}` and `/settings` — today. Image:
+  `ghcr.io/virtool/jobs-api`, Alpine. Four rules: it is **always "the jobs
   API"**, never "the control plane" — that names its role, not the service;
   **every route must refuse an unauthenticated caller or be named in
   `PUBLIC_ROUTES`**, which `src/__tests__/authorization.test.ts` enforces;
-  and a handler's floor is `requireJobRequest` (`src/auth/guard.ts`), which
+  **it serves records, never bytes** — a read hands back the recorded
+  `storageKey` and the workflow fetches the object itself, so no handler
+  streams a payload or builds a derived artifact; and a handler's floor is
+  `requireJobRequest` (`src/auth/guard.ts`), which
   authenticates a workflow pod as `job-{id}:{key}` over HTTP Basic and
   **returns** an opaque 401 rather than throwing one. It resolves to a
   `JobPrincipal` of `{ jobId }` — no user, no permissions — and there is no

--- a/apps/jobs-api/src/analyses/handlers.test.ts
+++ b/apps/jobs-api/src/analyses/handlers.test.ts
@@ -17,7 +17,11 @@ import { eq } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { seedJob } from "../auth/test/fixtures";
-import { type AnalysisHandlerDeps, handleFinalizeAnalysis } from "./handlers";
+import {
+	type AnalysisHandlerDeps,
+	handleFinalizeAnalysis,
+	handleGetAnalysis,
+} from "./handlers";
 
 let database: TestDatabase;
 let db: Db;
@@ -372,5 +376,96 @@ describe("handleFinalizeAnalysis", () => {
 		);
 
 		expect(response.status).toBe(400);
+	});
+});
+
+function get(analysisId: number | string, authenticated = true): Request {
+	return new Request(`https://jobs.virtool.test/analyses/${analysisId}`, {
+		headers: authenticated ? { authorization: `Basic ${credential}` } : {},
+	});
+}
+
+describe("handleGetAnalysis", () => {
+	it("serves the records a workflow runs against", async () => {
+		const analysisId = await seedAnalysis();
+
+		const response = await handleGetAnalysis(
+			deps,
+			get(analysisId),
+			String(analysisId),
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			id: analysisId,
+			index: { id: indexId, version: 1 },
+			ready: false,
+			reference: { id: referenceId, name: "Reference" },
+			sample: { id: expect.any(Number), name: expect.any(String) },
+			subtractions: [],
+			workflow: "pathoscope",
+		});
+	});
+
+	// Python's runtime falls back to reading `sample.id` when a job's args carry
+	// no `sample_id`, so flattening this to a bare id breaks every analysis whose
+	// job was created without one.
+	it("carries the sample as an object, not a bare id", async () => {
+		const analysisId = await seedAnalysis();
+
+		const response = await handleGetAnalysis(
+			deps,
+			get(analysisId),
+			String(analysisId),
+		);
+		const analysis = (await response.json()) as { sample: unknown };
+
+		expect(analysis.sample).toEqual(
+			expect.objectContaining({ id: expect.any(Number) }),
+		);
+	});
+
+	// The results blob is the expensive half of an analysis: reading it runs the
+	// history-patching format step. A workflow needs none of it, and a read that
+	// dragged it in would make every analysis read pay for that machinery.
+	it("does not serve results, even for a finished analysis", async () => {
+		const analysisId = await seedAnalysis({ ready: true, results: RESULTS });
+
+		const response = await handleGetAnalysis(
+			deps,
+			get(analysisId),
+			String(analysisId),
+		);
+		const rendered = await response.text();
+
+		expect(response.status).toBe(200);
+		expect(rendered).not.toContain("results");
+		expect(rendered).not.toContain("best_score");
+	});
+
+	it("reports 404 for an analysis that does not exist", async () => {
+		const response = await handleGetAnalysis(deps, get(404_040), "404040");
+
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual({ message: "Analysis not found" });
+	});
+
+	// A non-numeric segment names no row, and must not reach the database as one.
+	it("reports 404 for an id that is not a positive integer", async () => {
+		const response = await handleGetAnalysis(deps, get("counts"), "counts");
+
+		expect(response.status).toBe(404);
+	});
+
+	it("refuses an unauthenticated request", async () => {
+		const analysisId = await seedAnalysis();
+
+		const response = await handleGetAnalysis(
+			deps,
+			get(analysisId, false),
+			String(analysisId),
+		);
+
+		expect(response.status).toBe(401);
 	});
 });

--- a/apps/jobs-api/src/analyses/handlers.ts
+++ b/apps/jobs-api/src/analyses/handlers.ts
@@ -1,14 +1,16 @@
+import type { Analysis, WorkflowAnalysis } from "@virtool/contracts";
 import { FinalizeAnalysisRequest } from "@virtool/contracts";
 import {
 	AnalysisAlreadyFinalizedError,
 	AnalysisNotFoundError,
 	finalizeAnalysis,
+	getAnalysis,
 } from "@virtool/data/analyses/data";
 import type { Db } from "@virtool/data/db/pg";
 import type { Logger } from "@virtool/logger";
 import type { StorageBackend } from "@virtool/storage";
 import { requireJobRequest } from "../auth/guard";
-import { jsonError, parseRowId } from "../http";
+import { jsonError, parseRowId, type ReadHandlerDeps } from "../http";
 import { checkManifest, measureManifest } from "../manifest";
 
 /** What the analysis handlers need to serve a request. */
@@ -17,6 +19,72 @@ export type AnalysisHandlerDeps = {
 	storage: StorageBackend;
 	logger: Logger;
 };
+
+/**
+ * Narrow an analysis to what a workflow reads.
+ *
+ * `sample` stays an object carrying an id. Python's runtime falls back to
+ * reading it when a job's `args` carry no `sample_id`, so flattening it to a
+ * bare id breaks every analysis whose job was created without one.
+ *
+ * The results blob and the file rows are both dropped. A workflow reading an
+ * analysis is about to produce them, and `getAnalysis` deliberately does not
+ * read `results` — that is `getAnalysisResults`, which runs the history-patching
+ * format step this read must never pay for.
+ */
+function toWorkflowAnalysis(analysis: Analysis): WorkflowAnalysis {
+	return {
+		id: analysis.id,
+		index: { id: analysis.index.id, version: analysis.index.version },
+		ready: analysis.ready,
+		reference: {
+			id: analysis.reference.id,
+			name: analysis.reference.name,
+		},
+		sample: { id: analysis.sample.id, name: analysis.sample.name },
+		subtractions: analysis.subtractions.map((subtraction) => ({
+			id: subtraction.id,
+			name: subtraction.name,
+		})),
+		workflow: analysis.workflow,
+	};
+}
+
+/**
+ * Serve the analysis a workflow is running: the index and reference it is
+ * pinned to, the sample it came from, and the subtractions it must apply.
+ *
+ * Records only, and no results — see {@link toWorkflowAnalysis}.
+ */
+export async function handleGetAnalysis(
+	deps: ReadHandlerDeps,
+	request: Request,
+	analysisIdParam: string,
+): Promise<Response> {
+	const principal = await requireJobRequest(deps.db, request);
+
+	if (principal instanceof Response) {
+		return principal;
+	}
+
+	const analysisId = parseRowId(analysisIdParam);
+
+	if (analysisId === null) {
+		return jsonError(404, "Analysis not found");
+	}
+
+	try {
+		return Response.json(
+			toWorkflowAnalysis(await getAnalysis(deps.db, analysisId)),
+		);
+	} catch (err) {
+		if (err instanceof AnalysisNotFoundError) {
+			return jsonError(404, "Analysis not found");
+		}
+
+		throw err;
+	}
+}
 
 /**
  * Finalize an analysis: record its results blob and the files the workflow

--- a/apps/jobs-api/src/app.ts
+++ b/apps/jobs-api/src/app.ts
@@ -4,13 +4,19 @@ import type { Logger } from "@virtool/logger";
 import type { StorageBackend } from "@virtool/storage";
 import { Hono } from "hono";
 import { routePath } from "hono/route";
-import { handleFinalizeAnalysis } from "./analyses/handlers";
+import { handleFinalizeAnalysis, handleGetAnalysis } from "./analyses/handlers";
 import { handleGetCache, handleRegisterCache } from "./caches/handlers";
+import { handleGetIndex } from "./indexes/handlers";
 import { handleMetrics } from "./metrics/handler";
 import { createJobQueueReader } from "./metrics/jobs";
 import type { Metrics } from "./metrics/registry";
-import { handleFinalizeSample } from "./samples/handlers";
-import { handleFinalizeSubtraction } from "./subtraction/handlers";
+import { handleGetReference } from "./references/handlers";
+import { handleFinalizeSample, handleGetSample } from "./samples/handlers";
+import { handleGetSettings } from "./settings/handlers";
+import {
+	handleFinalizeSubtraction,
+	handleGetSubtraction,
+} from "./subtraction/handlers";
 
 /**
  * The routes that answer without a credential, and why each is allowed to.
@@ -118,6 +124,34 @@ export function createApp(deps: AppDeps): Hono {
 	app.patch("/analyses/:id", (c) =>
 		handleFinalizeAnalysis(deps, c.req.raw, c.req.param("id")),
 	);
+
+	// The metadata reads. A running workflow needs the records behind its job —
+	// what to align against, what to subtract, where the reads are — and it needs
+	// them as records only: it holds its own object-storage credentials and
+	// fetches every file itself using the `storageKey` each response carries.
+	// Nothing here writes a row, writes a blob, or builds a derived artifact.
+	app.get("/samples/:id", (c) =>
+		handleGetSample(deps, c.req.raw, c.req.param("id")),
+	);
+
+	app.get("/subtractions/:id", (c) =>
+		handleGetSubtraction(deps, c.req.raw, c.req.param("id")),
+	);
+
+	app.get("/indexes/:id", (c) =>
+		handleGetIndex(deps, c.req.raw, c.req.param("id")),
+	);
+
+	app.get("/analyses/:id", (c) =>
+		handleGetAnalysis(deps, c.req.raw, c.req.param("id")),
+	);
+
+	// `/refs`, not `/references` — Python's resource path for this domain.
+	app.get("/refs/:id", (c) =>
+		handleGetReference(deps, c.req.raw, c.req.param("id")),
+	);
+
+	app.get("/settings", (c) => handleGetSettings(deps, c.req.raw));
 
 	app.get("/metrics", (c) =>
 		handleMetrics(c, {

--- a/apps/jobs-api/src/http.ts
+++ b/apps/jobs-api/src/http.ts
@@ -1,3 +1,15 @@
+import type { Db } from "@virtool/data/db/pg";
+
+/**
+ * What a metadata read needs to serve a request.
+ *
+ * A database handle and nothing else. The reads hand a workflow records, never
+ * bytes — it holds its own object-storage credentials and fetches every file
+ * itself using the recorded key each response carries — so a read that could
+ * reach `storage` would be a read that could write one.
+ */
+export type ReadHandlerDeps = { db: Db };
+
 /**
  * The shape every deliberate 4xx in this service answers with.
  *

--- a/apps/jobs-api/src/indexes/handlers.test.ts
+++ b/apps/jobs-api/src/indexes/handlers.test.ts
@@ -1,0 +1,175 @@
+import { seedUser } from "@virtool/data/auth/test/fixtures";
+import type { Db } from "@virtool/data/db/pg";
+import { legacyHistory } from "@virtool/data/db/schema/history";
+import { indexes, indexFiles } from "@virtool/data/db/schema/indexes";
+import { jobs } from "@virtool/data/db/schema/jobs";
+import { legacyOtus } from "@virtool/data/db/schema/otus";
+import { legacyReferences } from "@virtool/data/db/schema/references";
+import { users } from "@virtool/data/db/schema/users";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import { seedIndex, seedReference } from "@virtool/data/indexes/test/fixtures";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { seedJob } from "../auth/test/fixtures";
+import type { ReadHandlerDeps } from "../http";
+import { handleGetIndex } from "./handlers";
+
+let database: TestDatabase;
+let db: Db;
+let deps: ReadHandlerDeps;
+let credential: string;
+let userId: number;
+let referenceId: number;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(indexFiles);
+	await db.delete(legacyHistory);
+	await db.delete(indexes);
+	await db.delete(legacyOtus);
+	await db.delete(legacyReferences);
+	await db.delete(jobs);
+	await db.delete(users);
+
+	userId = await seedUser(db);
+	referenceId = await seedReference(db, userId, { name: "Plant viruses" });
+
+	const job = await seedJob(db, userId, { workflow: "pathoscope" });
+
+	credential = Buffer.from(`job-${job.id}:${job.key}`).toString("base64");
+	deps = { db };
+});
+
+function get(indexId: number | string, authenticated = true): Request {
+	return new Request(`https://jobs.virtool.test/indexes/${indexId}`, {
+		headers: authenticated ? { authorization: `Basic ${credential}` } : {},
+	});
+}
+
+describe("handleGetIndex", () => {
+	it("serves the build, its manifest and its files", async () => {
+		const indexId = await seedIndex(db, { referenceId, userId, version: 3 });
+
+		await db
+			.update(indexes)
+			.set({ manifest: { otu1: 2, otu2: 5 } })
+			.where(eq(indexes.id, indexId));
+
+		await db.insert(indexFiles).values({
+			index_id: indexId,
+			name: "reference.1.bt2",
+			size: 2048,
+			storage_key: "indexes/7/aaaabbbbccccddddeeeeffff00001111",
+			type: "bowtie2",
+		});
+
+		const response = await handleGetIndex(deps, get(indexId), String(indexId));
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			id: indexId,
+			files: [
+				{
+					id: expect.any(Number),
+					name: "reference.1.bt2",
+					size: 2048,
+					storageKey: "indexes/7/aaaabbbbccccddddeeeeffff00001111",
+					type: "bowtie2",
+				},
+			],
+			manifest: { otu1: 2, otu2: 5 },
+			ready: true,
+			reference: { id: referenceId, name: "Plant viruses" },
+			version: 3,
+		});
+	});
+
+	// A migrated build's objects sit under whatever prefix they were written with,
+	// which no pattern reconstructs. If the handler ever composed a key rather than
+	// reading the column, this is the test that fails.
+	it("returns a migrated file's recorded key verbatim", async () => {
+		const indexId = await seedIndex(db, { referenceId, userId, version: 0 });
+		const legacyKey = "references/abc123/reference.fa.gz";
+
+		await db.insert(indexFiles).values({
+			index_id: indexId,
+			name: "reference.fa.gz",
+			size: 16,
+			storage_key: legacyKey,
+			type: "fasta",
+		});
+
+		const response = await handleGetIndex(deps, get(indexId), String(indexId));
+		const index = (await response.json()) as {
+			files: { storageKey: string }[];
+		};
+
+		expect(index.files[0]?.storageKey).toBe(legacyKey);
+	});
+
+	// Python's `create_index` task writes a build's artifacts eagerly. This read
+	// reports what the rows say and generates nothing, so an unfinished build
+	// answers with an empty file list rather than building one.
+	it("reports an unfinished build without producing its files", async () => {
+		const indexId = await seedIndex(db, {
+			referenceId,
+			userId,
+			version: 1,
+			ready: false,
+		});
+
+		const response = await handleGetIndex(deps, get(indexId), String(indexId));
+		const index = (await response.json()) as {
+			files: unknown[];
+			ready: boolean;
+		};
+
+		expect(index.ready).toBe(false);
+		expect(index.files).toEqual([]);
+	});
+
+	it("serves no download URL", async () => {
+		const indexId = await seedIndex(db, { referenceId, userId, version: 0 });
+
+		const response = await handleGetIndex(deps, get(indexId), String(indexId));
+
+		expect(await response.text()).not.toContain("downloadUrl");
+	});
+
+	it("reports 404 for a build that does not exist", async () => {
+		const response = await handleGetIndex(deps, get(404_040), "404040");
+
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual({ message: "Index not found" });
+	});
+
+	it("reports 404 for an id that is not a positive integer", async () => {
+		const response = await handleGetIndex(deps, get("latest"), "latest");
+
+		expect(response.status).toBe(404);
+	});
+
+	it("refuses an unauthenticated request", async () => {
+		const indexId = await seedIndex(db, { referenceId, userId, version: 0 });
+
+		const response = await handleGetIndex(
+			deps,
+			get(indexId, false),
+			String(indexId),
+		);
+
+		expect(response.status).toBe(401);
+	});
+});

--- a/apps/jobs-api/src/indexes/handlers.ts
+++ b/apps/jobs-api/src/indexes/handlers.ts
@@ -1,0 +1,68 @@
+import type { Index, WorkflowIndex } from "@virtool/contracts";
+import { getIndex, IndexNotFoundError } from "@virtool/data/indexes/data";
+import { requireJobRequest } from "../auth/guard";
+import { jsonError, parseRowId, type ReadHandlerDeps } from "../http";
+
+/**
+ * Narrow an index build to what a workflow reads.
+ *
+ * The mapping happens here rather than inside `@virtool/data`, which returns
+ * this shape to `apps/web`'s client as well — including the contributor and OTU
+ * lists a build page shows and the `downloadUrl` that has no meaning to a
+ * workflow.
+ *
+ * Each file carries its recorded `storageKey`; the workflow takes it to the
+ * bucket itself.
+ */
+function toWorkflowIndex(index: Index): WorkflowIndex {
+	return {
+		id: index.id,
+		files: index.files.map((file) => ({
+			id: file.id,
+			name: file.name,
+			size: file.size,
+			storageKey: file.storageKey,
+			type: file.type,
+		})),
+		manifest: index.manifest,
+		ready: index.ready,
+		reference: { id: index.reference.id, name: index.reference.name },
+		version: index.version,
+	};
+}
+
+/**
+ * Serve an index build's metadata, its manifest, and the files it produced.
+ *
+ * Records only. **This read must never build anything.** Python's `create_index`
+ * task writes a build's artifacts eagerly — this side stops at inserting the row
+ * that task claims — so a build whose files are not there yet answers with the
+ * rows that exist rather than generating the ones that do not.
+ */
+export async function handleGetIndex(
+	deps: ReadHandlerDeps,
+	request: Request,
+	indexIdParam: string,
+): Promise<Response> {
+	const principal = await requireJobRequest(deps.db, request);
+
+	if (principal instanceof Response) {
+		return principal;
+	}
+
+	const indexId = parseRowId(indexIdParam);
+
+	if (indexId === null) {
+		return jsonError(404, "Index not found");
+	}
+
+	try {
+		return Response.json(toWorkflowIndex(await getIndex(deps.db, indexId)));
+	} catch (err) {
+		if (err instanceof IndexNotFoundError) {
+			return jsonError(404, "Index not found");
+		}
+
+		throw err;
+	}
+}

--- a/apps/jobs-api/src/references/handlers.test.ts
+++ b/apps/jobs-api/src/references/handlers.test.ts
@@ -1,0 +1,118 @@
+import { seedUser } from "@virtool/data/auth/test/fixtures";
+import type { Db } from "@virtool/data/db/pg";
+import { jobs } from "@virtool/data/db/schema/jobs";
+import { legacyReferences } from "@virtool/data/db/schema/references";
+import { users } from "@virtool/data/db/schema/users";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import { seedReference } from "@virtool/data/indexes/test/fixtures";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { seedJob } from "../auth/test/fixtures";
+import type { ReadHandlerDeps } from "../http";
+import { handleGetReference } from "./handlers";
+
+let database: TestDatabase;
+let db: Db;
+let deps: ReadHandlerDeps;
+let credential: string;
+let userId: number;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(legacyReferences);
+	await db.delete(jobs);
+	await db.delete(users);
+
+	userId = await seedUser(db);
+
+	const job = await seedJob(db, userId, { workflow: "pathoscope" });
+
+	credential = Buffer.from(`job-${job.id}:${job.key}`).toString("base64");
+	deps = { db };
+});
+
+function get(referenceId: number | string, authenticated = true): Request {
+	return new Request(`https://jobs.virtool.test/refs/${referenceId}`, {
+		headers: authenticated ? { authorization: `Basic ${credential}` } : {},
+	});
+}
+
+describe("handleGetReference", () => {
+	it("serves the reference's metadata", async () => {
+		const referenceId = await seedReference(db, userId, {
+			name: "Plant viruses",
+		});
+
+		const response = await handleGetReference(
+			deps,
+			get(referenceId),
+			String(referenceId),
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			id: referenceId,
+			dataType: expect.any(String),
+			description: "",
+			name: "Plant viruses",
+			organism: "virus",
+		});
+	});
+
+	// The rights lists say who may edit a reference, which is not a question a
+	// workflow asks — and their `Date` fields would serialize to strings the wire
+	// shape does not describe.
+	it("serves no rights lists or build history", async () => {
+		const referenceId = await seedReference(db, userId, {
+			member: { build: true, modify: true },
+		});
+
+		const response = await handleGetReference(
+			deps,
+			get(referenceId),
+			String(referenceId),
+		);
+		const rendered = await response.text();
+
+		expect(rendered).not.toContain("users");
+		expect(rendered).not.toContain("groups");
+		expect(rendered).not.toContain("latestBuild");
+		expect(rendered).not.toContain("contributors");
+	});
+
+	it("reports 404 for a reference that does not exist", async () => {
+		const response = await handleGetReference(deps, get(404_040), "404040");
+
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual({ message: "Reference not found" });
+	});
+
+	it("reports 404 for an id that is not a positive integer", async () => {
+		const response = await handleGetReference(deps, get("latest"), "latest");
+
+		expect(response.status).toBe(404);
+	});
+
+	it("refuses an unauthenticated request", async () => {
+		const referenceId = await seedReference(db, userId);
+
+		const response = await handleGetReference(
+			deps,
+			get(referenceId, false),
+			String(referenceId),
+		);
+
+		expect(response.status).toBe(401);
+	});
+});

--- a/apps/jobs-api/src/references/handlers.ts
+++ b/apps/jobs-api/src/references/handlers.ts
@@ -1,0 +1,61 @@
+import type { Reference, WorkflowReference } from "@virtool/contracts";
+import {
+	getReference,
+	ReferenceNotFoundError,
+} from "@virtool/data/references/data";
+import { requireJobRequest } from "../auth/guard";
+import { jsonError, parseRowId, type ReadHandlerDeps } from "../http";
+
+/**
+ * Narrow a reference to what a workflow reads.
+ *
+ * The rights lists, contributors and build history the SPA shows are about who
+ * may edit a reference, which is not a question a workflow asks. Dropping them
+ * also keeps the `Date` values in those shapes off this wire, where they would
+ * serialize to strings the declared type does not describe.
+ */
+function toWorkflowReference(reference: Reference): WorkflowReference {
+	return {
+		id: reference.id,
+		dataType: reference.dataType,
+		description: reference.description,
+		name: reference.name,
+		organism: reference.organism,
+	};
+}
+
+/**
+ * Serve a reference's metadata.
+ *
+ * The path is `/refs/{id}`, matching Python's resource path for this domain
+ * rather than the spelled-out `/references` the package name would suggest.
+ */
+export async function handleGetReference(
+	deps: ReadHandlerDeps,
+	request: Request,
+	referenceIdParam: string,
+): Promise<Response> {
+	const principal = await requireJobRequest(deps.db, request);
+
+	if (principal instanceof Response) {
+		return principal;
+	}
+
+	const referenceId = parseRowId(referenceIdParam);
+
+	if (referenceId === null) {
+		return jsonError(404, "Reference not found");
+	}
+
+	try {
+		return Response.json(
+			toWorkflowReference(await getReference(deps.db, referenceId)),
+		);
+	} catch (err) {
+		if (err instanceof ReferenceNotFoundError) {
+			return jsonError(404, "Reference not found");
+		}
+
+		throw err;
+	}
+}

--- a/apps/jobs-api/src/samples/handlers.test.ts
+++ b/apps/jobs-api/src/samples/handlers.test.ts
@@ -23,7 +23,11 @@ import { asc, eq } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { seedJob } from "../auth/test/fixtures";
-import { handleFinalizeSample, type SampleHandlerDeps } from "./handlers";
+import {
+	handleFinalizeSample,
+	handleGetSample,
+	type SampleHandlerDeps,
+} from "./handlers";
 
 let database: TestDatabase;
 let db: Db;
@@ -443,5 +447,168 @@ describe("handleFinalizeSample", () => {
 
 		expect(read?.storage_key).toBe(file.storageKey);
 		expect(read?.upload).toBe(upload?.id);
+	});
+});
+
+function get(sampleId: number | string, authenticated = true): Request {
+	return new Request(`https://jobs.virtool.test/samples/${sampleId}`, {
+		headers: authenticated ? { authorization: `Basic ${credential}` } : {},
+	});
+}
+
+describe("handleGetSample", () => {
+	it("serves the sample and its reads", async () => {
+		const sampleId = await seedSample({
+			name: "Sample 1",
+			library_type: "srna",
+			quality: QUALITY,
+		});
+
+		await db.insert(sampleReads).values({
+			sample: String(sampleId),
+			sample_id: sampleId,
+			name: "reads_1.fq.gz",
+			name_on_disk: "reads_1.fq.gz",
+			size: 1024,
+			storage_key: "samples/3/aaaabbbbccccddddeeeeffff00001111",
+			uploaded_at: new Date(),
+		});
+
+		const response = await handleGetSample(
+			deps,
+			get(sampleId),
+			String(sampleId),
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			id: sampleId,
+			libraryType: "srna",
+			name: "Sample 1",
+			paired: false,
+			quality: QUALITY,
+			reads: [
+				{
+					id: expect.any(Number),
+					name: "reads_1.fq.gz",
+					size: 1024,
+					storageKey: "samples/3/aaaabbbbccccddddeeeeffff00001111",
+				},
+			],
+		});
+	});
+
+	// Derived from the reads rather than stored, and what a workflow branches on
+	// to decide whether it is running one file or two.
+	it("reports paired for a sample with two reads files", async () => {
+		const sampleId = await seedSample();
+
+		await db.insert(sampleReads).values([
+			{
+				sample: String(sampleId),
+				sample_id: sampleId,
+				name: "reads_1.fq.gz",
+				name_on_disk: "reads_1.fq.gz",
+				size: 1,
+				storage_key: "samples/1/a",
+				uploaded_at: new Date(),
+			},
+			{
+				sample: String(sampleId),
+				sample_id: sampleId,
+				name: "reads_2.fq.gz",
+				name_on_disk: "reads_2.fq.gz",
+				size: 1,
+				storage_key: "samples/1/b",
+				uploaded_at: new Date(),
+			},
+		]);
+
+		const response = await handleGetSample(
+			deps,
+			get(sampleId),
+			String(sampleId),
+		);
+		const sample = (await response.json()) as { paired: boolean };
+
+		expect(sample.paired).toBe(true);
+	});
+
+	// A migrated sample's reads sit under whatever prefix they were written with,
+	// which no pattern reconstructs. If the handler ever composed a key rather than
+	// reading the column, this is the test that fails.
+	it("returns a migrated read's recorded key verbatim", async () => {
+		const sampleId = await seedSample();
+		const legacyKey = "samples/abc123def456/reads_1.fq.gz";
+
+		await db.insert(sampleReads).values({
+			sample: String(sampleId),
+			sample_id: sampleId,
+			name: "reads_1.fq.gz",
+			name_on_disk: "reads_1.fq.gz",
+			size: 1,
+			storage_key: legacyKey,
+			uploaded_at: new Date(),
+		});
+
+		const response = await handleGetSample(
+			deps,
+			get(sampleId),
+			String(sampleId),
+		);
+		const sample = (await response.json()) as {
+			reads: { storageKey: string }[];
+		};
+
+		expect(sample.reads[0]?.storageKey).toBe(legacyKey);
+	});
+
+	it("serves no download URL and no name_on_disk", async () => {
+		const sampleId = await seedSample();
+
+		await db.insert(sampleReads).values({
+			sample: String(sampleId),
+			sample_id: sampleId,
+			name: "reads_1.fq.gz",
+			name_on_disk: "reads_1.fq.gz",
+			size: 1,
+			storage_key: "samples/1/a",
+			uploaded_at: new Date(),
+		});
+
+		const response = await handleGetSample(
+			deps,
+			get(sampleId),
+			String(sampleId),
+		);
+		const rendered = await response.text();
+
+		expect(rendered).not.toContain("downloadUrl");
+		expect(rendered).not.toContain("nameOnDisk");
+	});
+
+	it("reports 404 for a sample that does not exist", async () => {
+		const response = await handleGetSample(deps, get(404_040), "404040");
+
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual({ message: "Sample not found" });
+	});
+
+	it("reports 404 for an id that is not a positive integer", async () => {
+		const response = await handleGetSample(deps, get("latest"), "latest");
+
+		expect(response.status).toBe(404);
+	});
+
+	it("refuses an unauthenticated request", async () => {
+		const sampleId = await seedSample();
+
+		const response = await handleGetSample(
+			deps,
+			get(sampleId, false),
+			String(sampleId),
+		);
+
+		expect(response.status).toBe(401);
 	});
 });

--- a/apps/jobs-api/src/samples/handlers.ts
+++ b/apps/jobs-api/src/samples/handlers.ts
@@ -1,14 +1,16 @@
+import type { Sample, WorkflowSample } from "@virtool/contracts";
 import { FinalizeSampleRequest } from "@virtool/contracts";
 import type { Db } from "@virtool/data/db/pg";
 import {
 	finalizeSample,
+	getSample,
 	SampleAlreadyFinalizedError,
 	SampleNotFoundError,
 } from "@virtool/data/samples/data";
 import type { Logger } from "@virtool/logger";
 import type { StorageBackend } from "@virtool/storage";
 import { requireJobRequest } from "../auth/guard";
-import { jsonError, parseRowId } from "../http";
+import { jsonError, parseRowId, type ReadHandlerDeps } from "../http";
 import { checkManifest, measureManifest } from "../manifest";
 
 /** What the sample handlers need to serve a request. */
@@ -26,6 +28,67 @@ export type SampleHandlerDeps = {
  * exactly, and Python addresses a reads file by `name` in its download URL.
  */
 const FILE_NAMES = ["reads_1.fq.gz", "reads_2.fq.gz"] as const;
+
+/**
+ * Narrow a sample to what a workflow reads.
+ *
+ * The mapping happens here, at the handler boundary, rather than inside
+ * `@virtool/data` — `apps/web`'s client feature modules read the same data
+ * function, so renaming or dropping a field down there would break them at a
+ * distance.
+ *
+ * Each read carries its recorded `storageKey` and no download URL: the workflow
+ * takes the key to the bucket itself.
+ */
+function toWorkflowSample(sample: Sample): WorkflowSample {
+	return {
+		id: sample.id,
+		libraryType: sample.libraryType,
+		name: sample.name,
+		paired: sample.paired,
+		quality: sample.quality,
+		reads: sample.reads.map((read) => ({
+			id: read.id,
+			name: read.name,
+			size: read.size,
+			storageKey: read.storageKey,
+		})),
+	};
+}
+
+/**
+ * Serve a sample's metadata and the reads files that make it up.
+ *
+ * Records only. Nothing here reads or writes an object, and the response
+ * carries no bytes.
+ */
+export async function handleGetSample(
+	deps: ReadHandlerDeps,
+	request: Request,
+	sampleIdParam: string,
+): Promise<Response> {
+	const principal = await requireJobRequest(deps.db, request);
+
+	if (principal instanceof Response) {
+		return principal;
+	}
+
+	const sampleId = parseRowId(sampleIdParam);
+
+	if (sampleId === null) {
+		return jsonError(404, "Sample not found");
+	}
+
+	try {
+		return Response.json(toWorkflowSample(await getSample(deps.db, sampleId)));
+	} catch (err) {
+		if (err instanceof SampleNotFoundError) {
+			return jsonError(404, "Sample not found");
+		}
+
+		throw err;
+	}
+}
 
 /**
  * Finalize a sample: record its quality report and the reads the create_sample

--- a/apps/jobs-api/src/settings/handlers.test.ts
+++ b/apps/jobs-api/src/settings/handlers.test.ts
@@ -1,0 +1,84 @@
+import { seedUser } from "@virtool/data/auth/test/fixtures";
+import type { Db } from "@virtool/data/db/pg";
+import { jobs } from "@virtool/data/db/schema/jobs";
+import { settings } from "@virtool/data/db/schema/settings";
+import { users } from "@virtool/data/db/schema/users";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import { DEFAULT_SETTINGS } from "@virtool/data/settings/data";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { seedJob } from "../auth/test/fixtures";
+import type { ReadHandlerDeps } from "../http";
+import { handleGetSettings } from "./handlers";
+
+let database: TestDatabase;
+let db: Db;
+let deps: ReadHandlerDeps;
+let credential: string;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(settings);
+	await db.delete(jobs);
+	await db.delete(users);
+
+	const job = await seedJob(db, await seedUser(db), { workflow: "pathoscope" });
+
+	credential = Buffer.from(`job-${job.id}:${job.key}`).toString("base64");
+	deps = { db };
+});
+
+function get(authenticated = true): Request {
+	return new Request("https://jobs.virtool.test/settings", {
+		headers: authenticated ? { authorization: `Basic ${credential}` } : {},
+	});
+}
+
+describe("handleGetSettings", () => {
+	it("serves the settings row", async () => {
+		await db.insert(settings).values({
+			id: 1,
+			...DEFAULT_SETTINGS,
+			sampleAllWrite: true,
+			minimumPasswordLength: 12,
+		});
+
+		const response = await handleGetSettings(deps, get());
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			...DEFAULT_SETTINGS,
+			sampleAllWrite: true,
+			minimumPasswordLength: 12,
+		});
+	});
+
+	// The one read in this service that writes. `getSettings` seeds the defaults
+	// when the row is absent, mirroring Python's `SettingsData.ensure()`, so a
+	// database that has never seen a Python boot answers rather than failing.
+	it("seeds the defaults when the row is absent", async () => {
+		const response = await handleGetSettings(deps, get());
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual(DEFAULT_SETTINGS);
+		expect(await db.select().from(settings)).toHaveLength(1);
+	});
+
+	it("refuses an unauthenticated request", async () => {
+		const response = await handleGetSettings(deps, get(false));
+
+		expect(response.status).toBe(401);
+		expect(await db.select().from(settings)).toEqual([]);
+	});
+});

--- a/apps/jobs-api/src/settings/handlers.ts
+++ b/apps/jobs-api/src/settings/handlers.ts
@@ -1,0 +1,46 @@
+import type { WorkflowSettings } from "@virtool/contracts";
+import { getSettings, type Settings } from "@virtool/data/settings/data";
+import { requireJobRequest } from "../auth/guard";
+import type { ReadHandlerDeps } from "../http";
+
+/**
+ * Map the settings singleton onto the wire.
+ *
+ * The two shapes agree field for field today. Writing the mapping out anyway
+ * keeps the wire contract's spelling independent of the data layer's, which
+ * `apps/web`'s administration pages also read.
+ */
+function toWorkflowSettings(settings: Settings): WorkflowSettings {
+	return {
+		defaultSourceTypes: settings.defaultSourceTypes,
+		enableSentry: settings.enableSentry,
+		minimumPasswordLength: settings.minimumPasswordLength,
+		sampleAllRead: settings.sampleAllRead,
+		sampleAllWrite: settings.sampleAllWrite,
+		sampleGroup: settings.sampleGroup,
+		sampleGroupRead: settings.sampleGroupRead,
+		sampleGroupWrite: settings.sampleGroupWrite,
+	};
+}
+
+/**
+ * Serve the instance settings.
+ *
+ * There is no 404: the settings row is a singleton, and `getSettings` seeds the
+ * defaults when it is absent. **That makes this read a write** on a database
+ * that has never seen a Python boot — the one endpoint in this service where a
+ * GET can insert a row. It mirrors Python's `SettingsData.ensure()`, and the
+ * alternative is failing a workflow because nothing had written the row yet.
+ */
+export async function handleGetSettings(
+	deps: ReadHandlerDeps,
+	request: Request,
+): Promise<Response> {
+	const principal = await requireJobRequest(deps.db, request);
+
+	if (principal instanceof Response) {
+		return principal;
+	}
+
+	return Response.json(toWorkflowSettings(await getSettings(deps.db)));
+}

--- a/apps/jobs-api/src/subtraction/handlers.test.ts
+++ b/apps/jobs-api/src/subtraction/handlers.test.ts
@@ -23,6 +23,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { seedJob } from "../auth/test/fixtures";
 import {
 	handleFinalizeSubtraction,
+	handleGetSubtraction,
 	type SubtractionHandlerDeps,
 } from "./handlers";
 
@@ -373,5 +374,150 @@ describe("handleFinalizeSubtraction", () => {
 		expect(sizes).toHaveLength(2);
 		expect(begin).toBeGreaterThan(-1);
 		expect(lastSize).toBeLessThan(begin);
+	});
+});
+
+function get(subtractionId: number | string, authenticated = true): Request {
+	return new Request(
+		`https://jobs.virtool.test/subtractions/${subtractionId}`,
+		{ headers: authenticated ? { authorization: `Basic ${credential}` } : {} },
+	);
+}
+
+describe("handleGetSubtraction", () => {
+	it("serves the subtraction and its files", async () => {
+		const subtractionId = await seedSubtraction({
+			nickname: "Arabidopsis",
+			ready: true,
+			count: 12,
+			gc: GC,
+		});
+
+		await db.insert(subtractionFiles).values({
+			subtraction_id: subtractionId,
+			name: "subtraction.fa.gz",
+			size: 4096,
+			storage_key: "subtractions/1/aaaabbbbccccddddeeeeffff00001111",
+			type: "fasta",
+		});
+
+		const response = await handleGetSubtraction(
+			deps,
+			get(subtractionId),
+			String(subtractionId),
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			id: subtractionId,
+			count: 12,
+			files: [
+				{
+					id: expect.any(Number),
+					name: "subtraction.fa.gz",
+					size: 4096,
+					storageKey: "subtractions/1/aaaabbbbccccddddeeeeffff00001111",
+					type: "fasta",
+				},
+			],
+			gc: GC,
+			name: expect.any(String),
+			nickname: "Arabidopsis",
+			ready: true,
+		});
+	});
+
+	// The workflow reads the bytes itself and has no way to locate them but this
+	// key. A migrated object keeps whatever prefix it was written under, so the
+	// key here matches no pattern that could reconstruct it — if the handler ever
+	// composed one instead of reading the column, this is the test that fails.
+	it("returns a migrated file's recorded key verbatim", async () => {
+		const subtractionId = await seedSubtraction();
+		const legacyKey = "references/legacy-prefix/xyz/subtraction_1.fa.gz";
+
+		await db.insert(subtractionFiles).values({
+			subtraction_id: subtractionId,
+			name: "subtraction.fa.gz",
+			size: 8,
+			storage_key: legacyKey,
+			type: "fasta",
+		});
+
+		const response = await handleGetSubtraction(
+			deps,
+			get(subtractionId),
+			String(subtractionId),
+		);
+		const subtraction = (await response.json()) as {
+			files: { storageKey: string }[];
+		};
+
+		expect(subtraction.files[0]?.storageKey).toBe(legacyKey);
+	});
+
+	// A row written before keys were recorded names no object. The workflow must
+	// see the null and fail rather than be handed something it can guess with.
+	it("reports a null key for a file that predates keys being recorded", async () => {
+		const subtractionId = await seedSubtraction();
+
+		await db.insert(subtractionFiles).values({
+			subtraction_id: subtractionId,
+			name: "subtraction.fa.gz",
+			size: 8,
+			type: "fasta",
+		});
+
+		const response = await handleGetSubtraction(
+			deps,
+			get(subtractionId),
+			String(subtractionId),
+		);
+		const subtraction = (await response.json()) as {
+			files: { storageKey: string | null }[];
+		};
+
+		expect(subtraction.files[0]?.storageKey).toBeNull();
+	});
+
+	// The SPA reads the same data function, which returns snake_case names and a
+	// download URL. Neither belongs on this wire.
+	it("serves camelCase and no download URL", async () => {
+		const subtractionId = await seedSubtraction();
+
+		const response = await handleGetSubtraction(
+			deps,
+			get(subtractionId),
+			String(subtractionId),
+		);
+		const rendered = await response.text();
+
+		expect(rendered).not.toContain("download_url");
+		expect(rendered).not.toContain("created_at");
+		expect(rendered).not.toContain("linked_samples");
+	});
+
+	it("reports 404 for a subtraction that does not exist", async () => {
+		const response = await handleGetSubtraction(deps, get(404_040), "404040");
+
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual({ message: "Subtraction not found" });
+	});
+
+	it("reports 404 for an id that is not a positive integer", async () => {
+		const response = await handleGetSubtraction(deps, get("latest"), "latest");
+
+		expect(response.status).toBe(404);
+	});
+
+	it("refuses an unauthenticated request", async () => {
+		const subtractionId = await seedSubtraction();
+
+		const response = await handleGetSubtraction(
+			deps,
+			get(subtractionId, false),
+			String(subtractionId),
+		);
+
+		expect(response.status).toBe(401);
 	});
 });

--- a/apps/jobs-api/src/subtraction/handlers.ts
+++ b/apps/jobs-api/src/subtraction/handlers.ts
@@ -1,15 +1,17 @@
+import type { Subtraction, WorkflowSubtraction } from "@virtool/contracts";
 import { FinalizeSubtractionRequest } from "@virtool/contracts";
 import type { Db } from "@virtool/data/db/pg";
 import type { SubtractionFileType } from "@virtool/data/db/schema/subtractions";
 import {
 	finalizeSubtraction,
+	getSubtraction,
 	SubtractionAlreadyFinalizedError,
 	SubtractionNotFoundError,
 } from "@virtool/data/subtraction/data";
 import type { Logger } from "@virtool/logger";
 import type { StorageBackend } from "@virtool/storage";
 import { requireJobRequest } from "../auth/guard";
-import { jsonError, parseRowId } from "../http";
+import { jsonError, parseRowId, type ReadHandlerDeps } from "../http";
 import { checkManifest, measureManifest } from "../manifest";
 
 /** What the subtraction handlers need to serve a request. */
@@ -18,6 +20,71 @@ export type SubtractionHandlerDeps = {
 	storage: StorageBackend;
 	logger: Logger;
 };
+
+/**
+ * Narrow a subtraction to what a workflow reads.
+ *
+ * The mapping happens here rather than inside `@virtool/data`, which returns
+ * this shape to `apps/web`'s client as well — including the snake_case
+ * `created_at` and `linked_samples` that must not cross this wire, and the
+ * `download_url` that has no meaning to a workflow.
+ *
+ * Each file carries its recorded `storageKey`; the workflow takes it to the
+ * bucket itself.
+ */
+function toWorkflowSubtraction(subtraction: Subtraction): WorkflowSubtraction {
+	return {
+		id: subtraction.id,
+		count: subtraction.count,
+		files: subtraction.files.map((file) => ({
+			id: file.id,
+			name: file.name,
+			size: file.size,
+			storageKey: file.storageKey,
+			type: file.type,
+		})),
+		gc: subtraction.gc,
+		name: subtraction.name,
+		nickname: subtraction.nickname,
+		ready: subtraction.ready,
+	};
+}
+
+/**
+ * Serve a subtraction's metadata and the files that make it up — its source
+ * genome and the shards of its built bowtie2 index.
+ *
+ * Records only. Nothing here reads or writes an object.
+ */
+export async function handleGetSubtraction(
+	deps: ReadHandlerDeps,
+	request: Request,
+	subtractionIdParam: string,
+): Promise<Response> {
+	const principal = await requireJobRequest(deps.db, request);
+
+	if (principal instanceof Response) {
+		return principal;
+	}
+
+	const subtractionId = parseRowId(subtractionIdParam);
+
+	if (subtractionId === null) {
+		return jsonError(404, "Subtraction not found");
+	}
+
+	try {
+		return Response.json(
+			toWorkflowSubtraction(await getSubtraction(deps.db, subtractionId)),
+		);
+	} catch (err) {
+		if (err instanceof SubtractionNotFoundError) {
+			return jsonError(404, "Subtraction not found");
+		}
+
+		throw err;
+	}
+}
 
 /**
  * The only filenames a subtraction accepts, matching Python's

--- a/apps/web/src/tests/fake/indexes.ts
+++ b/apps/web/src/tests/fake/indexes.ts
@@ -67,6 +67,7 @@ export function createFakeIndexFile(overrides?: Partial<IndexFile>): IndexFile {
 		index: faker.number.int(),
 		name: faker.word.noun({ strategy: "any-length" }),
 		size: faker.number.int({ min: 20000 }),
+		storageKey: `indexes/${faker.number.int()}/${faker.string.uuid().replaceAll("-", "")}`,
 		type: "fasta",
 	};
 

--- a/apps/web/src/tests/fake/samples.ts
+++ b/apps/web/src/tests/fake/samples.ts
@@ -53,6 +53,7 @@ export function createFakeSampleRead(overrides?: Partial<Read>): Read {
 		nameOnDisk: faker.word.noun({ strategy: "any-length" }),
 		sample: faker.number.int(),
 		size: faker.number.int(),
+		storageKey: `samples/${faker.number.int()}/${faker.string.uuid().replaceAll("-", "")}`,
 		uploadedAt: faker.date.past().toISOString(),
 	};
 

--- a/apps/web/src/tests/fake/subtractions.ts
+++ b/apps/web/src/tests/fake/subtractions.ts
@@ -18,6 +18,7 @@ export function createFakeSubtractionFile(): SubtractionFile {
 		id: faker.number.int(),
 		name: `${faker.word.noun({ strategy: "any-length" })}s.fa`,
 		size: faker.number.int({ min: 20000 }),
+		storageKey: `subtractions/${faker.number.int()}/${faker.string.uuid().replaceAll("-", "")}`,
 		subtraction: faker.number.int(),
 		type: "fasta",
 	};

--- a/docs/jobs-api.md
+++ b/docs/jobs-api.md
@@ -44,6 +44,13 @@ process:
 | `src/auth/guard.ts` | `requireJobRequest` — the guard every handler starts with |
 | `src/auth/test/fixtures.ts` | `seedJob` — a job row and the plaintext key for it |
 | `src/caches/handlers.ts` | Cache lookup and registration |
+| `src/http.ts` | `jsonError`, `parseRowId`, and the `ReadHandlerDeps` a read takes |
+| `src/samples/handlers.ts` | Sample read and finalize |
+| `src/subtraction/handlers.ts` | Subtraction read and finalize |
+| `src/analyses/handlers.ts` | Analysis read and finalize |
+| `src/indexes/handlers.ts` | Index build read |
+| `src/references/handlers.ts` | Reference read |
+| `src/settings/handlers.ts` | Instance settings read |
 | `src/metrics/registry.ts` | `createMetrics` — this process's Prometheus registry |
 | `src/metrics/jobs.ts` | `createJobQueueReader` — the memoized job-queue read |
 | `src/metrics/handler.ts` | Token check, pre-scrape reads, response |
@@ -463,6 +470,113 @@ Python publishes free-form domain strings onto `client_events` and has
 been emitting `subtractions` all along; the client was dropping the
 frames because its schema did not accept them.
 
+## Metadata reads
+
+A running workflow needs the records behind its job: what to align
+against, what to subtract, where its reads are. Six endpoints serve
+them, each at Python's own resource path with no prefix.
+
+| Route | Data function | Shape |
+| --- | --- | --- |
+| `GET /samples/{id}` | `getSample` | `WorkflowSample` |
+| `GET /subtractions/{id}` | `getSubtraction` | `WorkflowSubtraction` |
+| `GET /indexes/{id}` | `getIndex` | `WorkflowIndex` |
+| `GET /analyses/{id}` | `getAnalysis` | `WorkflowAnalysis` |
+| `GET /refs/{id}` | `getReference` | `WorkflowReference` |
+| `GET /settings` | `getSettings` | `WorkflowSettings` |
+
+Every one calls the data function `apps/web` already calls. None adds a
+query for a table one of those reads, and none keeps a private copy of
+one. A missing row is a 404 through the handler's own mapping of the
+domain's `NotFoundError`, never a 500, and a path segment that is not a
+positive integer is a 404 before the database is touched — which is also
+what keeps `GET /jobs/counts`, still Python-served, from resolving here
+as a job read.
+
+The path for a reference is `/refs/{id}`, matching Python, not the
+spelled-out `/references` the package name suggests.
+
+### Records only, never bytes
+
+Under Python a workflow pulled its files through the jobs API. Workflows
+now hold their own credentials for the shared bucket and read it
+directly, so these endpoints owe them *records only*. No handler streams
+a payload, and no handler may call `storage.write` — a read that lazily
+built `index.sqlite` or an HMM annotation blob would put artifact
+generation on a path that is supposed to be a lookup. Python's
+`create_index` task writes a build's artifacts eagerly; this side reports
+the rows that exist and generates nothing, so an unfinished build answers
+with an empty file list rather than producing one.
+
+`ReadHandlerDeps` is `{ db }` and nothing else. A read cannot reach
+`storage` because it is never handed one.
+
+### Every file reference carries its recorded key
+
+**Keys are recorded, not derived.** Each file row holds its object's
+complete key in a `storage_key` column, and these responses pass it
+through verbatim. Nothing reconstructs one: a migrated row keeps whatever
+prefix its object was written under, so keys in the bucket are
+heterogeneous by design and no pattern regenerates them. A response that
+omitted the key would leave the workflow able to see that a file exists
+and reach none of it.
+
+The key is nullable wherever its column is — `sample_reads` and
+`subtraction_files` both predate keys being recorded — and `index_files`
+is `NOT NULL`. A workflow handed a null has nothing to fetch and must
+fail rather than guess.
+
+**This is not a privilege widening.** A workflow pod already holds
+unscoped credentials for the bucket, so the key is a locator, not a
+capability. The asymmetry lives on the write side instead: a manifest a
+workflow *sends* is checked against the resource's own prefix before its
+key is recorded, because a caller-supplied key there would let a
+job-authenticated caller point a row at an arbitrary object.
+
+### camelCase at the handler boundary, and narrower than the SPA's shapes
+
+The data functions are not consistent in case — `subtraction/data.ts`
+returns `created_at`, `linked_samples` and `download_url`, while
+`samples/data.ts` returns `libraryType` — and `apps/web`'s client feature
+modules read those same shapes. So the mapping to camelCase happens
+**in the handler**, and no field is renamed inside a data function.
+Renaming one there would break the web app silently, days later, in a
+different app.
+
+The `Workflow*` shapes are also deliberately narrower than what the SPA
+reads. They carry what a workflow branches on and drop the presentation
+fields — download URLs, contributor lists, linked samples, rights lists —
+which keeps `Date`-valued fields off a wire that only ever carries JSON
+strings, and keeps this contract from having to stay parseable against
+every field the UI grows.
+
+Two consequences worth stating outright:
+
+- **An analysis's `sample` is an object carrying an id, not a bare id.**
+  Python's runtime falls back to reading it when a job's `args` carry no
+  `sample_id`, so flattening it breaks every analysis whose job was
+  created without one.
+- **A sample's `paired` is derived from its reads**, not stored, and is
+  what a workflow branches on to decide whether it is running one file
+  or two.
+
+### Reading an analysis does not format it
+
+`getAnalysis` reads metadata and file rows only. The expensive half —
+reading the TOASTed `results` column and patching every OTU back to the
+version the analysis saw — is `getAnalysisResults`, a separate function
+this path never calls. A workflow needs none of it, and these responses
+carry no results at all.
+
+### The settings read is a write
+
+`GET /settings` has no 404: the row is a singleton, and `getSettings`
+seeds `DEFAULT_SETTINGS` when it is absent, mirroring Python's
+`SettingsData.ensure()`. That makes it the one endpoint here where a
+job-authenticated GET can insert a row. It is deliberate — the
+alternative is failing a workflow because nothing had written the row
+yet — but it is worth knowing rather than discovering.
+
 ## Metrics
 
 `GET /metrics` serves the Prometheus text exposition from this process's
@@ -758,7 +872,14 @@ for this service:
 
 ## What is not here yet
 
-This service serves health, metrics, the two cache endpoints and the
-three finalize routes. The job lifecycle endpoints — claim, ping, step
-start and finish — each land in their own issue, against the wire
-contract already written in `packages/contracts/src/jobsApi.ts`.
+This service serves health, metrics, the two cache endpoints, the three
+finalize routes and the six metadata reads. The job lifecycle endpoints —
+claim, `GET /jobs/{jobId}`, ping, step start and finish — each land in
+their own issue, against the wire contract already written in
+`packages/contracts/src/jobsApi.ts`.
+
+The reads cover the resources the four ported workflows name. Sample
+artifacts are not among them: `sample_artifacts` is touched only by
+`deleteSample`'s cleanup today, and no read path returns one. Add the
+read when a workflow needs it, alongside the key column that row already
+carries.

--- a/packages/contracts/src/indexes.ts
+++ b/packages/contracts/src/indexes.ts
@@ -79,6 +79,15 @@ export type IndexFile = {
 	/** The size in bytes, or null while the build has not recorded one */
 	size: number | null;
 
+	/**
+	 * The object's complete key in storage, as recorded when it was written.
+	 *
+	 * Nothing composes this from the row's identity: a migrated file keeps
+	 * whatever prefix its object was written under, so no pattern reconstructs
+	 * one. A workflow reads the bytes itself and has no other way to locate them.
+	 */
+	storageKey: string;
+
 	/** The kind of artifact the file holds */
 	type: string;
 };

--- a/packages/contracts/src/jobsApi.ts
+++ b/packages/contracts/src/jobsApi.ts
@@ -40,6 +40,20 @@
 //   PATCH  /analyses/{id}                      FinalizeAnalysisRequest    -> Analysis
 //   GET    /caches/{key}                       -                     -> Cache           (200 | 404)
 //   POST   /caches                             RegisterCacheRequest  -> CacheRegistered (201 | 200)
+//   GET    /samples/{id}                       -                     -> WorkflowSample       (200 | 404)
+//   GET    /subtractions/{id}                  -                     -> WorkflowSubtraction  (200 | 404)
+//   GET    /indexes/{id}                       -                     -> WorkflowIndex        (200 | 404)
+//   GET    /analyses/{id}                      -                     -> WorkflowAnalysis     (200 | 404)
+//   GET    /refs/{id}                          -                     -> WorkflowReference    (200 | 404)
+//   GET    /settings                           -                     -> WorkflowSettings     (200)
+//
+// The metadata reads are **records only, never bytes**. A workflow pod holds its
+// own object-storage credentials and fetches every file itself, so each file
+// reference carries the recorded `storageKey` and the response carries no
+// payload and no download URL. The `Workflow*` shapes are deliberately narrower
+// than the ones the SPA reads: they carry what a workflow actually branches on
+// and drop the presentation fields — download URLs, contributor lists, linked
+// samples — that would otherwise have to be kept parseable here forever.
 //
 // The cache shapes live in `./caches` rather than here, because they are the one
 // part of this surface a workflow reaches on its own behalf rather than on
@@ -60,10 +74,10 @@
 // only invite one to.
 
 import { z } from "zod";
-import { AnalysisFormat } from "./analyses";
+import { AnalysisFormat, AnalysisWorkflow } from "./analyses";
 import { JobState, JobWorkflow } from "./jobs";
 import { JsonObject } from "./json";
-import { Quality } from "./samples";
+import { LibraryType, Quality } from "./samples";
 import { NucleotideComposition } from "./subtractions";
 import { UserNested } from "./users";
 
@@ -377,3 +391,152 @@ export const FinalizeAnalysisRequest = z.object({
 });
 
 export type FinalizeAnalysisRequest = z.infer<typeof FinalizeAnalysisRequest>;
+
+/**
+ * A file reference on a metadata read, as a workflow receives it.
+ *
+ * **`storageKey` is what makes the reference usable at all.** Nothing composes
+ * a key from row identity on either side — a migrated object keeps whatever
+ * prefix it was written under, so no pattern reconstructs one — and a workflow
+ * that receives a reference without a key can see that the file exists and
+ * reach none of it.
+ *
+ * The key is nullable wherever its column is, which is every file table but
+ * `index_files`. A workflow handed a null must fail rather than guess: there is
+ * no fallback that finds the object.
+ *
+ * This is the read direction only. A manifest a workflow *sends* never carries
+ * a key it chose — see {@link JobFileManifest}, where the asymmetry is the
+ * point.
+ */
+const workflowFile = {
+	id: z.number().int(),
+	name: z.string(),
+	size: z.number().int().nullable(),
+};
+
+/** A reads file a workflow downloads to run against. */
+export const WorkflowSampleRead = z.object({
+	...workflowFile,
+	storageKey: z.string().nullable(),
+});
+
+export type WorkflowSampleRead = z.infer<typeof WorkflowSampleRead>;
+
+/** A subtraction's source genome or one shard of its built index. */
+export const WorkflowSubtractionFile = z.object({
+	...workflowFile,
+	storageKey: z.string().nullable(),
+	type: z.string(),
+});
+
+export type WorkflowSubtractionFile = z.infer<typeof WorkflowSubtractionFile>;
+
+/** A file an index build produced. `index_files.storage_key` is `NOT NULL`. */
+export const WorkflowIndexFile = z.object({
+	...workflowFile,
+	storageKey: z.string(),
+	type: z.string(),
+});
+
+export type WorkflowIndexFile = z.infer<typeof WorkflowIndexFile>;
+
+/**
+ * A sample, as a workflow reads it.
+ *
+ * `paired` is derived from the reads rather than stored, and is what a workflow
+ * branches on to decide whether it is running one file or two.
+ */
+export const WorkflowSample = z.object({
+	id: z.number().int(),
+	libraryType: LibraryType,
+	name: z.string(),
+	paired: z.boolean(),
+	quality: Quality.nullable(),
+	reads: z.array(WorkflowSampleRead),
+});
+
+export type WorkflowSample = z.infer<typeof WorkflowSample>;
+
+/** A subtraction, as a workflow reads it. */
+export const WorkflowSubtraction = z.object({
+	id: z.number().int(),
+	count: z.number().int().nullable(),
+	files: z.array(WorkflowSubtractionFile),
+	gc: NucleotideComposition.nullable(),
+	name: z.string(),
+	nickname: z.string(),
+	ready: z.boolean(),
+});
+
+export type WorkflowSubtraction = z.infer<typeof WorkflowSubtraction>;
+
+/**
+ * An index build, as a workflow reads it.
+ *
+ * `manifest` is the OTU-id to version map the build is pinned to, straight out
+ * of a JSONB column. Its keys are legacy Mongo OTU ids, so it is a record of
+ * strings rather than anything this side interprets.
+ */
+export const WorkflowIndex = z.object({
+	id: z.number().int(),
+	files: z.array(WorkflowIndexFile),
+	manifest: z.record(z.string(), z.number().int()),
+	ready: z.boolean(),
+	reference: z.object({ id: z.number().int(), name: z.string() }),
+	version: z.number().int(),
+});
+
+export type WorkflowIndex = z.infer<typeof WorkflowIndex>;
+
+/**
+ * An analysis, as a workflow reads it.
+ *
+ * **`sample` is an object carrying an id, not a bare id.** Python's workflow
+ * runtime falls back to reading it when a job's `args` carry no `sample_id`, so
+ * flattening it breaks every analysis whose job was created without one.
+ *
+ * No results and no files: an analysis a workflow is running has neither yet,
+ * and reading them would pull in the formatting layer this read exists to avoid.
+ */
+export const WorkflowAnalysis = z.object({
+	id: z.number().int(),
+	index: z.object({ id: z.number().int(), version: z.number().int() }),
+	ready: z.boolean(),
+	reference: z.object({ id: z.number().int(), name: z.string() }),
+	sample: z.object({ id: z.number().int(), name: z.string() }),
+	subtractions: z.array(z.object({ id: z.number().int(), name: z.string() })),
+	workflow: AnalysisWorkflow,
+});
+
+export type WorkflowAnalysis = z.infer<typeof WorkflowAnalysis>;
+
+/**
+ * A reference, as a workflow reads it.
+ *
+ * Metadata only. The rights lists, contributors and build history the SPA shows
+ * are about who may edit a reference, which is not a question a workflow asks.
+ */
+export const WorkflowReference = z.object({
+	id: z.number().int(),
+	dataType: z.string(),
+	description: z.string(),
+	name: z.string(),
+	organism: z.string(),
+});
+
+export type WorkflowReference = z.infer<typeof WorkflowReference>;
+
+/** The instance settings singleton, as a workflow reads it. */
+export const WorkflowSettings = z.object({
+	defaultSourceTypes: z.array(z.string()),
+	enableSentry: z.boolean(),
+	minimumPasswordLength: z.number().int(),
+	sampleAllRead: z.boolean(),
+	sampleAllWrite: z.boolean(),
+	sampleGroup: z.enum(["none", "force_choice", "users_primary_group"]),
+	sampleGroupRead: z.boolean(),
+	sampleGroupWrite: z.boolean(),
+});
+
+export type WorkflowSettings = z.infer<typeof WorkflowSettings>;

--- a/packages/contracts/src/samples.ts
+++ b/packages/contracts/src/samples.ts
@@ -6,8 +6,16 @@ import type { SearchResult } from "./search";
 import type { SubtractionNested } from "./subtractions";
 import type { UserNested } from "./users";
 
-/** The library preparation used to create a sample. */
-export type LibraryType = "amplicon" | "srna" | "other" | "normal";
+/**
+ * The library preparation used to create a sample.
+ *
+ * A schema rather than a plain union because the jobs API serves it to a
+ * workflow, whose client parses the response — and every workflow branches on
+ * it to decide whether it is running paired or amplicon logic.
+ */
+export const LibraryType = z.enum(["amplicon", "srna", "other", "normal"]);
+
+export type LibraryType = z.infer<typeof LibraryType>;
 
 /** The state of a single workflow for a sample. */
 export type WorkflowState = "complete" | "pending" | "none" | "incompatible";
@@ -44,6 +52,17 @@ export type Read = {
 	nameOnDisk: string;
 	sample: number;
 	size: number;
+
+	/**
+	 * The object's complete key in storage, as recorded when it was written, or
+	 * null for a file that predates keys being recorded.
+	 *
+	 * Nothing composes this from the row's identity: a migrated file keeps
+	 * whatever prefix its object was written under, so no pattern reconstructs
+	 * one. A workflow reads the bytes itself and has no other way to locate them.
+	 */
+	storageKey: string | null;
+
 	upload?: SampleReadUpload | null;
 	uploadedAt: string;
 };

--- a/packages/contracts/src/subtractions.ts
+++ b/packages/contracts/src/subtractions.ts
@@ -76,6 +76,17 @@ export type SubtractionFile = {
 	id: number;
 	name: string;
 	size: number;
+
+	/**
+	 * The object's complete key in storage, as recorded when it was written, or
+	 * null for a file that predates keys being recorded.
+	 *
+	 * Nothing composes this from the row's identity: a migrated file keeps
+	 * whatever prefix its object was written under, so no pattern reconstructs
+	 * one. A workflow reads the bytes itself and has no other way to locate them.
+	 */
+	storageKey: string | null;
+
 	subtraction: number;
 	type: string;
 };

--- a/packages/data/src/indexes/data.test.ts
+++ b/packages/data/src/indexes/data.test.ts
@@ -277,6 +277,9 @@ describe("getIndex", () => {
 				index: indexId,
 				name: "reference.fa.gz",
 				size: 2048,
+				// Read off the row, never composed — a migrated build's object keeps
+				// whatever prefix it was written under.
+				storageKey: `indexes/${indexId}/reference`,
 				type: "fasta",
 			},
 		]);

--- a/packages/data/src/indexes/data.ts
+++ b/packages/data/src/indexes/data.ts
@@ -355,6 +355,7 @@ async function getIndexFiles(
 			id: indexFiles.id,
 			name: indexFiles.name,
 			size: indexFiles.size,
+			storageKey: indexFiles.storage_key,
 			type: indexFiles.type,
 		})
 		.from(indexFiles)
@@ -366,6 +367,7 @@ async function getIndexFiles(
 		index: indexId,
 		name: row.name,
 		size: row.size,
+		storageKey: row.storageKey,
 		type: row.type ?? "",
 	}));
 }

--- a/packages/data/src/samples/data.ts
+++ b/packages/data/src/samples/data.ts
@@ -344,6 +344,7 @@ async function getReads(
 		nameOnDisk: read.name_on_disk,
 		sample: sampleId,
 		size: read.size ?? 0,
+		storageKey: read.storage_key,
 		upload:
 			upload == null
 				? null

--- a/packages/data/src/subtraction/data.test.ts
+++ b/packages/data/src/subtraction/data.test.ts
@@ -255,6 +255,9 @@ describe("getSubtraction", () => {
 				id: expect.any(Number),
 				name: "subtraction.fa.gz",
 				size: 100,
+				// Read off the row, never composed — a migrated file's object keeps
+				// whatever prefix it was written under.
+				storageKey: `subtractions/${subtractionId}/fasta`,
 				subtraction: subtractionId,
 				type: "fasta",
 			},

--- a/packages/data/src/subtraction/data.ts
+++ b/packages/data/src/subtraction/data.ts
@@ -269,6 +269,7 @@ async function getSubtractionFiles(
 		id: row.id,
 		name: row.name ?? "",
 		size: row.size ?? 0,
+		storageKey: row.storage_key,
 		subtraction: subtractionId,
 		type: (row.type ?? "fasta") as SubtractionFileType,
 	}));


### PR DESCRIPTION
## Summary

- Adds six read endpoints — `GET /samples/{id}`, `/subtractions/{id}`, `/indexes/{id}`, `/analyses/{id}`, `/refs/{id}`, `/settings` — so a running workflow can fetch the records behind its job, at Python's own resource paths with no prefix.
- Each handler reuses the data function `apps/web` already calls and maps it to a narrow camelCase `Workflow*` shape at the handler boundary, so no field is renamed inside a data function the web client also reads. Reads take `{ db }` and nothing else, so a read handler cannot reach storage or build a derived artifact.
- `Read`, `SubtractionFile` and `IndexFile` gain a recorded `storageKey`, selected from the row and never composed — a migrated object keeps whatever prefix it was written under, so a response without the key leaves a workflow unable to reach the bytes at all.