### PR TITLE
chore: add the task claim loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,10 +79,10 @@ This is a **pnpm monorepo**:
   spawner and the runner that claims and executes what it spawns. Image:
   `ghcr.io/virtool/tasks`, Alpine, no ingress and **no Service** — its HTTP
   listener serves only `/health/live`, `/health/ready` and a token-gated
-  `/metrics` on `VT_TASKS_PROBE_PORT` (9900). The two halves are turned off
-  independently with `VT_TASKS_SPAWN_ENABLED` and `VT_TASKS_CLAIM_ENABLED`
-  — both default `true` — which is what decouples their rollouts without a
-  second image. Everything is built inside `bootstrap()`; this app has no
+  `/metrics` on `VT_TASKS_PROBE_PORT` (9900). Neither half has a flag to
+  turn it off: the cutover from Python is two deployments inside a minute,
+  and a minute of task lag is invisible to a user, so there is nothing for a
+  staged rollout to buy. Everything is built inside `bootstrap()`; this app has no
   module-scope singleton of any kind, not config, not the pool, not the
   registry. See [docs/tasks.md](docs/tasks.md).
 - `apps/create-subtraction/` — `@virtool/create-subtraction`, the first workflow
@@ -126,7 +126,9 @@ This is a **pnpm monorepo**:
     service shares. Today that is `createShutdownController`
     (`./shutdown`) alone: readiness flip, LIFO hooks, listener, pool,
     Sentry **flush**, `process.exitCode` and an `.unref()`'d backstop,
-    with every dependency injected. It is **not** a home for the probe
+    with every dependency injected. Steps take an equal share of the
+    budget unless a hook declares its own `timeoutMs`, which is reserved
+    out of what the rest divide. It is **not** a home for the probe
     server or the metrics registries, however alike those look across
     the three services.
   - `@virtool/storage` — object storage: the S3 and Azure backends, the
@@ -987,12 +989,10 @@ take.
 
 `apps/tasks` is **one** process carrying both halves of the task system.
 The periodic spawner inserts scheduled tasks; the runner claims and
-executes them. Each is disabled independently — `VT_TASKS_SPAWN_ENABLED`
-and `VT_TASKS_CLAIM_ENABLED`, both defaulting to `true`, so an omitted key
-fails toward a working fleet rather than a pod that starts, passes every
-probe and does nothing. That is what decouples the two rollouts: the
-cutover from Python is one deployment started with claiming off, then one
-flag flip. Don't reintroduce a second binary to get the same effect.
+executes them. Neither half has a flag to turn it off — the cutover from
+Python is two deployments inside a minute, and a minute of task lag is
+invisible to a user, so a staged rollout buys nothing. Don't reintroduce a
+mode flag or a second binary to stage it.
 
 **Nothing in this app happens at import time.** `bootstrap()`
 (`src/bootstrap.ts`) is the composition root and builds all of it — config,
@@ -1005,8 +1005,11 @@ Four rules it carries:
 
 - **Config is the app's own zod schema**, parsed by `parseTasksConfig`,
   and every key keeps the `<KEY>_FILE` behaviour through the shared
-  `resolveFileBacked`. A boolean is spelled out rather than left to
-  `z.coerce.boolean()`, which reads `"false"` as `true`.
+  `resolveFileBacked`. `VT_TASKS_DRAIN_TIMEOUT` (25) is a **share** of
+  `VT_TASKS_SHUTDOWN_TIMEOUT` (40) rather than an addition to it, and the
+  parse rejects a drain that is not strictly smaller — the controller
+  silently takes the lesser of the two, so an oversized drain would
+  quietly become a shorter one.
 - **Liveness must never depend on Postgres.** `GET /health/live` is
   static. A database blip that failed it would restart the whole fleet
   and kill every task in flight. Readiness still probes Postgres, and
@@ -1023,7 +1026,11 @@ Four rules it carries:
   budget must stay under `terminationGracePeriodSeconds`. The sequence
   itself is `createShutdownController` from `@virtool/service/shutdown`,
   shared with the jobs API; only the hooks and the injected
-  `closeListener` are this app's.
+  `closeListener` are this app's. Every step takes an **equal share** of
+  the remaining budget unless a hook declares its own `timeoutMs`, which
+  is reserved out of what the rest divide — the runner's drain is the only
+  hook that does, because equal division caps any one step at a quarter of
+  the budget however little the others need.
 
 A claim is a **lease encoded on `acquired_at`** — live while that column
 is within `TASK_LEASE_SECONDS` (300) of now, renewed every
@@ -1041,7 +1048,10 @@ four rules hold them:
   `runner_id`**, which `buildRunnerId()` mints. Python never renews
   `acquired_at`, so its long-running tasks look abandoned; the scope is
   what stops a reclaim pulling live work out from under it. Never add a
-  flag to widen it.
+  flag to widen it. **There is no reclaim timer** — the claim is the
+  reclaim, and a second loop would only repeat it. `reclaimExpiredLeases`
+  has no caller on a running fleet and ships for the cutover's last step,
+  where the scope is widened to recover what Python was mid-flight on.
 - **Every runner write is fenced** on `runner_id` and `complete = false`
   and returns `false` when it matches nothing; `renewLeases` reports the
   ids it renewed so a caller can abandon the rest. `failTask` sets
@@ -1099,11 +1109,48 @@ declaration (`define.ts`), the debounced progress writer
 - **A reclaimed task re-runs from step zero, so every body must be
   idempotent.** Nothing records which steps already ran.
 
+The runner — `createTaskRunner` in `apps/tasks/src/runner.ts` — claims,
+dispatches and holds leases. It reads no config, opens no pool, installs
+no signal handler and binds no listener; `src/index.ts` builds it from the
+`AppContext` and registers `stop` as a shutdown hook. Six rules:
+
+- **One task at a time**, because replica count is the scaling lever and
+  the bodies are heavy enough that in-process concurrency would multiply
+  peak RSS rather than fill idle time. **But the seams are set-shaped** —
+  in-flight tasks are a `Map` and `renewLeases` renews a set — so raising
+  the cap stays a change to that file rather than a redesign of it.
+- **Supported types are read from the registry at claim time**, never
+  snapshotted. Python snapshots `BaseTask.__subclasses__()`, which holds
+  only the classes already imported, so one missing import silently
+  narrows what it can claim. An empty registry claims nothing.
+- **A claimed type with no handler is failed, never released.** Python
+  logs and returns, stranding the row with `acquired_at` set and
+  `error = NULL` — invisible, counted as running forever, and the cause
+  of the HPA's abandoned KEDA trigger. Releasing hot-loops instead, since
+  such a row is claimable by construction. It goes through `failTask` so
+  the frame goes out, and the branch stays even though the claim's
+  type filter should make it unreachable.
+- **A failed claim logs and continues.** A crash-loop on a database blip
+  is worse than a poll that found nothing.
+- **The heartbeat is an `.unref()`'d `setInterval` that measures its own
+  lateness** and logs above a threshold — event-loop starvation is what
+  loses a lease under a live runner, and that tripwire is what would
+  justify a worker thread. The ids `renewLeases` does not return are
+  fenced, and the runner aborts their signals. **Bulk OTU preparation
+  must yield**, or it starves the beat.
+- **Shutdown is drain, then release**: stop claiming, wait out the
+  in-flight task for `VT_TASKS_DRAIN_TIMEOUT` less a two-second reserve,
+  abort what is left, stop the heartbeat *after* the drain, then
+  `releaseRunnerClaims`. A release makes a task claimable in
+  milliseconds where abandoning it costs the full lease. `stop()` is
+  idempotent — a second call returns the first's promise — and never
+  rejects.
+
 See [docs/tasks.md](docs/tasks.md) for the full config table, the
 `AppContext` contract, the shutdown ordering and its guarantees, the
 probe and metrics surface, the lease, fencing and frame rules in full,
-and the framework's step model, terminal-outcome table and progress
-seam.
+the framework's step model, terminal-outcome table and progress seam,
+and the runner's loop, heartbeat and drain in full.
 
 ## Data
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1169,12 +1169,15 @@ no signal handler and binds no listener; `src/index.ts` builds it from the
   fenced, and the runner aborts their signals. **Bulk OTU preparation
   must yield**, or it starves the beat.
 - **Shutdown is drain, then release**: stop claiming, wait out the
-  in-flight task for `VT_TASKS_DRAIN_TIMEOUT` less a two-second reserve,
-  abort what is left, stop the heartbeat *after* the drain, then
+  in-flight task, abort what is left, **wait out a bounded grace for it
+  to actually stop**, stop the heartbeat *after* the drain, then
   `releaseRunnerClaims`. A release makes a task claimable in
-  milliseconds where abandoning it costs the full lease. `stop()` is
-  idempotent — a second call returns the first's promise — and never
-  rejects.
+  milliseconds where abandoning it costs the full lease. The grace is not
+  optional: `runTask` renews the lease to confirm ownership before
+  tearing down, so releasing on top of an abort makes that renewal fail
+  and **skips the body's `cleanup`**. All three phases share the one
+  `VT_TASKS_DRAIN_TIMEOUT` ceiling. `stop()` is idempotent — a second
+  call returns the first's promise — and never rejects.
 
 See [docs/tasks.md](docs/tasks.md) for the full config table, the
 `AppContext` contract, the shutdown ordering and its guarantees, the

--- a/apps/tasks/src/bootstrap.ts
+++ b/apps/tasks/src/bootstrap.ts
@@ -9,7 +9,10 @@ import {
 import { createEmitter } from "@virtool/data/events/emit";
 import { createLogger, type Logger } from "@virtool/logger";
 import { createSentryLogStream } from "@virtool/sentry/log";
-import { createShutdownController } from "@virtool/service/shutdown";
+import {
+	createShutdownController,
+	type ShutdownOptions,
+} from "@virtool/service/shutdown";
 import { createStorageBackend, type StorageBackend } from "@virtool/storage";
 import { parseTasksConfig, type TasksConfig } from "./config";
 import { initSentry, SERVICE } from "./instrument";
@@ -35,9 +38,15 @@ export type AppContext = {
 	 * reverse registration order; each is awaited; a throwing hook does not
 	 * prevent the others from running, though it does make the process exit
 	 * non-zero; and the whole sequence is bounded by the backstop, so a hook must
-	 * not assume unlimited time.
+	 * not assume unlimited time — one waiting out real work declares its own
+	 * ceiling with `options.timeoutMs` rather than taking the equal share, which
+	 * is sized for a socket close.
 	 */
-	onShutdown: (name: string, hook: () => Promise<void>) => void;
+	onShutdown: (
+		name: string,
+		hook: () => Promise<void>,
+		options?: ShutdownOptions,
+	) => void;
 	/** Flip readiness independently of shutdown — e.g. while draining. */
 	setReady: (ready: boolean) => void;
 };
@@ -170,12 +179,7 @@ export async function bootstrap(
 	}
 
 	logger.info(
-		{
-			port: config.probePort,
-			version: options.version,
-			claimEnabled: config.claimEnabled,
-			spawnEnabled: config.spawnEnabled,
-		},
+		{ port: config.probePort, version: options.version },
 		"listening",
 	);
 

--- a/apps/tasks/src/config.test.ts
+++ b/apps/tasks/src/config.test.ts
@@ -60,7 +60,8 @@ describe("parseTasksConfig", () => {
 
 		expect(config.postgresPoolMax).toBe(10);
 		expect(config.probePort).toBe(9900);
-		expect(config.shutdownTimeout).toBe(30);
+		expect(config.shutdownTimeout).toBe(40);
+		expect(config.drainTimeout).toBe(25);
 		expect(config.metricsToken).toBeUndefined();
 		expect(config.sentryDsn).toBeUndefined();
 	});
@@ -69,52 +70,29 @@ describe("parseTasksConfig", () => {
 		expect(() => parseTasksConfig({ VT_STORAGE_BACKEND: "s3" })).toThrowError();
 	});
 
-	describe("claim and spawn flags", () => {
-		// An omitted flag has to fail toward a working fleet. A default of `false`
-		// would make a deployment that never set it a silent no-op — a pod that
-		// starts, passes every probe, and does nothing at all.
-		it("defaults both to enabled", () => {
-			const config = parseTasksConfig(baseEnv());
-
-			expect(config.claimEnabled).toBe(true);
-			expect(config.spawnEnabled).toBe(true);
-		});
-
-		it("reads false, which is the value a rollout actually writes", () => {
-			const config = parseTasksConfig({
-				...baseEnv(),
-				VT_TASKS_CLAIM_ENABLED: "false",
-				VT_TASKS_SPAWN_ENABLED: "0",
-			});
-
-			expect(config.claimEnabled).toBe(false);
-			expect(config.spawnEnabled).toBe(false);
-		});
-
-		it("reads true", () => {
-			const config = parseTasksConfig({
-				...baseEnv(),
-				VT_TASKS_CLAIM_ENABLED: "true",
-				VT_TASKS_SPAWN_ENABLED: "1",
-			});
-
-			expect(config.claimEnabled).toBe(true);
-			expect(config.spawnEnabled).toBe(true);
-		});
-
-		it("rejects a value that is neither", () => {
+	describe("the drain window", () => {
+		// The drain is a share of the shutdown budget, and the controller silently
+		// takes the smaller of the two — so a drain set past the budget would
+		// quietly become a shorter one with nothing to say so.
+		it("rejects a drain the shutdown budget cannot hold", () => {
 			expect(() =>
-				parseTasksConfig({ ...baseEnv(), VT_TASKS_CLAIM_ENABLED: "yes" }),
-			).toThrowError();
+				parseTasksConfig({
+					...baseEnv(),
+					VT_TASKS_SHUTDOWN_TIMEOUT: "20",
+					VT_TASKS_DRAIN_TIMEOUT: "20",
+				}),
+			).toThrowError(/must be less than VT_TASKS_SHUTDOWN_TIMEOUT/);
 		});
 
-		it("treats an injected empty string as unset", () => {
+		it("accepts a drain inside it", () => {
 			const config = parseTasksConfig({
 				...baseEnv(),
-				VT_TASKS_CLAIM_ENABLED: "",
+				VT_TASKS_SHUTDOWN_TIMEOUT: "20",
+				VT_TASKS_DRAIN_TIMEOUT: "10",
 			});
 
-			expect(config.claimEnabled).toBe(true);
+			expect(config.shutdownTimeout).toBe(20);
+			expect(config.drainTimeout).toBe(10);
 		});
 	});
 

--- a/apps/tasks/src/config.ts
+++ b/apps/tasks/src/config.ts
@@ -21,10 +21,27 @@ const DEFAULT_PROBE_PORT = 9900;
  *
  * It must sit strictly under `terminationGracePeriodSeconds`, which covers
  * `preStop` and shutdown combined. The manifests use a 60 s grace period behind
- * a 10 s `preStop` sleep, leaving 50 s; 30 s is comfortably inside that, so an
- * overrun is reported by this process rather than cut short by SIGKILL.
+ * a 10 s `preStop` sleep, leaving 50 s; 40 s is inside that, so an overrun is
+ * reported by this process rather than cut short by SIGKILL.
+ *
+ * It has to cover {@link DEFAULT_DRAIN_TIMEOUT} and leave enough behind for the
+ * listener close, the pool drain and the Sentry flush, which divide the
+ * remainder between them.
  */
-const DEFAULT_SHUTDOWN_TIMEOUT = 30;
+const DEFAULT_SHUTDOWN_TIMEOUT = 40;
+
+/**
+ * Seconds in-flight tasks are given to finish on shutdown, when
+ * `VT_TASKS_DRAIN_TIMEOUT` is unset.
+ *
+ * Draining to completion is not on offer at any grace period we can set — these
+ * tasks run for minutes, and a cluster autoscaler force-removes a pod well
+ * before an hour whatever the field says. So the drain is a window, and what
+ * follows it is a release: a task handed back takes milliseconds to become
+ * claimable again, where one abandoned mid-flight sits out the full
+ * `TASK_LEASE_SECONDS` before any runner can touch it.
+ */
+const DEFAULT_DRAIN_TIMEOUT = 25;
 
 /** Everything this process reads from the environment at startup. */
 export type TasksConfig = {
@@ -34,23 +51,10 @@ export type TasksConfig = {
 	/** Seconds the shutdown sequence may run before the backstop gives up. */
 	shutdownTimeout: number;
 	/**
-	 * Whether this process claims and runs tasks.
-	 *
-	 * Set to `false` to deploy the spawner half alone, which is how the
-	 * TypeScript runner reaches production ahead of the cutover from Python: one
-	 * deployment spawns periodic tasks while Python still runs them, and flipping
-	 * this to `true` is the cutover. Defaults to `true`, so an omitted key fails
-	 * toward a working fleet rather than a silent no-op one.
+	 * Seconds in-flight tasks are given to finish before their claims are
+	 * released. Part of {@link TasksConfig.shutdownTimeout}, not additional to it.
 	 */
-	claimEnabled: boolean;
-	/**
-	 * Whether this process spawns periodic tasks.
-	 *
-	 * Every replica carries the spawner, so this exists to turn it off — during
-	 * the cutover window, when Python is still spawning the same periodic tasks
-	 * and two spawners would duplicate them.
-	 */
-	spawnEnabled: boolean;
+	drainTimeout: number;
 	/**
 	 * Gates the Prometheus scrape endpoint. Unset leaves `/metrics` reporting
 	 * 404, so a deployment never starts exposing internals on upgrade.
@@ -71,26 +75,6 @@ function optional() {
 	);
 }
 
-/**
- * Read a `VT_`-prefixed boolean.
- *
- * Spelled out rather than deferring to `z.coerce.boolean()`, which is a plain
- * truthiness cast: it reads the string `"false"` as `true`, so the one value a
- * deployment is most likely to write in order to turn something off would turn
- * it on instead.
- */
-function boolish(fallback: boolean) {
-	return z.preprocess(
-		(value) => (value === "" || value === undefined ? undefined : value),
-		z
-			.enum(["true", "false", "1", "0"])
-			.optional()
-			.transform((value) =>
-				value === undefined ? fallback : value === "true" || value === "1",
-			),
-	);
-}
-
 const TasksEnv = z.object({
 	VT_POSTGRES_URL: z.string().url(),
 	// Deployment tooling routinely injects an empty string for a value it has
@@ -108,8 +92,10 @@ const TasksEnv = z.object({
 		(value) => (value === "" ? undefined : value),
 		z.coerce.number().int().positive().optional(),
 	),
-	VT_TASKS_CLAIM_ENABLED: boolish(true),
-	VT_TASKS_SPAWN_ENABLED: boolish(true),
+	VT_TASKS_DRAIN_TIMEOUT: z.preprocess(
+		(value) => (value === "" ? undefined : value),
+		z.coerce.number().int().positive().optional(),
+	),
 	VT_METRICS_TOKEN: optional(),
 	// Listed here so it picks up the `<KEY>_FILE` resolution every other key
 	// gets. `@virtool/sentry`'s `readDsn` goes straight to `process.env` and
@@ -218,17 +204,49 @@ function buildStorage(
 	};
 }
 
-const TasksEnvSchema = TasksEnv.transform((raw, ctx) => ({
-	postgresUrl: raw.VT_POSTGRES_URL,
-	postgresPoolMax: raw.VT_POSTGRES_POOL_MAX ?? DEFAULT_POSTGRES_POOL_MAX,
-	probePort: raw.VT_TASKS_PROBE_PORT ?? DEFAULT_PROBE_PORT,
-	shutdownTimeout: raw.VT_TASKS_SHUTDOWN_TIMEOUT ?? DEFAULT_SHUTDOWN_TIMEOUT,
-	claimEnabled: raw.VT_TASKS_CLAIM_ENABLED,
-	spawnEnabled: raw.VT_TASKS_SPAWN_ENABLED,
-	metricsToken: raw.VT_METRICS_TOKEN,
-	sentryDsn: raw.VT_SENTRY_DSN,
-	storage: buildStorage(raw, ctx),
-}));
+/**
+ * Reject a drain window the shutdown budget cannot hold.
+ *
+ * The drain is a share of that budget, not an addition to it, and the shutdown
+ * controller silently takes the smaller of the two — so a drain set past the
+ * budget would quietly become a shorter one, and the operator who raised it
+ * would see no effect and no complaint. The three steps that follow the drain
+ * divide what is left, so the two values cannot be equal either.
+ */
+function checkDrainFits(
+	ctx: z.RefinementCtx,
+	drainTimeout: number,
+	shutdownTimeout: number,
+): void {
+	if (drainTimeout < shutdownTimeout) {
+		return;
+	}
+
+	ctx.addIssue({
+		code: "custom",
+		path: ["VT_TASKS_DRAIN_TIMEOUT"],
+		message: `VT_TASKS_DRAIN_TIMEOUT (${drainTimeout}) must be less than VT_TASKS_SHUTDOWN_TIMEOUT (${shutdownTimeout}), which it is a share of`,
+	});
+}
+
+const TasksEnvSchema = TasksEnv.transform((raw, ctx) => {
+	const shutdownTimeout =
+		raw.VT_TASKS_SHUTDOWN_TIMEOUT ?? DEFAULT_SHUTDOWN_TIMEOUT;
+	const drainTimeout = raw.VT_TASKS_DRAIN_TIMEOUT ?? DEFAULT_DRAIN_TIMEOUT;
+
+	checkDrainFits(ctx, drainTimeout, shutdownTimeout);
+
+	return {
+		postgresUrl: raw.VT_POSTGRES_URL,
+		postgresPoolMax: raw.VT_POSTGRES_POOL_MAX ?? DEFAULT_POSTGRES_POOL_MAX,
+		probePort: raw.VT_TASKS_PROBE_PORT ?? DEFAULT_PROBE_PORT,
+		shutdownTimeout,
+		drainTimeout,
+		metricsToken: raw.VT_METRICS_TOKEN,
+		sentryDsn: raw.VT_SENTRY_DSN,
+		storage: buildStorage(raw, ctx),
+	};
+});
 
 /**
  * Every environment key this process reads.

--- a/apps/tasks/src/framework/run.test.ts
+++ b/apps/tasks/src/framework/run.test.ts
@@ -4,10 +4,7 @@ import {
 	createTestDatabase,
 	type TestDatabase,
 } from "@virtool/data/db/test/fixtures";
-import {
-	CLIENT_EVENTS_CHANNEL,
-	type ClientEvent,
-} from "@virtool/data/events/channel";
+import type { ClientEvent } from "@virtool/data/events/channel";
 import {
 	acquireTask,
 	type ClaimedTask,
@@ -25,6 +22,7 @@ import {
 	vi,
 } from "vitest";
 import { z } from "zod";
+import { collectFrames as collect } from "../testing/frames";
 import { defineTask, type TaskRegistry } from "./define";
 import { runTask } from "./run";
 
@@ -80,53 +78,9 @@ async function claim(
 	return claimed;
 }
 
-/**
- * Collect the `client_events` frames published while `run` executes.
- *
- * The sentinel at the end is what makes a count sound: it is published after
- * everything `run` did, over the connection the emitter uses, so its arrival
- * proves every frame `run` published has already arrived. Waiting a fixed
- * interval instead would pass on a slow machine for the wrong reason.
- */
-async function collectFrames(run: () => Promise<void>): Promise<ClientEvent[]> {
-	const received: ClientEvent[] = [];
-	let seal: () => void = () => undefined;
-	const sealed = new Promise<void>((resolve) => {
-		seal = resolve;
-	});
-
-	const subscription = await database.client.listen(
-		CLIENT_EVENTS_CHANNEL,
-		(payload) => {
-			const event = JSON.parse(payload) as ClientEvent;
-
-			if (event.domain === "roles" && event.resource_id === "sentinel") {
-				seal();
-				return;
-			}
-
-			received.push(event);
-		},
-	);
-
-	try {
-		await run();
-
-		await database.client.notify(
-			CLIENT_EVENTS_CHANNEL,
-			JSON.stringify({
-				domain: "roles",
-				resource_id: "sentinel",
-				operation: "update",
-			}),
-		);
-
-		await sealed;
-	} finally {
-		await subscription.unlisten();
-	}
-
-	return received;
+/** Collect the `client_events` frames published while `run` executes. */
+function collectFrames(run: () => Promise<void>): Promise<ClientEvent[]> {
+	return collect(database.client, run);
 }
 
 describe("defineTask", () => {

--- a/apps/tasks/src/index.ts
+++ b/apps/tasks/src/index.ts
@@ -1,32 +1,39 @@
 import { createLogger } from "@virtool/logger";
 import { bootstrap } from "./bootstrap";
 import { SERVICE } from "./instrument";
+import { createTaskRunner } from "./runner";
+import { type TaskContext, taskRegistry } from "./tasks/registry";
 import { APP_VERSION } from "./version";
 
 /**
  * The tasks process.
  *
- * One binary carries both halves of Virtool's task system: the periodic
- * spawner, which inserts the scheduled tasks, and the runner, which claims and
- * executes them. Each is turned off independently — `VT_TASKS_SPAWN_ENABLED`
- * and `VT_TASKS_CLAIM_ENABLED`, both defaulting to `true` — which is what
- * decouples their rollouts without needing two images. The cutover from Python
- * is one deployment that starts with claiming off, and one flag flip.
- *
- * Both halves are placeholders here. This build starts, serves its probes and
- * shuts down cleanly; the spawn schedule and the claim loop land with the
- * issues that own them.
+ * One binary carries both halves of Virtool's task system: the periodic spawner,
+ * which inserts the scheduled tasks, and the runner, which claims and executes
+ * them. The runner is here; the spawn schedule lands with the issue that owns it.
  */
 async function main(): Promise<void> {
 	const context = await bootstrap({ version: APP_VERSION });
 
-	if (context.config.spawnEnabled) {
-		context.logger.info("periodic task spawning is enabled");
-	}
+	const ctx: TaskContext = { db: context.db, storage: context.storage };
 
-	if (context.config.claimEnabled) {
-		context.logger.info("task claiming is enabled");
-	}
+	const drainTimeoutMs = context.config.drainTimeout * 1_000;
+
+	const runner = createTaskRunner({
+		ctx,
+		db: context.db,
+		drainTimeoutMs,
+		logger: context.logger,
+		registry: taskRegistry,
+	});
+
+	// The runner's entire shutdown sequence is this one hook — the controller owns
+	// `process.exitCode`, the listener, the pool and the Sentry flush. It declares
+	// a ceiling of its own because the equal share the other steps take is sized
+	// for a socket close, and this one waits out a task that is mid-flight.
+	context.onShutdown("taskRunner", runner.stop, { timeoutMs: drainTimeoutMs });
+
+	runner.start();
 }
 
 try {

--- a/apps/tasks/src/runner.test.ts
+++ b/apps/tasks/src/runner.test.ts
@@ -1,0 +1,490 @@
+import type { Db } from "@virtool/data/db/pg";
+import { tasks } from "@virtool/data/db/schema/tasks";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import {
+	acquireTask,
+	type ClaimedTask,
+	createTask,
+	TASK_LEASE_SECONDS,
+} from "@virtool/data/tasks/data";
+import { createLogger, type Logger } from "@virtool/logger";
+import { eq, sql } from "drizzle-orm";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import { z } from "zod";
+import { defineTask, type TaskRegistry } from "./framework/define";
+import { createTaskRunner, dispatchTask, type TaskRunner } from "./runner";
+import { collectFrames } from "./testing/frames";
+
+const RUNNER = "ts-runner-a-1";
+
+/** How long a `waitFor` predicate has to come true before the test fails. */
+const WAIT_TIMEOUT_MS = 10_000;
+
+const logger: Logger = createLogger({ name: "test", level: "silent" });
+
+let database: TestDatabase;
+let db: Db;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(tasks);
+});
+
+async function readRow(taskId: number) {
+	const [row] = await db.select().from(tasks).where(eq(tasks.id, taskId));
+
+	if (row === undefined) {
+		throw new Error(`no task row with id ${taskId}`);
+	}
+
+	return row;
+}
+
+/** Put a task in the state a runner holding a lease `ageSeconds` old leaves it. */
+async function holdTask(
+	taskId: number,
+	runnerId: string,
+	ageSeconds: number,
+): Promise<void> {
+	await db
+		.update(tasks)
+		.set({
+			acquired_at: sql`timezone('utc', clock_timestamp()) - make_interval(secs => ${ageSeconds}::double precision)`,
+			runner_id: runnerId,
+		})
+		.where(eq(tasks.id, taskId));
+}
+
+/** Poll `predicate` until it holds, or fail the test. */
+async function waitFor(predicate: () => Promise<boolean>): Promise<void> {
+	const deadline = Date.now() + WAIT_TIMEOUT_MS;
+
+	while (Date.now() < deadline) {
+		if (await predicate()) {
+			return;
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+
+	throw new Error("timed out waiting for the runner");
+}
+
+/** A task type that does nothing, for a test that only cares it was dispatched. */
+function noopTask(run: () => Promise<void> = async () => undefined) {
+	return defineTask({ type: "install_hmms", payload: z.object({}), run });
+}
+
+type RunnerOverrides = {
+	drainTimeoutMs?: number;
+	heartbeatIntervalMs?: number;
+	pollIntervalMs?: number;
+};
+
+function buildRunner(
+	registry: TaskRegistry,
+	overrides: RunnerOverrides = {},
+): TaskRunner {
+	return createTaskRunner<unknown>({
+		ctx: undefined,
+		db,
+		drainTimeoutMs: overrides.drainTimeoutMs ?? 5_000,
+		logger,
+		// Fast enough that a test does not wait out Python's two seconds, and the
+		// interval is injectable for exactly that reason.
+		pollIntervalMs: overrides.pollIntervalMs ?? 10,
+		registry,
+		runnerId: RUNNER,
+		...(overrides.heartbeatIntervalMs !== undefined && {
+			heartbeatIntervalMs: overrides.heartbeatIntervalMs,
+		}),
+	});
+}
+
+describe("createTaskRunner", () => {
+	it("claims a pending task, dispatches its handler, and completes it", async () => {
+		const taskId = await createTask(db, "install_hmms", { release_id: 3 });
+		const seen: number[] = [];
+
+		const runner = buildRunner({
+			install_hmms: defineTask({
+				type: "install_hmms",
+				payload: z.object({ release_id: z.number() }),
+				run: async ({ payload }) => {
+					seen.push(payload.release_id);
+				},
+			}),
+		});
+
+		runner.start();
+
+		try {
+			await waitFor(async () => (await readRow(taskId)).complete === true);
+		} finally {
+			await runner.stop();
+		}
+
+		expect(seen).toEqual([3]);
+		expect(await readRow(taskId)).toMatchObject({
+			complete: true,
+			error: null,
+			progress: 100,
+		});
+	});
+
+	// Python snapshots `BaseTask.__subclasses__()` at construction, which holds
+	// only the classes already imported — so one missing import silently narrows
+	// what its runner can claim, with nothing to say so.
+	it("reads the supported types from the registry at claim time", async () => {
+		const registry: TaskRegistry = {};
+		const runner = buildRunner(registry);
+
+		runner.start();
+
+		try {
+			await waitFor(async () => runner.getLastTickAt() !== null);
+
+			const taskId = await createTask(db, "install_hmms");
+			const before = runner.getLastTickAt()?.getTime() ?? 0;
+
+			// An empty registry claims nothing at all rather than claiming work it
+			// cannot run, so the row survives a full poll untouched.
+			await waitFor(
+				async () => (runner.getLastTickAt()?.getTime() ?? 0) > before,
+			);
+
+			expect(await readRow(taskId)).toMatchObject({ acquired_at: null });
+
+			registry.install_hmms = noopTask();
+
+			await waitFor(async () => (await readRow(taskId)).complete === true);
+		} finally {
+			await runner.stop();
+		}
+	});
+
+	it("advances a last-tick timestamp for the probe seam", async () => {
+		const runner = buildRunner({});
+
+		expect(runner.getLastTickAt()).toBeNull();
+
+		runner.start();
+
+		try {
+			await waitFor(async () => runner.getLastTickAt() !== null);
+
+			const first = runner.getLastTickAt()?.getTime() ?? 0;
+
+			await waitFor(
+				async () => (runner.getLastTickAt()?.getTime() ?? 0) > first,
+			);
+		} finally {
+			await runner.stop();
+		}
+	});
+
+	// A crash-loop on a database hiccup is strictly worse than a poll that found
+	// nothing.
+	it("logs a failed claim and keeps polling", async () => {
+		const taskId = await createTask(db, "install_hmms");
+
+		const update = vi.spyOn(db, "update").mockImplementationOnce(() => {
+			throw new Error("connection reset by peer");
+		});
+
+		const runner = buildRunner({ install_hmms: noopTask() });
+
+		runner.start();
+
+		try {
+			await waitFor(async () => (await readRow(taskId)).complete === true);
+
+			// Asserted before the restore, which resets the call history with it.
+			expect(update).toHaveBeenCalled();
+		} finally {
+			await runner.stop();
+			update.mockRestore();
+		}
+	});
+
+	it("renews the lease of a task that outlives a heartbeat", async () => {
+		const taskId = await createTask(db, "install_hmms");
+
+		let finish: () => void = () => undefined;
+		const held = new Promise<void>((resolve) => {
+			finish = resolve;
+		});
+
+		const runner = buildRunner(
+			{ install_hmms: noopTask(() => held) },
+			{ heartbeatIntervalMs: 25 },
+		);
+
+		let first: number | undefined;
+
+		runner.start();
+
+		try {
+			await waitFor(async () => {
+				const { acquired_at } = await readRow(taskId);
+
+				if (acquired_at === null) {
+					return false;
+				}
+
+				first ??= acquired_at.getTime();
+
+				return acquired_at.getTime() > first;
+			});
+		} finally {
+			finish();
+			await runner.stop();
+		}
+	});
+
+	// The scope is what converts "make sure Python was drained first" from an
+	// operational hope into something the query enforces. Widening it belongs to
+	// the cutover, after Python's deployment is deleted — and this assertion is
+	// what stops a refactor doing it quietly.
+	it("reclaims an expired ts- lease and never touches Python's", async () => {
+		const ours = await createTask(db, "install_hmms");
+		const pythons = await createTask(db, "install_hmms");
+
+		await holdTask(ours, "ts-gone-1", TASK_LEASE_SECONDS + 60);
+		await holdTask(pythons, "somehost-4242", TASK_LEASE_SECONDS * 100);
+
+		const ran: number[] = [];
+
+		const runner = buildRunner({
+			install_hmms: defineTask({
+				type: "install_hmms",
+				payload: z.object({}),
+				run: async ({ taskId }) => {
+					ran.push(taskId);
+				},
+			}),
+		});
+
+		runner.start();
+
+		try {
+			await waitFor(async () => (await readRow(ours)).complete === true);
+		} finally {
+			await runner.stop();
+		}
+
+		expect(ran).toEqual([ours]);
+		expect(await readRow(pythons)).toMatchObject({
+			complete: false,
+			runner_id: "somehost-4242",
+		});
+	});
+
+	// Release converts an abandoned task from the full lease of dead time into
+	// milliseconds, which is the whole point of drain-then-release.
+	it("releases a claim still in flight when the drain window expires", async () => {
+		const taskId = await createTask(db, "install_hmms");
+
+		let started: () => void = () => undefined;
+		const running = new Promise<void>((resolve) => {
+			started = resolve;
+		});
+
+		const runner = buildRunner(
+			{
+				install_hmms: noopTask(async () => {
+					started();
+
+					// Ends only when the drain aborts it.
+					await new Promise<void>(() => undefined);
+				}),
+			},
+			// The reserve inside the runner leaves the wait very short and the
+			// release the rest.
+			{ drainTimeoutMs: 2_100 },
+		);
+
+		runner.start();
+
+		await running;
+		await runner.stop();
+
+		expect(await readRow(taskId)).toMatchObject({
+			acquired_at: null,
+			complete: false,
+			runner_id: null,
+		});
+	});
+
+	it("does not re-enter the drain on a second stop", async () => {
+		const taskId = await createTask(db, "install_hmms");
+
+		let started: () => void = () => undefined;
+		const running = new Promise<void>((resolve) => {
+			started = resolve;
+		});
+
+		const runner = buildRunner(
+			{
+				install_hmms: noopTask(async () => {
+					started();
+					await new Promise<void>(() => undefined);
+				}),
+			},
+			{ drainTimeoutMs: 2_100 },
+		);
+
+		runner.start();
+
+		await running;
+
+		const first = runner.stop();
+
+		// The same promise, not a second drain: a second signal that started one
+		// would release a claim the first pass is still draining.
+		expect(runner.stop()).toBe(first);
+
+		await first;
+
+		await expect(runner.stop()).resolves.toBeUndefined();
+
+		expect(await readRow(taskId)).toMatchObject({
+			acquired_at: null,
+			runner_id: null,
+		});
+	});
+
+	// The runner emits nothing itself. Every frame comes from the data layer,
+	// beside the write — which is why a claim produces none at all.
+	it("publishes one tasks frame for the completion and none for the claim", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		const runner = buildRunner({ install_hmms: noopTask() });
+
+		const frames = await collectFrames(database.client, async () => {
+			runner.start();
+
+			try {
+				await waitFor(async () => (await readRow(taskId)).complete === true);
+			} finally {
+				await runner.stop();
+			}
+		});
+
+		expect(frames).toEqual([
+			{ domain: "tasks", resource_id: taskId, operation: "update" },
+		]);
+	});
+});
+
+describe("dispatchTask", () => {
+	/** Claim a task by hand, which is the only way to get one of an unknown type. */
+	async function claimDirectly(type: string): Promise<ClaimedTask> {
+		await db.insert(tasks).values({
+			complete: false,
+			context: {},
+			count: 0,
+			created_at: new Date(),
+			progress: 0,
+			step: type,
+			type,
+		});
+
+		const claimed = await acquireTask(db, {
+			runnerId: RUNNER,
+			allowedTypes: [type],
+		});
+
+		if (claimed === null) {
+			throw new Error("the task under test was not claimable");
+		}
+
+		return claimed;
+	}
+
+	// Python acquires the row, finds no class for the name, logs and returns —
+	// leaving it claimed, incomplete and error-free. That row is invisible to
+	// every consumer, counted as running forever, and drawn as a bar that never
+	// moves. It is the documented cause of the abandoned KEDA trigger.
+	it("fails a task with no registered handler rather than stranding it", async () => {
+		const task = await claimDirectly("no_such_task");
+
+		const outcome = await dispatchTask({
+			ctx: undefined,
+			db,
+			logger,
+			registry: {},
+			signal: new AbortController().signal,
+			task,
+		});
+
+		const message = 'no handler registered for task type "no_such_task"';
+
+		expect(outcome).toEqual({ status: "failed", error: message });
+
+		const row = await readRow(task.id);
+
+		expect(row).toMatchObject({ complete: true, error: message });
+
+		// The exact Python failure state, asserted by name.
+		expect(
+			row.acquired_at !== null && row.error === null && row.complete === false,
+		).toBe(false);
+	});
+
+	// Releasing instead would hot-loop: an unknown row is claimable by
+	// construction, so it comes straight back on the next poll forever.
+	it("leaves a task it failed for having no handler unclaimable", async () => {
+		const task = await claimDirectly("no_such_task");
+
+		await dispatchTask({
+			ctx: undefined,
+			db,
+			logger,
+			registry: {},
+			signal: new AbortController().signal,
+			task,
+		});
+
+		await expect(
+			acquireTask(db, { runnerId: RUNNER, allowedTypes: ["no_such_task"] }),
+		).resolves.toBeNull();
+	});
+
+	it("publishes a tasks frame for a type it has no handler for", async () => {
+		const task = await claimDirectly("no_such_task");
+
+		const frames = await collectFrames(database.client, async () => {
+			await dispatchTask({
+				ctx: undefined,
+				db,
+				logger,
+				registry: {},
+				signal: new AbortController().signal,
+				task,
+			});
+		});
+
+		expect(frames).toEqual([
+			{ domain: "tasks", resource_id: task.id, operation: "update" },
+		]);
+	});
+});

--- a/apps/tasks/src/runner.test.ts
+++ b/apps/tasks/src/runner.test.ts
@@ -96,6 +96,7 @@ function noopTask(run: () => Promise<void> = async () => undefined) {
 }
 
 type RunnerOverrides = {
+	abortGraceMs?: number;
 	drainTimeoutMs?: number;
 	heartbeatIntervalMs?: number;
 	pollIntervalMs?: number;
@@ -117,6 +118,9 @@ function buildRunner(
 		pollIntervalMs: overrides.pollIntervalMs ?? 10,
 		registry,
 		runnerId: RUNNER,
+		// A body that ignores its signal burns the whole grace, so the tests that
+		// use one shorten it rather than waiting out the real three seconds twice.
+		abortGraceMs: overrides.abortGraceMs ?? 50,
 		...(overrides.heartbeatIntervalMs !== undefined && {
 			heartbeatIntervalMs: overrides.heartbeatIntervalMs,
 		}),
@@ -331,6 +335,53 @@ describe("createTaskRunner", () => {
 		await running;
 		await runner.stop();
 
+		expect(await readRow(taskId)).toMatchObject({
+			acquired_at: null,
+			complete: false,
+			runner_id: null,
+		});
+	});
+
+	// Releasing on top of the abort clears `runner_id` under a body that is still
+	// unwinding, so `runTask`'s ownership renewal fails, the run reports `fenced`,
+	// and the cleanup the abort path is supposed to run is skipped silently.
+	it("lets an aborted task run its cleanup before releasing its claim", async () => {
+		const taskId = await createTask(db, "install_hmms");
+		const cleaned: number[] = [];
+
+		let started: () => void = () => undefined;
+		const running = new Promise<void>((resolve) => {
+			started = resolve;
+		});
+
+		const runner = buildRunner(
+			{
+				install_hmms: defineTask({
+					type: "install_hmms",
+					payload: z.object({}),
+					cleanup: async ({ taskId: id }) => {
+						cleaned.push(id);
+					},
+					// Cooperative: it notices the abort and returns *cleanly*, which is
+					// the path a `catch`-only implementation misses entirely.
+					run: async ({ signal }) => {
+						started();
+
+						await new Promise<void>((resolve) => {
+							signal.addEventListener("abort", () => resolve(), { once: true });
+						});
+					},
+				}),
+			},
+			{ abortGraceMs: 2_000, drainTimeoutMs: 2_200 },
+		);
+
+		runner.start();
+
+		await running;
+		await runner.stop();
+
+		expect(cleaned).toEqual([taskId]);
 		expect(await readRow(taskId)).toMatchObject({
 			acquired_at: null,
 			complete: false,

--- a/apps/tasks/src/runner.ts
+++ b/apps/tasks/src/runner.ts
@@ -47,6 +47,22 @@ const HEARTBEAT_LAG_WARN_MS = 5_000;
  */
 const RELEASE_RESERVE_MS = 2_000;
 
+/**
+ * How long an aborted task is given to unwind before its claim is released
+ * anyway.
+ *
+ * **Releasing before it settles skips its `cleanup`.** `runTask` renews the
+ * lease to confirm it still holds the task before tearing anything down, and a
+ * release has already cleared `runner_id` — so the renewal matches nothing, the
+ * run reports `fenced`, and the cleanup that should have run on the abort path
+ * is silently skipped. Waiting is what keeps the claim alive long enough for the
+ * body to answer that question truthfully.
+ *
+ * A cooperative body unwinds in milliseconds, so this is spent only on one that
+ * ignores its signal — and for that one the release below is the right backstop.
+ */
+const ABORT_GRACE_MS = 3_000;
+
 /** The runner surface the app wires into its lifecycle. */
 export type TaskRunner = {
 	/** Begin claiming. Calling it again does nothing. */
@@ -97,6 +113,8 @@ export type TaskRunnerOptions<C> = {
 	pollIntervalMs?: number;
 	/** Defaults to `TASK_HEARTBEAT_SECONDS`. */
 	heartbeatIntervalMs?: number;
+	/** Defaults to {@link ABORT_GRACE_MS}. */
+	abortGraceMs?: number;
 	/** Overrides the progress debounce window. For tests. */
 	debounceMs?: number;
 };
@@ -467,7 +485,22 @@ export function createTaskRunner<C>(options: TaskRunnerOptions<C>): TaskRunner {
 		// resolves and releases its result instead of dispatching it.
 		stopping.abort();
 
-		const waitMs = Math.max(0, options.drainTimeoutMs - RELEASE_RESERVE_MS);
+		// The three phases share the one ceiling the hook declares. The grace is
+		// clamped rather than validated, so a drain window too small to hold it
+		// degrades to a shorter grace instead of overrunning the ceiling and being
+		// abandoned mid-release.
+		const graceMs = Math.max(
+			0,
+			Math.min(
+				options.abortGraceMs ?? ABORT_GRACE_MS,
+				options.drainTimeoutMs - RELEASE_RESERVE_MS,
+			),
+		);
+
+		const waitMs = Math.max(
+			0,
+			options.drainTimeoutMs - graceMs - RELEASE_RESERVE_MS,
+		);
 
 		if (loop !== undefined && !(await settles(loop, waitMs))) {
 			logger.warn(
@@ -479,6 +512,18 @@ export function createTaskRunner<C>(options: TaskRunnerOptions<C>): TaskRunner {
 			// working on past the release below.
 			for (const controller of inFlight.values()) {
 				controller.abort();
+			}
+
+			// Then wait for it to actually stop. The abort only *signals*; releasing
+			// on top of it clears `runner_id` under a body that is still unwinding,
+			// which makes `runTask`'s ownership renewal fail and skips the `cleanup`
+			// the abort path is supposed to run. The heartbeat is still going here,
+			// so the lease holds for however long the cleanup takes.
+			if (!(await settles(loop, graceMs))) {
+				logger.warn(
+					{ in_flight: inFlight.size, ms: graceMs },
+					"a task did not stop when it was aborted",
+				);
 			}
 		}
 

--- a/apps/tasks/src/runner.ts
+++ b/apps/tasks/src/runner.ts
@@ -1,0 +1,494 @@
+import { setTimeout as delay } from "node:timers/promises";
+import type { Db } from "@virtool/data/db/pg";
+import {
+	acquireTask,
+	buildRunnerId,
+	type ClaimedTask,
+	failTask,
+	releaseRunnerClaims,
+	releaseTask,
+	renewLeases,
+	TASK_HEARTBEAT_SECONDS,
+} from "@virtool/data/tasks/data";
+import type { Logger } from "@virtool/logger";
+import type { TaskRegistry } from "./framework/define";
+import { runTask, type TaskOutcome } from "./framework/run";
+
+/**
+ * How long the claim loop waits between polls.
+ *
+ * Python's interval, kept as it is. A LISTEN/NOTIFY wakeup would cut the latency
+ * between a task being spawned and picked up, but it is an optimisation over a
+ * claim path that has to be correct on polling alone first.
+ */
+export const POLL_INTERVAL_MS = 2_000;
+
+/**
+ * How late a heartbeat may run before it is reported.
+ *
+ * The hazard this watches for is event-loop starvation: a synchronous block
+ * longer than `TASK_LEASE_SECONDS` starves the renewal, the lease expires, and
+ * another runner claims a task that is still running — Kleppmann's
+ * garbage-collection pause in Node form. Task work is overwhelmingly I/O-bound,
+ * so this is a tripwire rather than an expected condition, and it is what would
+ * justify moving the heartbeat onto a worker thread. That move buys a second
+ * Postgres connection per replica and a duplicated database handle inside the
+ * worker, so it waits on a measurement rather than on theory.
+ */
+const HEARTBEAT_LAG_WARN_MS = 5_000;
+
+/**
+ * How much of the drain window is held back for the release.
+ *
+ * The whole window is the ceiling the shutdown hook declares, so a drain that
+ * spent all of it waiting would be abandoned mid-`UPDATE` and leave the claims
+ * it was handing back exactly where a hard kill would have.
+ */
+const RELEASE_RESERVE_MS = 2_000;
+
+/** The runner surface the app wires into its lifecycle. */
+export type TaskRunner = {
+	/** Begin claiming. Calling it again does nothing. */
+	start: () => void;
+	/**
+	 * Stop claiming, drain, release what is left.
+	 *
+	 * Idempotent — a second call returns the first one's promise rather than
+	 * draining again — and it never rejects. A failure in the release path is
+	 * logged, because the only move left to a caller winding the process down is
+	 * to carry on winding it down.
+	 */
+	stop: () => Promise<void>;
+	/**
+	 * When the claim loop last completed a poll, or `null` before the first one.
+	 *
+	 * The seam a liveness check would be built on. Nothing reads it today:
+	 * `GET /health/live` is deliberately static, because a liveness probe that
+	 * can fail restarts the fleet and kills every task in flight.
+	 */
+	getLastTickAt: () => Date | null;
+};
+
+/** What {@link createTaskRunner} needs. */
+export type TaskRunnerOptions<C> = {
+	db: Db;
+	logger: Logger;
+	/** The task types this runner will claim, keyed by their `type` column value. */
+	registry: TaskRegistry<C>;
+	/** Injected into every handler as `ctx`. */
+	ctx: C;
+	/**
+	 * Milliseconds `stop()` may take in total, matching the ceiling the shutdown
+	 * hook declares. Part of it is reserved for the release.
+	 */
+	drainTimeoutMs: number;
+	/** Defaults to `buildRunnerId()`. */
+	runnerId?: string;
+	/** Defaults to {@link POLL_INTERVAL_MS}. */
+	pollIntervalMs?: number;
+	/** Defaults to `TASK_HEARTBEAT_SECONDS`. */
+	heartbeatIntervalMs?: number;
+	/** Overrides the progress debounce window. For tests. */
+	debounceMs?: number;
+};
+
+/** What {@link dispatchTask} needs to run one claimed task. */
+export type DispatchTaskOptions<C> = {
+	db: Db;
+	logger: Logger;
+	registry: TaskRegistry<C>;
+	ctx: C;
+	task: ClaimedTask;
+	signal: AbortSignal;
+	debounceMs?: number;
+};
+
+/** Whether `promise` settled inside `ms`. Never rejects. */
+function settles(promise: Promise<void>, ms: number): Promise<boolean> {
+	return new Promise((resolve) => {
+		const timer = setTimeout(() => resolve(false), ms);
+
+		// The deadline must not be what holds the process open once the drain is
+		// over.
+		timer.unref();
+
+		promise.then(
+			() => {
+				clearTimeout(timer);
+				resolve(true);
+			},
+			() => {
+				clearTimeout(timer);
+				resolve(true);
+			},
+		);
+	});
+}
+
+/**
+ * Run a claimed task through its registered handler, or fail it for having none.
+ *
+ * **A type with no handler is failed, never released.** Python acquires the row,
+ * finds no class for the name, logs and returns — leaving `acquired_at` set,
+ * `complete = false` and `error = NULL`. That row is invisible to every
+ * consumer, counted as running forever, and drawn as a progress bar that never
+ * moves; it is the documented cause of the task runner's abandoned KEDA trigger.
+ * Releasing instead is no better: an unknown row is claimable by construction,
+ * so it comes straight back on the next poll and hot-loops without ever
+ * surfacing anything. Failing it is the only outcome a user can see.
+ *
+ * The claim already filters on the registry's keys, so this branch should be
+ * unreachable — which is exactly why it is a branch. The alternative is assuming
+ * the claim can only ever return a type this process knows, and that assumption
+ * is what the stranded rows were made of.
+ *
+ * Separate from the runner so a test can hand it a real claim of a type nothing
+ * is registered for, which the claim query will not produce.
+ */
+export async function dispatchTask<C>(
+	options: DispatchTaskOptions<C>,
+): Promise<TaskOutcome> {
+	const { ctx, db, logger, registry, signal, task } = options;
+
+	const def = registry[task.type];
+
+	if (def === undefined) {
+		const message = `no handler registered for task type "${task.type}"`;
+
+		logger.error({ task_id: task.id, type: task.type }, message);
+
+		try {
+			// Through `failTask`, not a write of its own: it sets `complete` beside
+			// `error`, and it is where the `tasks` frame that tells the UI comes
+			// from. A hand-rolled update here would strand the row again, silently.
+			if (!(await failTask(db, task.id, task.runnerId, message))) {
+				return { status: "fenced" };
+			}
+		} catch (err) {
+			logger.error(
+				{ err, task_id: task.id },
+				"failed to fail a task with no handler",
+			);
+
+			return { status: "aborted" };
+		}
+
+		return { status: "failed", error: message };
+	}
+
+	return runTask({
+		ctx,
+		db,
+		def,
+		logger,
+		signal,
+		task,
+		...(options.debounceMs !== undefined && { debounceMs: options.debounceMs }),
+	});
+}
+
+/**
+ * Build the loop that claims tasks, runs them, and holds their leases.
+ *
+ * **One task at a time**, matching Python. Replica count is the scaling lever
+ * and it already exists, and the bodies are heavy enough — a reference import
+ * parses tens of megabytes of JSON, an HMM install decompresses a
+ * multi-hundred-megabyte tarball — that in-process concurrency would multiply
+ * peak memory against a pod limit rather than fill idle time.
+ *
+ * The seams for many are built anyway: the in-flight tasks are a collection
+ * rather than a nullable single, and `renewLeases` renews a set. Raising the cap
+ * is meant to be a change to this file, not a redesign of it.
+ *
+ * It reads no configuration, opens no pool, installs no signal handler and binds
+ * no listener. All four are the app's, which calls `stop()` from a shutdown hook.
+ */
+export function createTaskRunner<C>(options: TaskRunnerOptions<C>): TaskRunner {
+	const { ctx, db, logger, registry } = options;
+
+	const runnerId = options.runnerId ?? buildRunnerId();
+	const pollIntervalMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
+	const heartbeatIntervalMs =
+		options.heartbeatIntervalMs ?? TASK_HEARTBEAT_SECONDS * 1_000;
+
+	/**
+	 * The tasks this runner holds, and the signal that stops each.
+	 *
+	 * A map rather than a single slot even though the cap is one, so the
+	 * heartbeat, the drain and the release are already written against a set.
+	 */
+	const inFlight = new Map<number, AbortController>();
+
+	/** Aborted by `stop()`. Ends the claim loop and wakes its poll wait. */
+	const stopping = new AbortController();
+
+	let lastTickAt: Date | null = null;
+	let loop: Promise<void> | undefined;
+	let heartbeat: NodeJS.Timeout | undefined;
+	let stopped: Promise<void> | undefined;
+	let beating = false;
+
+	async function release(task: ClaimedTask): Promise<void> {
+		try {
+			await releaseTask(db, task.id, task.runnerId);
+		} catch (err) {
+			logger.error(
+				{ err, task_id: task.id },
+				"failed to release a claimed task",
+			);
+		}
+	}
+
+	/**
+	 * Renew every lease this runner holds, and abandon what it turns out not to.
+	 *
+	 * `renewLeases` reports the ids it renewed rather than throwing, because a
+	 * partial result is the normal outcome: a task whose lease expired and was
+	 * reclaimed no longer carries this runner's id, so it is simply absent. The
+	 * difference is what has been fenced, and aborting its signal is how the body
+	 * learns to stop working on something another runner now owns.
+	 */
+	async function beat(): Promise<void> {
+		// A renewal slower than the interval would otherwise have a second beat
+		// firing on top of it, asking the same question and landing its `UPDATE`
+		// out of order behind the first.
+		if (beating) {
+			return;
+		}
+
+		beating = true;
+
+		try {
+			const ids = [...inFlight.keys()];
+
+			if (ids.length === 0) {
+				return;
+			}
+
+			const renewed = await renewLeases(db, ids, runnerId);
+
+			for (const id of ids) {
+				if (renewed.includes(id)) {
+					continue;
+				}
+
+				logger.warn(
+					{ task_id: id },
+					"abandoning a task whose lease this runner no longer holds",
+				);
+
+				inFlight.get(id)?.abort();
+			}
+		} catch (err) {
+			// Never fatal to the running task. Four beats of headroom exist precisely
+			// so a single blip is survivable, and the next beat retries.
+			logger.warn({ err }, "failed to renew task leases");
+		} finally {
+			beating = false;
+		}
+	}
+
+	function startHeartbeat(): void {
+		let expectedAt = performance.now() + heartbeatIntervalMs;
+
+		heartbeat = setInterval(() => {
+			const firedAt = performance.now();
+			const lag = firedAt - expectedAt;
+
+			expectedAt = firedAt + heartbeatIntervalMs;
+
+			if (lag > HEARTBEAT_LAG_WARN_MS) {
+				logger.warn(
+					{ lag_ms: Math.round(lag), in_flight: inFlight.size },
+					"the task heartbeat ran late",
+				);
+			}
+
+			void beat();
+		}, heartbeatIntervalMs);
+
+		// A heartbeat must never be the reason the process stays alive.
+		heartbeat.unref();
+	}
+
+	async function dispatch(task: ClaimedTask): Promise<void> {
+		const controller = new AbortController();
+
+		inFlight.set(task.id, controller);
+
+		try {
+			const outcome = await dispatchTask({
+				ctx,
+				db,
+				logger,
+				registry,
+				signal: controller.signal,
+				task,
+				...(options.debounceMs !== undefined && {
+					debounceMs: options.debounceMs,
+				}),
+			});
+
+			logger.info(
+				{ status: outcome.status, task_id: task.id, type: task.type },
+				"finished a task",
+			);
+
+			// `aborted` leaves the row carrying this runner's claim and incomplete —
+			// a drain that ran out, or a terminal write the database refused. Handing
+			// it back makes it claimable in milliseconds instead of after the whole
+			// lease. `fenced` is not ours to release, and the other two are terminal.
+			if (outcome.status === "aborted") {
+				await release(task);
+			}
+		} catch (err) {
+			// `runTask` always returns an outcome, so this is the genuinely
+			// unexpected. The row still carries the claim either way, so release it.
+			logger.error({ err, task_id: task.id }, "task dispatch failed");
+
+			await release(task);
+		} finally {
+			inFlight.delete(task.id);
+		}
+	}
+
+	async function tick(): Promise<void> {
+		let claimed: ClaimedTask | null;
+
+		try {
+			claimed = await acquireTask(db, {
+				runnerId,
+				// Read from the registry on every poll, never snapshotted at
+				// construction. Python snapshots `BaseTask.__subclasses__()`, which
+				// holds only the classes already imported, so one missing import
+				// silently narrows what its runner can claim. Reading live costs
+				// nothing and removes the class of bug.
+				allowedTypes: Object.keys(registry),
+			});
+		} catch (err) {
+			// A connection blip or a serialization failure does not earn a
+			// crash-loop, which is strictly worse than a poll that found nothing.
+			logger.error({ err }, "failed to claim a task");
+
+			return;
+		}
+
+		if (claimed === null) {
+			return;
+		}
+
+		if (stopping.signal.aborted) {
+			// The claim resolved after the drain began. Hand it back rather than
+			// starting a body with no time left to finish in.
+			await release(claimed);
+
+			return;
+		}
+
+		await dispatch(claimed);
+	}
+
+	async function run(): Promise<void> {
+		while (!stopping.signal.aborted) {
+			try {
+				await tick();
+			} catch (err) {
+				logger.error({ err }, "the task claim loop failed a poll");
+			}
+
+			lastTickAt = new Date();
+
+			if (stopping.signal.aborted) {
+				break;
+			}
+
+			try {
+				await delay(pollIntervalMs, undefined, { signal: stopping.signal });
+			} catch {
+				// `stop()` aborted the wait; the loop condition ends it.
+			}
+		}
+	}
+
+	/**
+	 * Stop claiming, wait out the in-flight work, then hand back what is left.
+	 *
+	 * Drain-then-release rather than drain-to-completion, which is not on offer at
+	 * any grace period we can set: these tasks run for minutes and a cluster
+	 * autoscaler force-removes a pod regardless of the field. A released task is
+	 * claimable again in milliseconds; an abandoned one sits out the full lease.
+	 *
+	 * Everything here is caught. `process.exitCode`, the listener, the pool and
+	 * the Sentry flush belong to the shutdown controller that calls this, and a
+	 * throw would take the steps after it down.
+	 */
+	async function drain(): Promise<void> {
+		// Observed by the claim loop, which stops claiming; a poll already in flight
+		// resolves and releases its result instead of dispatching it.
+		stopping.abort();
+
+		const waitMs = Math.max(0, options.drainTimeoutMs - RELEASE_RESERVE_MS);
+
+		if (loop !== undefined && !(await settles(loop, waitMs))) {
+			logger.warn(
+				{ in_flight: inFlight.size, ms: waitMs },
+				"the task drain window expired",
+			);
+
+			// Abort what is still running so a cooperative body stops rather than
+			// working on past the release below.
+			for (const controller of inFlight.values()) {
+				controller.abort();
+			}
+		}
+
+		// After the drain, not before: a task still working needs its lease held.
+		if (heartbeat !== undefined) {
+			clearInterval(heartbeat);
+			heartbeat = undefined;
+		}
+
+		try {
+			const released = await releaseRunnerClaims(db, runnerId);
+
+			if (released.length > 0) {
+				logger.info({ task_ids: released }, "released the claims still held");
+			}
+		} catch (err) {
+			logger.error({ err }, "failed to release this runner's claims");
+		}
+	}
+
+	return {
+		start() {
+			if (loop !== undefined) {
+				return;
+			}
+
+			logger.info(
+				{ runner_id: runnerId, types: Object.keys(registry) },
+				"task runner started",
+			);
+
+			startHeartbeat();
+
+			loop = run();
+		},
+
+		stop() {
+			if (stopped !== undefined) {
+				// A second signal must not start a second drain: it would release a
+				// claim the first pass is still draining.
+				logger.warn("the task runner is already stopping");
+
+				return stopped;
+			}
+
+			stopped = drain();
+
+			return stopped;
+		},
+
+		getLastTickAt: () => lastTickAt,
+	};
+}

--- a/apps/tasks/src/tasks/registry.ts
+++ b/apps/tasks/src/tasks/registry.ts
@@ -1,0 +1,24 @@
+import type { Db } from "@virtool/data/db/pg";
+import type { StorageBackend } from "@virtool/storage";
+import type { TaskRegistry } from "../framework/define";
+
+/**
+ * What every task handler is given as `ctx`.
+ *
+ * The handles a body needs and cannot construct: it is handed a database and
+ * object storage the way a `data.ts` function is. Its logger, its payload and
+ * its `taskId` arrive on `TaskHandlerArgs` instead.
+ */
+export type TaskContext = {
+	db: Db;
+	storage: StorageBackend;
+};
+
+/**
+ * Every task type this process claims and runs.
+ *
+ * Empty until the bodies are ported. The runner hands these keys to
+ * `acquireTask` as its allowed-types filter, so an empty registry claims nothing
+ * rather than claiming work it has no handler for.
+ */
+export const taskRegistry: TaskRegistry<TaskContext> = {};

--- a/apps/tasks/src/testing/frames.ts
+++ b/apps/tasks/src/testing/frames.ts
@@ -1,0 +1,60 @@
+import type { PgClient } from "@virtool/data/db/pg";
+import {
+	CLIENT_EVENTS_CHANNEL,
+	type ClientEvent,
+} from "@virtool/data/events/channel";
+
+/**
+ * Collect the `client_events` frames published while `run` executes.
+ *
+ * The sentinel published at the end is what makes a count sound: it goes over
+ * the same connection the emitter uses, after everything `run` did, so its
+ * arrival proves every frame `run` published has already been received. Waiting
+ * a fixed interval instead passes on a slow machine for the wrong reason, and a
+ * row that changed is not evidence a frame went out.
+ *
+ * `roles` is the sentinel's domain because it is the one domain keyed by a
+ * string, so a sentinel cannot be mistaken for a real frame about a task.
+ */
+export async function collectFrames(
+	client: PgClient,
+	run: () => Promise<void>,
+): Promise<ClientEvent[]> {
+	const received: ClientEvent[] = [];
+
+	let seal: () => void = () => undefined;
+
+	const sealed = new Promise<void>((resolve) => {
+		seal = resolve;
+	});
+
+	const subscription = await client.listen(CLIENT_EVENTS_CHANNEL, (payload) => {
+		const event = JSON.parse(payload) as ClientEvent;
+
+		if (event.domain === "roles" && event.resource_id === "sentinel") {
+			seal();
+			return;
+		}
+
+		received.push(event);
+	});
+
+	try {
+		await run();
+
+		await client.notify(
+			CLIENT_EVENTS_CHANNEL,
+			JSON.stringify({
+				domain: "roles",
+				resource_id: "sentinel",
+				operation: "update",
+			}),
+		);
+
+		await sealed;
+	} finally {
+		await subscription.unlisten();
+	}
+
+	return received;
+}

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -10,31 +10,13 @@ work reaches the outside world through Postgres and object storage.
 
 ## One process, two halves
 
-The spawner and the runner are **one binary**, not two.
+The spawner and the runner are **one binary**, not two. The spawner inserts the
+scheduled tasks; the runner claims and executes them.
 
-The spawner inserts the scheduled tasks; the runner claims and executes them.
-Each is turned off independently:
-
-| Variable | Default | Effect when `false` |
-| --- | --- | --- |
-| `VT_TASKS_SPAWN_ENABLED` | `true` | The process spawns no periodic tasks. |
-| `VT_TASKS_CLAIM_ENABLED` | `true` | The process claims and runs nothing. |
-
-Both default to `true` because an omitted flag has to fail toward a working
-fleet. A default of `false` would make a deployment that never set the key a
-silent no-op — a pod that starts, passes every probe, and does nothing at all.
-
-The two flags are what decouple the halves' rollouts, which is the whole reason
-separate binaries were ever considered. The cutover from Python is:
-
-1. Deploy with `VT_TASKS_CLAIM_ENABLED=false`. The TypeScript spawner runs in
-   production while Python still executes what it spawns.
-2. Stop Python's spawner and runner.
-3. Flip `VT_TASKS_CLAIM_ENABLED` to `true`.
-
-One image and one Deployment carry that whole sequence. Don't reintroduce a
-second binary to get the same effect — a mode flag on one artifact is the same
-decoupling with half the pipeline.
+Neither half has a flag to turn it off. The cutover from Python is two
+deployments inside a minute — delete Python's, create this one — and a minute of
+task lag is invisible to a user, so there is nothing for a staged rollout to buy.
+Don't reintroduce a mode flag or a second binary to stage it.
 
 ## Nothing happens at import time
 
@@ -118,9 +100,8 @@ Three of its behaviours are load-bearing and directly tested:
 | `VT_POSTGRES_URL` | — | Required. |
 | `VT_POSTGRES_POOL_MAX` | `10` | |
 | `VT_TASKS_PROBE_PORT` | `9900` | Hardcoded in the manifests; fixed, not arbitrary in practice. |
-| `VT_TASKS_SHUTDOWN_TIMEOUT` | `30` | **Seconds.** Must stay under the grace period — see below. |
-| `VT_TASKS_CLAIM_ENABLED` | `true` | |
-| `VT_TASKS_SPAWN_ENABLED` | `true` | |
+| `VT_TASKS_SHUTDOWN_TIMEOUT` | `40` | **Seconds.** Must stay under the grace period — see below. |
+| `VT_TASKS_DRAIN_TIMEOUT` | `25` | **Seconds.** A share of the shutdown budget, not an addition to it. |
 | `VT_METRICS_TOKEN` | unset | Unset leaves `/metrics` reporting 404. |
 | `VT_SENTRY_DSN` | unset | Unset disables Sentry. |
 | `VT_STORAGE_BACKEND` | — | Required, `s3` or `azure`. |
@@ -130,12 +111,14 @@ The schema is zod, in `src/config.ts`, and `TASKS_ENV_KEYS` is derived from it
 rather than listed by hand — a key missing from that list would silently lose
 its file variant.
 
-Booleans are spelled out as an enum of `true` / `false` / `1` / `0` rather than
-left to `z.coerce.boolean()`, which is a plain truthiness cast: it reads the
-string `"false"` as `true`, so the one value a deployment is most likely to
-write in order to turn something off would turn it on instead. An injected
-empty string reads as unset everywhere, which is what deployment tooling emits
-for a value it has nothing to put in.
+An injected empty string reads as unset everywhere, which is what deployment
+tooling emits for a value it has nothing to put in.
+
+`VT_TASKS_DRAIN_TIMEOUT` must be strictly less than
+`VT_TASKS_SHUTDOWN_TIMEOUT`, and the parse rejects it otherwise. The drain is a
+share of that budget and the shutdown controller silently takes the smaller of
+the two — so a drain set past the budget would quietly become a shorter one, and
+the operator who raised it would see neither an effect nor a complaint.
 
 ## Probes and metrics
 
@@ -237,14 +220,24 @@ caught and logged on its own, so a listener that will not close still leaves
 the pool to drain and Sentry to flush.
 
 That covers a step that *hangs* as well as one that throws, because the budget
-is **divided rather than pooled**: every step, each hook included, gets an
-equal share of the time still left when it starts, and is abandoned once that
-share is spent. A step that finishes early hands its remainder on. Awaiting the
-whole sequence against a single deadline instead would let one stuck socket eat
-the budget and take the pool drain and the Sentry flush with it — losing the
-record of the failure exactly when there was one to keep. An abandoned step is
-not cancelled, so the process may still have to be reaped; what the division
-buys is that everything after it still runs.
+is **divided rather than pooled**: every step gets a share of the time still
+left when it starts, and is abandoned once that share is spent. A step that
+finishes early hands its remainder on. Awaiting the whole sequence against a
+single deadline instead would let one stuck socket eat the budget and take the
+pool drain and the Sentry flush with it — losing the record of the failure
+exactly when there was one to keep. An abandoned step is not cancelled, so the
+process may still have to be reaped; what the division buys is that everything
+after it still runs.
+
+The share is **equal, except for a hook that declares a `timeoutMs` of its
+own**. Equal division is right for a socket close or a buffer flush, where a
+share is always more than enough, and wrong for a hook waiting out *work*: the
+ceiling on any one step is the budget over the number of steps, so a task drain
+would get a quarter of it however little the other three needed. A declared
+ceiling is reserved out of what the unbudgeted steps divide, so it cannot starve
+them. The task runner's drain is the only hook in the repo that uses it —
+`VT_TASKS_DRAIN_TIMEOUT` of a `VT_TASKS_SHUTDOWN_TIMEOUT`, 25 s of 40 s by
+default, leaving 5 s each for the listener, the pool and the Sentry flush.
 
 Then `process.exitCode` is set — `0` only when every step ran, `1` if any of
 them failed or the backstop fired first — and the loop drains. A failed
@@ -256,14 +249,19 @@ twice and close the pool out from under the first pass.
 
 The backstop is `.unref()`'d. Without that it holds the event loop open for its
 full budget on an otherwise clean shutdown, so a process that finished winding
-down in 200 ms would still sit there for thirty seconds.
+down in 200 ms would still sit there for the whole forty seconds.
 
 `VT_TASKS_SHUTDOWN_TIMEOUT` must stay strictly under
 `terminationGracePeriodSeconds`, which covers `preStop` *and* shutdown
 combined. The manifests use a 60 s grace period behind a 10 s `preStop` sleep,
-leaving 50 s; the 30 s default is comfortably inside it. Set it too high and
-SIGKILL lands before the backstop fires, and the process gets neither a clean
-shutdown nor a controlled failure.
+leaving 50 s; the 40 s default is inside it. Set it too high and SIGKILL lands
+before the backstop fires, and the process gets neither a clean shutdown nor a
+controlled failure.
+
+That `preStop` is inherited from the API base config and drains endpoints that
+do not exist — this Deployment's Service is `$patch: delete`d — so removing it
+hands the budget back a sixth of the grace period. Removing it belongs to the
+deployment manifests, not here.
 
 ### The image must not use `npm start`
 
@@ -325,8 +323,8 @@ one Postgres across all of them locally.
 ## The framework and the loops
 
 `bootstrap` is the floor. The task framework, the claim/lease/reclaim data
-layer, and the dispatch loops land on top of it, and each fills in its section
-here in its own commit:
+layer, the runner and the spawn schedule land on top of it, and each fills in
+its section here in its own commit:
 
 - **Framework** — `defineTask`, the step model, and the percent/fraction
   progress seam. Lives in `apps/tasks/src/framework/`: it is an execution shell
@@ -338,9 +336,11 @@ here in its own commit:
   `updateTaskProgress`. These are pure persistence over a table both halves
   write, so they belong in `packages/data/src/tasks/data.ts`, extending the
   module already there.
-- **The task bodies** — `apps/tasks/src/tasks/<type>.ts`, registered with the
-  runner's registry. The shell lives with its runtime, the way `functions.ts`
-  lives with the web app.
+- **The runner** — `apps/tasks/src/runner.ts`, the claim loop, the dispatcher and
+  the heartbeat. Its own section follows.
+- **The task bodies** — `apps/tasks/src/tasks/<type>.ts`, registered in
+  `apps/tasks/src/tasks/registry.ts`. The shell lives with its runtime, the way
+  `functions.ts` lives with the web app.
 
 Note there is **no `service.ts` tier available to a task body.** `service.ts` is
 the web app's orchestration layer and stays in `apps/web/src/server/<feature>/`,
@@ -619,10 +619,12 @@ buys three things: no background timer to schedule, nothing to keep alive when
 the fleet is idle, and no window between a sweep marking a row free and a
 claimer taking it. The queue heals as a side effect of ordinary work.
 
-`reclaimExpiredLeases` still ships as its own query. Nothing needs to call it on
-a running fleet; it exists for the cutover, where a deployment may be spawning
-tasks with `VT_TASKS_CLAIM_ENABLED=false` and so never running a claim to heal
-anything.
+**There is no reclaim timer, and adding one would be a second loop doing what
+the claim already does.** `reclaimExpiredLeases` still ships as its own query,
+with nothing calling it on a running fleet: it exists for the cutover, whose last
+step widens the `ts-` scope below to recover what Python was mid-flight on when
+its deployment was deleted. By then there is no claim left to fold that sweep
+into.
 
 Two things about the predicate are load-bearing:
 
@@ -700,3 +702,135 @@ state and then get no second frame. Typing them `Db` makes that unrepresentable
 instead of documenting it. If a task body ever genuinely needs a completion
 atomic with a final domain write, widening the parameter is a one-line change
 that has to answer the ordering question at the same time.
+
+## The runner
+
+`createTaskRunner` in `apps/tasks/src/runner.ts` is the loop that claims tasks,
+dispatches them, and holds their leases while they run. It returns three things
+and no more: `start()`, `stop()`, and `getLastTickAt()`.
+
+It reads no configuration, opens no pool, installs no signal handler and binds
+no listener. All four are the app's — `src/index.ts` builds it from the
+`AppContext` and registers `stop` as a shutdown hook.
+
+### One task at a time, on seams built for many
+
+Replica count is the scaling lever and it already exists. The bodies are heavy
+enough — a reference import parses tens of megabytes of JSON, an HMM install
+decompresses a multi-hundred-megabyte tarball — that in-process concurrency
+would multiply peak memory against a pod limit rather than fill idle time. And
+holding the cap at one means the cutover changes exactly one variable.
+
+The seams for many are built anyway. In-flight tasks are a `Map`, not a nullable
+single slot, and `renewLeases` renews a **set**. Raising the cap is meant to be a
+change to this file, not a redesign of it.
+
+### The claim loop
+
+A poll every `POLL_INTERVAL_MS` (2 000, Python's interval) when idle. An
+async `while` rather than a `setInterval`, so a task that runs for minutes cannot
+have a second poll firing on top of it.
+
+- **Supported types are read from the registry on every poll, never snapshotted.**
+  Python snapshots `BaseTask.__subclasses__()` at construction, which holds only
+  the classes already imported — so one missing import silently narrows what its
+  runner can claim, with nothing anywhere to say so. Reading live costs nothing
+  and removes the class of bug. An **empty** registry claims nothing at all,
+  because `acquireTask` short-circuits on an empty allowed-types list.
+- **A failed claim logs and continues.** A connection blip or a serialization
+  failure does not earn a crash-loop, which is strictly worse than a poll that
+  found nothing.
+- **`getLastTickAt()` is a seam, not a consumer.** It is what a
+  "has the loop ticked recently" liveness check would be built on. Nothing reads
+  it: `GET /health/live` is deliberately static, because a liveness probe that
+  can fail restarts the fleet and kills every task in flight.
+- A poll that resolves **after** the drain has begun releases its claim instead
+  of dispatching it. Starting a body with no time left to finish in is how a task
+  gets killed mid-write.
+
+### A type with no handler is failed, never released
+
+`dispatchTask` looks the claimed row's `type` up in the registry, and **fails the
+task** when it finds nothing — through `failTask`, so `complete` is set beside
+`error` and the `tasks` frame that tells the UI actually goes out.
+
+Python acquires the row, finds no class for the name, logs a warning and
+*returns*. The row keeps `acquired_at` set with `complete = false` and
+`error = NULL`: invisible to every consumer, counted as running forever by
+`get_counts`, and drawn as a progress bar that never moves. It is the documented
+cause of the task runner HPA's abandoned KEDA trigger.
+
+Releasing instead is no better. An unknown row is claimable by construction, so
+it returns on the very next poll and hot-loops for good, still surfacing nothing.
+Failing is the only outcome a user can see.
+
+The claim already filters on the registry's keys, so this branch should be
+unreachable — which is exactly why it is a branch rather than an assumption. It
+lives in its own exported function because a test cannot get a claim of an
+unknown type out of the claim query, and that test is the one worth having.
+
+### The heartbeat
+
+`renewLeases` for every in-flight task every `TASK_HEARTBEAT_SECONDS` against
+the `TASK_LEASE_SECONDS` lease, on a `setInterval` that is **`.unref()`'d** — a
+heartbeat must never be the reason the process stays alive. A beat still in
+flight when the next fires is skipped rather than stacked.
+
+A failed renewal logs at `warn` and retries on the next beat; it never touches
+the running task. Four beats of headroom exist precisely so one blip is
+survivable.
+
+`renewLeases` reports the ids it renewed, and the difference is what has been
+**fenced** — the lease expired and another runner owns the task. The runner
+aborts that task's signal, which is how the body learns to stop working on
+something it no longer holds. `runTask` then renews and checks the claim before
+its cleanup and reports `fenced`, so nothing is written and nothing is released.
+
+**Event-loop starvation is the real hazard.** A synchronous block longer than the
+lease starves the timer, the lease expires, and another runner claims work that
+is still running — Kleppmann's garbage-collection pause in Node form. The work is
+overwhelmingly I/O-bound, so the beat measures how late it ran and logs above
+`HEARTBEAT_LAG_WARN_MS`. That tripwire is what would justify moving the heartbeat
+onto a worker thread, which costs a second Postgres connection per replica and a
+duplicated database handle inside it. **The one genuinely CPU-heavy stretch is
+bulk OTU preparation during reference import and clone, and that loop must
+yield** — chunk it and `await` between chunks. The constraint belongs to those
+task bodies; the consequence lands here.
+
+### Shutdown is drain, then release
+
+`stop()` is the whole sequence, registered as a single shutdown hook. The
+controller owns everything around it — `process.exitCode`, the listener, the
+pool, the Sentry flush, and the guard against a second signal.
+
+1. Stop claiming. The loop observes it and its poll wait is woken rather than
+   waited out.
+2. Wait for the in-flight task, up to `VT_TASKS_DRAIN_TIMEOUT` less a two-second
+   reserve.
+3. If the window expires, abort what is still running so a cooperative body stops
+   instead of working on past the release.
+4. Stop the heartbeat — *after* the drain, because a task still working needs its
+   lease held.
+5. `releaseRunnerClaims`, clearing `acquired_at` and `runner_id`.
+
+Draining to completion is not on offer at any grace period we can set: these
+tasks run for minutes, and a cluster autoscaler force-removes a pod well before
+an hour whatever the field says. So the window is bounded and what follows it is
+a release — which is the point of this shape. A released task is claimable again
+in milliseconds; an abandoned one sits out the full `TASK_LEASE_SECONDS` of dead
+time.
+
+**The reserve is why the drain window is not the whole hook budget.** A drain
+that spent all of it waiting would be abandoned mid-`UPDATE` and leave the claims
+it was handing back exactly where a hard kill would have.
+
+`stop()` is idempotent — a second call returns the first one's promise rather
+than starting a second drain, which would release a claim the first pass is still
+draining — and it **never rejects**. Every failure inside it is logged, because
+the only move left to a caller winding the process down is to carry on winding it
+down, and a throw would take the steps after it with it.
+
+An `aborted` outcome from `runTask` is released for the same reason: the row
+still carries this runner's claim and is not complete, so handing it back beats
+letting it sit out the lease. `fenced` is not this runner's to release, and
+`completed` and `failed` are terminal.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -904,13 +904,29 @@ pool, the Sentry flush, and the guard against a second signal.
 
 1. Stop claiming. The loop observes it and its poll wait is woken rather than
    waited out.
-2. Wait for the in-flight task, up to `VT_TASKS_DRAIN_TIMEOUT` less a two-second
-   reserve.
+2. Wait for the in-flight task, up to `VT_TASKS_DRAIN_TIMEOUT` less the abort
+   grace and the release reserve.
 3. If the window expires, abort what is still running so a cooperative body stops
    instead of working on past the release.
-4. Stop the heartbeat — *after* the drain, because a task still working needs its
+4. **Wait for it to actually stop**, up to the abort grace.
+5. Stop the heartbeat — *after* the drain, because a task still working needs its
    lease held.
-5. `releaseRunnerClaims`, clearing `acquired_at` and `runner_id`.
+6. `releaseRunnerClaims`, clearing `acquired_at` and `runner_id`.
+
+**Step 4 is not politeness, and skipping it skips the body's `cleanup`.** The
+abort only *signals*. `runTask` renews the lease to confirm it still holds the
+task before tearing anything down, so a release landing on top of the abort
+clears `runner_id` under a body that is still unwinding: the renewal matches
+nothing, the run reports `fenced`, and the cleanup the abort path is supposed to
+run is skipped without a word. Waiting keeps the claim alive long enough for that
+ownership question to be answered truthfully. A cooperative body unwinds in
+milliseconds, so the grace is only ever spent on one that ignores its signal —
+and for that one the release is the correct backstop.
+
+The three phases share the one ceiling the hook declares, and the grace is
+**clamped rather than validated**: a drain window too small to hold it degrades
+to a shorter grace instead of overrunning the ceiling and being abandoned
+mid-release.
 
 Draining to completion is not on offer at any grace period we can set: these
 tasks run for minutes, and a cluster autoscaler force-removes a pod well before

--- a/packages/data/src/db/timeout.test.ts
+++ b/packages/data/src/db/timeout.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { withTimeout } from "./timeout";
+
+/**
+ * A promise that never settles.
+ *
+ * This is what the helper exists for: a query queued *client-side* behind a full
+ * pool, where no statement timeout applies and nothing will ever reject it. It
+ * is also what makes these tests deterministic — the timer cannot lose a race
+ * against something that never finishes, so there is no race.
+ */
+function never(): Promise<never> {
+	return new Promise(() => undefined);
+}
+
+describe("withTimeout", () => {
+	it("rejects once the bound passes", async () => {
+		await expect(withTimeout(never(), 5)).rejects.toThrow("timed out");
+	});
+
+	// Several probes share this helper, so a log line saying only "timed out"
+	// cannot be told from any other failure. The bound is what identifies it.
+	it("names the bound that was exceeded", async () => {
+		await expect(withTimeout(never(), 5)).rejects.toThrow(
+			"timed out after 5ms",
+		);
+	});
+
+	it("resolves what the promise resolved", async () => {
+		await expect(withTimeout(Promise.resolve("counts"), 1_000)).resolves.toBe(
+			"counts",
+		);
+	});
+
+	it("passes the promise's own rejection through", async () => {
+		await expect(
+			withTimeout(Promise.reject(new Error("connection reset")), 1_000),
+		).rejects.toThrow("connection reset");
+	});
+
+	// The timer is cleared on both paths. Without that a probe that answered in
+	// milliseconds would leave a pending timer for the whole bound, and on a
+	// short-lived process that is the difference between exiting and waiting it
+	// out. Counted rather than compared loosely, so an uncleared 30 s timer is a
+	// failure rather than a number that happens to be no larger.
+	it("clears the timer once the promise settles", async () => {
+		const timers = () =>
+			process
+				.getActiveResourcesInfo()
+				.filter((resource) => resource === "Timeout").length;
+
+		const before = timers();
+
+		await withTimeout(Promise.resolve(null), 30_000);
+
+		expect(timers()).toBe(before);
+	});
+});

--- a/packages/data/src/db/timeout.ts
+++ b/packages/data/src/db/timeout.ts
@@ -13,7 +13,10 @@
  * this helper and a log line saying only "timed out" cannot be told from any
  * other failure.
  */
-export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+export function withTimeout<T>(
+	promise: PromiseLike<T>,
+	ms: number,
+): Promise<T> {
 	let timer: ReturnType<typeof setTimeout> | undefined;
 
 	const deadline = new Promise<never>((_, reject) => {

--- a/packages/data/src/health/data.ts
+++ b/packages/data/src/health/data.ts
@@ -1,5 +1,6 @@
 import type { Logger } from "@virtool/logger";
 import type { PgClient } from "../db/pg";
+import { withTimeout } from "../db/timeout";
 
 const CHECK_TIMEOUT_MS = 5_000;
 
@@ -24,26 +25,6 @@ export function summarizeReadiness(postgres: StoreCheck): ReadyReport {
 		statusCode: ok ? 200 : 503,
 		checks: { postgres },
 	};
-}
-
-/** Reject if `promise` does not settle within `ms` milliseconds. */
-function withTimeout<T>(promise: PromiseLike<T>, ms: number): Promise<T> {
-	return new Promise<T>((resolve, reject) => {
-		const timer = setTimeout(() => {
-			reject(new Error(`health check timed out after ${ms}ms`));
-		}, ms);
-
-		promise.then(
-			(value) => {
-				clearTimeout(timer);
-				resolve(value);
-			},
-			(err) => {
-				clearTimeout(timer);
-				reject(err);
-			},
-		);
-	});
 }
 
 /** Probe Postgres with a trivial query. Never throws. */

--- a/packages/data/src/tasks/data.test.ts
+++ b/packages/data/src/tasks/data.test.ts
@@ -920,7 +920,9 @@ describe("readTaskQueueBounded", () => {
 		expect(snapshot.oldestQueuedAges).toHaveLength(1);
 	});
 
-	it("rejects rather than hanging when the deadline passes", async () => {
-		await expect(readTaskQueueBounded(db, 0)).rejects.toThrow("timed out");
-	});
+	// The bound itself is `withTimeout`'s, and `timeout.test.ts` covers it against
+	// a promise that genuinely never settles. Asserting it from here meant racing
+	// two real queries against a zero deadline — which `setTimeout` clamps to 1 ms,
+	// so under load the queries won and the test failed for no reason anyone could
+	// act on.
 });

--- a/packages/data/src/tasks/data.ts
+++ b/packages/data/src/tasks/data.ts
@@ -511,11 +511,11 @@ export async function releaseRunnerClaims(
  * Take back every claim held by one of our runners whose lease has run out, and
  * report which.
  *
- * {@link acquireTask} already reclaims as it claims, so nothing needs to call
- * this on a running fleet. It ships as its own query for the cutover, where a
- * fleet may be spawning tasks with claiming disabled and so never running a
- * claim to heal them, and because a reclaim that can be invoked directly is
- * testable and operable on its own.
+ * {@link acquireTask} already reclaims as it claims, so nothing calls this on a
+ * running fleet. It ships as its own query for the cutover, whose last step is
+ * widening the prefix scope below to recover what Python was mid-flight on when
+ * its deployment was deleted — a sweep that has to be invocable on its own,
+ * because by then there is no claim left to fold it into.
  *
  * Scoped to {@link RUNNER_ID_PREFIX}: a row Python holds is never touched.
  *

--- a/packages/service/src/shutdown.test.ts
+++ b/packages/service/src/shutdown.test.ts
@@ -256,6 +256,95 @@ describe("createShutdownController", () => {
 		]);
 	});
 
+	describe("a hook with a budget of its own", () => {
+		// Equal division suits a socket close, where a share is always more than
+		// enough. It badly under-serves a hook waiting out work: the ceiling on any
+		// one step is the budget over the number of steps, however little the rest
+		// need. Four steps at a 40 s budget caps a task drain at 10 s.
+		it("gives it more than the equal share would", async () => {
+			const order: string[] = [];
+			let elapsed = 0;
+
+			const controller = createShutdownController(
+				deps(order, { timeout: 0.4 }),
+			);
+
+			controller.onShutdown(
+				"drain",
+				async () => {
+					const startedAt = performance.now();
+
+					await new Promise<void>((resolve) => setTimeout(resolve, 250));
+
+					elapsed = performance.now() - startedAt;
+					order.push("drain");
+				},
+				{ timeoutMs: 300 },
+			);
+
+			await controller.shutdown("SIGTERM");
+
+			// An equal share of a 400 ms budget across four steps is 100 ms, which
+			// would have abandoned this hook well before it settled.
+			expect(elapsed).toBeGreaterThan(200);
+			expect(order).toEqual([
+				"setReady:false",
+				"drain",
+				"closeListener",
+				"closeDatabase",
+				"flushSentry",
+			]);
+			expect(process.exitCode).toBe(0);
+		});
+
+		it("abandons it at its own ceiling", async () => {
+			const order: string[] = [];
+
+			const controller = createShutdownController(deps(order, { timeout: 10 }));
+
+			controller.onShutdown("stuck", () => new Promise<void>(() => undefined), {
+				timeoutMs: 40,
+			});
+
+			await controller.shutdown("SIGTERM");
+
+			// Bounded by its declared ceiling rather than by the whole budget, so the
+			// steps behind it still run — and it is still a failed step.
+			expect(order).toEqual([
+				"setReady:false",
+				"closeListener",
+				"closeDatabase",
+				"flushSentry",
+			]);
+			expect(process.exitCode).toBe(1);
+		});
+
+		// Declaring a ceiling reserves the time rather than taking it out of the
+		// pool drain's share.
+		it("does not starve the steps behind it", async () => {
+			const order: string[] = [];
+
+			const controller = createShutdownController(
+				deps(order, {
+					timeout: 0.4,
+					closeDatabase: async () => {
+						await new Promise<void>((resolve) => setTimeout(resolve, 60));
+						order.push("closeDatabase");
+					},
+				}),
+			);
+
+			controller.onShutdown("stuck", () => new Promise<void>(() => undefined), {
+				timeoutMs: 200,
+			});
+
+			await controller.shutdown("SIGTERM");
+
+			expect(order).toContain("closeDatabase");
+			expect(order).toContain("flushSentry");
+		});
+	});
+
 	it("reports a non-zero exit code when the sequence overruns", async () => {
 		const controller = createShutdownController(
 			deps([], {

--- a/packages/service/src/shutdown.ts
+++ b/packages/service/src/shutdown.ts
@@ -13,6 +13,32 @@ type Outcome = "clean" | "failed" | "overran";
 type Step = {
 	name: string;
 	run: () => Promise<void>;
+	/**
+	 * A ceiling of its own, in milliseconds, instead of an equal share.
+	 *
+	 * See {@link ShutdownOptions.timeoutMs}.
+	 */
+	timeoutMs?: number;
+};
+
+/** How a registered hook departs from the equal-share budget. */
+export type ShutdownOptions = {
+	/**
+	 * Bound this hook explicitly rather than giving it an equal share.
+	 *
+	 * Equal division suits steps whose duration is a socket close or a buffer
+	 * flush, where a share is always more than enough. It badly under-serves a
+	 * hook that has to wait out *work* — draining a task a runner is mid-way
+	 * through — because the ceiling on any one step is the budget divided by the
+	 * number of steps, however little the others need.
+	 *
+	 * A hook that declares one takes the smaller of it and the time left, and
+	 * that amount is reserved out of what the unbudgeted steps behind it divide,
+	 * so declaring one cannot starve them. Keep the sum comfortably under
+	 * {@link ShutdownDeps.timeout}: the remainder is what closes the listener,
+	 * drains the pool and flushes Sentry.
+	 */
+	timeoutMs?: number;
 };
 
 /** What a step that never settled resolves to, rather than its own value. */
@@ -35,7 +61,11 @@ export type ShutdownDeps = {
 
 /** The shutdown surface {@link createShutdownController} returns. */
 export type ShutdownController = {
-	onShutdown: (name: string, hook: () => Promise<void>) => void;
+	onShutdown: (
+		name: string,
+		hook: () => Promise<void>,
+		options?: ShutdownOptions,
+	) => void;
 	/** Run the sequence. Safe to call more than once; later calls are ignored. */
 	shutdown: (signal: string) => Promise<void>;
 	/** Register SIGTERM and SIGINT handlers. */
@@ -132,12 +162,19 @@ function withDeadline<T>(
  * from one that did not.
  *
  * That holds for a step that *hangs* as well as one that throws, which is why
- * the budget is divided rather than pooled: every step, each hook included,
- * gets an equal share of the time still left when it starts, and is abandoned
- * once that share is spent. Awaiting the sequence against a single deadline
- * would let one stuck socket eat the whole budget and take the pool drain and
- * the Sentry flush down with it — so the failure would go unrecorded precisely
- * when there was something to record.
+ * the budget is divided rather than pooled: every step gets a share of the time
+ * still left when it starts, and is abandoned once that share is spent.
+ * Awaiting the sequence against a single deadline would let one stuck socket eat
+ * the whole budget and take the pool drain and the Sentry flush down with it —
+ * so the failure would go unrecorded precisely when there was something to
+ * record.
+ *
+ * The share is **equal**, except for a hook that declares a
+ * {@link ShutdownOptions.timeoutMs} of its own. Equal division is right for a
+ * socket close or a buffer flush, and wrong for a hook waiting out work: the
+ * ceiling on any one step is the budget over the number of steps, however
+ * little the rest need. A declared ceiling is reserved out of what the
+ * unbudgeted steps divide, so it cannot starve them.
  *
  * A step whose share runs out is abandoned, not cancelled — nothing here can
  * force a socket closed — so the process may still have to be reaped rather
@@ -188,11 +225,26 @@ export function createShutdownController(
 		const results: boolean[] = [];
 
 		for (const [index, step] of steps.entries()) {
-			// Each step gets an equal share of whatever is left, so one that never
-			// settles is abandoned with time still on the clock for the rest. A step
-			// that finishes early hands the remainder on to the steps behind it.
+			// Each step gets a share of whatever is left, so one that never settles is
+			// abandoned with time still on the clock for the rest. A step that
+			// finishes early hands the remainder on to the steps behind it.
+			const remaining = Math.max(0, deadline - performance.now());
+
+			// What the steps behind this one have claimed explicitly is subtracted
+			// before the rest is divided, so a hook that declares a ceiling reserves
+			// its time rather than taking it out of the pool drain's.
+			const reserved = steps
+				.slice(index + 1)
+				.reduce((total, later) => total + (later.timeoutMs ?? 0), 0);
+
+			const unbudgeted = steps
+				.slice(index)
+				.filter((each) => each.timeoutMs === undefined).length;
+
 			const share =
-				Math.max(0, deadline - performance.now()) / (steps.length - index);
+				step.timeoutMs === undefined
+					? Math.max(0, remaining - reserved) / unbudgeted
+					: Math.min(step.timeoutMs, remaining);
 
 			results.push(await runStep(step, share));
 		}
@@ -239,8 +291,14 @@ export function createShutdownController(
 	}
 
 	return {
-		onShutdown(name, run) {
-			hooks.push({ name, run });
+		onShutdown(name, run, options) {
+			hooks.push({
+				name,
+				run,
+				...(options?.timeoutMs !== undefined && {
+					timeoutMs: options.timeoutMs,
+				}),
+			});
 		},
 
 		shutdown,


### PR DESCRIPTION
## Summary
- Adds the claim loop, the runner half of `apps/tasks`. It claims tasks, dispatches them to registered handlers, holds their leases and drains in-flight work on shutdown. The periodic spawner is a separate change, and the registry is empty until the task bodies are ported, so this claims nothing yet.
- Fails a claimed type with no handler instead of leaving the row with `acquired_at` set and `error` null, which is what Python does — invisible to every consumer and counted as running forever. Supported types are read from the registry at claim time rather than snapshotted, and there is no reclaim timer: `acquireTask` already reclaims an expired lease as it claims.
- Lets a shutdown hook declare its own `timeoutMs` in `createShutdownController`. Equal division caps any one step at a quarter of the budget, which is right for a socket close and wrong for a drain waiting out a task.
- Removes `VT_TASKS_CLAIM_ENABLED` and `VT_TASKS_SPAWN_ENABLED`. The cutover from Python is two deployments inside a minute, so a staged rollout buys nothing.
- Tidies up `withTimeout`, the timeout helper the `/metrics` probes share: it had no test of its own and a duplicate copy in `health/data.ts`, and the only thing covering its timer path was a race that flaked under parallel load.

Closes VIR-2889.