### PR TITLE
fix: allow deletion of subtractions whose creation job failed

### DIFF
--- a/apps/web/src/subtraction/__tests__/utils.test.ts
+++ b/apps/web/src/subtraction/__tests__/utils.test.ts
@@ -1,5 +1,10 @@
+import { createFakeJobNested } from "@tests/fake/jobs";
 import { describe, expect, it } from "vitest";
-import { getSubtractionFastaName, isJobStateUnsuccessful } from "../utils";
+import {
+	getCreateJobStatus,
+	getSubtractionFastaName,
+	isJobStateUnsuccessful,
+} from "../utils";
 
 describe("getSubtractionFastaName()", () => {
 	it("lowercases and replaces whitespace with underscores", () => {
@@ -29,4 +34,38 @@ describe("isJobStateUnsuccessful()", () => {
 		expect(isJobStateUnsuccessful(undefined)).toBe(false);
 		expect(isJobStateUnsuccessful(null)).toBe(false);
 	});
+});
+
+describe("getCreateJobStatus()", () => {
+	it("is null when the subtraction has no job", () => {
+		expect(getCreateJobStatus(null)).toBeNull();
+	});
+
+	it("falls back to the nested job when none was fetched", () => {
+		const nested = createFakeJobNested({ progress: 40, state: "running" });
+
+		expect(getCreateJobStatus(nested)).toEqual({
+			progress: 40,
+			state: "running",
+		});
+	});
+
+	it("prefers the fetched job while neither state is terminal", () => {
+		const nested = createFakeJobNested({ progress: 40, state: "running" });
+
+		expect(
+			getCreateJobStatus(nested, { progress: 80, state: "running" }),
+		).toEqual({ progress: 80, state: "running" });
+	});
+
+	it.each(["cancelled", "failed"] as const)(
+		"keeps a nested %s state over a stale fetched one",
+		(state) => {
+			const nested = createFakeJobNested({ progress: 100, state });
+
+			expect(
+				getCreateJobStatus(nested, { progress: 40, state: "running" }),
+			).toEqual({ progress: 100, state });
+		},
+	);
 });

--- a/apps/web/src/subtraction/__tests__/utils.test.ts
+++ b/apps/web/src/subtraction/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getSubtractionFastaName } from "../utils";
+import { getSubtractionFastaName, isJobStateUnsuccessful } from "../utils";
 
 describe("getSubtractionFastaName()", () => {
 	it("lowercases and replaces whitespace with underscores", () => {
@@ -10,5 +10,23 @@ describe("getSubtractionFastaName()", () => {
 
 	it("collapses runs of whitespace", () => {
 		expect(getSubtractionFastaName("Foo  \tBar")).toBe("foo_bar.fa.gz");
+	});
+});
+
+describe("isJobStateUnsuccessful()", () => {
+	it.each(["cancelled", "failed"] as const)("is true for %s", (state) => {
+		expect(isJobStateUnsuccessful(state)).toBe(true);
+	});
+
+	it.each(["pending", "running", "succeeded"] as const)(
+		"is false for %s",
+		(state) => {
+			expect(isJobStateUnsuccessful(state)).toBe(false);
+		},
+	);
+
+	it("is false when the state is missing", () => {
+		expect(isJobStateUnsuccessful(undefined)).toBe(false);
+		expect(isJobStateUnsuccessful(null)).toBe(false);
 	});
 });

--- a/apps/web/src/subtraction/components/Detail/SubtractionDetail.tsx
+++ b/apps/web/src/subtraction/components/Detail/SubtractionDetail.tsx
@@ -1,15 +1,22 @@
 import { useCheckAdminRoleOrPermission } from "@administration/hooks";
 import { toGcContent } from "@app/format";
+import Alert from "@base/Alert";
 import BoxGroup from "@base/BoxGroup";
 import BoxGroupSection from "@base/BoxGroupSection";
+import Link from "@base/Link";
 import LoadingPlaceholder from "@base/LoadingPlaceholder";
 import NotFound from "@base/NotFound";
 import ViewHeader from "@base/ViewHeader";
 import ViewHeaderIcons from "@base/ViewHeaderIcons";
 import ViewHeaderTitle from "@base/ViewHeaderTitle";
+import { useFetchJob } from "@jobs/queries";
 import { useFetchSubtraction } from "@subtraction/queries";
-import { getSubtractionFastaName } from "@subtraction/utils";
+import {
+	getSubtractionFastaName,
+	isJobStateUnsuccessful,
+} from "@subtraction/utils";
 import type { NucleotideComposition } from "@virtool/contracts";
+import { TriangleAlert } from "lucide-react";
 import { SubtractionAttribution } from "../Attribution";
 import DeleteSubtraction from "./DeleteSubtraction";
 import EditSubtraction from "./EditSubtraction";
@@ -34,6 +41,17 @@ export default function SubtractionDetail() {
 	const { hasPermission: canModify } =
 		useCheckAdminRoleOrPermission("modify_subtraction");
 
+	// A create job that fails writes nothing to the subtraction, so no
+	// `subtractions` frame announces it. The job is followed directly instead, as
+	// the list rows do, so the view flips without a reload. The seed needs a
+	// user, and a job whose creator was removed has none.
+	const job = data?.job ?? null;
+	const { data: fetchedJob } = useFetchJob(
+		job?.id ?? Number.NaN,
+		job?.user ? { ...job, user: job.user } : undefined,
+	);
+	const jobState = fetchedJob?.state ?? job?.state;
+
 	if (isError) {
 		return <NotFound />;
 	}
@@ -43,6 +61,43 @@ export default function SubtractionDetail() {
 	}
 
 	if (!data.ready || !data.gc) {
+		if (job && isJobStateUnsuccessful(jobState)) {
+			return (
+				<>
+					<ViewHeader title={data.name}>
+						<ViewHeaderTitle>
+							{data.name}
+							{canModify && (
+								<ViewHeaderIcons>
+									<DeleteSubtraction subtraction={data} />
+								</ViewHeaderIcons>
+							)}
+						</ViewHeaderTitle>
+						{data.user ? (
+							<SubtractionAttribution
+								handle={data.user.handle}
+								time={data.createdAt}
+							/>
+						) : null}
+					</ViewHeader>
+					<Alert color="red" icon={TriangleAlert} level>
+						<span>
+							The create job{" "}
+							{jobState === "cancelled" ? "was cancelled" : "failed"}. This
+							subtraction can't be used and should be deleted.
+						</span>
+						<Link
+							className="ml-auto whitespace-nowrap text-red-800 underline"
+							to="/jobs/$jobId"
+							params={{ jobId: String(job.id) }}
+						>
+							View job
+						</Link>
+					</Alert>
+				</>
+			);
+		}
+
 		return <LoadingPlaceholder message="Subtraction is still being imported" />;
 	}
 

--- a/apps/web/src/subtraction/components/Detail/SubtractionDetail.tsx
+++ b/apps/web/src/subtraction/components/Detail/SubtractionDetail.tsx
@@ -12,6 +12,7 @@ import ViewHeaderTitle from "@base/ViewHeaderTitle";
 import { useFetchJob } from "@jobs/queries";
 import { useFetchSubtraction } from "@subtraction/queries";
 import {
+	getCreateJobStatus,
 	getSubtractionFastaName,
 	isJobStateUnsuccessful,
 } from "@subtraction/utils";
@@ -50,7 +51,7 @@ export default function SubtractionDetail() {
 		job?.id ?? Number.NaN,
 		job?.user ? { ...job, user: job.user } : undefined,
 	);
-	const jobState = fetchedJob?.state ?? job?.state;
+	const jobState = getCreateJobStatus(job, fetchedJob)?.state;
 
 	if (isError) {
 		return <NotFound />;
@@ -86,13 +87,17 @@ export default function SubtractionDetail() {
 							{jobState === "cancelled" ? "was cancelled" : "failed"}. This
 							subtraction can't be used and should be deleted.
 						</span>
-						<Link
-							className="ml-auto whitespace-nowrap text-red-800 underline"
-							to="/jobs/$jobId"
-							params={{ jobId: String(job.id) }}
-						>
-							View job
-						</Link>
+						{/* The jobs read inner-joins its user, so a job whose creator
+						    was removed is a 404 rather than a page worth linking to. */}
+						{job.user ? (
+							<Link
+								className="ml-auto whitespace-nowrap text-red-800 underline"
+								to="/jobs/$jobId"
+								params={{ jobId: String(job.id) }}
+							>
+								View job
+							</Link>
+						) : null}
 					</Alert>
 				</>
 			);

--- a/apps/web/src/subtraction/components/Detail/__tests__/SubtractionDetail.test.tsx
+++ b/apps/web/src/subtraction/components/Detail/__tests__/SubtractionDetail.test.tsx
@@ -115,6 +115,28 @@ describe("<SubtractionDetail />", () => {
 		},
 	);
 
+	it("should not link to the job of a failed subtraction whose creator was removed", async () => {
+		const permissions = createFakePermissions({ modify_subtraction: true });
+		const account = createFakeAccount({ permissions });
+		const failedSubtraction = createFakeSubtraction({
+			ready: false,
+			job: {
+				...createFakeJobNested({
+					state: "failed",
+					workflow: "create_subtraction",
+				}),
+				user: null,
+			},
+		});
+		mockGetSubtraction(failedSubtraction);
+
+		await renderRoute(formatSubtractionPath(failedSubtraction), { account });
+
+		expect(await screen.findByText(failedSubtraction.name)).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "delete" })).toBeInTheDocument();
+		expect(screen.queryByRole("link", { name: "View job" })).toBeNull();
+	});
+
 	it("should not offer deletion of a failed subtraction without permission", async () => {
 		const permissions = createFakePermissions({ modify_subtraction: false });
 		const account = createFakeAccount({ permissions });

--- a/apps/web/src/subtraction/components/Detail/__tests__/SubtractionDetail.test.tsx
+++ b/apps/web/src/subtraction/components/Detail/__tests__/SubtractionDetail.test.tsx
@@ -1,6 +1,7 @@
 import { getSubtractionFastaName } from "@subtraction/utils";
 import { screen } from "@testing-library/react";
 import { createFakeAccount } from "@tests/fake/account";
+import { createFakeJobNested } from "@tests/fake/jobs";
 import { createFakePermissions } from "@tests/fake/permissions";
 import { createFakeSubtraction } from "@tests/fake/subtractions";
 import { mockGetSubtraction } from "@tests/server-fn/subtractions";
@@ -56,7 +57,13 @@ describe("<SubtractionDetail />", () => {
 	});
 
 	it("should render pending message when subtraction is not ready", async () => {
-		const unreadySubtraction = createFakeSubtraction({ ready: false });
+		const unreadySubtraction = createFakeSubtraction({
+			ready: false,
+			job: createFakeJobNested({
+				state: "running",
+				workflow: "create_subtraction",
+			}),
+		});
 		const getSubtraction = mockGetSubtraction(unreadySubtraction);
 		await renderRoute(formatSubtractionPath(unreadySubtraction));
 
@@ -65,6 +72,65 @@ describe("<SubtractionDetail />", () => {
 		).toBeInTheDocument();
 
 		expect(getSubtraction).toHaveBeenCalled();
+	});
+
+	it.each([
+		["failed", "The create job failed."],
+		["cancelled", "The create job was cancelled."],
+	] as const)(
+		"should offer deletion when the create job %s",
+		async (state, sentence) => {
+			const permissions = createFakePermissions({ modify_subtraction: true });
+			const account = createFakeAccount({ permissions });
+			const job = createFakeJobNested({
+				state,
+				workflow: "create_subtraction",
+			});
+			const failedSubtraction = createFakeSubtraction({ ready: false, job });
+			const getSubtraction = mockGetSubtraction(failedSubtraction);
+
+			await renderRoute(formatSubtractionPath(failedSubtraction), { account });
+
+			expect(
+				await screen.findByText(failedSubtraction.name),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					`${sentence} This subtraction can't be used and should be deleted.`,
+				),
+			).toBeInTheDocument();
+			expect(screen.getByRole("link", { name: "View job" })).toHaveAttribute(
+				"href",
+				`/jobs/${job.id}`,
+			);
+			expect(
+				screen.getByRole("button", { name: "delete" }),
+			).toBeInTheDocument();
+			expect(screen.queryByRole("button", { name: "modify" })).toBeNull();
+			expect(
+				screen.queryByText("Subtraction is still being imported"),
+			).toBeNull();
+
+			expect(getSubtraction).toHaveBeenCalled();
+		},
+	);
+
+	it("should not offer deletion of a failed subtraction without permission", async () => {
+		const permissions = createFakePermissions({ modify_subtraction: false });
+		const account = createFakeAccount({ permissions });
+		const failedSubtraction = createFakeSubtraction({
+			ready: false,
+			job: createFakeJobNested({
+				state: "failed",
+				workflow: "create_subtraction",
+			}),
+		});
+		mockGetSubtraction(failedSubtraction);
+
+		await renderRoute(formatSubtractionPath(failedSubtraction), { account });
+
+		expect(await screen.findByText(failedSubtraction.name)).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "delete" })).toBeNull();
 	});
 
 	it("should not render icons when [canModify=true]", async () => {

--- a/apps/web/src/subtraction/components/SubtractionItem.tsx
+++ b/apps/web/src/subtraction/components/SubtractionItem.tsx
@@ -2,6 +2,7 @@ import BoxGroupSection from "@base/BoxGroupSection";
 import Link from "@base/Link";
 import ProgressCircle from "@base/ProgressCircle";
 import { useFetchJob } from "@jobs/queries";
+import { isJobStateUnsuccessful } from "@subtraction/utils";
 import type { SubtractionMinimal } from "@virtool/contracts";
 import { SubtractionAttribution } from "./Attribution";
 
@@ -23,6 +24,8 @@ export function SubtractionItem({
 		job?.user ? { ...job, user: job.user } : undefined,
 	);
 
+	const state = fetchedJob?.state ?? job?.state;
+
 	return (
 		<BoxGroupSection as="li" className="grid grid-cols-5 items-center">
 			<Link
@@ -37,9 +40,12 @@ export function SubtractionItem({
 			</div>
 			{!ready && job && (
 				<span className="flex items-center justify-end gap-1 font-medium">
+					{isJobStateUnsuccessful(state) && (
+						<span className="capitalize">{state}</span>
+					)}
 					<ProgressCircle
 						progress={fetchedJob?.progress ?? job.progress}
-						state={fetchedJob?.state ?? job.state}
+						state={state}
 					/>
 				</span>
 			)}

--- a/apps/web/src/subtraction/components/SubtractionItem.tsx
+++ b/apps/web/src/subtraction/components/SubtractionItem.tsx
@@ -2,7 +2,7 @@ import BoxGroupSection from "@base/BoxGroupSection";
 import Link from "@base/Link";
 import ProgressCircle from "@base/ProgressCircle";
 import { useFetchJob } from "@jobs/queries";
-import { isJobStateUnsuccessful } from "@subtraction/utils";
+import { getCreateJobStatus, isJobStateUnsuccessful } from "@subtraction/utils";
 import type { SubtractionMinimal } from "@virtool/contracts";
 import { SubtractionAttribution } from "./Attribution";
 
@@ -24,7 +24,7 @@ export function SubtractionItem({
 		job?.user ? { ...job, user: job.user } : undefined,
 	);
 
-	const state = fetchedJob?.state ?? job?.state;
+	const status = getCreateJobStatus(job, fetchedJob);
 
 	return (
 		<BoxGroupSection as="li" className="grid grid-cols-5 items-center">
@@ -38,15 +38,12 @@ export function SubtractionItem({
 			<div className="col-span-2 flex justify-start">
 				<SubtractionAttribution handle={user?.handle ?? ""} time={createdAt} />
 			</div>
-			{!ready && job && (
+			{!ready && status && (
 				<span className="flex items-center justify-end gap-1 font-medium">
-					{isJobStateUnsuccessful(state) && (
-						<span className="capitalize">{state}</span>
+					{isJobStateUnsuccessful(status.state) && (
+						<span className="capitalize">{status.state}</span>
 					)}
-					<ProgressCircle
-						progress={fetchedJob?.progress ?? job.progress}
-						state={state}
-					/>
+					<ProgressCircle progress={status.progress} state={status.state} />
 				</span>
 			)}
 		</BoxGroupSection>

--- a/apps/web/src/subtraction/components/__tests__/SubtractionItem.test.tsx
+++ b/apps/web/src/subtraction/components/__tests__/SubtractionItem.test.tsx
@@ -55,6 +55,32 @@ describe("<SubtractionItem />", () => {
 		},
 	);
 
+	it.each(["cancelled", "failed"] as const)(
+		"should label the state when the job %s",
+		async (state) => {
+			if (props.job) {
+				props.job.state = state;
+			}
+
+			await renderWithRouter(<SubtractionItem {...props} />);
+
+			expect(screen.getByText(state)).toBeInTheDocument();
+		},
+	);
+
+	it.each(["pending", "running"] as const)(
+		"should not label the state when the job is %s",
+		async (state) => {
+			if (props.job) {
+				props.job.state = state;
+			}
+
+			await renderWithRouter(<SubtractionItem {...props} />);
+
+			expect(screen.queryByText(state)).not.toBeInTheDocument();
+		},
+	);
+
 	it("should not render progress bar if job is ready", async () => {
 		props.ready = true;
 

--- a/apps/web/src/subtraction/utils.ts
+++ b/apps/web/src/subtraction/utils.ts
@@ -1,4 +1,4 @@
-import type { JobState } from "@virtool/contracts";
+import type { JobState, SubtractionJobMinimal } from "@virtool/contracts";
 
 /**
  * Derive a user-friendly FASTA filename from a subtraction name
@@ -17,4 +17,34 @@ export function getSubtractionFastaName(name: string) {
  */
 export function isJobStateUnsuccessful(state?: JobState | null): boolean {
 	return state === "cancelled" || state === "failed";
+}
+
+/** How far a subtraction's create job has got. */
+export type CreateJobStatus = {
+	progress: number;
+	state: JobState;
+};
+
+/**
+ * Reconcile the two views a subtraction page holds of its create job.
+ *
+ * Neither is reliably the fresher one. The job query is updated by SSE frames
+ * while it is mounted and skipped while it is not, so it can hold a `running`
+ * state pinned fresh by its seed long after the job ended; the subtraction read
+ * refetches on mount but no job event ever invalidates it. An unsuccessful
+ * state is permanent, so whichever source reports one settles it.
+ */
+export function getCreateJobStatus(
+	nested: SubtractionJobMinimal | null,
+	fetched?: CreateJobStatus,
+): CreateJobStatus | null {
+	if (!nested) {
+		return null;
+	}
+
+	if (!fetched || isJobStateUnsuccessful(nested.state)) {
+		return { progress: nested.progress, state: nested.state };
+	}
+
+	return { progress: fetched.progress, state: fetched.state };
 }

--- a/apps/web/src/subtraction/utils.ts
+++ b/apps/web/src/subtraction/utils.ts
@@ -1,7 +1,20 @@
+import type { JobState } from "@virtool/contracts";
+
 /**
  * Derive a user-friendly FASTA filename from a subtraction name
  * (e.g. "Arabidopsis thaliana" -> "arabidopsis_thaliana.fa.gz").
  */
 export function getSubtractionFastaName(name: string) {
 	return `${name.toLowerCase().replace(/\s+/g, "_")}.fa.gz`;
+}
+
+/**
+ * Whether a job reached a terminal state without producing anything.
+ *
+ * A subtraction whose create job ends this way is stuck at `ready: false` with
+ * no files, and nothing will ever finish it. The detail view has to offer
+ * deletion in that state, or the row is unreachable for the rest of its life.
+ */
+export function isJobStateUnsuccessful(state?: JobState | null): boolean {
+	return state === "cancelled" || state === "failed";
 }


### PR DESCRIPTION
## Summary
- A `create_subtraction` job that fails leaves its subtraction at `ready: false` with no files, and the detail view early-returned an indefinite "still being imported" spinner for any unready subtraction — so the delete button was never rendered and the row was unreachable for the rest of its life. It now branches on the job state and offers deletion when the job failed or was cancelled, alongside an alert linking to the job.
- List rows label that state instead of drawing a full red progress ring titled "Progress: 100%", so a stuck subtraction is visible without opening the detail view.
- Both views follow the job directly with `useFetchJob`. A failing job writes nothing to the subtraction, so no `subtractions` frame announces it and the page would otherwise need a reload to notice.