### PR TITLE
ci: skip the pathoscope jobs on prs that cannot affect them

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,10 +49,18 @@ jobs:
                   # This file is in the filter so that a change to the
                   # pathoscope jobs themselves is still gated by them. Neither
                   # job uses ./.github/actions/setup, so that action is not.
+                  #
+                  # `.dockerignore` is: build-pathoscope builds with
+                  # `context: .`, so a rule there decides what the Dockerfile's
+                  # `COPY packages/pathoscope-core .` can see. It already
+                  # carries `**/target` for that crate specifically, and a rule
+                  # that excluded the crate would fail the build on main with
+                  # nothing having caught it on the PR.
                   filters: |
                       pathoscope:
                         - 'packages/pathoscope-core/**'
                         - 'apps/workflow-pathoscope/**'
+                        - '.dockerignore'
                         - '.github/workflows/ci.yaml'
 
     # -------------------------------------------------------------------------

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,42 @@ env:
 
 jobs:
     # -------------------------------------------------------------------------
+    # Change detection
+    # -------------------------------------------------------------------------
+    # Only the pathoscope jobs are filtered. They are the expensive outliers: a
+    # libclang-dev install, a tools image pull for bowtie2 and a cargo build,
+    # both carrying 30-minute timeouts, on every PR including ones confined to
+    # apps/web. Everything else in this file is cheap enough that gating it
+    # would cost more in review attention than it saves in runner minutes.
+    #
+    # The filter step is skipped on `push`, so this job needs no checkout and no
+    # base-ref handling for that event: dorny/paths-filter reads the changed
+    # files from the pull request API, which only exists on a PR. A skipped step
+    # sets no output, and the consumers' `if` reads `push` first.
+    changes:
+        name: Changes
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        permissions:
+            pull-requests: read
+        outputs:
+            pathoscope: ${{ steps.filter.outputs.pathoscope }}
+        steps:
+            - name: Filter
+              id: filter
+              if: github.event_name == 'pull_request'
+              uses: dorny/paths-filter@v4
+              with:
+                  # This file is in the filter so that a change to the
+                  # pathoscope jobs themselves is still gated by them. Neither
+                  # job uses ./.github/actions/setup, so that action is not.
+                  filters: |
+                      pathoscope:
+                        - 'packages/pathoscope-core/**'
+                        - 'apps/workflow-pathoscope/**'
+                        - '.github/workflows/ci.yaml'
+
+    # -------------------------------------------------------------------------
     # Checks (repo-wide)
     # -------------------------------------------------------------------------
     checks:
@@ -102,6 +138,13 @@ jobs:
         name: Pathoscope / Build
         runs-on: ubuntu-24.04
         timeout-minutes: 30
+        needs: [changes]
+        # Unconditional on `push`, deliberately. `release-tag` lists this job in
+        # `needs`, and running it on every push to main keeps that gate complete
+        # without the skipped-dependency handling
+        # (`if: always() && !contains(needs.*.result, 'failure')`) a filtered
+        # dependency would otherwise force onto it. PRs get the savings.
+        if: github.event_name == 'push' || needs.changes.outputs.pathoscope == 'true'
         steps:
             - name: Checkout
               uses: actions/checkout@v7
@@ -211,6 +254,10 @@ jobs:
         name: Pathoscope / Test
         runs-on: ubuntu-24.04
         timeout-minutes: 30
+        needs: [changes]
+        # See the note on `build-pathoscope`: filtered on pull requests,
+        # unconditional on `push` so the `release-tag` gate stays complete.
+        if: github.event_name == 'push' || needs.changes.outputs.pathoscope == 'true'
         steps:
             - name: Checkout
               uses: actions/checkout@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,9 +208,9 @@ Building the crate needs `libclang-dev` installed, because `hts-sys` runs
 bindgen against htslib's headers.
 
 `pathoscope-test` and `build-pathoscope` are the only path-filtered jobs in
-`ci.yaml` — on a pull request they run only when the crate, the workflow app or
-`ci.yaml` changes. Extend the `changes` job's filter in the same commit as
-anything that gives either job a new input.
+`ci.yaml` — on a pull request they run only when the crate, the workflow app,
+`.dockerignore` or `ci.yaml` changes. Extend the `changes` job's filter in the
+same commit as anything that gives either job a new input.
 
 `pnpm build` builds **every app but `apps/site`**, which is gated by its own
 `site-build` CI job. `pnpm check` and `pnpm format` run biome over `apps` and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,11 @@ workspace. Run `cargo` there directly; a `pathoscope-test` CI job gates it.
 Building the crate needs `libclang-dev` installed, because `hts-sys` runs
 bindgen against htslib's headers.
 
+`pathoscope-test` and `build-pathoscope` are the only path-filtered jobs in
+`ci.yaml` — on a pull request they run only when the crate, the workflow app or
+`ci.yaml` changes. Extend the `changes` job's filter in the same commit as
+anything that gives either job a new input.
+
 `pnpm build` builds **every app but `apps/site`**, which is gated by its own
 `site-build` CI job. `pnpm check` and `pnpm format` run biome over `apps` and
 `packages` rather than a literal `apps/web/src`, so a new app's source is linted

--- a/docs/pathoscope-core.md
+++ b/docs/pathoscope-core.md
@@ -185,10 +185,11 @@ Each backs a specific `ldd ... => not found` against the slim base: perl and
 libgomp1 for bowtie2, libcurl4 and libncursesw6 for samtools. `pathoscope-core`
 itself needs none of them — `hts-sys` links htslib statically.
 
-Both the `build-pathoscope` and `publish-pathoscope` CI jobs set
-`cache-from: type=gha` and `cache-to: type=gha,mode=max` under a `pathoscope`
-scope. Dropping either from the publish job means the release path rebuilds
-htslib from scratch every time, which is the trap the old repo fell into.
+The `build-pathoscope` CI job sets `cache-from: type=gha` and
+`cache-to: type=gha,mode=max` under a `pathoscope` scope. There is no publish
+counterpart yet; when one is restored it needs the same pair, because dropping
+it means the release path rebuilds htslib from scratch every time, which is the
+trap the old repo fell into.
 
 **A job that exports a cache must run `docker/setup-buildx-action` first.** The
 runner's default builder uses the `docker` driver, which cannot export a build


### PR DESCRIPTION
## Summary
- Add a `changes` job running `dorny/paths-filter` over `packages/pathoscope-core/**`, `apps/workflow-pathoscope/**` and `ci.yaml` itself, and gate `pathoscope-test` and `build-pathoscope` on it. A PR confined to `apps/web` no longer pays for a `libclang-dev` install, a `ghcr.io/virtool/tools` pull for bowtie2 and a `cargo build` over a crate it cannot reach.
- Filtering is off on `push`, which keeps `release-tag`'s `needs` gate complete and free of `always() && !contains(needs.*.result, 'failure')`. The filter step is skipped there too, so the job needs no checkout and only `pull-requests: read`. Neither job is a required status check — `main`'s ruleset has no `required_status_checks` rule — so nothing needs an aggregator to stand in for a skipped job.
- Record the filter in `AGENTS.md`, and correct a line in `docs/pathoscope-core.md` that credited the gha cache settings to a `publish-pathoscope` job that does not exist.