### PR TITLE
chore: add the task framework with steps, progress and emission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1053,10 +1053,42 @@ four rules hold them:
   returned `false`. Those three take `Db` rather than `DbOrTx` so a
   frame cannot precede the commit of the row it describes.
 
+A task body is authored against the framework in
+`apps/tasks/src/framework/` — `defineTask` and the payload/step
+declaration (`define.ts`), the debounced progress writer
+(`progress.ts`), and `runTask` (`run.ts`). Six rules it carries:
+
+- **A body never persists and `data.ts` never learns about tasks.** The
+  seam between them is a trailing `onProgress?: (percent: number) =>
+  Promise<void>` on the data function — percent at that boundary,
+  **fraction** (0–1) at `runStep`'s `report`, and a body bridges the two
+  with `async (percent) => report(percent / 100)`. A caller rescales a
+  child's full range into its own band.
+- **A step is an equal slice of 0–100**, and rounding is **half-to-even**
+  to match Python's `round` — `Math.round(62.5)` is 63 and Python's is
+  62. Step entry and exit write immediately; everything between them is
+  debounced at `PROGRESS_DEBOUNCE_MS` (250) and flushed before the
+  terminal write.
+- **A progress decrease is dropped, not raised.** Python raises, which
+  lets a rounding wobble fail an otherwise-healthy task. Any
+  accumulating helper guards `total <= 0` rather than dividing blind, as
+  Python's does.
+- **`cleanup` runs on every outcome but success** — including a handler
+  that sees `signal.aborted` and returns *cleanly*, which a
+  `catch`-only implementation skips silently. Never after a fence:
+  another runner owns the task. A throwing cleanup is logged and never
+  masks the original error.
+- **An error is `` `${err.name}: ${err.message}` ``**, not Python's
+  `"<class 'ValueError'>: boom"`. A payload the schema rejects fails the
+  task before any handler code runs.
+- **A reclaimed task re-runs from step zero, so every body must be
+  idempotent.** Nothing records which steps already ran.
+
 See [docs/tasks.md](docs/tasks.md) for the full config table, the
 `AppContext` contract, the shutdown ordering and its guarantees, the
-probe and metrics surface, and the lease, fencing and frame rules in
-full.
+probe and metrics surface, the lease, fencing and frame rules in full,
+and the framework's step model, terminal-outcome table and progress
+seam.
 
 ## Data
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1056,7 +1056,7 @@ four rules hold them:
 A task body is authored against the framework in
 `apps/tasks/src/framework/` — `defineTask` and the payload/step
 declaration (`define.ts`), the debounced progress writer
-(`progress.ts`), and `runTask` (`run.ts`). Six rules it carries:
+(`progress.ts`), and `runTask` (`run.ts`). Eight rules it carries:
 
 - **A body never persists and `data.ts` never learns about tasks.** The
   seam between them is a trailing `onProgress?: (percent: number) =>
@@ -1066,21 +1066,36 @@ declaration (`define.ts`), the debounced progress writer
   child's full range into its own band.
 - **A step is an equal slice of 0–100**, and rounding is **half-to-even**
   to match Python's `round` — `Math.round(62.5)` is 63 and Python's is
-  62. Step entry and exit write immediately; everything between them is
-  debounced at `PROGRESS_DEBOUNCE_MS` (250) and flushed before the
-  terminal write.
-- **A progress decrease is dropped, not raised.** Python raises, which
-  lets a rounding wobble fail an otherwise-healthy task. Any
-  accumulating helper guards `total <= 0` rather than dividing blind, as
-  Python's does.
+  62. Only step *entry* writes immediately; a step writes nothing on the
+  way out, because the next entry carries the same value and an exit
+  write would report a step that threw as finished. Everything between
+  is debounced at `PROGRESS_DEBOUNCE_MS` (250) and flushed before the
+  terminal write, and again after `cleanup`.
+- **A step name absent from the declared `steps` has its progress
+  dropped**, at `warn` — it is a typo, and giving it the whole 0–100
+  range pins the bar at 100 for the rest of the run. A task that
+  declares no steps at all still maps each one onto the whole bar.
+- **A progress decrease is dropped, not raised**, and measured from the
+  claimed row's `progress` rather than from zero — a reclaimed task
+  re-runs from step zero and must not drag the bar back with it. Python
+  raises, which lets a rounding wobble fail an otherwise-healthy task.
+  Any accumulating helper guards `total <= 0` rather than dividing
+  blind, as Python's does.
 - **`cleanup` runs on every outcome but success** — including a handler
   that sees `signal.aborted` and returns *cleanly*, which a
   `catch`-only implementation skips silently. Never after a fence:
-  another runner owns the task. A throwing cleanup is logged and never
-  masks the original error.
+  another runner owns the task, and the claim is **renewed and checked**
+  first rather than inferred from whatever progress write happened to be
+  outstanding. A throwing cleanup is logged and never masks the original
+  error.
 - **An error is `` `${err.name}: ${err.message}` ``**, not Python's
   `"<class 'ValueError'>: boom"`. A payload the schema rejects fails the
   task before any handler code runs.
+- **`runTask` always returns an outcome**: a terminal write that rejects
+  reports `aborted`, the same as an already-aborted signal at dispatch,
+  because both leave the row claimed and incomplete for the caller to
+  release. `signal.aborted` is sampled once, before the flush that
+  precedes the terminal write.
 - **A reclaimed task re-runs from step zero, so every body must be
   idempotent.** Nothing records which steps already ran.
 

--- a/apps/tasks/package.json
+++ b/apps/tasks/package.json
@@ -26,6 +26,7 @@
 		"zod": "^4.3.5"
 	},
 	"devDependencies": {
+		"drizzle-orm": "^0.45.2",
 		"tsdown": "^0.22.14",
 		"vitest": "^4.1.10"
 	}

--- a/apps/tasks/src/framework/define.ts
+++ b/apps/tasks/src/framework/define.ts
@@ -36,8 +36,11 @@ export type TaskHelpers = {
 	 * each declared step occupies an equal slice of 0–100. Call `report(0..1)`
 	 * from inside to move progress within that slice.
 	 *
-	 * A name absent from the declared `steps` still sets the column, and its
-	 * reports map straight onto 0–100.
+	 * A task that declares no `steps` maps each step it runs onto the whole
+	 * 0–100 bar. A task that declares them and then runs a name absent from the
+	 * list still sets the column, but its reports are dropped and logged: the
+	 * name is a typo, and giving it the whole bar would pin progress at 100 for
+	 * the rest of the run.
 	 */
 	runStep: <T>(
 		name: string,

--- a/apps/tasks/src/framework/define.ts
+++ b/apps/tasks/src/framework/define.ts
@@ -1,0 +1,117 @@
+/**
+ * The authoring surface every task body is written against.
+ *
+ * A task body declares its type, the shape of its payload, and the sequence of
+ * steps it moves through. It reports progress through the reporter `runStep`
+ * hands it, and it never touches the `tasks` table, never emits a frame and
+ * never learns which runner is executing it. Persistence stays in
+ * `@virtool/data`; this module is the shell that calls it.
+ *
+ * **A `run` may execute more than once for the same `taskId`. Make every step
+ * idempotent.** A claim is a lease, and a lease that expires is reclaimed by
+ * another runner — which starts the body again from step zero, with whatever
+ * partial work the previous attempt left behind still in place. Nothing here
+ * records which steps already ran; the claim query deliberately dropped
+ * Python's `progress = 0` filter, because it excluded exactly the rows a
+ * reclaim exists for. A body that cannot tolerate re-entry must key its own
+ * idempotency off `taskId`.
+ */
+
+import type { Logger } from "@virtool/logger";
+import type { z } from "zod";
+
+/**
+ * Report progress within the current step, as a fraction from 0 to 1.
+ *
+ * Returns nothing: writes are coalesced on a debounce window, so there is no
+ * per-call round trip to wait on. Values outside `[0, 1]` are clamped, and a
+ * value below one already reported is ignored rather than written.
+ */
+export type StepProgressReporter = (frac: number) => void;
+
+/** Helpers exposed to a task handler at run time. */
+export type TaskHelpers = {
+	/**
+	 * Run a named step. Sets the row's `step` column and scales `progress` so
+	 * each declared step occupies an equal slice of 0–100. Call `report(0..1)`
+	 * from inside to move progress within that slice.
+	 *
+	 * A name absent from the declared `steps` still sets the column, and its
+	 * reports map straight onto 0–100.
+	 */
+	runStep: <T>(
+		name: string,
+		fn: (report: StepProgressReporter) => Promise<T>,
+	) => Promise<T>;
+};
+
+/** Arguments passed to a task handler. */
+export type TaskHandlerArgs<P, C> = {
+	taskId: number;
+	payload: P;
+	signal: AbortSignal;
+	helpers: TaskHelpers;
+	ctx: C;
+	logger: Logger;
+};
+
+/**
+ * A task type, as its author writes it. Construct with {@link defineTask}.
+ *
+ * `S` is the payload schema, so `run` and `cleanup` receive a payload already
+ * narrowed to what it parses. `C` is the context the runner injects; leave it
+ * off when a body does not read `ctx`.
+ */
+export type TaskDef<S extends z.ZodType, C = unknown> = {
+	/** Matches the `type` column, and the name Python's runner knows. */
+	type: string;
+	/** Parsed against the row's `context` before any handler code runs. */
+	payload: S;
+	/** Sequential step names. Each occupies an equal slice of 0–100 progress. */
+	steps?: readonly string[];
+	/**
+	 * Runs on any non-success terminal outcome — thrown or aborted. Never on
+	 * success, and never once another runner has reclaimed the task.
+	 *
+	 * A throwing `cleanup` is caught and logged; it does not mask the failure
+	 * that provoked it or change the error recorded on the row.
+	 */
+	cleanup?: (args: TaskHandlerArgs<z.infer<S>, C>) => Promise<void>;
+	/**
+	 * The body.
+	 *
+	 * **May execute more than once for the same `taskId`** — see this module's
+	 * documentation. Make every step idempotent.
+	 */
+	run: (args: TaskHandlerArgs<z.infer<S>, C>) => Promise<void>;
+};
+
+/**
+ * A task with its payload type erased, as a registry holds it.
+ *
+ * A registry maps names to tasks whose payloads have nothing in common, so the
+ * type it stores cannot name any one of them. {@link defineTask} performs the
+ * erasure once, which is what keeps the cast out of every task body and out of
+ * the runner.
+ */
+export type RegisteredTask<C = unknown> = TaskDef<z.ZodType, C>;
+
+/** Every task type a runner will dispatch, keyed by its `type` column value. */
+export type TaskRegistry<C = unknown> = Record<string, RegisteredTask<C>>;
+
+/**
+ * Register a task type.
+ *
+ * Identity at run time — it exists for the inference, giving `run` and
+ * `cleanup` a payload narrowed by `payload` without either being annotated,
+ * and for the payload erasure that lets one registry hold every task.
+ *
+ * The erasure is sound because the only caller of `run` parses `payload`
+ * first and passes what it produced: `runTask` never hands a body a value
+ * the body's own schema has not accepted.
+ */
+export function defineTask<S extends z.ZodType, C = unknown>(
+	def: TaskDef<S, C>,
+): RegisteredTask<C> {
+	return def as RegisteredTask<C>;
+}

--- a/apps/tasks/src/framework/progress.test.ts
+++ b/apps/tasks/src/framework/progress.test.ts
@@ -17,7 +17,6 @@ import {
 	vi,
 } from "vitest";
 import {
-	createAccumulator,
 	createProgressWriter,
 	PROGRESS_DEBOUNCE_MS,
 	roundHalfToEven,
@@ -147,6 +146,25 @@ describe("createProgressWriter", () => {
 		expect((await readRow(taskId)).progress).toBe(90);
 	});
 
+	it("measures a decrease from the progress already on the row", async () => {
+		const taskId = await heldTask(RUNNER_A);
+
+		await db.update(tasks).set({ progress: 87 }).where(eq(tasks.id, taskId));
+
+		const writer = createProgressWriter({
+			db,
+			taskId,
+			runnerId: RUNNER_A,
+			logger,
+			progress: 87,
+			debounceMs: NEVER_FIRES_MS,
+		});
+
+		await writer.setNow({ progress: 0, step: "one" });
+
+		expect(await readRow(taskId)).toMatchObject({ progress: 87, step: "one" });
+	});
+
 	it("writes a step change even when progress stands still", async () => {
 		const taskId = await heldTask(RUNNER_A);
 
@@ -240,26 +258,5 @@ describe("createProgressWriter", () => {
 
 		expect(countUpdates()).toBe(1);
 		expect((await readRow(taskId)).progress).toBe(0);
-	});
-});
-
-describe("createAccumulator", () => {
-	it("reports the fraction done as items are counted off", () => {
-		const report = vi.fn();
-		const add = createAccumulator(4, report);
-
-		add();
-		add(2);
-
-		expect(report).toHaveBeenNthCalledWith(1, 0.25);
-		expect(report).toHaveBeenNthCalledWith(2, 0.75);
-	});
-
-	it("guards a zero total instead of dividing by it", () => {
-		const report = vi.fn();
-		const add = createAccumulator(0, report);
-
-		expect(() => add()).not.toThrow();
-		expect(report).not.toHaveBeenCalled();
 	});
 });

--- a/apps/tasks/src/framework/progress.test.ts
+++ b/apps/tasks/src/framework/progress.test.ts
@@ -1,0 +1,265 @@
+import type { Db } from "@virtool/data/db/pg";
+import { tasks } from "@virtool/data/db/schema/tasks";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import { createTask } from "@virtool/data/tasks/data";
+import { createLogger, type Logger } from "@virtool/logger";
+import { eq } from "drizzle-orm";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import {
+	createAccumulator,
+	createProgressWriter,
+	PROGRESS_DEBOUNCE_MS,
+	roundHalfToEven,
+} from "./progress";
+
+const RUNNER_A = "ts-runner-a-1";
+const RUNNER_B = "ts-runner-b-2";
+
+/** Long enough that no test's debounce window closes on its own. */
+const NEVER_FIRES_MS = 60_000;
+
+const logger: Logger = createLogger({ name: "test", level: "silent" });
+
+let database: TestDatabase;
+let db: Db;
+let queries: string[] = [];
+
+beforeAll(async () => {
+	database = await createTestDatabase({
+		onQuery: (query) => {
+			queries.push(query);
+		},
+	});
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(tasks);
+	queries = [];
+});
+
+/** How many `UPDATE`s of the `tasks` table the connection has sent so far. */
+function countUpdates(): number {
+	return queries.filter((query) => query.includes('update "tasks"')).length;
+}
+
+async function readRow(taskId: number) {
+	const [row] = await db.select().from(tasks).where(eq(tasks.id, taskId));
+
+	if (row === undefined) {
+		throw new Error(`no task row with id ${taskId}`);
+	}
+
+	return row;
+}
+
+/** Insert a task and put it in the state a runner holding a live lease leaves. */
+async function heldTask(runnerId: string): Promise<number> {
+	const taskId = await createTask(db, "install_hmms");
+
+	await db
+		.update(tasks)
+		.set({ acquired_at: new Date(), runner_id: runnerId })
+		.where(eq(tasks.id, taskId));
+
+	queries = [];
+
+	return taskId;
+}
+
+describe("roundHalfToEven", () => {
+	it("breaks a tie to the even side, as Python's round does", () => {
+		expect(roundHalfToEven(62.5)).toBe(62);
+		expect(roundHalfToEven(12.5)).toBe(12);
+		expect(roundHalfToEven(63.5)).toBe(64);
+		expect(roundHalfToEven(37.5)).toBe(38);
+	});
+
+	it("rounds to the nearer integer otherwise", () => {
+		expect(roundHalfToEven(0.4)).toBe(0);
+		expect(roundHalfToEven(0.6)).toBe(1);
+		expect(roundHalfToEven(66.67)).toBe(67);
+		expect(roundHalfToEven(50)).toBe(50);
+	});
+});
+
+describe("createProgressWriter", () => {
+	it("debounces on a 250 ms window by default", () => {
+		expect(PROGRESS_DEBOUNCE_MS).toBe(250);
+	});
+
+	it("collapses a burst of writes into one, and flush lands the last value", async () => {
+		const taskId = await heldTask(RUNNER_A);
+
+		const writer = createProgressWriter({
+			db,
+			taskId,
+			runnerId: RUNNER_A,
+			logger,
+			debounceMs: NEVER_FIRES_MS,
+		});
+
+		for (let value = 1; value <= 20; value += 1) {
+			writer.set({ progress: value });
+		}
+
+		expect(countUpdates()).toBe(0);
+
+		await writer.flush();
+
+		expect(countUpdates()).toBe(1);
+		expect((await readRow(taskId)).progress).toBe(20);
+	});
+
+	it("ignores a decrease rather than writing it", async () => {
+		const taskId = await heldTask(RUNNER_A);
+
+		const writer = createProgressWriter({
+			db,
+			taskId,
+			runnerId: RUNNER_A,
+			logger,
+			debounceMs: NEVER_FIRES_MS,
+		});
+
+		writer.set({ progress: 90 });
+		await writer.flush();
+
+		writer.set({ progress: 40 });
+		await writer.flush();
+
+		expect(countUpdates()).toBe(1);
+		expect((await readRow(taskId)).progress).toBe(90);
+	});
+
+	it("writes a step change even when progress stands still", async () => {
+		const taskId = await heldTask(RUNNER_A);
+
+		const writer = createProgressWriter({
+			db,
+			taskId,
+			runnerId: RUNNER_A,
+			logger,
+			debounceMs: NEVER_FIRES_MS,
+		});
+
+		await writer.setNow({ progress: 25, step: "one" });
+		await writer.setNow({ progress: 25, step: "two" });
+
+		expect(countUpdates()).toBe(2);
+		expect(await readRow(taskId)).toMatchObject({ progress: 25, step: "two" });
+	});
+
+	it("writes nothing when nothing moved", async () => {
+		const taskId = await heldTask(RUNNER_A);
+
+		const writer = createProgressWriter({
+			db,
+			taskId,
+			runnerId: RUNNER_A,
+			logger,
+			debounceMs: NEVER_FIRES_MS,
+		});
+
+		await writer.setNow({ progress: 25, step: "one" });
+		await writer.setNow({ progress: 25, step: "one" });
+
+		expect(countUpdates()).toBe(1);
+	});
+
+	it("supersedes a pending write rather than writing both", async () => {
+		const taskId = await heldTask(RUNNER_A);
+
+		const writer = createProgressWriter({
+			db,
+			taskId,
+			runnerId: RUNNER_A,
+			logger,
+			debounceMs: NEVER_FIRES_MS,
+		});
+
+		writer.set({ progress: 10 });
+		await writer.setNow({ progress: 50 });
+
+		expect(countUpdates()).toBe(1);
+		expect((await readRow(taskId)).progress).toBe(50);
+	});
+
+	it("closes the window on its own once the debounce elapses", async () => {
+		const taskId = await heldTask(RUNNER_A);
+
+		const writer = createProgressWriter({
+			db,
+			taskId,
+			runnerId: RUNNER_A,
+			logger,
+			debounceMs: 5,
+		});
+
+		writer.set({ progress: 33 });
+
+		await vi.waitFor(async () => {
+			expect((await readRow(taskId)).progress).toBe(33);
+		});
+	});
+
+	it("stops writing once a write finds the task held by another runner", async () => {
+		const taskId = await heldTask(RUNNER_B);
+
+		const writer = createProgressWriter({
+			db,
+			taskId,
+			runnerId: RUNNER_A,
+			logger,
+			debounceMs: NEVER_FIRES_MS,
+		});
+
+		await writer.setNow({ progress: 10 });
+
+		expect(writer.isFenced()).toBe(true);
+		expect(countUpdates()).toBe(1);
+
+		writer.set({ progress: 20 });
+		await writer.setNow({ progress: 30 });
+		await writer.flush();
+
+		expect(countUpdates()).toBe(1);
+		expect((await readRow(taskId)).progress).toBe(0);
+	});
+});
+
+describe("createAccumulator", () => {
+	it("reports the fraction done as items are counted off", () => {
+		const report = vi.fn();
+		const add = createAccumulator(4, report);
+
+		add();
+		add(2);
+
+		expect(report).toHaveBeenNthCalledWith(1, 0.25);
+		expect(report).toHaveBeenNthCalledWith(2, 0.75);
+	});
+
+	it("guards a zero total instead of dividing by it", () => {
+		const report = vi.fn();
+		const add = createAccumulator(0, report);
+
+		expect(() => add()).not.toThrow();
+		expect(report).not.toHaveBeenCalled();
+	});
+});

--- a/apps/tasks/src/framework/progress.ts
+++ b/apps/tasks/src/framework/progress.ts
@@ -1,0 +1,229 @@
+import type { Db } from "@virtool/data/db/pg";
+import { updateTaskProgress } from "@virtool/data/tasks/data";
+import type { Logger } from "@virtool/logger";
+import type { StepProgressReporter } from "./define";
+
+/**
+ * How long progress writes are coalesced for.
+ *
+ * A body that reports per read pair, or per HMM profile, would otherwise cost
+ * one `UPDATE` and one `tasks` frame per item — and every frame is a refetch in
+ * every connected browser. A quarter of a second is below what a progress bar
+ * needs to look continuous, so nothing is lost by holding writes for it.
+ */
+export const PROGRESS_DEBOUNCE_MS = 250;
+
+/**
+ * Round the way Python's `round` does, breaking a tie to the even side.
+ *
+ * `Math.round` breaks ties upward, so it disagrees with Python on every exact
+ * half — `round(62.5)` is 62 there and 63 here. Progress is cosmetic, but
+ * Python still runs tasks until the cutover completes, and two runners writing
+ * different numbers for the same step of the same task type is a difference
+ * nobody would be able to explain later.
+ */
+export function roundHalfToEven(value: number): number {
+	const floor = Math.floor(value);
+	const remainder = value - floor;
+
+	if (remainder > 0.5) {
+		return floor + 1;
+	}
+
+	if (remainder < 0.5) {
+		return floor;
+	}
+
+	return floor % 2 === 0 ? floor : floor + 1;
+}
+
+/** A change to a task row's progress, its step name, or both. */
+export type ProgressValues = {
+	progress?: number;
+	step?: string;
+};
+
+/** Coalesces progress writes for one running task. */
+export type ProgressWriter = {
+	/** Record a change, to be written when the debounce window closes. */
+	set: (values: ProgressValues) => void;
+	/** Record a change and write it now, superseding anything pending. */
+	setNow: (values: ProgressValues) => Promise<void>;
+	/** Write anything still pending and wait for every write to land. */
+	flush: () => Promise<void>;
+	/** Whether a write has found the task no longer held by this runner. */
+	isFenced: () => boolean;
+};
+
+/** What {@link createProgressWriter} needs to write a task's progress. */
+export type ProgressWriterOptions = {
+	db: Db;
+	taskId: number;
+	runnerId: string;
+	logger: Logger;
+	/** Defaults to {@link PROGRESS_DEBOUNCE_MS}. */
+	debounceMs?: number;
+};
+
+/**
+ * Build the writer a running task reports through.
+ *
+ * It holds three guarantees the framework rests on. Progress never goes
+ * backwards: a value below one already recorded is dropped, so a rounding
+ * wobble or a retried chunk inside a data function cannot destroy an otherwise
+ * healthy task the way Python's raising handler does. Writes never overlap: one
+ * is chained behind the last, so a flush cannot race a debounced write into
+ * writing the older value second. And a write that matches nothing fences the
+ * writer for good — the task belongs to another runner from that moment, and
+ * this one must stop writing and stop emitting rather than announce a state the
+ * row is not in.
+ */
+export function createProgressWriter(
+	options: ProgressWriterOptions,
+): ProgressWriter {
+	const { db, taskId, runnerId, logger } = options;
+	const debounceMs = options.debounceMs ?? PROGRESS_DEBOUNCE_MS;
+
+	let progress = 0;
+	let step: string | undefined;
+	let pending = false;
+	let timer: NodeJS.Timeout | undefined;
+	let queue: Promise<void> = Promise.resolve();
+	let fenced = false;
+
+	async function write(): Promise<void> {
+		if (fenced) {
+			return;
+		}
+
+		try {
+			const held = await updateTaskProgress(db, taskId, runnerId, {
+				progress,
+				...(step !== undefined && { step }),
+			});
+
+			if (!held) {
+				fenced = true;
+				logger.warn(
+					{ task_id: taskId },
+					"stopped writing progress for a task this runner no longer holds",
+				);
+			}
+		} catch (err) {
+			// Progress is cosmetic, and a task that did its work must not be failed
+			// over a bar that did not move. A database that is genuinely gone will
+			// surface on the terminal write, which goes through the same pool.
+			logger.warn({ err, task_id: taskId }, "failed to write task progress");
+		}
+	}
+
+	function enqueue(): void {
+		queue = queue.then(write);
+	}
+
+	function clearTimer(): void {
+		if (timer !== undefined) {
+			clearTimeout(timer);
+			timer = undefined;
+		}
+	}
+
+	/** Fold `values` into the intended row state, and report whether it moved. */
+	function apply(values: ProgressValues): boolean {
+		let changed = false;
+
+		if (values.progress !== undefined) {
+			if (values.progress > progress) {
+				progress = values.progress;
+				changed = true;
+			} else if (values.progress < progress) {
+				logger.debug(
+					{ task_id: taskId, progress: values.progress, recorded: progress },
+					"ignored a task progress decrease",
+				);
+			}
+		}
+
+		if (values.step !== undefined && values.step !== step) {
+			step = values.step;
+			changed = true;
+		}
+
+		return changed;
+	}
+
+	function set(values: ProgressValues): void {
+		if (fenced || !apply(values)) {
+			return;
+		}
+
+		pending = true;
+
+		if (timer === undefined) {
+			timer = setTimeout(() => {
+				timer = undefined;
+
+				if (pending) {
+					pending = false;
+					enqueue();
+				}
+			}, debounceMs);
+
+			// A pending progress write must never be the reason the process stays
+			// alive; the terminal path flushes it.
+			timer.unref();
+		}
+	}
+
+	async function setNow(values: ProgressValues): Promise<void> {
+		const changed = apply(values);
+
+		clearTimer();
+
+		if (changed || pending) {
+			pending = false;
+			enqueue();
+		}
+
+		await queue;
+	}
+
+	async function flush(): Promise<void> {
+		clearTimer();
+
+		if (pending) {
+			pending = false;
+			enqueue();
+		}
+
+		await queue;
+	}
+
+	return { set, setNow, flush, isFenced: () => fenced };
+}
+
+/**
+ * Wrap a reporter so a body can count items off against a total rather than
+ * compute a fraction.
+ *
+ * `total <= 0` is guarded rather than divided by. Python's
+ * `AccumulatingProgressHandlerWrapper` divides blind, so a zero-length download
+ * raises `ZeroDivisionError` out of a progress helper and fails a task that had
+ * nothing to do.
+ */
+export function createAccumulator(
+	total: number,
+	report: StepProgressReporter,
+): (count?: number) => void {
+	let done = 0;
+
+	return function add(count = 1): void {
+		if (total <= 0) {
+			return;
+		}
+
+		done += count;
+
+		report(done / total);
+	};
+}

--- a/apps/tasks/src/framework/progress.ts
+++ b/apps/tasks/src/framework/progress.ts
@@ -1,7 +1,6 @@
 import type { Db } from "@virtool/data/db/pg";
 import { updateTaskProgress } from "@virtool/data/tasks/data";
 import type { Logger } from "@virtool/logger";
-import type { StepProgressReporter } from "./define";
 
 /**
  * How long progress writes are coalesced for.
@@ -61,6 +60,11 @@ export type ProgressWriterOptions = {
 	taskId: number;
 	runnerId: string;
 	logger: Logger;
+	/**
+	 * The progress already on the row, which the monotonic rule is measured
+	 * against. Defaults to 0.
+	 */
+	progress?: number;
 	/** Defaults to {@link PROGRESS_DEBOUNCE_MS}. */
 	debounceMs?: number;
 };
@@ -77,6 +81,11 @@ export type ProgressWriterOptions = {
  * writer for good — the task belongs to another runner from that moment, and
  * this one must stop writing and stop emitting rather than announce a state the
  * row is not in.
+ *
+ * The monotonic rule is measured from `options.progress`, the value already on
+ * the row, and not from zero. A reclaimed task re-runs from step zero, so its
+ * first step would otherwise write the bar back to 0 — a run that resumes at
+ * 87% must hold there until it passes it again.
  */
 export function createProgressWriter(
 	options: ProgressWriterOptions,
@@ -84,7 +93,7 @@ export function createProgressWriter(
 	const { db, taskId, runnerId, logger } = options;
 	const debounceMs = options.debounceMs ?? PROGRESS_DEBOUNCE_MS;
 
-	let progress = 0;
+	let progress = options.progress ?? 0;
 	let step: string | undefined;
 	let pending = false;
 	let timer: NodeJS.Timeout | undefined;
@@ -200,30 +209,4 @@ export function createProgressWriter(
 	}
 
 	return { set, setNow, flush, isFenced: () => fenced };
-}
-
-/**
- * Wrap a reporter so a body can count items off against a total rather than
- * compute a fraction.
- *
- * `total <= 0` is guarded rather than divided by. Python's
- * `AccumulatingProgressHandlerWrapper` divides blind, so a zero-length download
- * raises `ZeroDivisionError` out of a progress helper and fails a task that had
- * nothing to do.
- */
-export function createAccumulator(
-	total: number,
-	report: StepProgressReporter,
-): (count?: number) => void {
-	let done = 0;
-
-	return function add(count = 1): void {
-		if (total <= 0) {
-			return;
-		}
-
-		done += count;
-
-		report(done / total);
-	};
 }

--- a/apps/tasks/src/framework/run.test.ts
+++ b/apps/tasks/src/framework/run.test.ts
@@ -279,6 +279,120 @@ describe("runTask", () => {
 		});
 	});
 
+	it("leaves the bar where a step that threw started", async () => {
+		const task = await claim();
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			steps: ["one", "two", "three", "four"],
+			run: async ({ helpers }) => {
+				await helpers.runStep("one", async () => undefined);
+				await helpers.runStep("two", async () => {
+					throw new Error("boom");
+				});
+			},
+		});
+
+		const outcome = await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: new AbortController().signal,
+			debounceMs: NEVER_FIRES_MS,
+		});
+
+		expect(outcome).toEqual({ status: "failed", error: "Error: boom" });
+		expect(await readRow(task.id)).toMatchObject({
+			error: "Error: boom",
+			progress: 25,
+			step: "two",
+		});
+	});
+
+	it("never writes the bar below what a reclaimed task already reported", async () => {
+		const claimed = await claim();
+
+		// What a reclaim leaves behind: the previous attempt's progress on the row,
+		// and a body about to start again from step zero.
+		await db
+			.update(tasks)
+			.set({ progress: 87 })
+			.where(eq(tasks.id, claimed.id));
+
+		const task: ClaimedTask = { ...claimed, progress: 87 };
+		let insideSecondStep: number | null = null;
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			steps: ["one", "two"],
+			run: async ({ helpers, taskId }) => {
+				await helpers.runStep("one", async (report) => {
+					report(1);
+				});
+
+				await helpers.runStep("two", async () => {
+					insideSecondStep = (await readRow(taskId)).progress;
+				});
+			},
+		});
+
+		const outcome = await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: new AbortController().signal,
+			debounceMs: NEVER_FIRES_MS,
+		});
+
+		expect(outcome).toEqual({ status: "completed" });
+		expect(insideSecondStep).toBe(87);
+		expect(await readRow(task.id)).toMatchObject({
+			progress: 100,
+			step: "two",
+		});
+	});
+
+	it("drops the progress of a step the task does not declare", async () => {
+		const task = await claim();
+		let insideDeclaredStep: number | null = null;
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			steps: ["one", "two"],
+			run: async ({ helpers, taskId }) => {
+				// A typo against the declared steps. Taking the whole bar for it would
+				// write 100 and silence every declared step after it.
+				await helpers.runStep("on", async (report) => {
+					report(1);
+				});
+
+				await helpers.runStep("two", async () => {
+					insideDeclaredStep = (await readRow(taskId)).progress;
+				});
+			},
+		});
+
+		const outcome = await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: new AbortController().signal,
+			debounceMs: NEVER_FIRES_MS,
+		});
+
+		expect(outcome).toEqual({ status: "completed" });
+		expect(insideDeclaredStep).toBe(50);
+	});
+
 	it("names an undeclared step and maps its reports straight onto 0–100", async () => {
 		const task = await claim();
 
@@ -342,9 +456,11 @@ describe("runTask", () => {
 			});
 		});
 
-		// Two step entries, two step exits, and the completion.
+		// Two step entries and the completion. A step writes nothing on its way
+		// out: the next entry carries the same value, and the completion carries
+		// the last step's end.
 		expect(frames).toEqual(
-			Array.from({ length: 5 }, () => ({
+			Array.from({ length: 3 }, () => ({
 				domain: "tasks",
 				resource_id: task.id,
 				operation: "update",
@@ -507,6 +623,78 @@ describe("runTask", () => {
 
 		expect(outcome).toEqual({ status: "failed", error: "TypeError: kaboom" });
 		expect((await readRow(task.id)).error).toBe("TypeError: kaboom");
+	});
+
+	it("returns without running the handler when the signal is already aborted", async () => {
+		const task = await claim();
+		const run = vi.fn();
+		const cleanup = vi.fn(async () => undefined);
+		const controller = new AbortController();
+
+		controller.abort();
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			cleanup,
+			run,
+		});
+
+		const outcome = await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: controller.signal,
+		});
+
+		expect(outcome).toEqual({ status: "aborted" });
+		expect(run).not.toHaveBeenCalled();
+		expect(cleanup).not.toHaveBeenCalled();
+		expect(await readRow(task.id)).toMatchObject({
+			complete: false,
+			error: null,
+			progress: 0,
+		});
+	});
+
+	it("does not run cleanup after a reclaim no progress write could reveal", async () => {
+		const task = await claim();
+		const cleanup = vi.fn(async () => undefined);
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			cleanup,
+			run: async ({ taskId }) => {
+				// Nothing has been reported, so the writer has no outstanding write to
+				// discover the reclaim through.
+				await db
+					.update(tasks)
+					.set({ runner_id: OTHER_RUNNER })
+					.where(eq(tasks.id, taskId));
+
+				throw new Error("boom");
+			},
+		});
+
+		const outcome = await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: new AbortController().signal,
+			debounceMs: NEVER_FIRES_MS,
+		});
+
+		expect(outcome).toEqual({ status: "fenced" });
+		expect(cleanup).not.toHaveBeenCalled();
+		expect(await readRow(task.id)).toMatchObject({
+			complete: false,
+			error: null,
+		});
 	});
 
 	it("stops without writing when another runner has reclaimed the task", async () => {

--- a/apps/tasks/src/framework/run.test.ts
+++ b/apps/tasks/src/framework/run.test.ts
@@ -1,0 +1,549 @@
+import type { Db } from "@virtool/data/db/pg";
+import { tasks } from "@virtool/data/db/schema/tasks";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import {
+	CLIENT_EVENTS_CHANNEL,
+	type ClientEvent,
+} from "@virtool/data/events/channel";
+import {
+	acquireTask,
+	type ClaimedTask,
+	createTask,
+} from "@virtool/data/tasks/data";
+import { createLogger, type Logger } from "@virtool/logger";
+import { eq } from "drizzle-orm";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import { z } from "zod";
+import { defineTask, type TaskRegistry } from "./define";
+import { runTask } from "./run";
+
+const RUNNER = "ts-runner-a-1";
+const OTHER_RUNNER = "ts-runner-b-2";
+
+/** Long enough that no test's debounce window closes on its own. */
+const NEVER_FIRES_MS = 60_000;
+
+const logger: Logger = createLogger({ name: "test", level: "silent" });
+
+let database: TestDatabase;
+let db: Db;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(tasks);
+});
+
+async function readRow(taskId: number) {
+	const [row] = await db.select().from(tasks).where(eq(tasks.id, taskId));
+
+	if (row === undefined) {
+		throw new Error(`no task row with id ${taskId}`);
+	}
+
+	return row;
+}
+
+/** Insert a task and claim it, as the runner loop will. */
+async function claim(
+	context: Record<string, unknown> = {},
+): Promise<ClaimedTask> {
+	await createTask(db, "install_hmms", context);
+
+	const claimed = await acquireTask(db, {
+		runnerId: RUNNER,
+		allowedTypes: ["install_hmms"],
+	});
+
+	if (claimed === null) {
+		throw new Error("the task under test was not claimable");
+	}
+
+	return claimed;
+}
+
+/**
+ * Collect the `client_events` frames published while `run` executes.
+ *
+ * The sentinel at the end is what makes a count sound: it is published after
+ * everything `run` did, over the connection the emitter uses, so its arrival
+ * proves every frame `run` published has already arrived. Waiting a fixed
+ * interval instead would pass on a slow machine for the wrong reason.
+ */
+async function collectFrames(run: () => Promise<void>): Promise<ClientEvent[]> {
+	const received: ClientEvent[] = [];
+	let seal: () => void = () => undefined;
+	const sealed = new Promise<void>((resolve) => {
+		seal = resolve;
+	});
+
+	const subscription = await database.client.listen(
+		CLIENT_EVENTS_CHANNEL,
+		(payload) => {
+			const event = JSON.parse(payload) as ClientEvent;
+
+			if (event.domain === "roles" && event.resource_id === "sentinel") {
+				seal();
+				return;
+			}
+
+			received.push(event);
+		},
+	);
+
+	try {
+		await run();
+
+		await database.client.notify(
+			CLIENT_EVENTS_CHANNEL,
+			JSON.stringify({
+				domain: "roles",
+				resource_id: "sentinel",
+				operation: "update",
+			}),
+		);
+
+		await sealed;
+	} finally {
+		await subscription.unlisten();
+	}
+
+	return received;
+}
+
+describe("defineTask", () => {
+	it("erases the payload type so one registry holds unlike tasks", () => {
+		const registry: TaskRegistry = {
+			clone_reference: defineTask({
+				type: "clone_reference",
+				payload: z.object({ manifest: z.record(z.string(), z.number()) }),
+				run: async () => undefined,
+			}),
+			install_hmms: defineTask({
+				type: "install_hmms",
+				payload: z.object({ release_id: z.number() }),
+				run: async () => undefined,
+			}),
+		};
+
+		expect(Object.keys(registry)).toEqual(["clone_reference", "install_hmms"]);
+	});
+});
+
+describe("runTask", () => {
+	it("dispatches the handler and marks the task complete", async () => {
+		const task = await claim({ release_id: 7 });
+		const seen: unknown[] = [];
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({ release_id: z.number() }),
+			run: async ({ payload, taskId }) => {
+				seen.push({ payload, taskId });
+			},
+		});
+
+		const outcome = await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: new AbortController().signal,
+		});
+
+		expect(outcome).toEqual({ status: "completed" });
+		expect(seen).toEqual([{ payload: { release_id: 7 }, taskId: task.id }]);
+		expect(await readRow(task.id)).toMatchObject({
+			complete: true,
+			error: null,
+			progress: 100,
+		});
+	});
+
+	it("records the error and stops when the handler throws", async () => {
+		const task = await claim();
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			run: async () => {
+				throw new TypeError("kaboom");
+			},
+		});
+
+		const outcome = await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: new AbortController().signal,
+		});
+
+		expect(outcome).toEqual({ status: "failed", error: "TypeError: kaboom" });
+		expect(await readRow(task.id)).toMatchObject({
+			error: "TypeError: kaboom",
+		});
+	});
+
+	it("rejects a payload the schema does not accept, before the handler runs", async () => {
+		const task = await claim({ wrong: true });
+		const run = vi.fn();
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({ release_id: z.number() }),
+			run,
+		});
+
+		const outcome = await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: new AbortController().signal,
+		});
+
+		expect(run).not.toHaveBeenCalled();
+		expect(outcome.status).toBe("failed");
+		expect((await readRow(task.id)).error).toContain("Invalid payload");
+	});
+
+	it("scales progress into an equal slice per declared step", async () => {
+		const task = await claim();
+		const steps = ["one", "two", "three", "four"] as const;
+		const entries: Array<{ step: string | null; progress: number | null }> = [];
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			steps,
+			run: async ({ helpers, taskId }) => {
+				for (const name of steps) {
+					await helpers.runStep(name, async (report) => {
+						const row = await readRow(taskId);
+						entries.push({ progress: row.progress, step: row.step });
+
+						if (name === "three") {
+							report(0.5);
+
+							await vi.waitFor(async () => {
+								expect((await readRow(taskId)).progress).toBe(62);
+							});
+						}
+					});
+				}
+			},
+		});
+
+		const outcome = await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: new AbortController().signal,
+			debounceMs: 5,
+		});
+
+		expect(outcome).toEqual({ status: "completed" });
+		expect(entries).toEqual([
+			{ progress: 0, step: "one" },
+			{ progress: 25, step: "two" },
+			{ progress: 50, step: "three" },
+			{ progress: 75, step: "four" },
+		]);
+		expect(await readRow(task.id)).toMatchObject({
+			progress: 100,
+			step: "four",
+		});
+	});
+
+	it("names an undeclared step and maps its reports straight onto 0–100", async () => {
+		const task = await claim();
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			run: async ({ helpers, taskId }) => {
+				await helpers.runStep("downloading", async (report) => {
+					expect((await readRow(taskId)).step).toBe("downloading");
+
+					report(0.4);
+
+					await vi.waitFor(async () => {
+						expect((await readRow(taskId)).progress).toBe(40);
+					});
+				});
+			},
+		});
+
+		await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: new AbortController().signal,
+			debounceMs: 5,
+		});
+
+		expect(await readRow(task.id)).toMatchObject({
+			complete: true,
+			progress: 100,
+			step: "downloading",
+		});
+	});
+
+	it("publishes a tasks frame for every step transition and the terminal write", async () => {
+		const task = await claim();
+		const steps = ["one", "two"] as const;
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			steps,
+			run: async ({ helpers }) => {
+				for (const name of steps) {
+					await helpers.runStep(name, async () => undefined);
+				}
+			},
+		});
+
+		const frames = await collectFrames(async () => {
+			await runTask({
+				db,
+				def,
+				task,
+				ctx: undefined,
+				logger,
+				signal: new AbortController().signal,
+				debounceMs: NEVER_FIRES_MS,
+			});
+		});
+
+		// Two step entries, two step exits, and the completion.
+		expect(frames).toEqual(
+			Array.from({ length: 5 }, () => ({
+				domain: "tasks",
+				resource_id: task.id,
+				operation: "update",
+			})),
+		);
+	});
+
+	it("coalesces a burst of reports and still lands the last value", async () => {
+		const task = await claim();
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			run: async ({ helpers }) => {
+				await helpers.runStep("downloading", async (report) => {
+					for (let done = 1; done <= 10; done += 1) {
+						report(done * 0.097);
+					}
+				});
+
+				throw new Error("boom");
+			},
+		});
+
+		const frames = await collectFrames(async () => {
+			await runTask({
+				db,
+				def,
+				task,
+				ctx: undefined,
+				logger,
+				signal: new AbortController().signal,
+				debounceMs: NEVER_FIRES_MS,
+			});
+		});
+
+		// The step entry, the flushed final value, and the failure — against ten
+		// calls to `report`.
+		expect(frames).toHaveLength(3);
+		expect(await readRow(task.id)).toMatchObject({
+			error: "Error: boom",
+			progress: 97,
+		});
+	});
+
+	it("ignores a decrease instead of failing the task", async () => {
+		const task = await claim();
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			steps: ["only"],
+			run: async ({ helpers }) => {
+				await helpers.runStep("only", async (report) => {
+					report(0.9);
+					report(0.4);
+				});
+			},
+		});
+
+		const outcome = await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: new AbortController().signal,
+			debounceMs: NEVER_FIRES_MS,
+		});
+
+		expect(outcome).toEqual({ status: "completed" });
+		expect(await readRow(task.id)).toMatchObject({
+			error: null,
+			progress: 100,
+		});
+	});
+
+	it("runs cleanup when the handler observes an abort and returns cleanly", async () => {
+		const task = await claim();
+		const controller = new AbortController();
+		const cleanup = vi.fn(async () => undefined);
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			cleanup,
+			run: async ({ signal }) => {
+				controller.abort();
+
+				if (signal.aborted) {
+					return;
+				}
+
+				throw new Error("the signal did not reach the handler");
+			},
+		});
+
+		const outcome = await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: controller.signal,
+		});
+
+		expect(outcome).toEqual({ status: "aborted" });
+		expect(cleanup).toHaveBeenCalledTimes(1);
+		expect(await readRow(task.id)).toMatchObject({
+			complete: false,
+			error: null,
+		});
+	});
+
+	it("does not run cleanup on success", async () => {
+		const task = await claim();
+		const cleanup = vi.fn(async () => undefined);
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			cleanup,
+			run: async () => undefined,
+		});
+
+		await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: new AbortController().signal,
+		});
+
+		expect(cleanup).not.toHaveBeenCalled();
+	});
+
+	it("logs a throwing cleanup without overwriting the recorded error", async () => {
+		const task = await claim();
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			cleanup: async () => {
+				throw new Error("cleanup also broke");
+			},
+			run: async () => {
+				throw new TypeError("kaboom");
+			},
+		});
+
+		const outcome = await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: new AbortController().signal,
+		});
+
+		expect(outcome).toEqual({ status: "failed", error: "TypeError: kaboom" });
+		expect((await readRow(task.id)).error).toBe("TypeError: kaboom");
+	});
+
+	it("stops without writing when another runner has reclaimed the task", async () => {
+		const task = await claim();
+		const cleanup = vi.fn(async () => undefined);
+
+		const def = defineTask({
+			type: "install_hmms",
+			payload: z.object({}),
+			steps: ["only"],
+			cleanup,
+			run: async ({ helpers, taskId }) => {
+				await helpers.runStep("only", async () => {
+					await db
+						.update(tasks)
+						.set({ runner_id: OTHER_RUNNER })
+						.where(eq(tasks.id, taskId));
+				});
+			},
+		});
+
+		const outcome = await runTask({
+			db,
+			def,
+			task,
+			ctx: undefined,
+			logger,
+			signal: new AbortController().signal,
+			debounceMs: NEVER_FIRES_MS,
+		});
+
+		expect(outcome).toEqual({ status: "fenced" });
+		expect(cleanup).not.toHaveBeenCalled();
+		expect(await readRow(task.id)).toMatchObject({
+			complete: false,
+			error: null,
+			progress: 0,
+		});
+	});
+});

--- a/apps/tasks/src/framework/run.ts
+++ b/apps/tasks/src/framework/run.ts
@@ -3,6 +3,7 @@ import {
 	type ClaimedTask,
 	completeTask,
 	failTask,
+	renewLeases,
 } from "@virtool/data/tasks/data";
 import type { Logger } from "@virtool/logger";
 import type {
@@ -23,7 +24,8 @@ import {
  * `fenced` is not a failure of this runner's: the lease expired, another runner
  * has the task and is running it again from step zero. Nothing further may be
  * written or emitted for it. `aborted` is a shutdown — the row is left exactly
- * as it stands, for the caller to release.
+ * as it stands, for the caller to release — and is also what a terminal write
+ * the database refused reports, since that leaves the row in the same state.
  */
 export type TaskOutcome =
 	| { status: "completed" }
@@ -58,6 +60,7 @@ function describeError(err: unknown): string {
 function createHelpers(
 	steps: readonly string[],
 	writer: ProgressWriter,
+	logger: Logger,
 ): TaskHelpers {
 	async function runStep<T>(
 		name: string,
@@ -66,18 +69,39 @@ function createHelpers(
 		const index = steps.indexOf(name);
 		const declared = index !== -1;
 
+		// A task that declares no steps maps every step it runs onto the whole bar.
+		// A task that declares them and then runs a name absent from the list has a
+		// typo, and its reports are dropped rather than given that whole range:
+		// taking 0–100 for one step would drive the bar to 100 and, by the
+		// monotonic rule, silence every declared step that came after it.
+		const unknown = !declared && steps.length > 0;
+
+		if (unknown) {
+			logger.warn(
+				{ step: name, steps },
+				"dropped the progress of a step the task does not declare",
+			);
+		}
+
 		const sliceStart = declared ? (100 * index) / steps.length : 0;
 		const sliceEnd = declared ? (100 * (index + 1)) / steps.length : 100;
 
 		// The step name and the basis are written before the body runs, matching
 		// Python, and immediately rather than on the debounce: entering a step is
-		// the transition a watching user notices.
+		// the transition a watching user notices. There is no matching write on the
+		// way out — the next step's entry carries the same value, and the last
+		// step's end is what the completion writes. One that fired regardless of
+		// how the step ended would report a step that threw as finished.
 		await writer.setNow({
 			step: name,
 			...(declared && { progress: roundHalfToEven(sliceStart) }),
 		});
 
 		function report(frac: number): void {
+			if (unknown) {
+				return;
+			}
+
 			const clamped = Math.min(Math.max(frac, 0), 1);
 
 			writer.set({
@@ -87,17 +111,42 @@ function createHelpers(
 			});
 		}
 
-		try {
-			return await fn(report);
-		} finally {
-			if (declared) {
-				// So a step that reported nothing still advances the bar.
-				await writer.setNow({ progress: roundHalfToEven(sliceEnd) });
-			}
-		}
+		return await fn(report);
 	}
 
 	return { runStep };
+}
+
+/** The `task_id` and `type` every log record from a run carries. */
+type TaskFields = { task_id: number; type: string };
+
+/**
+ * Perform a terminal write and map it onto an outcome.
+ *
+ * A write that matches nothing is a fence — the lease expired and another
+ * runner owns the task. A write that *rejects* is neither: the row still
+ * carries this runner's claim and is not complete, so the outcome is `aborted`
+ * and the caller releases it for another runner to redo, which every body is
+ * required to be idempotent for. Letting the rejection escape instead would
+ * break the promise that a run always reports how it ended, and would leave the
+ * claim standing until its lease ran out.
+ */
+async function recordTerminal(
+	write: () => Promise<boolean>,
+	outcome: TaskOutcome,
+	logger: Logger,
+	fields: TaskFields,
+): Promise<TaskOutcome> {
+	try {
+		return (await write()) ? outcome : { status: "fenced" };
+	} catch (err) {
+		logger.error(
+			{ err, ...fields },
+			"failed to record a task's terminal state",
+		);
+
+		return { status: "aborted" };
+	}
 }
 
 /** Run `def.cleanup`, swallowing anything it throws. */
@@ -138,9 +187,10 @@ async function runCleanup<C>(
  * path looks exactly like success to a naive `catch`-only implementation, and
  * skips the cleanup silently.
  *
- * It runs nothing after a fence. A `false` from a guarded write means the lease
- * expired and another runner now owns the task and is re-running it; a cleanup
- * here would be tearing down the new owner's work.
+ * It runs nothing after a fence. A lease that expired means another runner owns
+ * the task and is re-running it, and a cleanup here would be tearing down the
+ * new owner's work — so the claim is renewed and checked before the cleanup
+ * rather than inferred from whatever write happened to be outstanding.
  *
  * This function does not release, retry or reschedule. It writes progress and a
  * terminal status, and returns — what to do with an `aborted` or `fenced`
@@ -151,11 +201,21 @@ export async function runTask<C>(
 ): Promise<TaskOutcome> {
 	const { ctx, db, def, logger, signal, task } = options;
 
+	const fields: TaskFields = { task_id: task.id, type: def.type };
+
+	if (signal.aborted) {
+		// The claim and this dispatch are not one operation, so a SIGTERM can land
+		// between them. A body started here would run a whole step through the
+		// drain and be killed mid-write with nothing recorded.
+		return { status: "aborted" };
+	}
+
 	const writer = createProgressWriter({
 		db,
 		taskId: task.id,
 		runnerId: task.runnerId,
 		logger,
+		progress: task.progress,
 		...(options.debounceMs !== undefined && { debounceMs: options.debounceMs }),
 	});
 
@@ -167,18 +227,21 @@ export async function runTask<C>(
 			.join("; ")}`;
 
 		logger.error(
-			{ task_id: task.id, type: def.type, message },
+			{ ...fields, message },
 			"task payload did not match its schema",
 		);
 
-		const held = await failTask(db, task.id, task.runnerId, message);
-
-		return held ? { status: "failed", error: message } : { status: "fenced" };
+		return recordTerminal(
+			() => failTask(db, task.id, task.runnerId, message),
+			{ status: "failed", error: message },
+			logger,
+			fields,
+		);
 	}
 
 	const args: TaskHandlerArgs<unknown, C> = {
 		ctx,
-		helpers: createHelpers(def.steps ?? [], writer),
+		helpers: createHelpers(def.steps ?? [], writer, logger),
 		logger,
 		payload: parsed.data,
 		signal,
@@ -195,34 +258,67 @@ export async function runTask<C>(
 		threw = true;
 	}
 
+	// Sampled before the flush, which is a round trip. An abort arriving inside it
+	// would otherwise turn a run that finished into an abort, tearing down work
+	// that succeeded and leaving the task to be done again.
+	const aborted = signal.aborted;
+
 	await writer.flush();
 
 	if (writer.isFenced()) {
-		logger.warn(
-			{ task_id: task.id, type: def.type },
-			"abandoned a task reclaimed by another runner",
-		);
+		logger.warn(fields, "abandoned a task reclaimed by another runner");
 
 		return { status: "fenced" };
 	}
 
-	if (!threw && !signal.aborted) {
-		const held = await completeTask(db, task.id, task.runnerId);
+	if (!threw && !aborted) {
+		return recordTerminal(
+			() => completeTask(db, task.id, task.runnerId),
+			{ status: "completed" },
+			logger,
+			fields,
+		);
+	}
 
-		return held ? { status: "completed" } : { status: "fenced" };
+	// The writer's fence flag only flips when a progress write happened to be
+	// outstanding, so a body that reported nothing since its last flush arrives
+	// here still believing it holds the task. Renewing the lease answers that
+	// directly, and holds the claim for however long the cleanup takes.
+	let held: boolean;
+
+	try {
+		held = (await renewLeases(db, [task.id], task.runnerId)).length > 0;
+	} catch (err) {
+		// A claim that cannot be vouched for does not get a cleanup: tearing down a
+		// task another runner has taken over is worse than leaving a half-built one
+		// behind. The row still carries this claim, so the caller releases it.
+		logger.error(
+			{ err, ...fields },
+			"could not confirm this runner still holds the task",
+		);
+
+		return { status: "aborted" };
+	}
+
+	if (!held) {
+		logger.warn(fields, "abandoned a task reclaimed by another runner");
+
+		return { status: "fenced" };
 	}
 
 	await runCleanup(def, args, logger);
 
-	if (signal.aborted) {
+	// A cleanup reports progress like any other step, and the debounce timer is
+	// `.unref()`'d — without this its write lands after the terminal one, where it
+	// matches nothing and reports a fence that never happened.
+	await writer.flush();
+
+	if (aborted) {
 		// Abort wins over a throw. A body interrupted mid-shutdown usually throws
 		// on its way out, and recording that as a permanent failure would burn a
 		// task whose only problem was the pod going away.
 		if (threw) {
-			logger.debug(
-				{ err: failure, task_id: task.id, type: def.type },
-				"task threw while aborting",
-			);
+			logger.debug({ err: failure, ...fields }, "task threw while aborting");
 		}
 
 		return { status: "aborted" };
@@ -230,12 +326,12 @@ export async function runTask<C>(
 
 	const message = describeError(failure);
 
-	logger.error(
-		{ err: failure, task_id: task.id, type: def.type },
-		"task failed",
+	logger.error({ err: failure, ...fields }, "task failed");
+
+	return recordTerminal(
+		() => failTask(db, task.id, task.runnerId, message),
+		{ status: "failed", error: message },
+		logger,
+		fields,
 	);
-
-	const held = await failTask(db, task.id, task.runnerId, message);
-
-	return held ? { status: "failed", error: message } : { status: "fenced" };
 }

--- a/apps/tasks/src/framework/run.ts
+++ b/apps/tasks/src/framework/run.ts
@@ -1,0 +1,241 @@
+import type { Db } from "@virtool/data/db/pg";
+import {
+	type ClaimedTask,
+	completeTask,
+	failTask,
+} from "@virtool/data/tasks/data";
+import type { Logger } from "@virtool/logger";
+import type {
+	RegisteredTask,
+	StepProgressReporter,
+	TaskHandlerArgs,
+	TaskHelpers,
+} from "./define";
+import {
+	createProgressWriter,
+	type ProgressWriter,
+	roundHalfToEven,
+} from "./progress";
+
+/**
+ * How a run ended.
+ *
+ * `fenced` is not a failure of this runner's: the lease expired, another runner
+ * has the task and is running it again from step zero. Nothing further may be
+ * written or emitted for it. `aborted` is a shutdown — the row is left exactly
+ * as it stands, for the caller to release.
+ */
+export type TaskOutcome =
+	| { status: "completed" }
+	| { status: "failed"; error: string }
+	| { status: "aborted" }
+	| { status: "fenced" };
+
+/** What {@link runTask} needs to dispatch one claimed task. */
+export type RunTaskOptions<C> = {
+	db: Db;
+	def: RegisteredTask<C>;
+	task: ClaimedTask;
+	ctx: C;
+	logger: Logger;
+	signal: AbortSignal;
+	/** Overrides the progress debounce window. For tests. */
+	debounceMs?: number;
+};
+
+/**
+ * Render an error for the `error` column.
+ *
+ * Python writes `f"{type(e)}: {e!s}"`, which puts `"<class 'ValueError'>: boom"`
+ * in front of a user. The name alone is what anyone reading the task list
+ * actually wants.
+ */
+function describeError(err: unknown): string {
+	return err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+}
+
+/** Build the `runStep` a handler scales its progress through. */
+function createHelpers(
+	steps: readonly string[],
+	writer: ProgressWriter,
+): TaskHelpers {
+	async function runStep<T>(
+		name: string,
+		fn: (report: StepProgressReporter) => Promise<T>,
+	): Promise<T> {
+		const index = steps.indexOf(name);
+		const declared = index !== -1;
+
+		const sliceStart = declared ? (100 * index) / steps.length : 0;
+		const sliceEnd = declared ? (100 * (index + 1)) / steps.length : 100;
+
+		// The step name and the basis are written before the body runs, matching
+		// Python, and immediately rather than on the debounce: entering a step is
+		// the transition a watching user notices.
+		await writer.setNow({
+			step: name,
+			...(declared && { progress: roundHalfToEven(sliceStart) }),
+		});
+
+		function report(frac: number): void {
+			const clamped = Math.min(Math.max(frac, 0), 1);
+
+			writer.set({
+				progress: roundHalfToEven(
+					sliceStart + clamped * (sliceEnd - sliceStart),
+				),
+			});
+		}
+
+		try {
+			return await fn(report);
+		} finally {
+			if (declared) {
+				// So a step that reported nothing still advances the bar.
+				await writer.setNow({ progress: roundHalfToEven(sliceEnd) });
+			}
+		}
+	}
+
+	return { runStep };
+}
+
+/** Run `def.cleanup`, swallowing anything it throws. */
+async function runCleanup<C>(
+	def: RegisteredTask<C>,
+	args: TaskHandlerArgs<unknown, C>,
+	logger: Logger,
+): Promise<void> {
+	if (def.cleanup === undefined) {
+		return;
+	}
+
+	try {
+		await def.cleanup(args);
+	} catch (err) {
+		// Never rethrown: the failure that provoked the cleanup is the one worth
+		// recording, and losing it to a secondary error in the handler that was
+		// meant to tidy up after it is how the original cause disappears.
+		logger.error(
+			{ err, task_id: args.taskId, type: def.type },
+			"task cleanup failed",
+		);
+	}
+}
+
+/**
+ * Dispatch one claimed task and report how it ended.
+ *
+ * The whole terminal contract lives here. A handler that returns while the
+ * signal is clear completes the task; one that throws fails it, with
+ * `${err.name}: ${err.message}` on the row. A payload the schema rejects fails
+ * it before any handler code runs. Progress is flushed before either terminal
+ * write, so a bar can never be stranded at the value a pending debounce was
+ * holding.
+ *
+ * `cleanup` runs on every outcome but success — including the one that is easy
+ * to miss, where a handler notices `signal.aborted` and returns *cleanly*. That
+ * path looks exactly like success to a naive `catch`-only implementation, and
+ * skips the cleanup silently.
+ *
+ * It runs nothing after a fence. A `false` from a guarded write means the lease
+ * expired and another runner now owns the task and is re-running it; a cleanup
+ * here would be tearing down the new owner's work.
+ *
+ * This function does not release, retry or reschedule. It writes progress and a
+ * terminal status, and returns — what to do with an `aborted` or `fenced`
+ * outcome is the runner's.
+ */
+export async function runTask<C>(
+	options: RunTaskOptions<C>,
+): Promise<TaskOutcome> {
+	const { ctx, db, def, logger, signal, task } = options;
+
+	const writer = createProgressWriter({
+		db,
+		taskId: task.id,
+		runnerId: task.runnerId,
+		logger,
+		...(options.debounceMs !== undefined && { debounceMs: options.debounceMs }),
+	});
+
+	const parsed = def.payload.safeParse(task.context);
+
+	if (!parsed.success) {
+		const message = `Invalid payload: ${parsed.error.issues
+			.map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+			.join("; ")}`;
+
+		logger.error(
+			{ task_id: task.id, type: def.type, message },
+			"task payload did not match its schema",
+		);
+
+		const held = await failTask(db, task.id, task.runnerId, message);
+
+		return held ? { status: "failed", error: message } : { status: "fenced" };
+	}
+
+	const args: TaskHandlerArgs<unknown, C> = {
+		ctx,
+		helpers: createHelpers(def.steps ?? [], writer),
+		logger,
+		payload: parsed.data,
+		signal,
+		taskId: task.id,
+	};
+
+	let failure: unknown;
+	let threw = false;
+
+	try {
+		await def.run(args);
+	} catch (err) {
+		failure = err;
+		threw = true;
+	}
+
+	await writer.flush();
+
+	if (writer.isFenced()) {
+		logger.warn(
+			{ task_id: task.id, type: def.type },
+			"abandoned a task reclaimed by another runner",
+		);
+
+		return { status: "fenced" };
+	}
+
+	if (!threw && !signal.aborted) {
+		const held = await completeTask(db, task.id, task.runnerId);
+
+		return held ? { status: "completed" } : { status: "fenced" };
+	}
+
+	await runCleanup(def, args, logger);
+
+	if (signal.aborted) {
+		// Abort wins over a throw. A body interrupted mid-shutdown usually throws
+		// on its way out, and recording that as a permanent failure would burn a
+		// task whose only problem was the pod going away.
+		if (threw) {
+			logger.debug(
+				{ err: failure, task_id: task.id, type: def.type },
+				"task threw while aborting",
+			);
+		}
+
+		return { status: "aborted" };
+	}
+
+	const message = describeError(failure);
+
+	logger.error(
+		{ err: failure, task_id: task.id, type: def.type },
+		"task failed",
+	);
+
+	const held = await failTask(db, task.id, task.runnerId, message);
+
+	return held ? { status: "failed", error: message } : { status: "fenced" };
+}

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -332,7 +332,7 @@ here in its own commit:
   progress seam. Lives in `apps/tasks/src/framework/`: it is an execution shell
   rather than persistence, only this process ever runs a task, and it needs zod,
   which `@virtool/data` does not depend on and should not start to. It
-  publishes **no** frames of its own — see below.
+  publishes **no** frames of its own — see below. Its own section follows.
 - **Claim, lease and reclaim** — `acquireTask`, `renewLeases`, `completeTask`,
   `failTask`, `releaseTask`, `releaseRunnerClaims`, `reclaimExpiredLeases`,
   `updateTaskProgress`. These are pure persistence over a table both halves
@@ -347,6 +347,204 @@ the web app's orchestration layer and stays in `apps/web/src/server/<feature>/`,
 unreachable from here. A body's cross-`data` orchestration goes either into
 `@virtool/data` — when it is persistence plus injected external IO — or into
 the handler module itself. Do not add a `service.ts` under `packages/data/`.
+
+## The framework
+
+Three modules under `apps/tasks/src/framework/`:
+
+| Module | Holds |
+| --- | --- |
+| `define.ts` | `defineTask`, `TaskDef`, `TaskHelpers`, `TaskHandlerArgs`, `RegisteredTask`, `TaskRegistry` |
+| `progress.ts` | `createProgressWriter`, `PROGRESS_DEBOUNCE_MS`, `roundHalfToEven`, `createAccumulator` |
+| `run.ts` | `runTask`, `TaskOutcome` |
+
+A body declares a type, a payload schema and its steps, and gets back a payload
+already parsed, an `AbortSignal`, a `runStep`, the injected context and a
+logger. It never touches the `tasks` table, never emits, and never learns which
+runner is executing it.
+
+`defineTask` is identity at run time. It exists for two things: inferring the
+payload type from the schema so neither `run` nor `cleanup` needs an
+annotation, and **erasing** that payload type on the way out so one
+`TaskRegistry` can hold tasks whose payloads have nothing in common. The
+erasure is the reason there is no `any` in the registry type, and it is sound
+because the only caller of `run` is `runTask`, which parses `payload` first and
+passes what the schema produced. A body that reads `ctx` supplies both type
+arguments: `defineTask<typeof payloadSchema, TaskContext>({ ... })`.
+
+### Steps are equal slices of 0–100
+
+`runStep(name, fn)` looks `name` up in the declared `steps` and gives it an
+equal slice of the bar. Entry writes `step = name` and the slice's basis; exit
+writes the slice's end, so a step that reported nothing still advances. Both
+are written **immediately** rather than on the debounce — entering a step is
+the transition a watching user notices. `report(frac)` clamps `frac` into
+`[0, 1]` and maps it into the slice.
+
+A name that is **not** in `steps` — or a task that declares none — still sets
+the column, and its reports map straight onto 0–100. Nothing is written on
+entry or exit for one, because there is no slice to write.
+
+Rounding is **half-to-even**, matching Python's `round`, not `Math.round`.
+`Math.round(62.5)` is 63 and Python's is 62, and Python still runs tasks until
+the cutover finishes; two runners writing different numbers for the same step
+of the same task type is a difference nobody could explain later.
+
+With four steps, entering the third writes 50, and `report(0.5)` inside it
+writes 62 — arithmetically Python's `basis + progress * (1 / n)`, which is a
+match rather than a divergence.
+
+### Progress writes are debounced, monotonic and serialized
+
+`createProgressWriter` coalesces writes on `PROGRESS_DEBOUNCE_MS` (250). A body
+reporting per HMM profile would otherwise cost one `UPDATE` and one `tasks`
+frame per item, and every frame is a refetch in every connected browser. A
+quarter of a second is below what a bar needs to look continuous.
+
+Three properties it holds:
+
+- **Monotonic.** A value below one already recorded is logged at `debug` and
+  dropped. Python's `TaskProgressHandler.set_progress` **raises** on a
+  decrease, which means a rounding wobble or a retried chunk inside a data
+  function destroys an otherwise-healthy reference import. Progress is
+  cosmetic; it does not get to fail a task.
+- **Serialized.** Each write is chained behind the last, so a flush cannot race
+  a debounced write into landing the older value second.
+- **Fenced for good.** A write that matches nothing means the lease expired and
+  another runner owns the task. The writer stops there — no further write, no
+  further frame, no retry.
+
+A write that throws is logged at `warn` and swallowed for the same reason the
+decrease is: a task that did its work must not fail over a bar that did not
+move. A database that is genuinely gone surfaces on the terminal write, which
+goes through the same pool.
+
+`createAccumulator(total, report)` lets a body count items off instead of
+computing a fraction, and **guards `total <= 0`**. Python's
+`AccumulatingProgressHandlerWrapper` divides blind, so a zero-length download
+raises `ZeroDivisionError` out of a progress helper and fails a task that had
+nothing to do.
+
+### The terminal contract
+
+`runTask` returns a `TaskOutcome` and writes at most one terminal status.
+
+| Outcome | When | Row |
+| --- | --- | --- |
+| `completed` | `run` returned, signal clear | `complete = true`, `progress = 100` |
+| `failed` | `run` threw, or the payload failed its schema | `error` set |
+| `aborted` | the signal aborted, whether `run` threw or returned | untouched — the caller releases |
+| `fenced` | a guarded write matched nothing | untouched — another runner owns it |
+
+Progress is flushed before either terminal write, so a bar can never be
+stranded at the value a pending debounce was holding.
+
+An error is recorded as `` `${err.name}: ${err.message}` `` — `String(err)` for
+a non-`Error`. Python writes `f"{type(e)}: {e!s}"`, which puts
+`"<class 'ValueError'>: boom"` in front of a user; the name alone is what
+anyone reading the task list wants.
+
+A payload the schema rejects fails the task **before any handler code runs**,
+with a message beginning `Invalid payload`. `cleanup` does not run for it —
+nothing ran to clean up, and there is no parsed payload to hand it.
+
+Abort **wins over a throw**. A body interrupted mid-shutdown usually throws on
+its way out, and recording that as a permanent failure would burn a task whose
+only problem was the pod going away.
+
+`runTask` does not release, retry or reschedule. What to do with an `aborted`
+or `fenced` outcome is the runner's.
+
+### `cleanup` runs on every outcome but success
+
+Including the one that is easy to miss: a handler that notices
+`signal.aborted` and returns **cleanly**. That path looks exactly like success
+to a `catch`-only implementation and skips the cleanup silently, which is why
+there is a test for it by name.
+
+It does **not** run after a fence. Another runner owns the task and is
+re-running it from step zero; a cleanup here would be tearing down the new
+owner's work.
+
+A throwing `cleanup` is caught and logged and never rethrown. Losing the
+failure that provoked it to a secondary error in the handler meant to tidy up
+after it is how an original cause disappears.
+
+### A reclaimed task re-runs from step zero
+
+The claim query deliberately dropped Python's `progress = 0` filter, so a task
+whose lease expired starts again from the top with whatever partial work the
+previous attempt left in place. Nothing records which steps already ran.
+
+**Every task body must be idempotent.** `taskId` is on `TaskHandlerArgs`
+precisely so a body can key its own idempotency off it, and a `runStep`
+boundary is the natural place to check whether the work is already done.
+
+### The progress seam into `data.ts`
+
+A data function reports progress through an injected callback and never learns
+that a task exists:
+
+```ts
+export async function populateSomething(
+	db: DbOrTx,
+	values: SomethingValues,
+	onProgress?: (percent: number) => Promise<void>,
+): Promise<void>;
+```
+
+- **Optional and trailing**, and deliberately not universal — several task
+  bodies pass nothing.
+- **Percent (0–100)** at the `data.ts` boundary. `runStep`'s `report` takes a
+  **fraction (0–1)**, because it is scaling into a slice. A body bridges the
+  two explicitly: `async (percent) => report(percent / 100)`.
+- **Called with optional-call syntax at every site**: `await onProgress?.(n)`.
+- `data.ts` never imports the framework, never touches the `tasks` table and
+  never emits.
+
+It composes by rescaling. A caller that does 5% of the work itself before
+handing off maps the child's full range into the band it has left:
+
+```ts
+export async function populateImportedReference(
+	db: DbOrTx,
+	values: ImportValues,
+	onProgress?: (percent: number) => Promise<void>,
+): Promise<void> {
+	await createReferenceRow(db, values);
+	await onProgress?.(5);
+
+	await insertOtus(db, values.otus, async (percent) => {
+		await onProgress?.(5 + percent * 0.95);
+	});
+}
+```
+
+And in the body, where the fraction and the percent meet:
+
+```ts
+await helpers.runStep("import_otus", async (report) => {
+	await populateImportedReference(ctx.db, values, async (percent) => {
+		report(percent / 100);
+	});
+});
+```
+
+### Testing the framework
+
+`apps/tasks`'s own Vitest project, against `createTestDatabase()` from
+`@virtool/data/db/test/fixtures` — a real row, a real claim and a real
+`LISTEN`. Two things are asserted rather than assumed:
+
+- **Intermediate progress values**, not just a terminal `progress = 100`. A
+  body that jumps straight to complete passes a terminal-only assertion.
+- **The frames themselves**, collected off `client_events` with a sentinel
+  frame published last so a count of zero means zero rather than "not yet".
+  A row that changed is not evidence a frame went out.
+
+The debounce is exercised by passing `debounceMs` rather than by faking
+timers: a window long enough never to close proves coalescing, and the flush
+before the terminal write proves the last value still lands.
 
 ## Claiming, leases and fencing
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -355,7 +355,7 @@ Three modules under `apps/tasks/src/framework/`:
 | Module | Holds |
 | --- | --- |
 | `define.ts` | `defineTask`, `TaskDef`, `TaskHelpers`, `TaskHandlerArgs`, `RegisteredTask`, `TaskRegistry` |
-| `progress.ts` | `createProgressWriter`, `PROGRESS_DEBOUNCE_MS`, `roundHalfToEven`, `createAccumulator` |
+| `progress.ts` | `createProgressWriter`, `PROGRESS_DEBOUNCE_MS`, `roundHalfToEven` |
 | `run.ts` | `runTask`, `TaskOutcome` |
 
 A body declares a type, a payload schema and its steps, and gets back a payload
@@ -375,15 +375,27 @@ arguments: `defineTask<typeof payloadSchema, TaskContext>({ ... })`.
 ### Steps are equal slices of 0–100
 
 `runStep(name, fn)` looks `name` up in the declared `steps` and gives it an
-equal slice of the bar. Entry writes `step = name` and the slice's basis; exit
-writes the slice's end, so a step that reported nothing still advances. Both
-are written **immediately** rather than on the debounce — entering a step is
-the transition a watching user notices. `report(frac)` clamps `frac` into
-`[0, 1]` and maps it into the slice.
+equal slice of the bar. Entry writes `step = name` and the slice's basis,
+**immediately** rather than on the debounce — entering a step is the transition
+a watching user notices. `report(frac)` clamps `frac` into `[0, 1]` and maps it
+into the slice.
 
-A name that is **not** in `steps` — or a task that declares none — still sets
-the column, and its reports map straight onto 0–100. Nothing is written on
-entry or exit for one, because there is no slice to write.
+**A step writes nothing on the way out.** The next step's entry writes the same
+value the exit would have, and the last step's end is what the completion
+writes — so an exit write is a second `UPDATE` and a second frame for a number
+already going out, and every frame is a refetch in every connected browser.
+More than cosmetics: an exit write that fired however the step ended would
+report a step that *threw* as finished, leaving a failed task sitting at 75%
+and — on the abort path — releasing the row for another runner with a progress
+value no attempt actually reached.
+
+A task that declares **no** steps maps every step it runs onto the whole 0–100
+bar. A task that declares them and then runs a name absent from the list has a
+typo, and its reports are **dropped**, at `warn`: giving that step the whole
+range would write 100 and, by the monotonic rule, silence every declared step
+that came after it — a bar pinned at 100 for the rest of the run. Nothing ties
+`runStep`'s `name` to `steps` at compile time, so this is the only place the
+mistake surfaces.
 
 Rounding is **half-to-even**, matching Python's `round`, not `Math.round`.
 `Math.round(62.5)` is 63 and Python's is 62, and Python still runs tasks until
@@ -403,11 +415,15 @@ quarter of a second is below what a bar needs to look continuous.
 
 Three properties it holds:
 
-- **Monotonic.** A value below one already recorded is logged at `debug` and
-  dropped. Python's `TaskProgressHandler.set_progress` **raises** on a
-  decrease, which means a rounding wobble or a retried chunk inside a data
-  function destroys an otherwise-healthy reference import. Progress is
-  cosmetic; it does not get to fail a task.
+- **Monotonic, from the value already on the row.** A value below one already
+  recorded is logged at `debug` and dropped. Python's
+  `TaskProgressHandler.set_progress` **raises** on a decrease, which means a
+  rounding wobble or a retried chunk inside a data function destroys an
+  otherwise-healthy reference import. Progress is cosmetic; it does not get to
+  fail a task. The baseline is seeded from `ClaimedTask.progress` rather than
+  from zero — a reclaimed task re-runs from step zero, and a writer starting at
+  0 would send a run resuming at 87% straight back to the beginning of the bar
+  in every connected browser.
 - **Serialized.** Each write is chained behind the last, so a flush cannot race
   a debounced write into landing the older value second.
 - **Fenced for good.** A write that matches nothing means the lease expired and
@@ -419,25 +435,41 @@ decrease is: a task that did its work must not fail over a bar that did not
 move. A database that is genuinely gone surfaces on the terminal write, which
 goes through the same pool.
 
-`createAccumulator(total, report)` lets a body count items off instead of
-computing a fraction, and **guards `total <= 0`**. Python's
-`AccumulatingProgressHandlerWrapper` divides blind, so a zero-length download
-raises `ZeroDivisionError` out of a progress helper and fails a task that had
-nothing to do.
+A body that wants to count items off against a total rather than compute a
+fraction writes that arithmetic itself for now. Whatever ends up sharing it
+must **guard `total <= 0`**: Python's `AccumulatingProgressHandlerWrapper`
+divides blind, so a zero-length download raises `ZeroDivisionError` out of a
+progress helper and fails a task that had nothing to do.
 
 ### The terminal contract
 
-`runTask` returns a `TaskOutcome` and writes at most one terminal status.
+`runTask` returns a `TaskOutcome` and writes at most one terminal status. It
+**always returns one** — a terminal write that rejects is folded into an
+outcome rather than escaping, since a rejection would leave the caller with no
+outcome to act on and the claim standing until its lease ran out.
 
 | Outcome | When | Row |
 | --- | --- | --- |
 | `completed` | `run` returned, signal clear | `complete = true`, `progress = 100` |
 | `failed` | `run` threw, or the payload failed its schema | `error` set |
-| `aborted` | the signal aborted, whether `run` threw or returned | untouched — the caller releases |
-| `fenced` | a guarded write matched nothing | untouched — another runner owns it |
+| `aborted` | the signal aborted, or a terminal write was refused | untouched — the caller releases |
+| `fenced` | a guarded write matched nothing, or the lease was gone | untouched — another runner owns it |
+
+A refused terminal write — a pool timeout, a reset connection — is `aborted`
+because it leaves the row in exactly the state an abort does: this runner's
+claim, not complete. The caller releases it and the task runs again, which
+every body is required to be idempotent for.
 
 Progress is flushed before either terminal write, so a bar can never be
 stranded at the value a pending debounce was holding.
+
+`signal.aborted` is sampled **once**, immediately after `run` returns and
+before that flush. The flush is a round trip; an abort arriving inside it would
+otherwise turn a run that finished into an abort, tear down work that
+succeeded, and leave the task to be done a second time. A signal that is
+already aborted when `runTask` is entered returns `aborted` **without running
+the body at all** — the claim and the dispatch are not one operation, and a
+body started during a drain gets killed mid-write with nothing recorded.
 
 An error is recorded as `` `${err.name}: ${err.message}` `` — `String(err)` for
 a non-`Error`. Python writes `f"{type(e)}: {e!s}"`, which puts
@@ -465,6 +497,22 @@ there is a test for it by name.
 It does **not** run after a fence. Another runner owns the task and is
 re-running it from step zero; a cleanup here would be tearing down the new
 owner's work.
+
+**The claim is renewed and checked immediately before the cleanup**, rather
+than inferred from the progress writer's fence flag. That flag only flips when
+a progress write happened to be outstanding, so a body with coarse steps — or
+one that throws before its next `report` — reaches the cleanup still believing
+it holds a task another runner reclaimed 300 s ago. The renewal answers the
+question directly and holds the claim for however long the cleanup takes. A
+renewal that *rejects* skips the cleanup too and reports `aborted`: tearing
+down a task another runner may have taken over is worse than leaving a
+half-built one behind.
+
+Progress is flushed **again** after the cleanup. A cleanup reports through the
+same writer, and its debounce timer is `.unref()`'d — so without the second
+flush its write either lands after the terminal one, where it matches nothing
+and logs a fence that never happened, or is dropped silently on the way out of
+a shutdown.
 
 A throwing `cleanup` is caught and logged and never rethrown. Losing the
 failure that provoked it to a secondary error in the handler meant to tidy up

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
         specifier: ^4.3.5
         version: 4.4.3
     devDependencies:
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(postgres@3.4.9)
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(oxc-resolver@11.24.2)(tsx@4.23.0)(typescript@7.0.2)


### PR DESCRIPTION
## Summary

- Adds `apps/tasks/src/framework/` — the surface every task body is authored against. `define.ts` carries `defineTask` and the payload/step declaration, `progress.ts` the debounced writer (250 ms, monotonic, serialized, fenced for good on a `false` return) plus the zero-total-guarded accumulator, and `run.ts` the terminal contract as a `completed` / `failed` / `aborted` / `fenced` outcome. Progress is flushed before either terminal write, so a bar cannot be stranded at a pending debounce value. The framework calls `emit` nowhere — every `tasks` frame comes from `@virtool/data`'s task functions — but it owns the cadence, and the tests assert the frames off `client_events` rather than assuming a changed row produced one.
- Three decisions worth review. Rounding is **half-to-even** to match Python's `round`, not `Math.round` — the two disagree on every exact half, and Python still runs tasks until the cutover finishes. `defineTask` **erases** its payload type on the way out so one `TaskRegistry` can hold unlike tasks without an `any` the linter would reject. And `aborted` and `fenced` write no terminal status: an abort leaves the row for the runner to release, and a fence means another runner owns the task and is re-running it, so `cleanup` deliberately does not fire there.
- **No production effect until the runner cutover.** This is the source half of D16; Python is the runner until then, so nothing here debounces a write anyone sees yet. The half that helps immediately is the client-side batching queue, which is a separate issue.