### PR TITLE
chore: drop client disconnect errors from sentry reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -629,6 +629,15 @@ a name conflict). The Sentry `beforeSend` filter drops `ClientError`
 `Error` is reported as a false incident. A bare `throw` stays reserved
 for the genuinely unexpected.
 
+That same filter drops the `Error: aborted` Node raises when a client's
+socket closes mid-request — unactionable by construction, and steady
+traffic here because the SSE client probes `HEAD /events` from its
+`onerror` handler, which is exactly when a deploy is tearing the
+connection down. It matches `ECONNRESET` **paired with** the literal
+message `aborted`, never the code alone: `ECONNRESET` also arrives from
+connections this side opens — Postgres, object storage, GenBank — and
+those are real incidents.
+
 **Never set a null-body status — 204, 205, or 304 — from a server
 function.** Start always serializes a body for an RPC call, so the
 `Response` constructor rejects the pair and the operation reports a

--- a/apps/web/src/server/__tests__/sentryFilters.test.ts
+++ b/apps/web/src/server/__tests__/sentryFilters.test.ts
@@ -19,6 +19,11 @@ function eventWithType(type: string): ErrorEvent {
 	return { exception: { values: [{ type }] } } as ErrorEvent;
 }
 
+/** The shape node's `abortIncoming` produces: a plain `Error` carrying a code. */
+function connResetError(message: string): Error {
+	return Object.assign(new Error(message), { code: "ECONNRESET" });
+}
+
 describe("dropExpectedClientErrors", () => {
 	it("drops an event whose original exception is an UnauthorizedError", () => {
 		const result = dropExpectedClientErrors(
@@ -63,6 +68,30 @@ describe("dropExpectedClientErrors", () => {
 		const event = eventWithType(CLIENT_ERROR_NAME);
 
 		expect(dropExpectedClientErrors(event, {} as EventHint)).toBeNull();
+	});
+
+	it("drops the error node raises when a client goes away mid-request", () => {
+		const result = dropExpectedClientErrors(eventWithType("Error"), {
+			originalException: connResetError("aborted"),
+		} as EventHint);
+
+		expect(result).toBeNull();
+	});
+
+	it("keeps an ECONNRESET from a connection this side opened", () => {
+		const event = eventWithType("Error");
+		const hint = {
+			originalException: connResetError("read ECONNRESET"),
+		} as EventHint;
+
+		expect(dropExpectedClientErrors(event, hint)).toBe(event);
+	});
+
+	it("keeps an aborted error that carries no ECONNRESET code", () => {
+		const event = eventWithType("Error");
+		const hint = { originalException: new Error("aborted") } as EventHint;
+
+		expect(dropExpectedClientErrors(event, hint)).toBe(event);
 	});
 
 	it("keeps an unrelated error event", () => {

--- a/apps/web/src/server/sentryFilters.ts
+++ b/apps/web/src/server/sentryFilters.ts
@@ -12,15 +12,16 @@ const EXPECTED_CLIENT_ERROR_NAMES = new Set<string>([
 ]);
 
 /**
- * Sentry `beforeSend` hook that drops a server function's expected client-facing
- * errors before they are reported.
+ * Sentry `beforeSend` hook that drops errors the client caused before they are
+ * reported.
  *
- * Two kinds slip through here, both routine control flow rather than incidents:
- * the auth middleware's 401/403 rejections (`UnauthorizedError` /
- * `ForbiddenError`), whose name the client's retry guard reads to bounce to the
- * login wall; and the handlers' deliberate 4xx `ClientError`s — a bad login, a
- * missing record, a name conflict — which the client renders as a message.
- * Reporting either only buries real errors in noise.
+ * Three kinds slip through here, all routine rather than incidents: the auth
+ * middleware's 401/403 rejections (`UnauthorizedError` / `ForbiddenError`),
+ * whose name the client's retry guard reads to bounce to the login wall; the
+ * handlers' deliberate 4xx `ClientError`s — a bad login, a missing record, a
+ * name conflict — which the client renders as a message; and a request whose
+ * socket closed before the response was written. Reporting any of them only
+ * buries real errors in noise.
  */
 export function dropExpectedClientErrors(
 	event: ErrorEvent,
@@ -28,11 +29,35 @@ export function dropExpectedClientErrors(
 ): ErrorEvent | null {
 	if (
 		isExpectedClientError(hint.originalException) ||
-		eventReportsClientError(event)
+		eventReportsClientError(event) ||
+		isClientDisconnect(hint.originalException)
 	) {
 		return null;
 	}
 	return event;
+}
+
+/**
+ * Recognise the error Node raises when a client goes away mid-request.
+ *
+ * `abortIncoming` destroys every request still in flight on a socket that
+ * closed, and the stack it produces is pure Node internals — no application
+ * frame, because no application code ran. It is unactionable by construction:
+ * the peer is gone. The web app draws a steady stream of these because the SSE
+ * client probes `HEAD /events` from its `onerror` handler, which is exactly
+ * when a deploy is tearing the connection down, so every connected tab
+ * contributes one.
+ *
+ * The pair is matched, never the code alone. `ECONNRESET` also arrives from
+ * connections this side *opens* — Postgres, object storage, GenBank — and those
+ * are real incidents. Node's message here is the literal `aborted`.
+ */
+function isClientDisconnect(exception: unknown): boolean {
+	return (
+		exception instanceof Error &&
+		exception.message === "aborted" &&
+		(exception as { code?: unknown }).code === "ECONNRESET"
+	);
 }
 
 function isExpectedClientError(exception: unknown): boolean {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,19 @@ ports consume it. `service.ts` and `functions.ts` live in
   logic — if a handler grows a multi-step orchestration with rollbacks
   or branching, that is the signal to extract a `service.ts`.
 
+  The same filter drops one thing no handler throws: the `Error:
+  aborted` Node's `abortIncoming` raises when a client's socket closes
+  with a request still in flight. Its stack is pure Node internals —
+  no application frame, because no application code ran — and it is
+  unactionable by construction, the peer having gone. The web app draws
+  a steady stream of them because the SSE client probes `HEAD /events`
+  from its `onerror` handler, which is exactly when a deploy is tearing
+  the connection down, so every connected tab contributes one. The
+  match is `code === "ECONNRESET"` **paired with** the literal message
+  `aborted`. Never widen it to the code alone: `ECONNRESET` also
+  arrives from connections this side opens — Postgres, object storage,
+  GenBank — where it is a real incident.
+
   The status a handler sets is always a 4xx or a 2xx that carries a
   body. **A null-body status — 204, 205, or 304 — is not available
   here.** Start's server-function handler serializes the `{ result,

--- a/docs/jobs-api.md
+++ b/docs/jobs-api.md
@@ -1185,6 +1185,14 @@ handler returns a 4xx response rather than throwing, so nothing routine
 reaches Sentry to be filtered. Add a filter only if a route starts
 throwing for an expected outcome — and prefer not to.
 
+The web app's filter also drops the `Error: aborted` a closed client
+socket raises, and that half does not carry over either. It reports
+what `app.onError` is handed, and a socket closing under an in-flight
+request never reaches Hono's `compose` to become one. Should such an
+event ever show up here, port the *paired* `ECONNRESET`-and-`aborted`
+match rather than filtering the code, which this service sees from
+Postgres and object storage as a genuine failure.
+
 ## Configuration
 
 | Variable | Default | Meaning |


### PR DESCRIPTION
## Summary

- `HEAD /events` was reporting `Error: aborted` to Sentry — Node's `abortIncoming` destroying a request whose client socket closed first. The stack is pure Node internals with no application frame, because no application code ran, and it is unactionable by construction: the peer is gone. The web app draws a steady stream of them because the SSE client probes `HEAD /events` from its `onerror` handler, which is exactly when a deploy is tearing the connection down, so every connected tab contributes one.
- `dropExpectedClientErrors` now drops it. The match is `ECONNRESET` paired with the literal message `aborted`, **never the code alone** — `ECONNRESET` also arrives from connections this side opens (Postgres, object storage, GenBank), where it is a real incident. Error shape verified by reproducing it against a real `node:http` server on Node 24 rather than read off the stack trace.
- `apps/jobs-api` gets no equivalent: it reports what `app.onError` is handed, and a socket closing under an in-flight request never reaches Hono's `compose` to become one. Its "no `beforeSend` filter" rationale is updated so the asymmetry stays deliberate rather than looking like an oversight.

Fixes VIRTOOL-M