### PR TITLE
chore: add task and queue metric series for the spawner and runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -944,6 +944,26 @@ reports zero rather than its last backlog. The workflow list is
 `JobWorkflow.options` from `@virtool/contracts` — the one definition;
 don't mint a second.
 
+**Task and queue visibility is `apps/tasks`'s.**
+`virtool_task_spawn_total{type,outcome}`,
+`virtool_task_runs_total{type,outcome}`,
+`virtool_task_duration_seconds{type}`, `virtool_tasks{type,state}` and
+`virtool_tasks_oldest_queued_age_seconds{type}` live on that process's
+registry. Five rules hold them: `type` is bounded by `TaskName` from
+`@virtool/contracts` with an unrecognised value folded into `other`
+(`tasks.type` is plain `text`, so nothing narrows the column itself);
+the histogram's buckets are **task-sized**, 1 s to 2 h, because
+`virtool_http_*`'s top out at 10 s and would put every bioinformatics
+task in `+Inf`; `outcome` labels the counters and never the histogram;
+the **spawn** counter is pre-declared over its whole cross product so
+`skipped_locked` at zero can be told from a counter that was never
+wired, while the run counter is observed-only; and the queue gauges are
+built only when `spawnEnabled`, so N runner replicas don't each scan the
+same table. The queue read reproduces Python's `get_counts` predicate
+term for term — `complete = false AND error IS NULL`, split on
+`acquired_at` — which is what makes the cutover comparison
+apples-to-apples. Don't change it.
+
 `server/metrics/registry.ts` owns the one process-wide `Registry`.
 Default process metrics keep prom-client's standard unprefixed names
 (`process_*`, `nodejs_*`) so off-the-shelf dashboards match; everything
@@ -1053,10 +1073,17 @@ four rules hold them:
   returned `false`. Those three take `Db` rather than `DbOrTx` so a
   frame cannot precede the commit of the row it describes.
 
+The spawn and claim loops report through the `virtool_task_*` and
+`virtool_tasks*` series described under **Metrics** above. `recordSpawn`
+and `recordRun` are the only way a loop writes one — never register a
+metric from a loop, and never read `tasks` from a scrape by any route
+but `readTaskQueueBounded`, whose predicate is Python's.
+
 See [docs/tasks.md](docs/tasks.md) for the full config table, the
 `AppContext` contract, the shutdown ordering and its guarantees, the
-probe and metrics surface, and the lease, fencing and frame rules in
-full.
+probe and metrics surface including the five task series and their
+bucket, label and folding rules, and the lease, fencing and frame rules
+in full.
 
 ## Data
 

--- a/apps/tasks/src/bootstrap.ts
+++ b/apps/tasks/src/bootstrap.ts
@@ -13,6 +13,7 @@ import { createShutdownController } from "@virtool/service/shutdown";
 import { createStorageBackend, type StorageBackend } from "@virtool/storage";
 import { parseTasksConfig, type TasksConfig } from "./config";
 import { initSentry, SERVICE } from "./instrument";
+import { createTaskQueueReader } from "./metrics/queue";
 import { createMetrics } from "./metrics/registry";
 import { createProbeServer } from "./probes";
 
@@ -136,6 +137,11 @@ export async function bootstrap(
 		logger,
 		metrics: createMetrics(options.version),
 		metricsToken: config.metricsToken,
+		// The queue gauges are the spawner half's. A claim-only deployment leaves
+		// this unset and its scrapes touch the database not at all — which is what
+		// keeps N runner replicas from each scanning the same table to publish N
+		// copies of one queue depth.
+		readTaskQueue: config.spawnEnabled ? createTaskQueueReader(db) : undefined,
 		isReady: () => ready,
 	});
 

--- a/apps/tasks/src/metrics/handler.ts
+++ b/apps/tasks/src/metrics/handler.ts
@@ -1,10 +1,21 @@
 import { isBearerTokenValid } from "@virtool/contracts/bearer";
+import type { Logger } from "@virtool/logger";
 import type { ProbeResponse } from "../probes";
+import type { TaskQueueReader } from "./queue";
 import type { Metrics } from "./registry";
 
 /** What {@link handleMetrics} needs to answer a scrape. */
 export type MetricsDeps = {
 	metrics: Metrics;
+	logger: Logger;
+	/**
+	 * Refreshes the queue gauges, or absent when this process is not spawning.
+	 *
+	 * The queue series belong to the spawner half. Every replica carries a
+	 * runner, so a reader wired unconditionally would have N replicas each
+	 * scanning the same table on every scrape to publish N copies of one number.
+	 */
+	readTaskQueue: TaskQueueReader | undefined;
 	/** The request's `Authorization` header, verbatim. */
 	authorization: string | undefined;
 	token: string | undefined;
@@ -42,6 +53,21 @@ export async function handleMetrics(deps: MetricsDeps): Promise<ProbeResponse> {
 			body: "Unauthorized",
 			headers: { "www-authenticate": "Bearer" },
 		};
+	}
+
+	if (deps.readTaskQueue) {
+		try {
+			deps.metrics.setTaskQueue(await deps.readTaskQueue());
+		} catch (err) {
+			// A Postgres outage is exactly when the rest of these metrics matter
+			// most, so a failed or slow read drops only the gauges it feeds rather
+			// than failing the scrape. They are dropped rather than left to go
+			// stale: a queue depth is only meaningful as of a moment, and re-serving
+			// the last one would have Prometheus record it as fresh on every scrape
+			// of the outage.
+			deps.metrics.clearTaskQueue();
+			deps.logger.warn({ err }, "could not read task queue counts");
+		}
 	}
 
 	return {

--- a/apps/tasks/src/metrics/queue.test.ts
+++ b/apps/tasks/src/metrics/queue.test.ts
@@ -1,0 +1,105 @@
+import type { Db } from "@virtool/data/db/pg";
+import { tasks } from "@virtool/data/db/schema/tasks";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createTaskQueueReader } from "./queue";
+
+let database: TestDatabase;
+let db: Db;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(tasks);
+});
+
+async function seedQueuedTask(type: string, ageSeconds = 0): Promise<void> {
+	await db.insert(tasks).values({
+		complete: false,
+		context: {},
+		count: 0,
+		created_at: new Date(Date.now() - ageSeconds * 1000),
+		progress: 0,
+		step: type,
+		type,
+	});
+}
+
+describe("createTaskQueueReader", () => {
+	it("reads counts and ages together", async () => {
+		await seedQueuedTask("install_hmms", 300);
+
+		const snapshot = await createTaskQueueReader(db)();
+
+		expect(snapshot.counts).toEqual([
+			{ type: "install_hmms", queued: 1, running: 0 },
+		]);
+		expect(snapshot.oldestQueuedAges).toHaveLength(1);
+		expect(snapshot.oldestQueuedAges[0]?.ageSeconds).toBeGreaterThanOrEqual(
+			300,
+		);
+	});
+
+	// Two Prometheus replicas, or a human curling in a loop, would otherwise
+	// multiply the scan across the pool this process claims tasks over.
+	it("does not re-query inside its TTL", async () => {
+		await seedQueuedTask("install_hmms");
+
+		let clock = 0;
+		const read = createTaskQueueReader(db, { ttlMs: 10_000, now: () => clock });
+
+		expect(await read()).toEqual(await read());
+
+		await seedQueuedTask("install_hmms");
+		clock = 9_999;
+
+		expect((await read()).counts).toEqual([
+			{ type: "install_hmms", queued: 1, running: 0 },
+		]);
+
+		clock = 10_000;
+
+		expect((await read()).counts).toEqual([
+			{ type: "install_hmms", queued: 2, running: 0 },
+		]);
+	});
+
+	// A cache keyed only on the last settled result would let two scrapes
+	// arriving together each open their own query.
+	it("shares an in-flight read between concurrent callers", async () => {
+		await seedQueuedTask("install_hmms");
+
+		const read = createTaskQueueReader(db);
+		const [first, second] = await Promise.all([read(), read()]);
+
+		expect(first).toBe(second);
+	});
+
+	// Holding a failure for the full TTL would keep these series dark for ten
+	// seconds past a blip that lasted one.
+	it("does not cache a failed read", async () => {
+		const broken = new Proxy(
+			{},
+			{
+				get() {
+					throw new Error("postgres is down");
+				},
+			},
+		) as Db;
+
+		const read = createTaskQueueReader(broken);
+
+		await expect(read()).rejects.toThrow("postgres is down");
+		await expect(read()).rejects.toThrow("postgres is down");
+	});
+});

--- a/apps/tasks/src/metrics/queue.ts
+++ b/apps/tasks/src/metrics/queue.ts
@@ -1,0 +1,65 @@
+import type { Db } from "@virtool/data/db/pg";
+import {
+	readTaskQueueBounded,
+	type TaskQueueSnapshot,
+} from "@virtool/data/tasks/data";
+
+/**
+ * How long a task-queue read is reused before another scrape re-queries.
+ *
+ * Well under a typical 15–60 s scrape interval, so a scrape still sees a fresh
+ * queue. The point is the other direction: two Prometheus replicas, or a human
+ * curling the endpoint in a loop, would otherwise multiply the scan across the
+ * very pool this process claims and heartbeats tasks over.
+ */
+export const TASK_QUEUE_TTL_MS = 10_000;
+
+/** A task-queue read, memoized. */
+export type TaskQueueReader = () => Promise<TaskQueueSnapshot>;
+
+/** Test seams for {@link createTaskQueueReader}. */
+type TaskQueueReaderOptions = {
+	ttlMs?: number;
+	now?: () => number;
+};
+
+/**
+ * Build the memoized task-queue read a `/metrics` scrape calls.
+ *
+ * A factory rather than module state, so a test gets its own memo and cannot
+ * see what another suite left behind — the same rule `createMetrics` follows.
+ *
+ * In-flight reads are shared, not just settled ones: two scrapes arriving
+ * together should cost one query, which a cache keyed only on the last result
+ * would not give.
+ *
+ * A rejection is **not** cached. The read is bounded already, and holding a
+ * failure for the full TTL would keep these series dark for ten seconds past a
+ * blip that lasted one.
+ */
+export function createTaskQueueReader(
+	db: Db,
+	{ ttlMs = TASK_QUEUE_TTL_MS, now = Date.now }: TaskQueueReaderOptions = {},
+): TaskQueueReader {
+	let pending: Promise<TaskQueueSnapshot> | undefined;
+	let cached: { snapshot: TaskQueueSnapshot; readAt: number } | undefined;
+
+	return function readTaskQueue() {
+		if (cached && now() - cached.readAt < ttlMs) {
+			return Promise.resolve(cached.snapshot);
+		}
+
+		if (!pending) {
+			pending = readTaskQueueBounded(db)
+				.then((snapshot) => {
+					cached = { snapshot, readAt: now() };
+					return snapshot;
+				})
+				.finally(() => {
+					pending = undefined;
+				});
+		}
+
+		return pending;
+	};
+}

--- a/apps/tasks/src/metrics/registry.test.ts
+++ b/apps/tasks/src/metrics/registry.test.ts
@@ -1,0 +1,320 @@
+import { PeriodicTaskName, TaskName } from "@virtool/contracts";
+import type { TaskQueueSnapshot } from "@virtool/data/tasks/data";
+import { describe, expect, it } from "vitest";
+import { createMetrics, type Metrics } from "./registry";
+
+const VERSION = "1.2.3";
+
+function build(): Metrics {
+	return createMetrics(VERSION);
+}
+
+/** Every sample line for `name`, in render order. */
+async function lines(metrics: Metrics, name: string): Promise<string[]> {
+	return (await metrics.render())
+		.split("\n")
+		.filter((line) => line.startsWith(name) && !line.startsWith(`${name}_`));
+}
+
+/** The value of the one sample matching `selector`, or `undefined`. */
+async function sample(
+	metrics: Metrics,
+	selector: string,
+): Promise<number | undefined> {
+	const line = (await metrics.render())
+		.split("\n")
+		.find((candidate) => candidate.startsWith(selector));
+
+	return line ? Number(line.slice(line.lastIndexOf(" ") + 1)) : undefined;
+}
+
+const EMPTY_QUEUE: TaskQueueSnapshot = { counts: [], oldestQueuedAges: [] };
+
+describe("createMetrics", () => {
+	it("gives each caller its own registry", async () => {
+		const first = build();
+		const second = build();
+
+		first.recordRun({
+			type: "install_hmms",
+			outcome: "succeeded",
+			durationSeconds: 1,
+		});
+
+		expect(await lines(second, "virtool_task_runs_total")).toEqual([]);
+	});
+
+	it("registers the default process metrics unprefixed", async () => {
+		const rendered = await build().render();
+
+		expect(rendered).toContain("process_cpu_seconds_total");
+		expect(rendered).toContain("nodejs_eventloop_lag_seconds");
+	});
+
+	it("pins virtool_app_info at 1 with the version", async () => {
+		expect(
+			await sample(build(), `virtool_app_info{version="${VERSION}"}`),
+		).toBe(1);
+	});
+
+	it("registers no virtool_http_ series", async () => {
+		expect(await build().render()).not.toContain("virtool_http_");
+	});
+});
+
+describe("recordSpawn", () => {
+	it("pre-declares every schedule and outcome at zero", async () => {
+		const metrics = build();
+
+		expect(await lines(metrics, "virtool_task_spawn_total")).toHaveLength(
+			PeriodicTaskName.options.length * 3,
+		);
+
+		// The evidence VIR-2888 gates on is `skipped_locked` being *visible*, so
+		// that "the lock was never contended" can be told from "the counter was
+		// never wired up".
+		expect(
+			await sample(
+				metrics,
+				'virtool_task_spawn_total{type="sweep_blast",outcome="skipped_locked"}',
+			),
+		).toBe(0);
+	});
+
+	it("counts an outcome against its task type", async () => {
+		const metrics = build();
+
+		metrics.recordSpawn("refresh_hmms", "spawned");
+		metrics.recordSpawn("refresh_hmms", "not_due");
+		metrics.recordSpawn("refresh_hmms", "not_due");
+
+		expect(
+			await sample(
+				metrics,
+				'virtool_task_spawn_total{type="refresh_hmms",outcome="spawned"}',
+			),
+		).toBe(1);
+		expect(
+			await sample(
+				metrics,
+				'virtool_task_spawn_total{type="refresh_hmms",outcome="not_due"}',
+			),
+		).toBe(2);
+	});
+});
+
+describe("recordRun", () => {
+	it("counts the outcome and observes the duration", async () => {
+		const metrics = build();
+
+		metrics.recordRun({
+			type: "create_index",
+			outcome: "failed",
+			durationSeconds: 42,
+		});
+
+		expect(
+			await sample(
+				metrics,
+				'virtool_task_runs_total{type="create_index",outcome="failed"}',
+			),
+		).toBe(1);
+		expect(
+			await sample(
+				metrics,
+				'virtool_task_duration_seconds_count{type="create_index"}',
+			),
+		).toBe(1);
+		expect(
+			await sample(
+				metrics,
+				'virtool_task_duration_seconds_sum{type="create_index"}',
+			),
+		).toBe(42);
+	});
+
+	it("does not split the histogram by outcome", async () => {
+		const metrics = build();
+
+		metrics.recordRun({
+			type: "create_index",
+			outcome: "failed",
+			durationSeconds: 1,
+		});
+
+		expect(await build().render()).not.toContain(
+			"virtool_task_duration_seconds_bucket{outcome",
+		);
+		expect(
+			await sample(
+				metrics,
+				'virtool_task_duration_seconds_count{type="create_index"}',
+			),
+		).toBe(1);
+	});
+
+	// Request-sized buckets top out at 10 s, which would put a reference import
+	// and a two-hour index build in the same `+Inf` bucket and leave the
+	// histogram unable to express any quantile above the median.
+	it("has buckets a long task can land in", async () => {
+		const metrics = build();
+
+		metrics.recordRun({
+			type: "import_reference",
+			outcome: "succeeded",
+			durationSeconds: 900,
+		});
+
+		expect(
+			await sample(
+				metrics,
+				'virtool_task_duration_seconds_bucket{le="600",type="import_reference"}',
+			),
+		).toBe(0);
+		expect(
+			await sample(
+				metrics,
+				'virtool_task_duration_seconds_bucket{le="1800",type="import_reference"}',
+			),
+		).toBe(1);
+	});
+
+	it("folds a type the union does not name onto other", async () => {
+		const metrics = build();
+
+		metrics.recordRun({
+			type: "a_python_task",
+			outcome: "succeeded",
+			durationSeconds: 1,
+		});
+
+		expect(
+			await sample(
+				metrics,
+				'virtool_task_runs_total{type="other",outcome="succeeded"}',
+			),
+		).toBe(1);
+		expect(await metrics.render()).not.toContain("a_python_task");
+	});
+});
+
+describe("setTaskQueue", () => {
+	it("reports queued and running separately", async () => {
+		const metrics = build();
+
+		metrics.setTaskQueue({
+			counts: [{ type: "install_hmms", queued: 3, running: 1 }],
+			oldestQueuedAges: [{ type: "install_hmms", ageSeconds: 90 }],
+		});
+
+		expect(
+			await sample(
+				metrics,
+				'virtool_tasks{type="install_hmms",state="queued"}',
+			),
+		).toBe(3);
+		expect(
+			await sample(
+				metrics,
+				'virtool_tasks{type="install_hmms",state="running"}',
+			),
+		).toBe(1);
+		expect(
+			await sample(
+				metrics,
+				'virtool_tasks_oldest_queued_age_seconds{type="install_hmms"}',
+			),
+		).toBe(90);
+	});
+
+	it("writes the whole cross product, so a drained queue reports zero", async () => {
+		const metrics = build();
+
+		metrics.setTaskQueue({
+			counts: [{ type: "install_hmms", queued: 3, running: 0 }],
+			oldestQueuedAges: [{ type: "install_hmms", ageSeconds: 90 }],
+		});
+
+		metrics.setTaskQueue(EMPTY_QUEUE);
+
+		expect(
+			await sample(
+				metrics,
+				'virtool_tasks{type="install_hmms",state="queued"}',
+			),
+		).toBe(0);
+		expect(
+			await sample(
+				metrics,
+				'virtool_tasks_oldest_queued_age_seconds{type="install_hmms"}',
+			),
+		).toBe(0);
+		expect(await lines(metrics, "virtool_tasks{")).toHaveLength(
+			(TaskName.options.length + 1) * 2,
+		);
+	});
+
+	it("adds counts folded onto other rather than overwriting", async () => {
+		const metrics = build();
+
+		metrics.setTaskQueue({
+			counts: [
+				{ type: "a_python_task", queued: 2, running: 1 },
+				{ type: "another_python_task", queued: 3, running: 0 },
+			],
+			oldestQueuedAges: [],
+		});
+
+		expect(
+			await sample(metrics, 'virtool_tasks{type="other",state="queued"}'),
+		).toBe(5);
+		expect(
+			await sample(metrics, 'virtool_tasks{type="other",state="running"}'),
+		).toBe(1);
+	});
+
+	it("takes the oldest age of what folds onto other", async () => {
+		const metrics = build();
+
+		metrics.setTaskQueue({
+			counts: [],
+			oldestQueuedAges: [
+				{ type: "a_python_task", ageSeconds: 30 },
+				{ type: "another_python_task", ageSeconds: 900 },
+			],
+		});
+
+		expect(
+			await sample(
+				metrics,
+				'virtool_tasks_oldest_queued_age_seconds{type="other"}',
+			),
+		).toBe(900);
+	});
+});
+
+describe("clearTaskQueue", () => {
+	// Dropped rather than zeroed: an absent series says "unknown", which is true
+	// during a Postgres outage. Zero would assert an empty queue.
+	it("drops the queue series without touching the rest", async () => {
+		const metrics = build();
+
+		metrics.setTaskQueue({
+			counts: [{ type: "install_hmms", queued: 3, running: 1 }],
+			oldestQueuedAges: [{ type: "install_hmms", ageSeconds: 90 }],
+		});
+		metrics.recordRun({
+			type: "install_hmms",
+			outcome: "succeeded",
+			durationSeconds: 1,
+		});
+
+		metrics.clearTaskQueue();
+
+		expect(await lines(metrics, "virtool_tasks{")).toEqual([]);
+		expect(
+			await lines(metrics, "virtool_tasks_oldest_queued_age_seconds{"),
+		).toEqual([]);
+		expect(await lines(metrics, "virtool_task_runs_total")).toHaveLength(1);
+	});
+});

--- a/apps/tasks/src/metrics/registry.ts
+++ b/apps/tasks/src/metrics/registry.ts
@@ -1,13 +1,88 @@
-import { collectDefaultMetrics, Gauge, Registry } from "prom-client";
+import { PeriodicTaskName, TaskName } from "@virtool/contracts";
+import type { TaskQueueSnapshot } from "@virtool/data/tasks/data";
+import {
+	Counter,
+	collectDefaultMetrics,
+	Gauge,
+	Histogram,
+	Registry,
+} from "prom-client";
+
+/**
+ * The label an unrecognised `tasks.type` value is folded into.
+ *
+ * `type` is a plain `text` column with no constraint on either side, so
+ * "bounded by the union" is only true if this side makes it so. A typo, or a
+ * task a future Python release adds, must not mint a series that never retires.
+ */
+const OTHER_TASK = "other";
+
+/**
+ * The task names that keep their own label.
+ *
+ * A row whose type really is the string `other` is an unrecognised task, not a
+ * recognised one, so the set is {@link TaskName} rather than the wider list of
+ * labels this process may emit.
+ */
+const KNOWN_TASKS = new Set<string>(TaskName.options);
+
+/** Every task label this process will ever emit. */
+const TASK_LABELS = [...TaskName.options, OTHER_TASK];
+
+/** The two halves Python's `get_counts` splits the active queue into. */
+const QUEUE_STATES = ["queued", "running"] as const;
+
+/** How a spawn attempt for a periodic task ended. */
+export type SpawnOutcome = "spawned" | "skipped_locked" | "not_due";
+
+/** Every spawn outcome, for pre-declaring the counter's label set. */
+const SPAWN_OUTCOMES: SpawnOutcome[] = ["spawned", "skipped_locked", "not_due"];
+
+/** How a claimed task ended. */
+export type RunOutcome = "succeeded" | "failed";
+
+/**
+ * Bucket boundaries for task duration, in seconds: 1 s to 2 h.
+ *
+ * Deliberately **not** the `virtool_http_*` buckets, which top out at 10 s.
+ * Reference imports and index builds run for minutes, so request-sized buckets
+ * would put nearly every task in `+Inf` and leave the histogram unable to
+ * express any quantile at all. The low end still resolves a sweep that finds
+ * nothing, which is the common case for the 30-second BLAST sweep.
+ */
+const TASK_DURATION_BUCKETS = [
+	1, 5, 15, 30, 60, 120, 300, 600, 1800, 3600, 7200,
+];
+
+/** One finished task run, as the claim loop observed it. */
+export type TaskRunSample = {
+	/**
+	 * The claimed row's `type`, verbatim.
+	 *
+	 * Typed `string` rather than `TaskName` because it comes off an
+	 * unconstrained column; it is folded onto a bounded label here.
+	 */
+	type: string;
+	outcome: RunOutcome;
+	durationSeconds: number;
+};
 
 /** The metrics surface this process exposes, as returned by {@link createMetrics}. */
 export type Metrics = {
+	recordSpawn: (type: PeriodicTaskName, outcome: SpawnOutcome) => void;
+	recordRun: (sample: TaskRunSample) => void;
+	setTaskQueue: (snapshot: TaskQueueSnapshot) => void;
+	clearTaskQueue: () => void;
 	contentType: string;
 	render: () => Promise<string>;
 };
 
+function taskLabel(type: string): string {
+	return KNOWN_TASKS.has(type) ? type : OTHER_TASK;
+}
+
 /**
- * Build this process's Prometheus registry.
+ * Build this process's Prometheus registry and the handles that write to it.
  *
  * A factory rather than a module-scope singleton, so a test gets its own
  * registry and cannot see what another suite happened to register — and so
@@ -19,10 +94,8 @@ export type Metrics = {
  * dashboard works across all three; the processes are told apart by the
  * scrape's target labels, not by renaming a metric.
  *
- * Only the process defaults and `virtool_app_info` are registered. The
- * `virtool_http_*` series are web-specific — their buckets top out at 10 s, and
- * this process serves nothing but probes — and the task and queue series belong
- * to the issues that add the claim and spawn loops.
+ * The `virtool_http_*` series are deliberately absent: they are web-specific,
+ * their buckets top out at 10 s, and this process serves nothing but probes.
  */
 export function createMetrics(version: string): Metrics {
 	const registry = new Registry();
@@ -44,8 +117,133 @@ export function createMetrics(version: string): Metrics {
 		registers: [registry],
 	}).set({ version }, 1);
 
+	const spawns = new Counter({
+		name: "virtool_task_spawn_total",
+		help: "Periodic task spawn attempts, by task type and outcome.",
+		labelNames: ["type", "outcome"],
+		registers: [registry],
+	});
+
+	// Pre-declared over the whole cross product, because a counter's children do
+	// not exist until one is incremented and an absent series cannot be told from
+	// a zero one. Two readings depend on the difference: `rate()` needs a prior
+	// sample to subtract, so an unseeded counter reports nothing until its
+	// *second* increment; and `skipped_locked` staying at zero — the spawner
+	// never losing the advisory lock — has to be visible as zero rather than as
+	// a missing series, since that is the evidence the lock is shared with
+	// Python's spawner rather than being taken uncontested.
+	//
+	// The cross product is bounded and known here in a way the run counter's is
+	// not: the spawn schedule is fixed at build time, while which types a runner
+	// claims is configuration this registry never sees.
+	for (const type of PeriodicTaskName.options) {
+		for (const outcome of SPAWN_OUTCOMES) {
+			spawns.inc({ type, outcome }, 0);
+		}
+	}
+
+	const runs = new Counter({
+		name: "virtool_task_runs_total",
+		help: "Tasks run to completion by this process, by task type and outcome.",
+		labelNames: ["type", "outcome"],
+		registers: [registry],
+	});
+
+	// `outcome` is deliberately absent here. Duration buckets are a property of
+	// the work, not of how it ended, and splitting them would halve the samples
+	// behind every quantile to express a dimension the counter above already
+	// carries.
+	const runDuration = new Histogram({
+		name: "virtool_task_duration_seconds",
+		help: "Time from claim to terminal write for a task run, in seconds.",
+		labelNames: ["type"],
+		buckets: TASK_DURATION_BUCKETS,
+		registers: [registry],
+	});
+
+	// The queue dimension, reported by the spawner half alone — every replica
+	// carries a runner, and N replicas each running this scan against the same
+	// table buys nothing but load. Both labels are bounded by construction.
+	const tasksGauge = new Gauge({
+		name: "virtool_tasks",
+		help: "Active tasks, by type and queue state.",
+		labelNames: ["type", "state"],
+		registers: [registry],
+	});
+
+	const oldestQueuedTaskAge = new Gauge({
+		name: "virtool_tasks_oldest_queued_age_seconds",
+		help: "Age of the oldest task still waiting for a runner, by type.",
+		labelNames: ["type"],
+		registers: [registry],
+	});
+
 	return {
+		recordSpawn(type, outcome) {
+			// No fold: the caller's type is the schedule, which this union is.
+			spawns.inc({ type, outcome });
+		},
+
+		recordRun(sample) {
+			const type = taskLabel(sample.type);
+
+			runs.inc({ type, outcome: sample.outcome });
+			runDuration.observe({ type }, sample.durationSeconds);
+		},
+
+		setTaskQueue(snapshot) {
+			// Write the whole cross product as zero first. A gauge holds its last
+			// value forever, so a type that drains would otherwise report its final
+			// backlog indefinitely — the worst possible failure for an alert on
+			// queue depth.
+			for (const type of TASK_LABELS) {
+				oldestQueuedTaskAge.set({ type }, 0);
+
+				for (const state of QUEUE_STATES) {
+					tasksGauge.set({ type, state }, 0);
+				}
+			}
+
+			// Folding several types onto `other` puts several rows on one label, so
+			// counts add rather than overwrite.
+			for (const row of snapshot.counts) {
+				const type = taskLabel(row.type);
+
+				tasksGauge.inc({ type, state: "queued" }, row.queued);
+				tasksGauge.inc({ type, state: "running" }, row.running);
+			}
+
+			// An age does not add, so a folded label takes the oldest of what falls
+			// into it — which is what "the oldest queued task" means for every other
+			// label too.
+			const oldest = new Map<string, number>();
+
+			for (const row of snapshot.oldestQueuedAges) {
+				const type = taskLabel(row.type);
+
+				oldest.set(type, Math.max(oldest.get(type) ?? 0, row.ageSeconds));
+			}
+
+			for (const [type, ageSeconds] of oldest) {
+				oldestQueuedTaskAge.set({ type }, ageSeconds);
+			}
+		},
+
+		clearTaskQueue() {
+			// Drop the series rather than leaving them standing. A gauge holds its
+			// last value forever, so a refresh that failed would otherwise have every
+			// scrape of the outage record a stale backlog as a *fresh* sample —
+			// hiding a queue that grew behind a flat line, or holding an alert open
+			// for one that drained. An absent series says "unknown", which is the
+			// true answer, and `absent()` can alert on it.
+			//
+			// Zeroing would be worse than either: it asserts an empty queue.
+			tasksGauge.reset();
+			oldestQueuedTaskAge.reset();
+		},
+
 		contentType: registry.contentType,
+
 		render: () => registry.metrics(),
 	};
 }

--- a/apps/tasks/src/probes.test.ts
+++ b/apps/tasks/src/probes.test.ts
@@ -269,6 +269,62 @@ describe("GET /metrics", () => {
 	});
 });
 
+describe("GET /metrics queue gauges", () => {
+	async function scrape(overrides: Partial<ProbeDeps>): Promise<string> {
+		const probe = await serve(overrides);
+
+		try {
+			return await (
+				await probe.get("/metrics", {
+					authorization: `Bearer ${METRICS_TOKEN}`,
+				})
+			).text();
+		} finally {
+			await probe.close();
+		}
+	}
+
+	it("refreshes the queue gauges from the reader", async () => {
+		const body = await scrape({
+			readTaskQueue: async () => ({
+				counts: [{ type: "install_hmms", queued: 4, running: 1 }],
+				oldestQueuedAges: [{ type: "install_hmms", ageSeconds: 120 }],
+			}),
+		});
+
+		expect(body).toContain(
+			'virtool_tasks{type="install_hmms",state="queued"} 4',
+		);
+		expect(body).toContain(
+			'virtool_tasks_oldest_queued_age_seconds{type="install_hmms"} 120',
+		);
+	});
+
+	// The queue gauges are the spawner half's. Every replica carries a runner, so
+	// a reader wired unconditionally would have N replicas each scanning the same
+	// table on every scrape to publish N copies of one number.
+	it("emits no queue series when spawning is disabled", async () => {
+		const body = await scrape({ readTaskQueue: undefined });
+
+		expect(body).not.toContain("virtool_tasks{");
+		expect(body).not.toContain("virtool_tasks_oldest_queued_age_seconds{");
+		expect(body).toContain("process_cpu_seconds_total");
+	});
+
+	// A Postgres outage is when the rest of these metrics matter most, so a
+	// failed read drops only the gauges it feeds. They are dropped rather than
+	// left stale: re-serving the last depth would have Prometheus record it as
+	// fresh on every scrape of the outage.
+	it("drops the queue series and still answers 200 when the read fails", async () => {
+		const body = await scrape({
+			readTaskQueue: () => Promise.reject(new Error("postgres is down")),
+		});
+
+		expect(body).not.toContain("virtool_tasks{");
+		expect(body).toContain("virtool_app_info{");
+	});
+});
+
 describe("anything else", () => {
 	it("answers 404", async () => {
 		const probe = await serve();

--- a/apps/tasks/src/probes.ts
+++ b/apps/tasks/src/probes.ts
@@ -3,6 +3,7 @@ import type { PgClient } from "@virtool/data/db/pg";
 import { checkPostgres, summarizeReadiness } from "@virtool/data/health/data";
 import type { Logger } from "@virtool/logger";
 import { handleMetrics } from "./metrics/handler";
+import type { TaskQueueReader } from "./metrics/queue";
 import type { Metrics } from "./metrics/registry";
 
 /** A response the probe listener writes out verbatim. */
@@ -18,6 +19,8 @@ export type ProbeDeps = {
 	logger: Logger;
 	metrics: Metrics;
 	metricsToken: string | undefined;
+	/** Refreshes the queue gauges on scrape; absent when spawning is disabled. */
+	readTaskQueue?: TaskQueueReader;
 	/** Whether this process is currently accepting work. */
 	isReady: () => boolean;
 };
@@ -97,6 +100,8 @@ async function route(
 	if (path === "/metrics") {
 		return handleMetrics({
 			metrics: deps.metrics,
+			logger: deps.logger,
+			readTaskQueue: deps.readTaskQueue,
 			authorization,
 			token: deps.metricsToken,
 		});

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -173,10 +173,10 @@ difference between a safe rollout and a blind one.
 ### `GET /metrics`
 
 A private `prom-client` `Registry` holding `collectDefaultMetrics` — left
-unprefixed so off-the-shelf Node dashboards match — plus `virtool_app_info`.
-Nothing else yet. The `virtool_http_*` series are web-specific: their buckets
-top out at 10 s, and this process serves nothing but probes. Task and queue
-series belong to the issues that add the loops.
+unprefixed so off-the-shelf Node dashboards match — plus `virtool_app_info` and
+the task series below. The `virtool_http_*` series are deliberately absent:
+they are web-specific, their buckets top out at 10 s, and this process serves
+nothing but probes.
 
 The gate is `isBearerTokenValid` from `@virtool/contracts/bearer`, shared with
 the other two services. It screens the length before `timingSafeEqual`, which
@@ -190,6 +190,92 @@ needs no Service and yields genuine per-pod series, but cannot carry a bearer
 token — under the semantics above that means no metrics at all. If that is the
 route taken, the handler needs a deliberate third state. Do not reach it by
 quietly dropping the gate.
+
+### The task and queue series
+
+Five series beyond the process defaults, built by `createMetrics` in
+`src/metrics/registry.ts`:
+
+| Series | Type | Labels | Written by |
+| --- | --- | --- | --- |
+| `virtool_task_spawn_total` | counter | `type`, `outcome` | the spawn loop, via `recordSpawn` |
+| `virtool_task_runs_total` | counter | `type`, `outcome` | the claim loop, via `recordRun` |
+| `virtool_task_duration_seconds` | histogram | `type` | the claim loop, via `recordRun` |
+| `virtool_tasks` | gauge | `type`, `state` | the scrape, via `setTaskQueue` |
+| `virtool_tasks_oldest_queued_age_seconds` | gauge | `type` | the scrape, via `setTaskQueue` |
+
+`outcome` on the spawn counter is `spawned`, `skipped_locked` or `not_due` —
+the three ways a cycle can end for one scheduled type. On the run counter it is
+`succeeded` or `failed`.
+
+Seven rules hold these together:
+
+- **`type` is bounded here, not by the column.** `tasks.type` is plain `text`
+  with no CHECK constraint on either side, so a row may carry a name from a
+  typo or from a future Python release. `TaskName` (`@virtool/contracts`) is
+  the union of the nine names Virtool runs, and anything outside it folds onto
+  `other` at the moment it becomes a label. Nothing narrows the column itself:
+  a claimed row's `type` stays `string` all the way to `recordRun`.
+- **The spawn counter is pre-declared over its whole cross product; the run
+  counter is not.** A counter's children do not exist until one is incremented,
+  and an absent series cannot be told from a zero one — which matters twice
+  over for `skipped_locked`, since "the advisory lock was never contended" and
+  "the counter was never wired up" must not look alike, and `rate()` needs a
+  prior sample to subtract from. The spawn schedule is fixed at build time
+  (`PeriodicTaskName`) so the cross product is knowable; which types a runner
+  claims is configuration this registry never sees, so the run counter is
+  observed-only.
+- **`outcome` labels the counter and never the histogram.** Duration buckets
+  are a property of the work, not of how it ended, and splitting them would
+  halve the samples behind every quantile to express a dimension the counter
+  already carries.
+- **The buckets are task-sized: 1 s to 2 h.** `virtool_http_*`'s top out at
+  10 s, which would put a reference import and an index build in the same
+  `+Inf` bucket and leave the histogram unable to express a quantile above the
+  median. The low end still resolves a BLAST sweep that finds nothing, which is
+  the common case for the thirty-second schedule.
+- **The queue gauges are the spawner half's.** `bootstrap` builds the reader
+  only when `spawnEnabled`, and the handler skips the refresh when it is
+  absent, so a claim-only deployment's scrapes touch the database not at all.
+  Every replica carries a runner; a reader wired unconditionally would have N
+  replicas each scanning the same table to publish N copies of one number.
+- **The whole `type` × `state` cross product is written as zero on each
+  refresh**, so a type that drains reports zero rather than holding its last
+  backlog forever — the worst possible failure for an alert on queue depth.
+  Counts *add* into a folded label; an age takes the oldest of what falls into
+  it.
+- **A failed refresh drops the queue series rather than zeroing or keeping
+  them.** An absent series says "unknown", which is the true answer during a
+  Postgres outage and which `absent()` can alert on. Leaving them standing
+  would have Prometheus record a stale depth as a fresh sample on every scrape
+  of the outage; zeroing would assert an empty queue. The rest of the scrape is
+  unaffected — a database outage is when the process metrics matter most.
+
+### The queue read is Python's `get_counts`, term for term
+
+`readTaskCounts` and `readOldestQueuedTaskAges` (`@virtool/data/tasks/data`)
+count under `complete = false AND error IS NULL`, splitting on
+`acquired_at IS NULL` for `queued` and `IS NOT NULL` for `running`. That is
+Python's `TasksData.get_counts` exactly, and it is also the predicate of
+Python's `idx_tasks_active` partial index — so the reads are served by it
+rather than scanning a table whose completed rows accumulate without bound.
+Reproducing it is what makes the pre- and post-cutover comparison
+apples-to-apples; changing it silently invalidates that comparison.
+
+Both terms are required, and neither implies the other. A Python failure writes
+`error` and leaves `complete` false, so a row can be failed and incomplete at
+once — which is why `failTask` here sets both.
+
+The `type` breakdown is additional to Python, which reports two scalars.
+Summing over `type` reproduces them exactly, so it costs the comparison
+nothing and is what makes the gauge actionable.
+
+`readTaskQueueBounded` runs both concurrently under one 2-second deadline, for
+the reason every `/metrics` probe carries one: the query runs on the pool this
+process claims and heartbeats over, so a saturated pool queues it *client-side*
+where no statement timeout applies. `createTaskQueueReader`
+(`src/metrics/queue.ts`) memoizes the result for 10 s and shares in-flight
+reads, so two Prometheus replicas cost one query; a rejection is not cached.
 
 ### The version label
 

--- a/packages/contracts/src/tasks.ts
+++ b/packages/contracts/src/tasks.ts
@@ -1,3 +1,47 @@
+import { z } from "zod";
+
+/**
+ * A task the spawner inserts on a schedule.
+ *
+ * These are the five Python's `startup_periodic_tasks` carries, spelled with
+ * the `name` of the task class rather than its Python identifier, because the
+ * `name` is what lands in `tasks.type`. Their intervals are the spawner's, not
+ * this union's.
+ *
+ * Kept apart from {@link TaskName} because the spawn-outcome counter's label
+ * set *is* the schedule: a series for a type nothing ever spawns would sit at
+ * zero forever and read as a task that never runs.
+ */
+export const PeriodicTaskName = z.enum([
+	"evict_caches_lru",
+	"reap_orphaned_uploads",
+	"refresh_hmms",
+	"sweep_blast",
+	"timeout_jobs",
+]);
+
+export type PeriodicTaskName = z.infer<typeof PeriodicTaskName>;
+
+/**
+ * Every task name Virtool runs — the five periodic ones plus the four created
+ * in response to a request.
+ *
+ * **This bounds a metric label, not a row.** `tasks.type` is a plain `text`
+ * column with no CHECK constraint on either side, so a row may legitimately
+ * carry a name this union has never heard of — a typo, or a task a future
+ * Python release adds. Anything reading the column keeps it typed `string` and
+ * folds an unrecognised value onto `other` at the point it becomes a label.
+ */
+export const TaskName = z.enum([
+	...PeriodicTaskName.options,
+	"clone_reference",
+	"create_index",
+	"import_reference",
+	"install_hmms",
+]);
+
+export type TaskName = z.infer<typeof TaskName>;
+
 /**
  * A background task's live progress and metadata, as it is embedded in the
  * resources a task acts on.

--- a/packages/data/src/tasks/data.test.ts
+++ b/packages/data/src/tasks/data.test.ts
@@ -21,6 +21,9 @@ import {
 	failTask,
 	getTask,
 	getTasks,
+	readOldestQueuedTaskAges,
+	readTaskCounts,
+	readTaskQueueBounded,
 	reclaimExpiredLeases,
 	releaseRunnerClaims,
 	releaseTask,
@@ -809,5 +812,115 @@ describe("frames", () => {
 		});
 
 		expect(frames).toEqual([]);
+	});
+});
+
+describe("readTaskCounts", () => {
+	it("splits active tasks into queued and running, by type", async () => {
+		await createTask(db, "install_hmms");
+		const running = await createTask(db, "install_hmms");
+		const other = await createTask(db, "create_index");
+
+		await holdTask(running, RUNNER_A, 10);
+		await holdTask(other, RUNNER_A, 10);
+
+		const counts = await readTaskCounts(db);
+
+		expect([...counts].sort((a, b) => a.type.localeCompare(b.type))).toEqual([
+			{ type: "create_index", queued: 0, running: 1 },
+			{ type: "install_hmms", queued: 1, running: 1 },
+		]);
+	});
+
+	it("counts a type the union does not name", async () => {
+		await db.insert(tasks).values({
+			complete: false,
+			context: {},
+			count: 0,
+			created_at: new Date(),
+			progress: 0,
+			step: "a_python_task",
+			type: "a_python_task",
+		});
+
+		expect(await readTaskCounts(db)).toEqual([
+			{ type: "a_python_task", queued: 1, running: 0 },
+		]);
+	});
+
+	// The predicate is Python's `get_counts`, and the pre/post-cutover comparison
+	// only holds if both sides count the same rows. A failure is the case worth
+	// pinning: `failTask` sets `complete` as well as `error`, but Python's failure
+	// path writes `error` alone, so a row can be failed and incomplete at once.
+	it("excludes complete, failed, and failed-but-incomplete tasks", async () => {
+		const completed = await createTask(db, "install_hmms");
+		await holdTask(completed, RUNNER_A, 1);
+		await completeTask(db, completed, RUNNER_A);
+
+		const failed = await createTask(db, "install_hmms");
+		await holdTask(failed, RUNNER_A, 1);
+		await failTask(db, failed, RUNNER_A, "it broke");
+
+		const pythonStyleFailure = await createTask(db, "install_hmms");
+		await db
+			.update(tasks)
+			.set({ error: "python wrote this" })
+			.where(eq(tasks.id, pythonStyleFailure));
+
+		expect(await readTaskCounts(db)).toEqual([]);
+	});
+
+	it("returns nothing for an empty queue", async () => {
+		expect(await readTaskCounts(db)).toEqual([]);
+	});
+});
+
+describe("readOldestQueuedTaskAges", () => {
+	it("reports the oldest unclaimed task per type", async () => {
+		const older = await createTask(db, "install_hmms");
+		await createTask(db, "install_hmms");
+
+		await db
+			.update(tasks)
+			.set({ created_at: new Date(Date.now() - 600 * 1000) })
+			.where(eq(tasks.id, older));
+
+		const [row] = await readOldestQueuedTaskAges(db);
+
+		expect(row?.type).toBe("install_hmms");
+		// A wide window: the assertion is that the age is measured from the older
+		// row and in UTC, not that the clocks agree to the second.
+		expect(row?.ageSeconds).toBeGreaterThan(550);
+		expect(row?.ageSeconds).toBeLessThan(650);
+	});
+
+	it("ignores a claimed task, however old", async () => {
+		const taskId = await createTask(db, "install_hmms");
+
+		await db
+			.update(tasks)
+			.set({ created_at: new Date(Date.now() - 600 * 1000) })
+			.where(eq(tasks.id, taskId));
+
+		await holdTask(taskId, RUNNER_A, 10);
+
+		expect(await readOldestQueuedTaskAges(db)).toEqual([]);
+	});
+});
+
+describe("readTaskQueueBounded", () => {
+	it("returns both reads together", async () => {
+		await createTask(db, "install_hmms");
+
+		const snapshot = await readTaskQueueBounded(db);
+
+		expect(snapshot.counts).toEqual([
+			{ type: "install_hmms", queued: 1, running: 0 },
+		]);
+		expect(snapshot.oldestQueuedAges).toHaveLength(1);
+	});
+
+	it("rejects rather than hanging when the deadline passes", async () => {
+		await expect(readTaskQueueBounded(db, 0)).rejects.toThrow("timed out");
 	});
 });

--- a/packages/data/src/tasks/data.ts
+++ b/packages/data/src/tasks/data.ts
@@ -1,10 +1,11 @@
 import { hostname } from "node:os";
-import type { JsonObject, Task } from "@virtool/contracts";
+import type { JsonObject, Task, TaskName } from "@virtool/contracts";
 import {
 	and,
 	asc,
 	eq,
 	inArray,
+	isNotNull,
 	isNull,
 	like,
 	lt,
@@ -15,6 +16,7 @@ import {
 import type { Db, DbOrTx } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import { tasks as tasksTable } from "../db/schema/tasks";
+import { withTimeout } from "../db/timeout";
 import { AppError } from "../errors";
 import { emit } from "../events/emit";
 
@@ -24,12 +26,15 @@ export class TaskNotFoundError extends AppError {}
 /**
  * A task type the TS server can spawn. The runner supports every Python task
  * name, but this union only lists the ones we create from here.
+ *
+ * Written as a subset of {@link TaskName} rather than as its own list of
+ * strings, so a name that drifts from the one Python's task class carries is a
+ * compile error here instead of a row no runner ever claims.
  */
-export type TaskType =
-	| "clone_reference"
-	| "create_index"
-	| "import_reference"
-	| "install_hmms";
+export type TaskType = Extract<
+	TaskName,
+	"clone_reference" | "create_index" | "import_reference" | "install_hmms"
+>;
 
 /**
  * Insert a pending task of `type` and return its id.
@@ -505,6 +510,133 @@ export async function releaseRunnerClaims(
 		.returning({ id: tasksTable.id });
 
 	return rows.map((row) => row.id);
+}
+
+/**
+ * The predicate Python's `TasksData.get_counts` counts under: a task that is
+ * neither finished nor failed.
+ *
+ * Reproduced term for term, because the pre- and post-cutover comparison is
+ * only apples-to-apples if both sides count the same rows. It is also the
+ * predicate of Python's `idx_tasks_active` partial index, so the reads below
+ * are served by it rather than scanning a table whose completed rows accumulate
+ * without bound.
+ *
+ * Note that `error IS NULL` and `complete = false` are *both* required. A
+ * Python failure writes `error` and leaves `complete` false, so neither term
+ * implies the other on rows Python wrote.
+ */
+function isActive(): SQL | undefined {
+	return and(eq(tasksTable.complete, false), isNull(tasksTable.error));
+}
+
+/** Active tasks of one type, split the way Python's `get_counts` splits them. */
+export type TaskCount = {
+	type: string;
+	/** Active and unclaimed — Python's `queued`. */
+	queued: number;
+	/** Active and claimed — Python's `running`. */
+	running: number;
+};
+
+/** How long the oldest unclaimed task of a type has been waiting. */
+export type OldestQueuedTaskAge = {
+	type: string;
+	ageSeconds: number;
+};
+
+/** The active task queue as a `/metrics` scrape reports it. */
+export type TaskQueueSnapshot = {
+	counts: TaskCount[];
+	oldestQueuedAges: OldestQueuedTaskAge[];
+};
+
+/**
+ * How long a scrape waits on the task-queue reads before abandoning them.
+ *
+ * Matched to the job queue's bound, and for the same reason: these run on the
+ * pool this process claims and heartbeats tasks over, so a saturated pool
+ * queues them *client-side*, where no statement timeout applies.
+ */
+export const TASK_QUEUE_PROBE_TIMEOUT_MS = 2000;
+
+/**
+ * Count the active tasks of each type, queued and running.
+ *
+ * The two counts come from one grouped scan rather than two queries, since they
+ * partition the same predicate — and a queue read split across two statements
+ * can report a task in neither half, or in both, if it is claimed between them.
+ *
+ * The `type` breakdown is additional to Python, which reports two scalars.
+ * Summing over `type` reproduces them exactly, so the breakdown costs the
+ * comparison nothing and is what makes the gauge actionable: "twelve queued"
+ * says nothing about whether anything can drain them.
+ */
+export async function readTaskCounts(db: Db): Promise<TaskCount[]> {
+	return db
+		.select({
+			type: tasksTable.type,
+			queued: sql<number>`
+				count(*) filter (where ${isNull(tasksTable.acquired_at)})
+			`.mapWith(Number),
+			running: sql<number>`
+				count(*) filter (where ${isNotNull(tasksTable.acquired_at)})
+			`.mapWith(Number),
+		})
+		.from(tasksTable)
+		.where(isActive())
+		.groupBy(tasksTable.type);
+}
+
+/**
+ * Age the oldest task still waiting for a runner, per type.
+ *
+ * Depth alone cannot tell a busy fleet from a stalled one — a queue holding at
+ * twelve looks the same whether it is being drained and refilled or not being
+ * drained at all. This is the series that separates them, and during the
+ * cutover it is the one that says the TypeScript runner has actually started
+ * claiming.
+ *
+ * The subtraction happens in Postgres, with `created_at` pinned to UTC on the
+ * way into it. The column is a naive `timestamp`, so left to the session's time
+ * zone the age would be wrong by that offset — and both writers, Python and
+ * Drizzle, store UTC.
+ */
+export async function readOldestQueuedTaskAges(
+	db: Db,
+): Promise<OldestQueuedTaskAge[]> {
+	return db
+		.select({
+			type: tasksTable.type,
+			ageSeconds: sql<number>`
+				extract(epoch from (now() - (min(${tasksTable.created_at}) at time zone 'UTC')))
+			`.mapWith(Number),
+		})
+		.from(tasksTable)
+		.where(and(isActive(), isNull(tasksTable.acquired_at)))
+		.groupBy(tasksTable.type);
+}
+
+/**
+ * Both task-queue reads at once, bounded by
+ * {@link TASK_QUEUE_PROBE_TIMEOUT_MS}.
+ *
+ * This is what a `/metrics` handler should call. The two reads are independent,
+ * so they go out concurrently and share one deadline.
+ *
+ * Still throws on timeout or query failure. A caller drops these series and
+ * logs, rather than failing the whole scrape.
+ */
+export function readTaskQueueBounded(
+	db: Db,
+	timeoutMs: number = TASK_QUEUE_PROBE_TIMEOUT_MS,
+): Promise<TaskQueueSnapshot> {
+	return withTimeout(
+		Promise.all([readTaskCounts(db), readOldestQueuedTaskAges(db)]).then(
+			([counts, oldestQueuedAges]) => ({ counts, oldestQueuedAges }),
+		),
+		timeoutMs,
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Defines the five `virtool_task_*`/`virtool_tasks*` Prometheus series on the tasks registry, plus the `recordSpawn`/`recordRun`/`setTaskQueue` seams the spawn and claim loops will call when they land.
- Adds the queue read, which reproduces Python's `get_counts` predicate term for term (`complete = false AND error IS NULL`, split on `acquired_at`) and so is served by its `idx_tasks_active` partial index, keeping the cutover comparison apples-to-apples.
- Bounds the `type` label with new `TaskName`/`PeriodicTaskName` enums in `@virtool/contracts`, folding any unrecognised `tasks.type` value onto `other` — the column stays unconstrained `text` on both sides.