### PR TITLE
ci: stop release-ghcr from showing an unresolved matrix name on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -358,7 +358,12 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: pnpm exec semantic-release
     release-ghcr:
-        name: Release / GHCR / ${{ matrix.image }}
+        # No `${{ matrix.image }}` in the name: this job's `if` is false on
+        # every PR (it only runs post-merge, on push to main), and GitHub
+        # skips a job before expanding its matrix — so a matrix-templated
+        # name would render as the literal, unresolved expression on every
+        # PR's checks list instead of a real image name.
+        name: Release / GHCR
         runs-on: ubuntu-24.04
         timeout-minutes: 20
         if: github.repository_owner == 'Virtool' && github.event_name == 'push' && needs.release-tag.outputs.git-tag != ''


### PR DESCRIPTION
## Summary

- `release-ghcr` only runs post-merge on push to `main`, so its job-level `if` is false on every PR — and GitHub skips a job before expanding its matrix, so `${{ matrix.image }}` rendered as literal, unresolved template text in the checks list on every single PR instead of a real image name
- Drops the matrix variable from the job's `name`, so a skipped PR run shows a single clean `Release / GHCR` row