### PR TITLE
chore: add the task claim, lease and completion data layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1015,9 +1015,38 @@ Four rules it carries:
   shared with the jobs API; only the hooks and the injected
   `closeListener` are this app's.
 
+A claim is a **lease encoded on `acquired_at`** — live while that column
+is within `TASK_LEASE_SECONDS` (300) of now, renewed every
+`TASK_HEARTBEAT_SECONDS` (60). No lease column and no DDL. The claim,
+lease and completion queries are `packages/data/src/tasks/data.ts`, and
+four rules hold them:
+
+- **Reclaim is folded into the claim**, as a disjunction in one
+  statement, and the whole predicate is repeated as the outer `UPDATE`'s
+  trailing guard — under Read Committed a blocked updater re-evaluates
+  its own `WHERE` and never the subquery that chose the row. Python's
+  `progress = 0` term is deliberately dropped: it excluded exactly the
+  rows a reclaim exists for.
+- **Anything that takes work back off a runner is scoped to a `ts-`
+  `runner_id`**, which `buildRunnerId()` mints. Python never renews
+  `acquired_at`, so its long-running tasks look abandoned; the scope is
+  what stops a reclaim pulling live work out from under it. Never add a
+  flag to widen it.
+- **Every runner write is fenced** on `runner_id` and `complete = false`
+  and returns `false` when it matches nothing; `renewLeases` reports the
+  ids it renewed so a caller can abandon the rest. `failTask` sets
+  `complete` as well as `error`, which Python does not. Every timestamp
+  write is `timezone('utc', clock_timestamp())`, never `now()`.
+- **The data layer publishes every `tasks` frame** — from
+  `updateTaskProgress`, `completeTask` and `failTask` only, never from a
+  claim, release or reclaim, and never from a guarded write that
+  returned `false`. Those three take `Db` rather than `DbOrTx` so a
+  frame cannot precede the commit of the row it describes.
+
 See [docs/tasks.md](docs/tasks.md) for the full config table, the
-`AppContext` contract, the shutdown ordering and its guarantees, and the
-probe and metrics surface.
+`AppContext` contract, the shutdown ordering and its guarantees, the
+probe and metrics surface, and the lease, fencing and frame rules in
+full.
 
 ## Data
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -58,7 +58,7 @@ function and a test suite cannot afford that.
 4. **Open the pool.** `createDb(config, "tasks")`.
 5. **Install the client-event emitter.** `createEmitter({ client, logger })` —
    without it every `emit()` inside `@virtool/data` throws, and the `tasks`
-   frames the framework publishes never reach the SPA.
+   frames the data layer publishes never reach the SPA.
 6. **Build storage.** `createStorageBackend(config.storage)`.
 7. **Register signal handlers**, then **start the probe listener** — *last*, so
    nothing it reports on is still being built when the kubelet's first probe
@@ -328,15 +328,16 @@ one Postgres across all of them locally.
 layer, and the dispatch loops land on top of it, and each fills in its section
 here in its own commit:
 
-- **Framework** — `defineTask`, the step model, the percent/fraction progress
-  seam, and event emission. Lives in `apps/tasks/src/framework/`: it is an
-  execution shell rather than persistence, only this process ever runs a task,
-  and it needs zod, which `@virtool/data` does not depend on and should not
-  start to.
+- **Framework** — `defineTask`, the step model, and the percent/fraction
+  progress seam. Lives in `apps/tasks/src/framework/`: it is an execution shell
+  rather than persistence, only this process ever runs a task, and it needs zod,
+  which `@virtool/data` does not depend on and should not start to. It
+  publishes **no** frames of its own — see below.
 - **Claim, lease and reclaim** — `acquireTask`, `renewLeases`, `completeTask`,
-  `failTask`, `releaseTask`, `releaseRunnerClaims`, `reclaimExpiredLeases`.
-  These are pure persistence over a table both halves write, so they belong in
-  `packages/data/src/tasks/data.ts`, extending the module already there.
+  `failTask`, `releaseTask`, `releaseRunnerClaims`, `reclaimExpiredLeases`,
+  `updateTaskProgress`. These are pure persistence over a table both halves
+  write, so they belong in `packages/data/src/tasks/data.ts`, extending the
+  module already there.
 - **The task bodies** — `apps/tasks/src/tasks/<type>.ts`, registered with the
   runner's registry. The shell lives with its runtime, the way `functions.ts`
   lives with the web app.
@@ -346,3 +347,110 @@ the web app's orchestration layer and stays in `apps/web/src/server/<feature>/`,
 unreachable from here. A body's cross-`data` orchestration goes either into
 `@virtool/data` — when it is persistence plus injected external IO — or into
 the handler module itself. Do not add a `service.ts` under `packages/data/`.
+
+## Claiming, leases and fencing
+
+A claim is a lease with a deadline, and the deadline is encoded on
+`acquired_at` itself: a claim is live while `acquired_at` is within
+`TASK_LEASE_SECONDS` of now, and renewing it is a write to that same column.
+There is no lease column, no expiry column and no DDL — the `tasks` table is
+Python's, owned through Alembic, and Python still writes it.
+
+| Constant | Value | Meaning |
+| --- | --- | --- |
+| `TASK_LEASE_SECONDS` | 300 | How long a claim survives without a heartbeat. |
+| `TASK_HEARTBEAT_SECONDS` | 60 | How often the holder should renew it. |
+
+Five to one is the ratio Solid Queue and Sidekiq both settled on: four
+consecutive heartbeats can be lost — a GC pause, a blocked event loop, a brief
+partition — before live work becomes claimable by someone else.
+
+### Reclaim is part of the claim
+
+`acquireTask` matches a task that is unclaimed **or** whose lease has run out,
+as one disjunction in one statement. That is graphile-worker's shape, and it
+buys three things: no background timer to schedule, nothing to keep alive when
+the fleet is idle, and no window between a sweep marking a row free and a
+claimer taking it. The queue heals as a side effect of ordinary work.
+
+`reclaimExpiredLeases` still ships as its own query. Nothing needs to call it on
+a running fleet; it exists for the cutover, where a deployment may be spawning
+tasks with `VT_TASKS_CLAIM_ENABLED=false` and so never running a claim to heal
+anything.
+
+Two things about the predicate are load-bearing:
+
+- **Python's `progress = 0` term is gone.** It was there to avoid re-running
+  partially-finished work, but a row worth reclaiming has almost always reported
+  progress — so the term excluded precisely the rows a reclaim exists for.
+- **The whole predicate is repeated as the outer `UPDATE`'s guard.** The
+  candidate is chosen by a subquery under `FOR UPDATE SKIP LOCKED`; under Read
+  Committed an updater that blocks on a row re-evaluates only its own `WHERE`
+  when the lock clears, never the subquery that chose the row. Without the
+  repeat, a claimer queued behind the winner overwrites the winner's claim. It
+  has to be the *whole* disjunction — an `acquired_at IS NULL` term alone passes
+  for a row that was reclaimed a moment ago, which is not why it was chosen.
+
+### `ts-` scoping is the drain assumption, enforced
+
+Every query that takes work back off a runner is scoped to a `runner_id`
+beginning `ts-`, which is what `buildRunnerId()` mints (`ts-{hostname}-{pid}`;
+Python uses `{hostname}-{pid}`).
+
+Python never renews `acquired_at`. A task it claimed and has been working for
+longer than the lease is therefore indistinguishable from an abandoned one, and
+a reclaimer that could see it would pull live work out from under the Python
+runner. Scoping at the query level makes the drain assumption enforceable
+rather than a note in a runbook, which is why there is deliberately **no
+configuration flag to widen it**. Widening happens once Python runs no tasks at
+all, as an edit here.
+
+### Every write a runner makes is fenced
+
+`completeTask`, `failTask`, `updateTaskProgress` and `releaseTask` all guard on
+`runner_id` and `complete = false`, and return `false` when they match nothing.
+A runner that stalled past its lease and woke to find the task reassigned can
+therefore write nothing at all — it cannot finish, fail, advance or release a
+task someone else now owns.
+
+`renewLeases` is the channel that tells it so. It renews conditionally and
+returns the ids it actually renewed, so a caller diffs the result against what
+it asked for and abandons the difference. A partial result is the normal
+outcome, not an error, which is why it reports rather than throwing.
+
+Failure is terminal here, and that is a deliberate divergence: `failTask` sets
+`complete` as well as `error`, where Python's failure path writes `error` alone
+and leaves `complete` false — stranding the row outside both halves of its own
+`get_counts`.
+
+Every timestamp write is `timezone('utc', clock_timestamp())`. `now()` is the
+transaction's start time and is frozen for its whole length, which on a
+heartbeat back-dates the lease by however long the transaction has already
+run — the difference between a renewed lease and one another runner is free to
+take. The `timezone('utc', ...)` wrapper is explicit and so immune to the
+session's `TimeZone`, which `localtimestamp` is not.
+
+### The data layer publishes every `tasks` frame
+
+`updateTaskProgress`, `completeTask` and `failTask` each emit one `tasks`
+frame. The framework and the runner emit none — there is one place a `tasks`
+row changes, so there is one place the frame comes from.
+
+Nothing else emits. `acquireTask`, `renewLeases`, `releaseTask`,
+`releaseRunnerClaims` and `reclaimExpiredLeases` are all silent: a claim, a
+release and a reclaim each leave the row in the state a client last saw it in,
+and a heartbeat every minute per running task would cost every connected
+browser a refetch for a timestamp no view renders.
+
+**A guarded write that returns `false` emits nothing.** A frame for a change
+that did not happen costs every browser a refetch and announces a state the row
+is not in.
+
+These functions take `Db` rather than `DbOrTx`, which is what keeps the frame
+honest. `emit` publishes over the emitter's own pooled connection, not the
+caller's, so a call nested in an open transaction would put the frame on the
+wire before the row it describes had committed — the SPA would refetch the old
+state and then get no second frame. Typing them `Db` makes that unrepresentable
+instead of documenting it. If a task body ever genuinely needs a completion
+atomic with a final domain write, widening the parameter is a one-line change
+that has to answer the ordering question at the same time.

--- a/packages/data/src/db/test/fixtures.ts
+++ b/packages/data/src/db/test/fixtures.ts
@@ -8,10 +8,30 @@ import { testLogger } from "../../test/logger";
 import type { Db, PgClient } from "../pg";
 import * as schema from "../schema";
 
+/** A second connection to a {@link TestDatabase}, and the way to close it. */
+export type TestConnection = {
+	db: Db;
+	client: PgClient;
+	close: () => Promise<void>;
+};
+
 /** An isolated Postgres database, seeded with the schema, for one test file. */
 export type TestDatabase = {
 	db: Db;
 	client: PgClient;
+	/**
+	 * Open another connection to the same database.
+	 *
+	 * The fixture's own pool is `max: 1`, so two operations a test awaits
+	 * concurrently do not reach Postgres concurrently — they queue in the driver
+	 * and run one after the other. Anything asserting on what Postgres does when
+	 * two sessions genuinely contend for a row — `FOR UPDATE SKIP LOCKED`, a lock
+	 * wait, an advisory lock — needs a session of its own or it proves nothing.
+	 *
+	 * Hand `close` to `onTestFinished`. `drop` forces the database closed and so
+	 * will take an unclosed one with it, but only at the end of the file.
+	 */
+	connect: () => TestConnection;
 	drop: () => Promise<void>;
 };
 
@@ -83,6 +103,16 @@ export async function createTestDatabase(
 		await client.unsafe(statement);
 	}
 
+	function connect(): TestConnection {
+		const extra = postgres(url.toString(), { max: 1 });
+
+		return {
+			db: drizzle(extra, { schema }),
+			client: extra,
+			close: () => extra.end(),
+		};
+	}
+
 	async function drop(): Promise<void> {
 		await client.end();
 		await admin.unsafe(`drop database if exists "${name}" with (force)`);
@@ -91,5 +121,5 @@ export async function createTestDatabase(
 
 	createEmitter({ client, logger: testLogger });
 
-	return { db: drizzle(client, { schema }), client, drop };
+	return { db: drizzle(client, { schema }), client, connect, drop };
 }

--- a/packages/data/src/tasks/data.test.ts
+++ b/packages/data/src/tasks/data.test.ts
@@ -515,6 +515,17 @@ describe("releaseTask", () => {
 
 		expect(await readRow(taskId)).toMatchObject({ runner_id: RUNNER_B });
 	});
+
+	it("never releases a task Python is holding", async () => {
+		// The scope has to hold at the query, not at the caller: a Python-format id
+		// reaching this argument would otherwise hand live work to our fleet.
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, "somehost-4242", 10);
+
+		await expect(releaseTask(db, taskId, "somehost-4242")).resolves.toBe(false);
+
+		expect(await readRow(taskId)).toMatchObject({ runner_id: "somehost-4242" });
+	});
 });
 
 describe("releaseRunnerClaims", () => {
@@ -544,6 +555,15 @@ describe("releaseRunnerClaims", () => {
 		await expect(releaseRunnerClaims(db, RUNNER_A)).resolves.toEqual([]);
 
 		expect(await readRow(taskId)).toMatchObject({ runner_id: RUNNER_A });
+	});
+
+	it("never releases the claims of a Python runner", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, "somehost-4242", 10);
+
+		await expect(releaseRunnerClaims(db, "somehost-4242")).resolves.toEqual([]);
+
+		expect(await readRow(taskId)).toMatchObject({ runner_id: "somehost-4242" });
 	});
 });
 

--- a/packages/data/src/tasks/data.test.ts
+++ b/packages/data/src/tasks/data.test.ts
@@ -1,13 +1,48 @@
 import { eq } from "drizzle-orm";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	onTestFinished,
+} from "vitest";
 
 import type { Db } from "../db/pg";
 import { tasks } from "../db/schema/tasks";
 import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
-import { createTask, getTask, getTasks, TaskNotFoundError } from "./data";
+import { CLIENT_EVENTS_CHANNEL, type ClientEvent } from "../events/channel";
+import {
+	acquireTask,
+	buildRunnerId,
+	completeTask,
+	createTask,
+	failTask,
+	getTask,
+	getTasks,
+	reclaimExpiredLeases,
+	releaseRunnerClaims,
+	releaseTask,
+	renewLeases,
+	TASK_HEARTBEAT_SECONDS,
+	TASK_LEASE_SECONDS,
+	TaskNotFoundError,
+	updateTaskProgress,
+} from "./data";
 
 let database: TestDatabase;
 let db: Db;
+
+const RUNNER_A = "ts-runner-a-1";
+const RUNNER_B = "ts-runner-b-2";
+
+const ALL_TYPES = [
+	"clone_reference",
+	"create_index",
+	"import_reference",
+	"install_hmms",
+] as const;
 
 beforeAll(async () => {
 	database = await createTestDatabase();
@@ -22,13 +57,33 @@ beforeEach(async () => {
 	await db.delete(tasks);
 });
 
+/** Read a row straight out of the table, bypassing every mapper. */
+async function readRow(taskId: number) {
+	const [row] = await db.select().from(tasks).where(eq(tasks.id, taskId));
+
+	return row;
+}
+
+/** Put `taskId` in the state a runner holding a lease `secondsAgo` old leaves. */
+async function holdTask(
+	taskId: number,
+	runnerId: string,
+	secondsAgo: number,
+): Promise<void> {
+	await db
+		.update(tasks)
+		.set({
+			acquired_at: new Date(Date.now() - secondsAgo * 1000),
+			runner_id: runnerId,
+		})
+		.where(eq(tasks.id, taskId));
+}
+
 describe("createTask", () => {
 	it("inserts a pending task the runner will claim", async () => {
 		const taskId = await createTask(db, "install_hmms", { user_id: 1 });
 
-		const [row] = await db.select().from(tasks).where(eq(tasks.id, taskId));
-
-		expect(row).toMatchObject({
+		expect(await readRow(taskId)).toMatchObject({
 			type: "install_hmms",
 			step: "install_hmms",
 			context: { user_id: 1 },
@@ -42,9 +97,7 @@ describe("createTask", () => {
 	it("defaults the context to an empty object", async () => {
 		const taskId = await createTask(db, "install_hmms");
 
-		const [row] = await db.select().from(tasks).where(eq(tasks.id, taskId));
-
-		expect(row?.context).toEqual({});
+		expect((await readRow(taskId))?.context).toEqual({});
 	});
 });
 
@@ -85,5 +138,656 @@ describe("getTasks", () => {
 
 	it("returns an empty array for empty input", async () => {
 		await expect(getTasks(db, [])).resolves.toEqual([]);
+	});
+});
+
+describe("buildRunnerId", () => {
+	it("marks the runner as this service's and names the process", () => {
+		const runnerId = buildRunnerId();
+
+		expect(runnerId.startsWith("ts-")).toBe(true);
+		expect(runnerId.endsWith(`-${process.pid}`)).toBe(true);
+	});
+});
+
+describe("lease constants", () => {
+	it("leaves room for four missed heartbeats", () => {
+		expect(TASK_LEASE_SECONDS).toBe(300);
+		expect(TASK_HEARTBEAT_SECONDS).toBe(60);
+		expect(TASK_LEASE_SECONDS / TASK_HEARTBEAT_SECONDS).toBe(5);
+	});
+});
+
+describe("acquireTask", () => {
+	it("claims a pending task and stamps the lease", async () => {
+		const taskId = await createTask(db, "install_hmms", { user_id: 3 });
+
+		const claimed = await acquireTask(db, {
+			runnerId: RUNNER_A,
+			allowedTypes: ["install_hmms"],
+		});
+
+		expect(claimed).toMatchObject({
+			id: taskId,
+			type: "install_hmms",
+			context: { user_id: 3 },
+			progress: 0,
+			runnerId: RUNNER_A,
+			step: "install_hmms",
+		});
+		expect(claimed?.acquiredAt).toBeInstanceOf(Date);
+
+		expect(await readRow(taskId)).toMatchObject({ runner_id: RUNNER_A });
+	});
+
+	it("takes the oldest task first", async () => {
+		const older = await createTask(db, "install_hmms");
+		const newer = await createTask(db, "install_hmms");
+
+		await db
+			.update(tasks)
+			.set({ created_at: new Date("2020-01-01T00:00:00Z") })
+			.where(eq(tasks.id, newer));
+
+		const claimed = await acquireTask(db, {
+			runnerId: RUNNER_A,
+			allowedTypes: ["install_hmms"],
+		});
+
+		expect(claimed?.id).toBe(newer);
+		expect(claimed?.id).not.toBe(older);
+	});
+
+	it("claims only the allowed types", async () => {
+		await createTask(db, "install_hmms");
+
+		await expect(
+			acquireTask(db, {
+				runnerId: RUNNER_A,
+				allowedTypes: ["clone_reference"],
+			}),
+		).resolves.toBeNull();
+	});
+
+	it("returns null when the runner allows no types at all", async () => {
+		await createTask(db, "install_hmms");
+
+		await expect(
+			acquireTask(db, { runnerId: RUNNER_A, allowedTypes: [] }),
+		).resolves.toBeNull();
+	});
+
+	it("returns null when nothing is waiting", async () => {
+		await expect(
+			acquireTask(db, { runnerId: RUNNER_A, allowedTypes: [...ALL_TYPES] }),
+		).resolves.toBeNull();
+	});
+
+	it("claims a pending task that has already reported progress", async () => {
+		// Python's claim carries an `AND progress = 0` term, which excludes exactly
+		// the rows a reclaim exists for: work abandoned part-way through.
+		const taskId = await createTask(db, "install_hmms");
+
+		await db.update(tasks).set({ progress: 42 }).where(eq(tasks.id, taskId));
+
+		const claimed = await acquireTask(db, {
+			runnerId: RUNNER_A,
+			allowedTypes: ["install_hmms"],
+		});
+
+		expect(claimed).toMatchObject({ id: taskId, progress: 42 });
+	});
+
+	it("ignores a completed task", async () => {
+		const taskId = await createTask(db, "install_hmms");
+
+		await db.update(tasks).set({ complete: true }).where(eq(tasks.id, taskId));
+
+		await expect(
+			acquireTask(db, { runnerId: RUNNER_A, allowedTypes: ["install_hmms"] }),
+		).resolves.toBeNull();
+	});
+
+	it("ignores a failed task", async () => {
+		const taskId = await createTask(db, "install_hmms");
+
+		await db.update(tasks).set({ error: "boom" }).where(eq(tasks.id, taskId));
+
+		await expect(
+			acquireTask(db, { runnerId: RUNNER_A, allowedTypes: ["install_hmms"] }),
+		).resolves.toBeNull();
+	});
+
+	it("reclaims a lease that has run out", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, TASK_LEASE_SECONDS + 60);
+
+		const claimed = await acquireTask(db, {
+			runnerId: RUNNER_B,
+			allowedTypes: ["install_hmms"],
+		});
+
+		expect(claimed).toMatchObject({ id: taskId, runnerId: RUNNER_B });
+	});
+
+	it("leaves a live lease alone", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, TASK_LEASE_SECONDS - 60);
+
+		await expect(
+			acquireTask(db, { runnerId: RUNNER_B, allowedTypes: ["install_hmms"] }),
+		).resolves.toBeNull();
+
+		expect(await readRow(taskId)).toMatchObject({ runner_id: RUNNER_A });
+	});
+
+	it("never reclaims a task Python is holding", async () => {
+		// Python does not renew `acquired_at`, so any long-running task of its
+		// looks abandoned. The `ts-` scoping is the only thing keeping this side
+		// from pulling live work out from under it.
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, "somehost-4242", TASK_LEASE_SECONDS * 100);
+
+		await expect(
+			acquireTask(db, { runnerId: RUNNER_B, allowedTypes: ["install_hmms"] }),
+		).resolves.toBeNull();
+
+		expect(await readRow(taskId)).toMatchObject({ runner_id: "somehost-4242" });
+	});
+
+	it("honours a shorter lease passed by the caller", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, 30);
+
+		await expect(
+			acquireTask(db, {
+				runnerId: RUNNER_B,
+				allowedTypes: ["install_hmms"],
+				leaseSeconds: 10,
+			}),
+		).resolves.toMatchObject({ id: taskId, runnerId: RUNNER_B });
+	});
+
+	it("gives one task to exactly one of two racing runners", async () => {
+		const taskId = await createTask(db, "install_hmms");
+
+		const first = database.connect();
+		const second = database.connect();
+
+		onTestFinished(async () => {
+			await Promise.all([first.close(), second.close()]);
+		});
+
+		const claimed = await Promise.all([
+			acquireTask(first.db, {
+				runnerId: RUNNER_A,
+				allowedTypes: ["install_hmms"],
+			}),
+			acquireTask(second.db, {
+				runnerId: RUNNER_B,
+				allowedTypes: ["install_hmms"],
+			}),
+		]);
+
+		const winners = claimed.filter((task) => task !== null);
+
+		expect(winners).toHaveLength(1);
+		expect(winners[0]?.id).toBe(taskId);
+		expect(await readRow(taskId)).toMatchObject({
+			runner_id: winners[0]?.runnerId,
+		});
+	});
+});
+
+describe("renewLeases", () => {
+	it("renews the leases the runner holds and reports them", async () => {
+		const first = await createTask(db, "install_hmms");
+		const second = await createTask(db, "clone_reference");
+
+		await holdTask(first, RUNNER_A, TASK_LEASE_SECONDS - 30);
+		await holdTask(second, RUNNER_A, TASK_LEASE_SECONDS - 30);
+
+		const before = (await readRow(first))?.acquired_at;
+
+		await expect(renewLeases(db, [first, second], RUNNER_A)).resolves.toEqual(
+			expect.arrayContaining([first, second]),
+		);
+
+		const after = (await readRow(first))?.acquired_at;
+
+		expect(after?.getTime()).toBeGreaterThan(before?.getTime() as number);
+	});
+
+	it("returns an empty array for empty input", async () => {
+		await expect(renewLeases(db, [], RUNNER_A)).resolves.toEqual([]);
+	});
+
+	it("omits a task another runner now holds", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_B, 10);
+
+		await expect(renewLeases(db, [taskId], RUNNER_A)).resolves.toEqual([]);
+	});
+
+	it("omits a task that has already finished", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, 10);
+		await db.update(tasks).set({ complete: true }).where(eq(tasks.id, taskId));
+
+		await expect(renewLeases(db, [taskId], RUNNER_A)).resolves.toEqual([]);
+	});
+});
+
+describe("completeTask", () => {
+	it("marks the task complete at full progress", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, 10);
+
+		await expect(completeTask(db, taskId, RUNNER_A)).resolves.toBe(true);
+
+		expect(await readRow(taskId)).toMatchObject({
+			complete: true,
+			progress: 100,
+			error: null,
+		});
+	});
+
+	it("refuses a runner that no longer holds the task", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_B, 10);
+
+		await expect(completeTask(db, taskId, RUNNER_A)).resolves.toBe(false);
+	});
+
+	it("refuses a task that is already complete", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, 10);
+
+		await expect(completeTask(db, taskId, RUNNER_A)).resolves.toBe(true);
+		await expect(completeTask(db, taskId, RUNNER_A)).resolves.toBe(false);
+	});
+});
+
+describe("failTask", () => {
+	it("records the error and finishes the task", async () => {
+		// Python writes `error` alone and leaves `complete` false, which strands the
+		// row outside both halves of its own `get_counts`. Failure is terminal here.
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, 10);
+
+		await expect(failTask(db, taskId, RUNNER_A, "it broke")).resolves.toBe(
+			true,
+		);
+
+		expect(await readRow(taskId)).toMatchObject({
+			complete: true,
+			error: "it broke",
+		});
+	});
+
+	it("refuses a runner that no longer holds the task", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_B, 10);
+
+		await expect(failTask(db, taskId, RUNNER_A, "it broke")).resolves.toBe(
+			false,
+		);
+
+		expect(await readRow(taskId)).toMatchObject({ error: null });
+	});
+
+	it("leaves a failed task unclaimable", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, 10);
+		await failTask(db, taskId, RUNNER_A, "it broke");
+		await releaseRunnerClaims(db, RUNNER_A);
+
+		await expect(
+			acquireTask(db, { runnerId: RUNNER_B, allowedTypes: ["install_hmms"] }),
+		).resolves.toBeNull();
+	});
+});
+
+describe("updateTaskProgress", () => {
+	it("writes progress and the step name", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, 10);
+
+		await expect(
+			updateTaskProgress(db, taskId, RUNNER_A, {
+				progress: 55,
+				step: "unpack",
+			}),
+		).resolves.toBe(true);
+
+		expect(await readRow(taskId)).toMatchObject({
+			progress: 55,
+			step: "unpack",
+		});
+	});
+
+	it("leaves the step alone when none is given", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, 10);
+
+		await updateTaskProgress(db, taskId, RUNNER_A, { progress: 20 });
+
+		expect(await readRow(taskId)).toMatchObject({
+			progress: 20,
+			step: "install_hmms",
+		});
+	});
+
+	it("refuses a runner that no longer holds the task", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_B, 10);
+
+		await expect(
+			updateTaskProgress(db, taskId, RUNNER_A, { progress: 55 }),
+		).resolves.toBe(false);
+
+		expect(await readRow(taskId)).toMatchObject({ progress: 0 });
+	});
+});
+
+describe("releaseTask", () => {
+	it("hands the task back for another runner to take", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, 10);
+
+		await expect(releaseTask(db, taskId, RUNNER_A)).resolves.toBe(true);
+
+		expect(await readRow(taskId)).toMatchObject({
+			acquired_at: null,
+			runner_id: null,
+		});
+
+		await expect(
+			acquireTask(db, { runnerId: RUNNER_B, allowedTypes: ["install_hmms"] }),
+		).resolves.toMatchObject({ id: taskId });
+	});
+
+	it("refuses a runner that no longer holds the task", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_B, 10);
+
+		await expect(releaseTask(db, taskId, RUNNER_A)).resolves.toBe(false);
+
+		expect(await readRow(taskId)).toMatchObject({ runner_id: RUNNER_B });
+	});
+});
+
+describe("releaseRunnerClaims", () => {
+	it("hands back every unfinished task the runner holds", async () => {
+		const first = await createTask(db, "install_hmms");
+		const second = await createTask(db, "clone_reference");
+		const other = await createTask(db, "create_index");
+
+		await holdTask(first, RUNNER_A, 10);
+		await holdTask(second, RUNNER_A, 10);
+		await holdTask(other, RUNNER_B, 10);
+
+		await expect(releaseRunnerClaims(db, RUNNER_A)).resolves.toEqual(
+			expect.arrayContaining([first, second]),
+		);
+
+		expect(await readRow(first)).toMatchObject({ runner_id: null });
+		expect(await readRow(second)).toMatchObject({ runner_id: null });
+		expect(await readRow(other)).toMatchObject({ runner_id: RUNNER_B });
+	});
+
+	it("leaves a finished task's record of who ran it", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, 10);
+		await completeTask(db, taskId, RUNNER_A);
+
+		await expect(releaseRunnerClaims(db, RUNNER_A)).resolves.toEqual([]);
+
+		expect(await readRow(taskId)).toMatchObject({ runner_id: RUNNER_A });
+	});
+});
+
+describe("reclaimExpiredLeases", () => {
+	it("takes back a lease that has run out", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, TASK_LEASE_SECONDS + 60);
+
+		await expect(reclaimExpiredLeases(db)).resolves.toEqual([taskId]);
+
+		expect(await readRow(taskId)).toMatchObject({
+			acquired_at: null,
+			runner_id: null,
+		});
+	});
+
+	it("leaves a live lease alone", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, TASK_LEASE_SECONDS - 60);
+
+		await expect(reclaimExpiredLeases(db)).resolves.toEqual([]);
+	});
+
+	it("never touches a task Python is holding", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, "somehost-4242", TASK_LEASE_SECONDS * 100);
+
+		await expect(reclaimExpiredLeases(db)).resolves.toEqual([]);
+
+		expect(await readRow(taskId)).toMatchObject({ runner_id: "somehost-4242" });
+	});
+
+	it("leaves finished and failed tasks alone", async () => {
+		const completed = await createTask(db, "install_hmms");
+		const failed = await createTask(db, "clone_reference");
+
+		await holdTask(completed, RUNNER_A, TASK_LEASE_SECONDS + 60);
+		await holdTask(failed, RUNNER_A, TASK_LEASE_SECONDS + 60);
+
+		await db
+			.update(tasks)
+			.set({ complete: true })
+			.where(eq(tasks.id, completed));
+		await db.update(tasks).set({ error: "boom" }).where(eq(tasks.id, failed));
+
+		await expect(reclaimExpiredLeases(db)).resolves.toEqual([]);
+	});
+
+	it("honours a shorter lease passed by the caller", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, 30);
+
+		await expect(
+			reclaimExpiredLeases(db, { leaseSeconds: 10 }),
+		).resolves.toEqual([taskId]);
+	});
+});
+
+describe("fencing", () => {
+	it("shuts a runner out of a task whose lease it lost", async () => {
+		const taskId = await createTask(db, "install_hmms");
+
+		const held = await acquireTask(db, {
+			runnerId: RUNNER_A,
+			allowedTypes: ["install_hmms"],
+		});
+
+		expect(held?.id).toBe(taskId);
+
+		// Runner A stalls for longer than the lease, and runner B picks the task up.
+		await holdTask(taskId, RUNNER_A, TASK_LEASE_SECONDS + 60);
+
+		await expect(
+			acquireTask(db, { runnerId: RUNNER_B, allowedTypes: ["install_hmms"] }),
+		).resolves.toMatchObject({ id: taskId, runnerId: RUNNER_B });
+
+		// Runner A wakes up. Every write it can make is refused, and its heartbeat
+		// is how it finds out.
+		await expect(renewLeases(db, [taskId], RUNNER_A)).resolves.toEqual([]);
+		await expect(
+			updateTaskProgress(db, taskId, RUNNER_A, { progress: 90 }),
+		).resolves.toBe(false);
+		await expect(completeTask(db, taskId, RUNNER_A)).resolves.toBe(false);
+		await expect(failTask(db, taskId, RUNNER_A, "too late")).resolves.toBe(
+			false,
+		);
+		await expect(releaseTask(db, taskId, RUNNER_A)).resolves.toBe(false);
+
+		expect(await readRow(taskId)).toMatchObject({
+			complete: false,
+			error: null,
+			progress: 0,
+			runner_id: RUNNER_B,
+		});
+	});
+});
+
+describe("timestamps", () => {
+	it("writes UTC whatever the session's timezone is", async () => {
+		// `timezone('utc', clock_timestamp())` is explicit and so immune to the
+		// session's TimeZone. `localtimestamp`, or a `now()::timestamp`, is not —
+		// it would store Vancouver's wall time in a column Python reads as UTC.
+		const connection = database.connect();
+		onTestFinished(() => connection.close());
+
+		await connection.client.unsafe("set time zone 'America/Vancouver'");
+
+		await createTask(db, "install_hmms");
+
+		const claimed = await acquireTask(connection.db, {
+			runnerId: RUNNER_A,
+			allowedTypes: ["install_hmms"],
+		});
+
+		expect(
+			Math.abs((claimed?.acquiredAt.getTime() as number) - Date.now()),
+		).toBeLessThan(60_000);
+	});
+});
+
+describe("frames", () => {
+	/**
+	 * Collect the `client_events` frames published while `run` executes.
+	 *
+	 * The sentinel at the end is what makes an assertion of *no* frames sound: it
+	 * is published after everything `run` did, over the same connection the
+	 * emitter uses, so its arrival proves any frame `run` published has already
+	 * arrived too. Waiting a fixed interval instead would pass on a slow machine
+	 * for the wrong reason.
+	 */
+	async function collectFrames(
+		run: () => Promise<void>,
+	): Promise<ClientEvent[]> {
+		const received: ClientEvent[] = [];
+		let seal: () => void = () => undefined;
+		const sealed = new Promise<void>((resolve) => {
+			seal = resolve;
+		});
+
+		const subscription = await database.client.listen(
+			CLIENT_EVENTS_CHANNEL,
+			(payload) => {
+				const event = JSON.parse(payload) as ClientEvent;
+
+				if (event.domain === "roles" && event.resource_id === "sentinel") {
+					seal();
+					return;
+				}
+
+				received.push(event);
+			},
+		);
+
+		try {
+			await run();
+
+			await database.client.notify(
+				CLIENT_EVENTS_CHANNEL,
+				JSON.stringify({
+					domain: "roles",
+					resource_id: "sentinel",
+					operation: "update",
+				}),
+			);
+
+			await sealed;
+		} finally {
+			await subscription.unlisten();
+		}
+
+		return received;
+	}
+
+	it("publishes one frame per progress write", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, 10);
+
+		const frames = await collectFrames(async () => {
+			await updateTaskProgress(db, taskId, RUNNER_A, { progress: 10 });
+			await updateTaskProgress(db, taskId, RUNNER_A, { progress: 20 });
+		});
+
+		expect(frames).toEqual([
+			{ domain: "tasks", resource_id: taskId, operation: "update" },
+			{ domain: "tasks", resource_id: taskId, operation: "update" },
+		]);
+	});
+
+	it("publishes a frame when a task completes", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, 10);
+
+		const frames = await collectFrames(async () => {
+			await completeTask(db, taskId, RUNNER_A);
+		});
+
+		expect(frames).toEqual([
+			{ domain: "tasks", resource_id: taskId, operation: "update" },
+		]);
+	});
+
+	it("publishes a frame when a task fails", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_A, 10);
+
+		const frames = await collectFrames(async () => {
+			await failTask(db, taskId, RUNNER_A, "it broke");
+		});
+
+		expect(frames).toEqual([
+			{ domain: "tasks", resource_id: taskId, operation: "update" },
+		]);
+	});
+
+	it("publishes nothing for claiming, releasing or reclaiming", async () => {
+		const claimable = await createTask(db, "install_hmms");
+		const expired = await createTask(db, "clone_reference");
+
+		await holdTask(expired, RUNNER_B, TASK_LEASE_SECONDS + 60);
+
+		const frames = await collectFrames(async () => {
+			await acquireTask(db, {
+				runnerId: RUNNER_A,
+				allowedTypes: ["install_hmms"],
+			});
+			await renewLeases(db, [claimable], RUNNER_A);
+			await releaseTask(db, claimable, RUNNER_A);
+			await releaseRunnerClaims(db, RUNNER_A);
+			await reclaimExpiredLeases(db);
+		});
+
+		expect(frames).toEqual([]);
+	});
+
+	it("publishes nothing when a fenced write changes nothing", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		await holdTask(taskId, RUNNER_B, 10);
+
+		const frames = await collectFrames(async () => {
+			await updateTaskProgress(db, taskId, RUNNER_A, { progress: 10 });
+			await completeTask(db, taskId, RUNNER_A);
+			await failTask(db, taskId, RUNNER_A, "it broke");
+		});
+
+		expect(frames).toEqual([]);
 	});
 });

--- a/packages/data/src/tasks/data.ts
+++ b/packages/data/src/tasks/data.ts
@@ -1,9 +1,22 @@
-import type { Task } from "@virtool/contracts";
-import { inArray } from "drizzle-orm";
+import { hostname } from "node:os";
+import type { JsonObject, Task } from "@virtool/contracts";
+import {
+	and,
+	asc,
+	eq,
+	inArray,
+	isNull,
+	like,
+	lt,
+	or,
+	type SQL,
+	sql,
+} from "drizzle-orm";
 import type { Db, DbOrTx } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import { tasks as tasksTable } from "../db/schema/tasks";
 import { AppError } from "../errors";
+import { emit } from "../events/emit";
 
 /** Thrown when a requested task does not exist. */
 export class TaskNotFoundError extends AppError {}
@@ -91,4 +104,433 @@ export async function getTask(db: Db, taskId: number): Promise<Task> {
 	}
 
 	return task;
+}
+
+/**
+ * How long a claim stays valid without a heartbeat.
+ *
+ * The lease is encoded on `acquired_at` itself — a claim is live while
+ * `acquired_at` is within this many seconds of now — so renewing one is a write
+ * to a column that already exists. There is no lease column and no DDL; the
+ * `tasks` table is Python's.
+ */
+export const TASK_LEASE_SECONDS = 300;
+
+/**
+ * How often the holder of a claim should renew it.
+ *
+ * Five to one against {@link TASK_LEASE_SECONDS}, the ratio Solid Queue and
+ * Sidekiq both settled on: four consecutive heartbeats can be lost — to a
+ * garbage-collection pause, a blocked event loop, a brief partition — before a
+ * live runner's work becomes claimable by someone else.
+ */
+export const TASK_HEARTBEAT_SECONDS = 60;
+
+/**
+ * Marks a `runner_id` as belonging to this service rather than to Python.
+ *
+ * Every query that takes work back off a runner is scoped to this prefix.
+ * Python never renews `acquired_at`, so a row it claimed and has been working
+ * for longer than the lease is indistinguishable from an abandoned one — a
+ * reclaimer that could see it would pull live work out from under the Python
+ * runner. Scoping at the query level is what makes the drain assumption
+ * enforceable rather than a note in a runbook, which is why there is
+ * deliberately no configuration flag to widen it. Widening happens once Python
+ * no longer runs tasks at all, as an edit here.
+ */
+const RUNNER_ID_PREFIX = "ts-";
+
+/** A task just claimed by a runner, with the lease it now holds. */
+export type ClaimedTask = {
+	id: number;
+	type: string;
+	context: JsonObject;
+	step: string | null;
+	progress: number;
+	createdAt: Date;
+	acquiredAt: Date;
+	runnerId: string;
+};
+
+/** What {@link acquireTask} needs to claim a task. */
+export type AcquireTaskOptions = {
+	runnerId: string;
+	allowedTypes: readonly string[];
+	leaseSeconds?: number;
+};
+
+/** New progress, and optionally a new step name, for {@link updateTaskProgress}. */
+export type TaskProgressValues = {
+	progress: number;
+	step?: string;
+};
+
+/**
+ * Identify this process as a task runner.
+ *
+ * `{hostname}-{pid}` is Python's format, prefixed to mark the row as this
+ * service's. The column is `varchar(255)`, which a Kubernetes pod name and a
+ * pid cannot come close to filling — and Postgres raises on overflow rather
+ * than truncating, so a hostname that did would fail the claim loudly instead
+ * of minting an id that collides with another runner's.
+ */
+export function buildRunnerId(): string {
+	return `${RUNNER_ID_PREFIX}${hostname()}-${process.pid}`;
+}
+
+/**
+ * The current UTC wall time, matching the naive `timestamp` columns Python
+ * writes.
+ *
+ * `clock_timestamp()` rather than `now()`, which is the *transaction's* start
+ * time and is frozen for its whole length. On a heartbeat that back-dates the
+ * lease by however long the transaction has already run, which is the
+ * difference between a renewed lease and one another runner is free to take.
+ */
+function nowUtc(): SQL {
+	return sql`timezone('utc', clock_timestamp())`;
+}
+
+/**
+ * Match a task no runner holds — never claimed, or claimed by a runner of ours
+ * whose lease has run out.
+ *
+ * Reclaim is folded in here rather than run from a background timer, which is
+ * graphile-worker's shape: the claim heals the queue as a side effect of doing
+ * its ordinary work, so there is no second loop to schedule, nothing to keep
+ * alive when the fleet is idle, and no window between a sweep marking a row
+ * free and a claimer taking it.
+ *
+ * Python's `progress = 0` term is deliberately absent. It was there to avoid
+ * re-running partially-finished work, but a row worth reclaiming has almost
+ * always reported progress, so the term excluded exactly the rows the reclaim
+ * exists for.
+ */
+function isClaimable(
+	allowedTypes: readonly string[],
+	leaseSeconds: number,
+): SQL | undefined {
+	return and(
+		eq(tasksTable.complete, false),
+		isNull(tasksTable.error),
+		inArray(tasksTable.type, [...allowedTypes]),
+		or(
+			isNull(tasksTable.acquired_at),
+			and(
+				like(tasksTable.runner_id, `${RUNNER_ID_PREFIX}%`),
+				lt(tasksTable.acquired_at, expiredBefore(leaseSeconds)),
+			),
+		),
+	);
+}
+
+/** The `acquired_at` a lease of `leaseSeconds` must be later than to still be live. */
+function expiredBefore(leaseSeconds: number): SQL {
+	return sql`${nowUtc()} - make_interval(secs => ${leaseSeconds}::double precision)`;
+}
+
+/**
+ * Claim the oldest task of an allowed type for `runnerId`, or return `null`
+ * when there is nothing to take.
+ *
+ * The candidate is picked under `FOR UPDATE SKIP LOCKED` over a one-row window,
+ * so a fleet of runners polling together each lock a different row rather than
+ * queueing on the same one and waking to find it taken.
+ *
+ * The predicate is then **repeated** on the outer update. Under Read Committed
+ * an updater blocked on a row re-evaluates only its own `WHERE` when the lock
+ * clears — not the subquery that chose the row — so without the repeat a
+ * claimer that queued behind another would overwrite the winner's claim with
+ * its own. The whole disjunction has to be repeated, not just an
+ * `acquired_at IS NULL` term, or a row reclaimed a moment ago passes a guard
+ * that no longer describes why it was chosen.
+ *
+ * Emits nothing. A claim changes no field any client displays, and a runner
+ * polling an empty queue would otherwise put a frame on every browser each time
+ * it found work.
+ */
+export async function acquireTask(
+	db: Db,
+	options: AcquireTaskOptions,
+): Promise<ClaimedTask | null> {
+	const { runnerId, allowedTypes } = options;
+	const leaseSeconds = options.leaseSeconds ?? TASK_LEASE_SECONDS;
+
+	if (allowedTypes.length === 0) {
+		return null;
+	}
+
+	const candidate = db
+		.select({ id: tasksTable.id })
+		.from(tasksTable)
+		.where(isClaimable(allowedTypes, leaseSeconds))
+		.orderBy(asc(tasksTable.created_at))
+		.limit(1)
+		.for("update", { skipLocked: true });
+
+	const [row] = await db
+		.update(tasksTable)
+		.set({ acquired_at: nowUtc(), runner_id: runnerId })
+		.where(
+			and(
+				eq(tasksTable.id, sql`(${candidate})`),
+				isClaimable(allowedTypes, leaseSeconds),
+			),
+		)
+		.returning({
+			acquiredAt: tasksTable.acquired_at,
+			context: tasksTable.context,
+			createdAt: tasksTable.created_at,
+			id: tasksTable.id,
+			progress: tasksTable.progress,
+			runnerId: tasksTable.runner_id,
+			step: tasksTable.step,
+			type: tasksTable.type,
+		});
+
+	if (!row) {
+		return null;
+	}
+
+	if (row.acquiredAt === null || row.runnerId === null) {
+		// Both columns were written by the statement that returned this row. They
+		// are nullable only because an unclaimed task leaves them empty.
+		throw new Error("claimed task came back without a lease");
+	}
+
+	return {
+		acquiredAt: row.acquiredAt,
+		context: (row.context ?? {}) as JsonObject,
+		createdAt: row.createdAt,
+		id: row.id,
+		progress: row.progress ?? 0,
+		runnerId: row.runnerId,
+		step: row.step,
+		type: row.type,
+	};
+}
+
+/**
+ * Renew the leases `runnerId` holds on `taskIds`, and report which were
+ * actually renewed.
+ *
+ * The renewal is conditional, and the returned ids are how a runner learns it
+ * has been fenced: a task whose lease expired and was reclaimed no longer
+ * carries this runner's id, so it is silently absent from the result. Callers
+ * diff the result against what they asked for and abandon the difference —
+ * which is why this reports rather than throwing, since a partial result is the
+ * normal outcome, not an error.
+ *
+ * Emits nothing, for the reason {@link acquireTask} does not: a heartbeat every
+ * minute per running task would cost every connected browser a refetch for a
+ * timestamp no view displays.
+ */
+export async function renewLeases(
+	db: Db,
+	taskIds: readonly number[],
+	runnerId: string,
+): Promise<number[]> {
+	if (taskIds.length === 0) {
+		return [];
+	}
+
+	const rows = await db
+		.update(tasksTable)
+		.set({ acquired_at: nowUtc() })
+		.where(
+			and(
+				inArray(tasksTable.id, [...taskIds]),
+				eq(tasksTable.runner_id, runnerId),
+				eq(tasksTable.complete, false),
+			),
+		)
+		.returning({ id: tasksTable.id });
+
+	return rows.map((row) => row.id);
+}
+
+/**
+ * Mark the task `runnerId` holds as complete.
+ *
+ * Returns `false` when the write matched nothing — the task is already
+ * finished, or this runner was fenced and no longer holds it. A fenced runner
+ * finishing its work must not be able to report on a task someone else now
+ * owns.
+ */
+export async function completeTask(
+	db: Db,
+	taskId: number,
+	runnerId: string,
+): Promise<boolean> {
+	return writeHeldTask(db, taskId, runnerId, {
+		complete: true,
+		progress: 100,
+	});
+}
+
+/**
+ * Mark the task `runnerId` holds as failed, recording `message`.
+ *
+ * Sets `complete` as well as `error`, which Python does not: its failure path
+ * writes `error` alone and leaves `complete` false, so a failed task stays
+ * forever in the set its own `get_counts` reports as neither queued nor
+ * running. Failure is terminal here.
+ *
+ * Returns `false` under the same fencing rule as {@link completeTask}.
+ */
+export async function failTask(
+	db: Db,
+	taskId: number,
+	runnerId: string,
+	message: string,
+): Promise<boolean> {
+	return writeHeldTask(db, taskId, runnerId, {
+		complete: true,
+		error: message,
+	});
+}
+
+/**
+ * Record progress, and optionally a new step name, for the task `runnerId`
+ * holds.
+ *
+ * Returns `false` under the same fencing rule as {@link completeTask}.
+ */
+export async function updateTaskProgress(
+	db: Db,
+	taskId: number,
+	runnerId: string,
+	values: TaskProgressValues,
+): Promise<boolean> {
+	return writeHeldTask(db, taskId, runnerId, {
+		progress: values.progress,
+		...(values.step !== undefined && { step: values.step }),
+	});
+}
+
+/**
+ * Apply `values` to a task only while `runnerId` still holds it, and emit one
+ * `tasks` frame if it did.
+ *
+ * The guard is what makes every write through here fenced: `runner_id` pins the
+ * row to its current holder and `complete` keeps a finished task from being
+ * written again. A write that matches nothing emits nothing — a frame for a
+ * change that did not happen costs every connected browser a refetch and
+ * reports a state the row is not in.
+ */
+async function writeHeldTask(
+	db: Db,
+	taskId: number,
+	runnerId: string,
+	values: Partial<typeof tasksTable.$inferInsert>,
+): Promise<boolean> {
+	const rows = await db
+		.update(tasksTable)
+		.set(values)
+		.where(
+			and(
+				eq(tasksTable.id, taskId),
+				eq(tasksTable.runner_id, runnerId),
+				eq(tasksTable.complete, false),
+			),
+		)
+		.returning({ id: tasksTable.id });
+
+	if (rows.length === 0) {
+		return false;
+	}
+
+	await emit("tasks", taskId, "update");
+
+	return true;
+}
+
+/**
+ * Give up the claim `runnerId` holds on `taskId`, leaving the task for another
+ * runner.
+ *
+ * This is the shutdown path: a runner draining on SIGTERM hands its work back
+ * rather than letting it sit until the lease expires. Returns `false` when the
+ * runner no longer holds the task.
+ *
+ * Emits nothing. The task returns to exactly the state a client last saw it
+ * in — nothing about the row that any view renders has changed.
+ */
+export async function releaseTask(
+	db: Db,
+	taskId: number,
+	runnerId: string,
+): Promise<boolean> {
+	const rows = await db
+		.update(tasksTable)
+		.set({ acquired_at: null, runner_id: null })
+		.where(
+			and(
+				eq(tasksTable.id, taskId),
+				eq(tasksTable.runner_id, runnerId),
+				eq(tasksTable.complete, false),
+			),
+		)
+		.returning({ id: tasksTable.id });
+
+	return rows.length > 0;
+}
+
+/**
+ * Give up every unfinished claim `runnerId` holds, and report which.
+ *
+ * The bulk form of {@link releaseTask}, for a runner draining on shutdown or
+ * clearing whatever a previous incarnation left behind at startup. Emits
+ * nothing, for the same reason.
+ */
+export async function releaseRunnerClaims(
+	db: Db,
+	runnerId: string,
+): Promise<number[]> {
+	const rows = await db
+		.update(tasksTable)
+		.set({ acquired_at: null, runner_id: null })
+		.where(
+			and(eq(tasksTable.runner_id, runnerId), eq(tasksTable.complete, false)),
+		)
+		.returning({ id: tasksTable.id });
+
+	return rows.map((row) => row.id);
+}
+
+/**
+ * Take back every claim held by one of our runners whose lease has run out, and
+ * report which.
+ *
+ * {@link acquireTask} already reclaims as it claims, so nothing needs to call
+ * this on a running fleet. It ships as its own query for the cutover, where a
+ * fleet may be spawning tasks with claiming disabled and so never running a
+ * claim to heal them, and because a reclaim that can be invoked directly is
+ * testable and operable on its own.
+ *
+ * Scoped to {@link RUNNER_ID_PREFIX}: a row Python holds is never touched.
+ *
+ * Emits nothing. A reclaimed task is pending again, which is the state a client
+ * last saw it in.
+ */
+export async function reclaimExpiredLeases(
+	db: Db,
+	options: { leaseSeconds?: number } = {},
+): Promise<number[]> {
+	const leaseSeconds = options.leaseSeconds ?? TASK_LEASE_SECONDS;
+
+	const rows = await db
+		.update(tasksTable)
+		.set({ acquired_at: null, runner_id: null })
+		.where(
+			and(
+				like(tasksTable.runner_id, `${RUNNER_ID_PREFIX}%`),
+				lt(tasksTable.acquired_at, expiredBefore(leaseSeconds)),
+				eq(tasksTable.complete, false),
+				isNull(tasksTable.error),
+			),
+		)
+		.returning({ id: tasksTable.id });
+
+	return rows.map((row) => row.id);
 }

--- a/packages/data/src/tasks/data.ts
+++ b/packages/data/src/tasks/data.ts
@@ -453,6 +453,10 @@ async function writeHeldTask(
  * rather than letting it sit until the lease expires. Returns `false` when the
  * runner no longer holds the task.
  *
+ * Scoped to {@link RUNNER_ID_PREFIX} like every other query that takes work off
+ * a runner, so the scope holds however the id was obtained rather than only
+ * when it came from {@link buildRunnerId}.
+ *
  * Emits nothing. The task returns to exactly the state a client last saw it
  * in — nothing about the row that any view renders has changed.
  */
@@ -468,6 +472,7 @@ export async function releaseTask(
 			and(
 				eq(tasksTable.id, taskId),
 				eq(tasksTable.runner_id, runnerId),
+				like(tasksTable.runner_id, `${RUNNER_ID_PREFIX}%`),
 				eq(tasksTable.complete, false),
 			),
 		)
@@ -480,8 +485,8 @@ export async function releaseTask(
  * Give up every unfinished claim `runnerId` holds, and report which.
  *
  * The bulk form of {@link releaseTask}, for a runner draining on shutdown or
- * clearing whatever a previous incarnation left behind at startup. Emits
- * nothing, for the same reason.
+ * clearing whatever a previous incarnation left behind at startup. Scoped and
+ * silent for the same reasons.
  */
 export async function releaseRunnerClaims(
 	db: Db,
@@ -491,7 +496,11 @@ export async function releaseRunnerClaims(
 		.update(tasksTable)
 		.set({ acquired_at: null, runner_id: null })
 		.where(
-			and(eq(tasksTable.runner_id, runnerId), eq(tasksTable.complete, false)),
+			and(
+				eq(tasksTable.runner_id, runnerId),
+				like(tasksTable.runner_id, `${RUNNER_ID_PREFIX}%`),
+				eq(tasksTable.complete, false),
+			),
 		)
 		.returning({ id: tasksTable.id });
 


### PR DESCRIPTION
## Summary

- Extends `packages/data/src/tasks/data.ts` with `acquireTask`, `renewLeases`, `completeTask`, `failTask`, `updateTaskProgress`, `releaseTask`, `releaseRunnerClaims` and `reclaimExpiredLeases` over the `tasks` table Python owns — no schema change, and no callers until the framework lands.
- Encodes a claim as a lease on `acquired_at`, live for `TASK_LEASE_SECONDS` and renewed every `TASK_HEARTBEAT_SECONDS`, with reclaim folded into the claim predicate so the queue heals without a background timer. The whole predicate repeats as the outer `UPDATE`'s trailing guard, since under Read Committed a blocked updater re-evaluates its own `WHERE` and never the subquery that chose the row.
- Fences every runner write on `runner_id` and `complete`, scopes reclaim to `ts-` runner ids so Python's long-running tasks are never mistaken for abandoned, and publishes `tasks` frames from `updateTaskProgress`, `completeTask` and `failTask` only — never from a guarded write that changed nothing.