### PR TITLE
chore: port the create_index task body

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1252,6 +1252,33 @@ Its manifest fetch also carries an `AbortSignal.timeout`, without which
 a hung connection holds the lease until it expires and the reclaim
 starts a second hung fetch behind the first.
 
+`create_index` is the second, and the first to take the progress seam
+and the first to write to object storage. Its body is one call to
+`generateTaskIndex`; four rules are its own:
+
+- **An already-ready build is a successful no-op**, where Python raises
+  `"Index is already ready"`. A reclaim re-runs a body from step zero,
+  so a build whose work already committed would otherwise fail its task
+  and show a red error against an index that is fine.
+- **The artifact streams and is never buffered.** A real reference is
+  hundreds of megabytes of JSON, so the manifest is patched 500 OTUs at
+  a time and each chunk is serialized straight into a `createGzip()`
+  stream. The chunk loop also `await setImmediate()`s, because
+  serializing a whole reference in one synchronous stretch starves the
+  heartbeat and gets the task reclaimed out from under itself.
+- **The OTU order is the manifest's stored order**, read back with
+  `jsonb_each ... with ordinality` rather than from a parsed object.
+  `JSON.parse` hoists array-index-like keys to the front, an
+  eight-character OTU id is all digits often enough that a real
+  reference has one, and the artifact's order decides which isolate
+  `cd-hit-est` keeps.
+- **There is no compensating delete on failure.** A write that lands
+  where the commit does not leaves an object no row names, and a hard
+  exit between the two leaves the same one with nothing to catch it —
+  so it is the orphan sweep's, not a `cleanup` hook's. The one delete
+  the body does make is **after** the commit: keys are minted per write,
+  so a rebuild repoints the row and orphans the object it replaced.
+
 See [docs/tasks.md](docs/tasks.md) for the full config table, the
 `AppContext` contract, the shutdown ordering and its guarantees, the
 probe and metrics surface including the five task series and their
@@ -1306,11 +1333,16 @@ positionally and Python still writes the same tables. Reshaping it from
 this side misapplies every diff already recorded and corrupts the
 analyses read path. Renormalizing is a Python-side migration.
 
-**An index build is started here and finished by Python.**
-`createIndex` (`@virtool/data/indexes/data`) inserts the pending `indexes` row,
-stamps every unbuilt `legacy_history` row with it, and creates the
-`create_index` task the Python runner claims — that task writes the
-artifact, records each file's `storage_key`, and flips `ready`. The
+**An index build is two writes with a task between them, and this side
+runs both.** `createIndex` (`@virtool/data/indexes/data`) inserts the
+pending `indexes` row, stamps every unbuilt `legacy_history` row with it,
+and creates a `create_index` task; `generateTaskIndex`, in the same
+module, is what the runner that claims it executes — patching the
+manifest's OTUs, streaming `reference-v2.json.gz` to a minted key,
+recording the `index_files` row with that key, stamping
+`last_indexed_version` and flipping `ready`. Python's `CreateIndexTask`
+does the same work and both runners are live until the cutover, so the
+two must stay interchangeable. The
 insert runs under
 `pg_try_advisory_xact_lock(hashtext('index_build:{referenceId}'))`, the
 same key Python takes, so a build started from either service excludes

--- a/apps/tasks/src/tasks/create-index.test.ts
+++ b/apps/tasks/src/tasks/create-index.test.ts
@@ -1,0 +1,285 @@
+import { gunzipSync } from "node:zlib";
+import { seedUser } from "@virtool/data/auth/test/fixtures";
+import type { Db } from "@virtool/data/db/pg";
+import { legacyHistory } from "@virtool/data/db/schema/history";
+import { indexes, indexFiles } from "@virtool/data/db/schema/indexes";
+import { legacyOtus } from "@virtool/data/db/schema/otus";
+import { legacyReferences } from "@virtool/data/db/schema/references";
+import { tasks } from "@virtool/data/db/schema/tasks";
+import { users } from "@virtool/data/db/schema/users";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import { seedReference } from "@virtool/data/indexes/test/fixtures";
+import { acquireTask, type ClaimedTask } from "@virtool/data/tasks/data";
+import { createLogger, type Logger } from "@virtool/logger";
+import { MemoryStorage, type StorageBackend } from "@virtool/storage";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { runTask } from "../framework/run";
+import { createIndexTask } from "./create-index";
+import type { TaskContext } from "./registry";
+
+const RUNNER = "ts-runner-a-1";
+
+const logger: Logger = createLogger({ name: "test", level: "silent" });
+
+let database: TestDatabase;
+let db: Db;
+let storage: StorageBackend;
+let ctx: TaskContext;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(indexFiles);
+	await db.delete(legacyHistory);
+	await db.delete(legacyOtus);
+	await db.delete(indexes);
+	await db.delete(legacyReferences);
+	await db.delete(tasks);
+	await db.delete(users);
+
+	storage = new MemoryStorage();
+	ctx = { db, storage };
+});
+
+let handleCounter = 0;
+
+/**
+ * Seed a reference with `count` OTUs and a pending task-backed build, then claim
+ * the task the way the runner will.
+ */
+async function claimBuild(count = 2): Promise<{
+	task: ClaimedTask;
+	indexId: number;
+	referenceId: number;
+}> {
+	handleCounter += 1;
+
+	const userId = await seedUser(db, { handle: `builder${handleCounter}` });
+	const referenceId = await seedReference(db, userId);
+
+	const otus = Array.from({ length: count }, (_, index) => ({
+		id: `otu${String(index).padStart(5, "0")}`,
+		version: 1,
+	}));
+
+	if (otus.length > 0) {
+		await db.insert(legacyOtus).values(
+			otus.map(({ id, version }) => ({
+				id,
+				data: {
+					_id: id,
+					name: `OTU ${id}`,
+					isolates: [{ id: `iso_${id}`, source_type: "isolate" }],
+					version,
+				},
+				name: `OTU ${id}`,
+				abbreviation: "",
+				reference_id: referenceId,
+				verified: true,
+				version,
+			})),
+		);
+	}
+
+	const manifest: Record<string, number> = {};
+
+	for (const otu of otus) {
+		manifest[otu.id] = otu.version;
+	}
+
+	const [taskRow] = await db
+		.insert(tasks)
+		.values({
+			complete: false,
+			context: {},
+			count: 0,
+			created_at: new Date(),
+			progress: 0,
+			step: createIndexTask.type,
+			type: createIndexTask.type,
+		})
+		.returning({ id: tasks.id });
+
+	const taskId = taskRow?.id as number;
+
+	const [indexRow] = await db
+		.insert(indexes)
+		.values({
+			created_at: new Date(),
+			manifest,
+			ready: false,
+			reference_id: referenceId,
+			storage_key: `5f9a${handleCounter}legacymongoslug`,
+			user_id: userId,
+			version: 0,
+			task_id: taskId,
+		})
+		.returning({ id: indexes.id });
+
+	const indexId = indexRow?.id as number;
+
+	await db
+		.update(tasks)
+		.set({ context: { index_id: indexId } })
+		.where(eq(tasks.id, taskId));
+
+	const claimed = await acquireTask(db, {
+		runnerId: RUNNER,
+		allowedTypes: [createIndexTask.type],
+	});
+
+	if (claimed === null) {
+		throw new Error("the task under test was not claimable");
+	}
+
+	return { task: claimed, indexId, referenceId };
+}
+
+function readRow(taskId: number) {
+	return db
+		.select()
+		.from(tasks)
+		.where(eq(tasks.id, taskId))
+		.then(([row]) => row);
+}
+
+function run(task: ClaimedTask, signal = new AbortController().signal) {
+	return runTask({ db, def: createIndexTask, task, ctx, logger, signal });
+}
+
+describe("createIndexTask", () => {
+	it("runs a claimed task through to complete and publishes the artifact", async () => {
+		const { task, indexId } = await claimBuild();
+
+		expect(await run(task)).toEqual({ status: "completed" });
+
+		expect(await readRow(task.id)).toMatchObject({
+			complete: true,
+			error: null,
+			progress: 100,
+			step: "build_index",
+		});
+
+		const [index] = await db
+			.select({ ready: indexes.ready })
+			.from(indexes)
+			.where(eq(indexes.id, indexId));
+
+		expect(index?.ready).toBe(true);
+
+		const [file] = await db
+			.select()
+			.from(indexFiles)
+			.where(eq(indexFiles.index_id, indexId));
+
+		expect(file?.name).toBe("reference-v2.json.gz");
+
+		const parts: Uint8Array[] = [];
+
+		for await (const part of storage.read(file?.storage_key ?? "")) {
+			parts.push(part);
+		}
+
+		const artifact = JSON.parse(
+			gunzipSync(Buffer.concat(parts)).toString(),
+		) as { otus: unknown[] };
+
+		expect(artifact.otus).toHaveLength(2);
+	});
+
+	// A reclaim re-runs a body from step zero, and the first attempt may already
+	// have committed. The second must leave what the first left rather than
+	// failing the task over an index that is perfectly fine.
+	it("is idempotent across a re-run", async () => {
+		const { task, indexId } = await claimBuild();
+
+		expect(await run(task)).toEqual({ status: "completed" });
+
+		const [afterFirst] = await db
+			.select()
+			.from(indexFiles)
+			.where(eq(indexFiles.index_id, indexId));
+
+		// Claiming again needs the row back in a claimable state; the build itself
+		// stays ready, which is the condition under test.
+		await db
+			.update(tasks)
+			.set({ complete: false, runner_id: null, acquired_at: null })
+			.where(eq(tasks.id, task.id));
+
+		const second = await acquireTask(db, {
+			runnerId: RUNNER,
+			allowedTypes: [createIndexTask.type],
+		});
+
+		expect(second).not.toBeNull();
+		expect(await run(second as ClaimedTask)).toEqual({ status: "completed" });
+
+		const rows = await db
+			.select()
+			.from(indexFiles)
+			.where(eq(indexFiles.index_id, indexId));
+
+		expect(rows).toEqual([afterFirst]);
+	});
+
+	// The payload is parsed before any handler code runs, so a row carrying
+	// something else fails the task rather than reaching the data layer.
+	it("fails the task when the payload does not name an index", async () => {
+		const { task } = await claimBuild();
+
+		await db
+			.update(tasks)
+			.set({ context: { index_id: "abc" } })
+			.where(eq(tasks.id, task.id));
+
+		const reclaimed = { ...task, context: { index_id: "abc" } };
+
+		const outcome = await run(reclaimed);
+
+		expect(outcome.status).toBe("failed");
+		expect(await readRow(task.id)).toMatchObject({ complete: true });
+	});
+
+	// Nothing is registered and the build stays unfinished, so a rebuild can
+	// replace it. The half-written object is the orphan sweep's.
+	it("fails the task and leaves the build unfinished when the manifest is corrupt", async () => {
+		const { task, indexId } = await claimBuild();
+
+		await db
+			.update(indexes)
+			.set({ manifest: { otughost: 3 } })
+			.where(eq(indexes.id, indexId));
+
+		const outcome = await run(task);
+
+		expect(outcome).toMatchObject({ status: "failed" });
+		expect(outcome).toMatchObject({
+			error: expect.stringContaining("IndexManifestError"),
+		});
+
+		const [index] = await db
+			.select({ ready: indexes.ready })
+			.from(indexes)
+			.where(eq(indexes.id, indexId));
+
+		expect(index?.ready).toBe(false);
+		expect(
+			await db
+				.select()
+				.from(indexFiles)
+				.where(eq(indexFiles.index_id, indexId)),
+		).toEqual([]);
+	});
+});

--- a/apps/tasks/src/tasks/create-index.ts
+++ b/apps/tasks/src/tasks/create-index.ts
@@ -1,0 +1,62 @@
+import { generateTaskIndex } from "@virtool/data/indexes/data";
+import { z } from "zod";
+import { defineTask } from "../framework/define";
+import type { TaskContext } from "./registry";
+
+/**
+ * `create_index` carries the build it is to finish.
+ *
+ * The id is an integer. Python's `generate_task_index` also accepts the
+ * stringified legacy form, for a task enqueued before the integer-id cutover,
+ * but nothing produces one: `createIndex` writes `{ index_id: index.id }` and
+ * the only `CreateIndexTask` construction left on Python's side is in
+ * `virtool/fake`.
+ */
+const payload = z.object({ index_id: z.number().int().positive() });
+
+/**
+ * Finish a reference index build.
+ *
+ * The port of Python's `CreateIndexTask`, whose body is one call. Everything
+ * this runs is `generateTaskIndex`: patch every OTU in the manifest, stream the
+ * gzipped artifact to object storage, register the file, stamp
+ * `last_indexed_version` and flip `ready`.
+ *
+ * It is idempotent as a reclaim requires, in two layers. A re-run that finds the
+ * build already ready returns without writing anything — where Python raises,
+ * which would fail the task and show an error against an index that is fine. A
+ * re-run of a build that did *not* finish redoes the whole thing: the artifact
+ * is rewritten under a fresh key and the `index_files` upsert repoints the row
+ * at it, with the object it replaced deleted after the commit.
+ *
+ * It takes no `signal`. There is nothing here to forward one into — the storage
+ * write, the patch reads and the transaction take none — so an abort arrives as
+ * a rejection from whatever was in flight, or the run finishes. The chunk loop
+ * yields the event loop so the heartbeat stays live while it works.
+ */
+export const createIndexTask = defineTask<typeof payload, TaskContext>({
+	type: "create_index",
+	payload,
+	// Python names its step after the bound method it runs, `BaseTask.run`
+	// writing `func.__name__` into the column. Both runners write `build_index`
+	// for the same work until the cutover completes.
+	steps: ["build_index"],
+	async run({ ctx, helpers, logger, payload }) {
+		await helpers.runStep("build_index", async (report) => {
+			// Python's task takes no progress handler and jumps 0 to 100. This is the
+			// longest-running of the ten bodies — a reference clone's worth of OTUs —
+			// and the chunked patch loop makes its position knowable, so it is
+			// reported. `report` takes a fraction where the data layer publishes
+			// percent.
+			await generateTaskIndex(
+				ctx.db,
+				ctx.storage,
+				logger,
+				payload.index_id,
+				async (percent) => {
+					report(percent / 100);
+				},
+			);
+		});
+	},
+});

--- a/apps/tasks/src/tasks/registry.ts
+++ b/apps/tasks/src/tasks/registry.ts
@@ -1,6 +1,7 @@
 import type { Db } from "@virtool/data/db/pg";
 import type { StorageBackend } from "@virtool/storage";
 import type { TaskRegistry } from "../framework/define";
+import { createIndexTask } from "./create-index";
 import { refreshHmmsTask } from "./refresh-hmms";
 
 /**
@@ -30,5 +31,6 @@ export type TaskContext = {
  * another; `registry.test.ts` fails on any that do.
  */
 export const taskRegistry: TaskRegistry<TaskContext> = {
+	create_index: createIndexTask,
 	refresh_hmms: refreshHmmsTask,
 };

--- a/docs/database.md
+++ b/docs/database.md
@@ -247,19 +247,29 @@ export async function invalidateUserSessions(
 `data.ts` function normally touches. Reach for `Db` only when the function
 genuinely needs something a transaction cannot give it.
 
-### Advisory locks, and the half-owned index build
+### Advisory locks, and the two-part index build
 
 Starting an index build is the one write that takes a Postgres advisory
-lock, and the reason is that Python still performs the second half of it.
+lock, and the reason is that a build is two writes with a task between
+them — either service can be running either half.
 
 `createIndex` (`@virtool/data/indexes/data`) inserts the pending `indexes` row,
 stamps every `legacy_history` row whose `index_id` is `NULL` with the new
-build, and creates a `create_index` task. The Python task runner claims
-that task, patches every OTU in the manifest back to the version the
-build was pinned to, gzips the artifact into a freshly minted key,
-records the `index_files` row **with that key on it**, promotes
+build, and creates a `create_index` task. Whichever runner claims that
+task finishes the build: `generateTaskIndex`, in the same module, patches
+every OTU in the manifest back to the version the build was pinned to,
+gzips the artifact into a freshly minted key, records the `index_files`
+row **with that key on it**, promotes
 `legacy_otus.last_indexed_version`, and only then sets `ready = true`.
-Nothing on this side finishes a build.
+
+Python's `CreateIndexTask` does the same thing, and both runners are live
+until the cutover, so the two halves must stay interchangeable. The
+artifact is `reference-v2.json.gz` on both sides, the `index_files` row
+carries the legacy `index` string column on both sides, and the OTUs are
+serialized in the manifest's **stored** order — read back out of the
+JSONB column rather than from a parsed object, because `JSON.parse`
+hoists array-index-like keys and an eight-character OTU id is all digits
+often enough to matter.
 
 Two builds of one reference would each stamp the other's changes and then
 collide on the `(reference_id, version)` unique constraint, so the insert

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -821,6 +821,87 @@ task and starts a second hung fetch behind the first. A timeout is reported as
 `Could not reach Virtool.ca`, the same as a refused connection, because to the
 caller it means the same thing.
 
+### `create_index`, the second body
+
+`create_index` finishes a reference index build. Its body is one call to
+`generateTaskIndex` (`@virtool/data/indexes/data`) inside one step,
+`build_index` — Python's method name, so both runners write the same value to
+the `step` column. The domain function patches every OTU in the build's manifest
+back to the version the manifest pins it to, streams the result to object
+storage as `reference-v2.json.gz`, registers the `index_files` row, stamps
+`legacy_otus.last_indexed_version` and flips `ready`.
+
+It is the first body to take the progress seam. Python's task declares no
+progress handler and jumps 0 to 100; this is the longest-running of the ten and
+the chunked patch loop makes its position knowable, so the data function takes a
+trailing `onProgress?: (percent: number) => Promise<void>` and the body bridges
+it with `async (percent) => report(percent / 100)`. Percent at the `data.ts`
+boundary, fraction at `runStep`'s reporter.
+
+Four decisions are worth knowing before changing it.
+
+**An already-ready build is a successful no-op.** Python raises
+`ResourceConflictError("Index is already ready")`. Porting that verbatim would
+fail the task whenever a reclaim re-ran a build whose work had already
+committed — a red error in the UI against an index that is perfectly fine — so
+this side logs at `info` and returns. That is the general shape for any body
+guarding on a terminal-state column.
+
+**Nothing is buffered.** A real reference decompresses to hundreds of megabytes
+of JSON, and Python holds all of it twice: once as a list of documents and again
+as a gzip buffer. Here the manifest is patched 500 OTUs at a time —
+Python's `OTU_ID_CHUNK_SIZE` — and each chunk is serialized straight into a
+`createGzip()` stream handed to `StorageBackend.write`, so peak memory is set by
+the chunk size rather than by the reference. Python's `concurrency=25` /
+`window_size=100` patcher is deliberately not reproduced: `patchOtusToVersions`
+resolves a whole chunk in a fixed handful of queries, so there is nothing for
+that apparatus to do.
+
+The chunk loop also `await setImmediate()`s. The heartbeat that holds the lease
+is a timer, and serializing a whole reference in one synchronous stretch starves
+it — the task is then reclaimed out from under a runner that is still working on
+it.
+
+Two failure modes the streaming introduced, both guarded. `pipe` does not
+forward a source error to its destination, so the encoder's failure is
+explicitly forwarded onto the gzip stream; without it a manifest naming a
+version history cannot produce would end the stream cleanly and publish a
+truncated artifact as a successful build. And a manifest entry that patches to
+`null` throws `IndexManifestError` rather than being serialized — a manifest
+entry is proof the OTU existed at that version, so a null is corruption, not a
+routine miss.
+
+**The OTU order is the manifest's stored order.** It is read back with
+`jsonb_each ... with ordinality`, not from the parsed `manifest` column.
+`JSON.parse` hoists array-index-like keys to the front of an object and sorts
+them numerically; an OTU id is eight characters drawn from digits and lowercase
+letters, so a reference of any size is likely to have one that is all digits.
+Python iterates the dict `json.loads` gives it, which is the JSONB order, and
+the artifact's OTU order decides which isolate `cd-hit-est` keeps as a cluster
+representative — so a divergence here changes analysis results.
+
+`reference.created_at` is rendered in SQL for the same class of reason. Python's
+orjson writes six fractional digits, or none when there are no microseconds;
+`Date.toISOString` always writes exactly three and postgres.js has already
+truncated the other three, having parsed a naive `timestamp` with `new Date(x)`
+— which V8 reads as local time, so a process outside UTC would shift every
+timestamp in the artifact.
+
+**There is no compensating delete on failure.** The storage write happens first
+and outside the transaction, because storage cannot join one. A write that lands
+where the commit does not leaves an object no row names — and so does a hard
+exit between the two, which no `catch` can cover, so the orphan is the sweep's
+either way and a cleanup here would only handle the half where the process
+survives. Python's second, fresh-session delete of the `index_files` row is
+dropped for a different reason: its three writes are one real transaction here,
+so a database failure rolls the row back on its own.
+
+The one delete the body does make is **after** the commit. Keys are minted per
+write rather than composed from the file name, so a rebuild writes a new object
+and the upsert repoints the row at it — leaving the previous artifact orphaned
+on every successful rebuild. That one is deleted immediately and its failures
+logged, never raised, because the build has already succeeded.
+
 ### Frames are the framework's, never a body's
 
 A body never emits. `updateTaskProgress`, `completeTask` and `failTask` publish

--- a/packages/data/src/db/schema/indexes.ts
+++ b/packages/data/src/db/schema/indexes.ts
@@ -2,11 +2,10 @@
 // Python service via Alembic. Do not generate or push migrations from this side.
 // Keep in sync with `../../../../../../virtool/virtool/indexes/sql.py`.
 //
-// `indexes` is written from here — starting a build inserts the row — so every
-// column the real table requires is declared. `index_files` is read-only from
-// this side: the Python `create_index` task writes it when a build finishes.
-// Its legacy `index` string column is therefore deliberately not declared,
-// following `history.ts`; nothing here inserts a row that would have to fill it.
+// Both tables are written from here — starting a build inserts the `indexes`
+// row and the `create_index` task registers the artifact it produces — so every
+// column the real tables require is declared, the legacy `index` string column
+// on `index_files` included.
 
 import {
 	bigint,
@@ -17,6 +16,7 @@ import {
 	pgTable,
 	text,
 	timestamp,
+	unique,
 } from "drizzle-orm/pg-core";
 
 export const indexes = pgTable("indexes", {
@@ -60,16 +60,30 @@ export const indexes = pgTable("indexes", {
  */
 export const indexType = pgEnum("indextype", ["json", "fasta", "bowtie2"]);
 
-export const indexFiles = pgTable("index_files", {
-	id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
-	name: text("name").notNull(),
-	index_id: bigint("index_id", { mode: "number" }).notNull(),
-	type: indexType("type"),
-	size: bigint("size", { mode: "number" }),
-	// The file's complete object-storage key, superseding the per-index
-	// `indexes.storage_key` slug keys were previously composed from.
-	storage_key: text("storage_key").unique().notNull(),
-});
+export const indexFiles = pgTable(
+	"index_files",
+	{
+		id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
+		name: text("name").notNull(),
+		// The owning build's id as a string, predating `index_id` and dropped by a
+		// later cleanup revision. Nullable, so nothing has to fill it, but Python
+		// writes `str(index_id)` and this side writes the same — a row is then
+		// identical whichever runner built it.
+		index: text("index"),
+		index_id: bigint("index_id", { mode: "number" }).notNull(),
+		type: indexType("type"),
+		size: bigint("size", { mode: "number" }),
+		// The file's complete object-storage key, superseding the per-index
+		// `indexes.storage_key` slug keys were previously composed from.
+		storage_key: text("storage_key").unique().notNull(),
+	},
+	(table) => [
+		// `index_files_index_id_name_key`. Declared because a build's registration
+		// of its artifact upserts on it, and an `ON CONFLICT` naming columns no
+		// constraint covers is an error rather than an insert.
+		unique("index_files_index_id_name_key").on(table.index_id, table.name),
+	],
+);
 
 /** A row from the `indexes` table. */
 export type IndexRow = typeof indexes.$inferSelect;

--- a/packages/data/src/indexes/artifact.test.ts
+++ b/packages/data/src/indexes/artifact.test.ts
@@ -1,0 +1,93 @@
+import { gunzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import { type OtuChunk, streamArtifact } from "./artifact";
+
+async function collect(
+	iterable: AsyncIterable<Uint8Array>,
+): Promise<Uint8Array> {
+	const parts: Uint8Array[] = [];
+
+	for await (const part of iterable) {
+		parts.push(part);
+	}
+
+	return Buffer.concat(parts);
+}
+
+async function* chunksOf(...chunks: OtuChunk[]): AsyncIterable<OtuChunk> {
+	for (const chunk of chunks) {
+		yield chunk;
+	}
+}
+
+const reference = {
+	_id: 7,
+	created_at: "2026-01-02T03:04:05.123456Z",
+	name: "Plant Viruses",
+	organism: "virus",
+};
+
+async function build(...chunks: OtuChunk[]): Promise<string> {
+	return gunzipSync(
+		await collect(streamArtifact(reference, chunksOf(...chunks))),
+	).toString();
+}
+
+describe("streamArtifact", () => {
+	it("writes the envelope Python writes, with the OTUs last", async () => {
+		const text = await build([{ _id: "otu1" }], [{ _id: "otu2" }]);
+
+		// The field order is asserted on the text rather than the parsed object,
+		// because it is the bytes workflows read and a parse would hide a reorder.
+		expect(text).toBe(
+			'{"_id":7,"created_at":"2026-01-02T03:04:05.123456Z","data_type":"genome",' +
+				'"name":"Plant Viruses","organism":"virus",' +
+				'"otus":[{"_id":"otu1"},{"_id":"otu2"}]}',
+		);
+	});
+
+	// Python hard-codes it rather than reading the reference row, and workflows
+	// consume the field, so it is a wire value and not a fact about the row.
+	it("hard-codes data_type to genome", async () => {
+		expect(JSON.parse(await build([]))).toMatchObject({ data_type: "genome" });
+	});
+
+	it("writes a valid empty otus array when the manifest is empty", async () => {
+		expect(JSON.parse(await build())).toEqual({
+			_id: 7,
+			created_at: "2026-01-02T03:04:05.123456Z",
+			data_type: "genome",
+			name: "Plant Viruses",
+			organism: "virus",
+			otus: [],
+		});
+	});
+
+	it("keeps OTUs in the order the chunks yield them", async () => {
+		const text = await build(
+			[{ _id: "c" }, { _id: "a" }],
+			[{ _id: "b" }],
+			[{ _id: "z" }, { _id: "y" }],
+		);
+
+		expect(
+			(JSON.parse(text) as { otus: { _id: string }[] }).otus.map(
+				(otu) => otu._id,
+			),
+		).toEqual(["c", "a", "b", "z", "y"]);
+	});
+
+	// The chunk source is pulled as the gzip stream takes bytes, so a source that
+	// throws part-way surfaces on the write rather than being swallowed into a
+	// truncated artifact.
+	it("propagates a failure from the chunk source", async () => {
+		async function* failing(): AsyncIterable<OtuChunk> {
+			yield [{ _id: "otu1" }];
+			throw new Error("history is corrupt");
+		}
+
+		await expect(collect(streamArtifact(reference, failing()))).rejects.toThrow(
+			"history is corrupt",
+		);
+	});
+});

--- a/packages/data/src/indexes/artifact.ts
+++ b/packages/data/src/indexes/artifact.ts
@@ -1,0 +1,90 @@
+// The `reference-v2.json.gz` artifact a finished build publishes, encoded as a
+// stream.
+//
+// A real reference decompresses to hundreds of megabytes of JSON. Python builds
+// the whole document in memory and gzips it in one call, which costs two
+// allocations of that size; nothing here holds more than one chunk of OTUs at a
+// time, so peak memory is set by the chunk size rather than by the reference.
+//
+// The field order is Python's — the reference envelope, then `otus` — because
+// the artifact is read by workflows that both services still run.
+
+import { Readable } from "node:stream";
+import { createGzip } from "node:zlib";
+
+/** The reference envelope an artifact opens with. */
+export type ArtifactReference = {
+	/** The integer Postgres primary key, despite the Mongo-shaped field name. */
+	_id: number;
+	/** Pre-rendered to match Python's serializer exactly. */
+	created_at: string;
+	name: string;
+	organism: string;
+};
+
+/** One page of OTU documents, in the order the manifest names them. */
+export type OtuChunk = readonly unknown[];
+
+/**
+ * Encode the artifact as UTF-8 JSON, one chunk of OTUs at a time.
+ *
+ * `data_type` is hard-coded to `"genome"` rather than read from the reference,
+ * matching Python. Workflows consume the field, so it is a wire value here and
+ * not a fact about the row.
+ */
+async function* encode(
+	reference: ArtifactReference,
+	chunks: AsyncIterable<OtuChunk>,
+): AsyncIterable<Uint8Array> {
+	const encoder = new TextEncoder();
+
+	const envelope = JSON.stringify({
+		_id: reference._id,
+		created_at: reference.created_at,
+		data_type: "genome",
+		name: reference.name,
+		organism: reference.organism,
+	});
+
+	// Reopen the object rather than serializing `otus` into it, so the OTUs are
+	// never a value the envelope has to hold.
+	yield encoder.encode(`${envelope.slice(0, -1)},"otus":[`);
+
+	let first = true;
+
+	for await (const chunk of chunks) {
+		for (const otu of chunk) {
+			yield encoder.encode(
+				first ? JSON.stringify(otu) : `,${JSON.stringify(otu)}`,
+			);
+			first = false;
+		}
+	}
+
+	yield encoder.encode("]}");
+}
+
+/**
+ * Gzip the artifact into the async iterable `StorageBackend.write` consumes.
+ *
+ * The gzip stream is what applies backpressure: the encoder is pulled only as
+ * fast as the compressor and the upload behind it take bytes, so a slow bucket
+ * cannot make the OTU chunks queue up in memory.
+ *
+ * The error forwarding is load-bearing and must not be dropped. `pipe` does not
+ * propagate a source failure to its destination, so a chunk source that throws
+ * part-way — the manifest naming a version history cannot produce — would end
+ * the gzip stream cleanly. The caller would store a truncated artifact, record
+ * its size and mark the build ready, having been told nothing went wrong.
+ */
+export function streamArtifact(
+	reference: ArtifactReference,
+	chunks: AsyncIterable<OtuChunk>,
+): AsyncIterable<Uint8Array> {
+	const source = Readable.from(encode(reference, chunks));
+	const gzip = createGzip();
+
+	source.on("error", (err) => gzip.destroy(err));
+
+	return source.pipe(gzip);
+}

--- a/packages/data/src/indexes/data.ts
+++ b/packages/data/src/indexes/data.ts
@@ -1,12 +1,13 @@
 // Reading and building reference indexes.
 //
 // A port of `virtool.indexes.db`, `virtool.indexes.data`, and the index half of
-// `virtool.references.data`. Python still owns the *finishing* of a build — the
-// `create_index` task patches every OTU in the manifest, writes the artifact to
-// object storage, and flips `ready` — so everything here stops at inserting the
-// row that task claims.
+// `virtool.references.data`, both halves of a build included: `createIndex`
+// inserts the pending row and creates the task, and `generateTaskIndex` is what
+// that task runs — patching every OTU in the manifest, writing the artifact to
+// object storage, and flipping `ready`.
 
 import { randomUUID } from "node:crypto";
+import { setImmediate } from "node:timers/promises";
 import type {
 	Index,
 	IndexContributor,
@@ -15,6 +16,12 @@ import type {
 	IndexOtu,
 	IndexSearchResult,
 } from "@virtool/contracts";
+import type { Logger } from "@virtool/logger";
+import {
+	deleteKeys,
+	mintStorageKey,
+	type StorageBackend,
+} from "@virtool/storage";
 import {
 	and,
 	asc,
@@ -35,11 +42,18 @@ import { legacyReferences } from "../db/schema/references";
 import { tasks } from "../db/schema/tasks";
 import { users } from "../db/schema/users";
 import { AppError } from "../errors";
+import { emit } from "../events/emit";
+import {
+	type OtuSpecifier,
+	otuSpecifierKey,
+	patchOtusToVersions,
+} from "../history/data";
 import {
 	ReferenceArchivedError,
 	ReferenceNotFoundError,
 } from "../references/data";
 import { createTask } from "../tasks/data";
+import { type OtuChunk, streamArtifact } from "./artifact";
 
 /** Thrown when a requested index does not exist. */
 export class IndexNotFoundError extends AppError {}
@@ -56,6 +70,21 @@ export class UnverifiedOtusError extends AppError {}
 
 /** Thrown when a reference has no changes for a build to include. */
 export class NoUnbuiltChangesError extends AppError {}
+
+/**
+ * Thrown when a build is not one a task may finish — backed by a job, or by
+ * neither a job nor a task.
+ */
+export class IndexBuildTypeError extends AppError {}
+
+/**
+ * Thrown when the manifest names an OTU version history cannot produce.
+ *
+ * A manifest entry is proof the OTU existed at that version, so this is a
+ * corrupted manifest or corrupted history rather than a routine miss, and the
+ * build fails rather than publishing an artifact with a hole in it.
+ */
+export class IndexManifestError extends AppError {}
 
 /** Options accepted by {@link findIndexes}. */
 export type FindIndexesOptions = {
@@ -634,4 +663,299 @@ export async function createIndex(
 	});
 
 	return getIndex(db, indexId);
+}
+
+// Python's `OTU_ID_CHUNK_SIZE`. It bounds both halves of a build: how many OTU
+// documents are held at once while the artifact streams, and how many ids go
+// into one `last_indexed_version` statement.
+const OTU_ID_CHUNK_SIZE = 500;
+
+/** The file a finished build publishes. Python's `REFERENCE_JSON_V2_FILE_NAME`. */
+const REFERENCE_JSON_V2_FILE_NAME = "reference-v2.json.gz";
+
+// The reference envelope, with `created_at` rendered in Postgres rather than
+// from a `Date`.
+//
+// Two things go wrong reading it as a `Date`. postgres.js parses a `timestamp
+// without time zone` with `new Date(x)`, and the wire text carries no offset, so
+// V8's fallback reads it as *local* time and a process outside UTC shifts every
+// timestamp in the artifact by its offset. And `toISOString` always writes
+// exactly three fractional digits, where orjson writes six or, when there are no
+// microseconds at all, none — and a `Date` has already truncated the other three
+// by then. Rendering in SQL sidesteps both, and matches Python byte for byte.
+async function readArtifactReference(db: DbOrTx, referenceId: number) {
+	const [row] = await db
+		.select({
+			id: legacyReferences.id,
+			name: legacyReferences.name,
+			organism: legacyReferences.organism,
+			createdAt: sql<string>`
+				to_char(${legacyReferences.created_at}, 'YYYY-MM-DD"T"HH24:MI:SS')
+				|| case
+					when to_char(${legacyReferences.created_at}, 'US') = '000000' then ''
+					else '.' || to_char(${legacyReferences.created_at}, 'US')
+				end
+				|| 'Z'
+			`,
+		})
+		.from(legacyReferences)
+		.where(eq(legacyReferences.id, referenceId))
+		.limit(1);
+
+	return row;
+}
+
+// The manifest as ordered pairs, in the order Python iterates it.
+//
+// The order is the artifact's OTU order, and so the order of every downstream
+// artifact built from it — including which isolate `cd-hit-est` keeps as a
+// cluster representative. Python gets it from `json.loads`, which preserves the
+// JSONB text order. Reading the column into a JavaScript object would not:
+// `JSON.parse` hoists array-index-like keys to the front and sorts them
+// numerically, and an eight-character OTU id drawn from digits and lowercase
+// letters is all digits often enough that a real reference has one.
+async function readManifestOrder(
+	db: DbOrTx,
+	indexId: number,
+): Promise<OtuSpecifier[]> {
+	return db.execute<OtuSpecifier>(sql`
+		select entry.key as "otuId", (entry.value #>> '{}')::int as version
+		from ${indexes},
+			jsonb_each(${indexes.manifest}) with ordinality as entry(key, value, ord)
+		where ${indexes.id} = ${indexId}
+		order by entry.ord
+	`);
+}
+
+// Stamp `last_indexed_version` on every OTU of the reference whose `version` has
+// moved since the last build.
+//
+// The value lives twice on `legacy_otus` — in the promoted column and in the
+// `data` JSONB the OTU document is recovered from — and both are written by the
+// same statement, so they cannot come out of a stamp disagreeing.
+//
+// `jsonb_set` on the one key is also the only correct write: `data` is verbatim
+// Mongo, and reading the document out, mutating it and writing it back would
+// round-trip the whole shape through this side's JSON handling. The diffs
+// already recorded against it address it as Python wrote it.
+async function stampLastIndexedVersions(
+	tx: DbOrTx,
+	referenceId: number,
+): Promise<void> {
+	const rows = await tx
+		.select({ id: legacyOtus.id, version: legacyOtus.version })
+		.from(legacyOtus)
+		.where(
+			and(
+				eq(legacyOtus.reference_id, referenceId),
+				sql`${legacyOtus.version} is distinct from ${legacyOtus.last_indexed_version}`,
+			),
+		);
+
+	const idsByVersion = new Map<number, string[]>();
+
+	for (const { id, version } of rows) {
+		const ids = idsByVersion.get(version);
+
+		if (ids === undefined) {
+			idsByVersion.set(version, [id]);
+		} else {
+			ids.push(id);
+		}
+	}
+
+	for (const [version, ids] of idsByVersion) {
+		for (let start = 0; start < ids.length; start += OTU_ID_CHUNK_SIZE) {
+			await tx
+				.update(legacyOtus)
+				.set({
+					last_indexed_version: version,
+					data: sql`jsonb_set(${legacyOtus.data}, '{last_indexed_version}', to_jsonb(${version}::int))`,
+				})
+				.where(
+					inArray(legacyOtus.id, ids.slice(start, start + OTU_ID_CHUNK_SIZE)),
+				);
+		}
+	}
+}
+
+/**
+ * Finish a task-backed build: write its artifact and mark it ready.
+ *
+ * The port of Python's `generate_task_index`, and the whole of what the
+ * `create_index` task runs. It patches every OTU in the manifest to the version
+ * the manifest pins it to, streams the result to object storage as
+ * `reference-v2.json.gz`, registers the file and flips `ready`.
+ *
+ * `onProgress` reports percent complete on chunk boundaries. It is the seam a
+ * task body bridges to its step reporter; nothing here knows a task exists.
+ *
+ * Two divergences from Python, both deliberate:
+ *
+ * An **already-ready index is a successful no-op**, where Python raises. A claim
+ * is a lease, so a body may re-run from step zero after its work has already
+ * completed and committed — a reclaim is concurrent rather than successive.
+ * Porting the raise verbatim would fail the task and show a red error against an
+ * index that is perfectly fine.
+ *
+ * Only the **integer** id is accepted, where Python also takes the stringified
+ * legacy form for a task enqueued before the integer-id cutover. Nothing enqueues
+ * one: `createIndex` writes `{ index_id: index.id }`, an integer, and the only
+ * `CreateIndexTask` construction left on Python's side is in `virtool/fake`.
+ */
+export async function generateTaskIndex(
+	db: Db,
+	storage: StorageBackend,
+	logger: Logger,
+	indexId: number,
+	onProgress?: (percent: number) => Promise<void>,
+): Promise<void> {
+	const [row] = await db
+		.select({
+			jobId: indexes.job_id,
+			ready: indexes.ready,
+			referenceId: indexes.reference_id,
+			taskId: indexes.task_id,
+		})
+		.from(indexes)
+		.where(eq(indexes.id, indexId))
+		.limit(1);
+
+	if (row === undefined) {
+		throw new IndexNotFoundError("Index does not exist");
+	}
+
+	// The `ck_indexes_job_or_task` CHECK constraint already makes "both set"
+	// impossible, so only "neither" is reachable — a legacy build whose job was
+	// deleted before the jobs migration. Python's message covers both and the
+	// constraint is not this repo's to rely on, so both are kept.
+	if ((row.jobId === null) === (row.taskId === null)) {
+		throw new IndexBuildTypeError(
+			"Index must be backed by exactly one job or task build",
+		);
+	}
+
+	if (row.jobId !== null) {
+		throw new IndexBuildTypeError("Index must be backed by a task build");
+	}
+
+	if (row.ready) {
+		logger.info({ indexId }, "index is already ready; nothing to build");
+
+		return;
+	}
+
+	const reference = await readArtifactReference(db, row.referenceId);
+
+	if (reference === undefined) {
+		throw new ReferenceNotFoundError("Reference does not exist");
+	}
+
+	const specifiers = await readManifestOrder(db, indexId);
+
+	// Minted, never composed. A rebuild therefore writes a new object rather than
+	// overwriting the previous one, which is what the post-commit delete below is
+	// for.
+	const storageKey = mintStorageKey("indexes", indexId);
+
+	let patched = 0;
+
+	async function* chunks(): AsyncIterable<OtuChunk> {
+		for (let start = 0; start < specifiers.length; start += OTU_ID_CHUNK_SIZE) {
+			const slice = specifiers.slice(start, start + OTU_ID_CHUNK_SIZE);
+
+			// One batched read per chunk. Python patches each OTU on its own behind a
+			// windowed concurrency loop; this resolves a whole chunk in a fixed
+			// handful of queries, so there is nothing for that apparatus to do.
+			const documents = await patchOtusToVersions(db, slice);
+
+			yield slice.map(({ otuId, version }) => {
+				const document = documents.get(otuSpecifierKey(otuId, version));
+
+				if (!document) {
+					throw new IndexManifestError(
+						`OTU ${otuId} could not be patched to the version the manifest pins it to`,
+					);
+				}
+
+				return document;
+			});
+
+			patched += slice.length;
+
+			await onProgress?.((patched / specifiers.length) * 100);
+
+			// Serializing a chunk is a synchronous stretch, and the runner's heartbeat
+			// is a timer. Without a macrotask boundary between chunks a large
+			// reference starves it and the task is reclaimed out from under itself.
+			await setImmediate();
+		}
+	}
+
+	// Storage cannot participate in the transaction below. A write that lands
+	// where the commit does not — a failure here, or a hard exit between the two —
+	// leaves an object no row names, which the orphan sweep collects. Deleting it
+	// here would only cover the half of that where this process survives.
+	const size = await storage.write(
+		storageKey,
+		streamArtifact(
+			{
+				_id: reference.id,
+				created_at: reference.createdAt,
+				name: reference.name,
+				organism: reference.organism,
+			},
+			chunks(),
+		),
+	);
+
+	const replacedKey = await db.transaction(async (tx) => {
+		const [existing] = await tx
+			.select({ storageKey: indexFiles.storage_key })
+			.from(indexFiles)
+			.where(
+				and(
+					eq(indexFiles.index_id, indexId),
+					eq(indexFiles.name, REFERENCE_JSON_V2_FILE_NAME),
+				),
+			)
+			.limit(1);
+
+		await tx
+			.insert(indexFiles)
+			.values({
+				index: String(indexId),
+				index_id: indexId,
+				name: REFERENCE_JSON_V2_FILE_NAME,
+				size,
+				storage_key: storageKey,
+				type: "json",
+			})
+			.onConflictDoUpdate({
+				target: [indexFiles.index_id, indexFiles.name],
+				set: { size, storage_key: storageKey, type: "json" },
+			});
+
+		await stampLastIndexedVersions(tx, row.referenceId);
+
+		await tx
+			.update(indexes)
+			.set({ ready: true })
+			.where(eq(indexes.id, indexId));
+
+		return existing?.storageKey ?? null;
+	});
+
+	// Committed, so the row now names the new object and the one it replaced is an
+	// orphan. Cleaning it up must not fail a build that otherwise succeeded.
+	if (replacedKey !== null) {
+		for (const failure of await deleteKeys(storage, [replacedKey])) {
+			logger.error(
+				{ err: failure.error, indexId, key: failure.key },
+				"index storage cleanup failed; file orphaned",
+			);
+		}
+	}
+
+	await emit("indexes", indexId, "update");
 }

--- a/packages/data/src/indexes/generateTaskIndex.test.ts
+++ b/packages/data/src/indexes/generateTaskIndex.test.ts
@@ -1,0 +1,582 @@
+import { gunzipSync } from "node:zlib";
+import { MemoryStorage } from "@virtool/storage";
+import { eq, sql } from "drizzle-orm";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import { seedUser } from "../auth/test/fixtures";
+import type { Db } from "../db/pg";
+import { takeFirstOrThrow } from "../db/rows";
+import { legacyHistory } from "../db/schema/history";
+import { indexes, indexFiles } from "../db/schema/indexes";
+import { legacyOtus } from "../db/schema/otus";
+import { legacyReferences } from "../db/schema/references";
+import { tasks } from "../db/schema/tasks";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { testLogger } from "../test/logger";
+import {
+	generateTaskIndex,
+	IndexBuildTypeError,
+	IndexManifestError,
+	IndexNotFoundError,
+} from "./data";
+import { seedReference } from "./test/fixtures";
+
+const ARTIFACT = "reference-v2.json.gz";
+
+let database: TestDatabase;
+let db: Db;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(indexFiles);
+	await db.delete(legacyHistory);
+	await db.delete(legacyOtus);
+	await db.delete(indexes);
+	await db.delete(legacyReferences);
+	await db.delete(tasks);
+	await db.delete(users);
+});
+
+let handleCounter = 0;
+
+async function seedNextUser(): Promise<number> {
+	handleCounter += 1;
+
+	return seedUser(db, { handle: `builder${handleCounter}` });
+}
+
+async function seedTask(): Promise<number> {
+	return takeFirstOrThrow(
+		await db
+			.insert(tasks)
+			.values({
+				complete: false,
+				context: {},
+				count: 0,
+				created_at: new Date(),
+				progress: 0,
+				step: "build_index",
+				type: "create_index",
+			})
+			.returning({ id: tasks.id }),
+	).id;
+}
+
+// OTU ids are the 8-character Mongo id, so a seeder mints them. `data` is the
+// verbatim Mongo document the artifact is built from, so it carries `isolates`
+// — a document without one is malformed and never reaches a join.
+async function seedOtus(
+	referenceId: number,
+	otus: { id: string; version: number }[],
+): Promise<void> {
+	await db.insert(legacyOtus).values(
+		otus.map(({ id, version }) => ({
+			id,
+			data: {
+				_id: id,
+				name: `OTU ${id}`,
+				isolates: [{ id: `iso_${id}`, source_type: "isolate" }],
+				version,
+			},
+			name: `OTU ${id}`,
+			abbreviation: "",
+			reference_id: referenceId,
+			verified: true,
+			version,
+		})),
+	);
+}
+
+// `storage_key` is unique on `indexes` and is dead — nothing composes a key from
+// it. Each seeded build gets one anyway, and it is deliberately unlike the row
+// id so a write derived from either is distinguishable from a minted key.
+let slugCounter = 0;
+
+async function seedBuild(values: {
+	referenceId: number;
+	userId: number;
+	manifest: Record<string, number>;
+	ready?: boolean;
+	backing?: "task" | "job" | "neither";
+}): Promise<number> {
+	slugCounter += 1;
+
+	const backing = values.backing ?? "task";
+
+	return takeFirstOrThrow(
+		await db
+			.insert(indexes)
+			.values({
+				created_at: new Date(),
+				manifest: values.manifest,
+				ready: values.ready ?? false,
+				reference_id: values.referenceId,
+				storage_key: `5f9a${slugCounter}legacymongoslug`,
+				user_id: values.userId,
+				version: 0,
+				job_id: backing === "job" ? 4242 : null,
+				task_id: backing === "task" ? await seedTask() : null,
+			})
+			.returning({ id: indexes.id }),
+	).id;
+}
+
+/** A reference with one OTU pinned at its live version, ready to build. */
+async function seedBuildable(): Promise<{
+	referenceId: number;
+	indexId: number;
+	otuId: string;
+}> {
+	const userId = await seedNextUser();
+	const referenceId = await seedReference(db, userId);
+
+	await seedOtus(referenceId, [{ id: "otualpha", version: 4 }]);
+
+	const indexId = await seedBuild({
+		referenceId,
+		userId,
+		manifest: { otualpha: 4 },
+	});
+
+	return { referenceId, indexId, otuId: "otualpha" };
+}
+
+async function readFileRow(indexId: number) {
+	const [row] = await db
+		.select()
+		.from(indexFiles)
+		.where(eq(indexFiles.index_id, indexId));
+
+	return row;
+}
+
+async function readArtifact(storage: MemoryStorage, key: string) {
+	const parts: Uint8Array[] = [];
+
+	for await (const part of storage.read(key)) {
+		parts.push(part);
+	}
+
+	return JSON.parse(gunzipSync(Buffer.concat(parts)).toString()) as {
+		_id: number;
+		created_at: string;
+		data_type: string;
+		name: string;
+		organism: string;
+		otus: { _id: string }[];
+	};
+}
+
+async function listKeys(storage: MemoryStorage): Promise<string[]> {
+	const keys: string[] = [];
+
+	for await (const object of storage.list("")) {
+		keys.push(object.key);
+	}
+
+	return keys.sort();
+}
+
+describe("generateTaskIndex", () => {
+	it("registers the artifact under a minted key and marks the build ready", async () => {
+		const storage = new MemoryStorage();
+		const { indexId } = await seedBuildable();
+
+		const [before] = await db
+			.select({ slug: indexes.storage_key })
+			.from(indexes)
+			.where(eq(indexes.id, indexId));
+
+		await generateTaskIndex(db, storage, testLogger, indexId);
+
+		const file = await readFileRow(indexId);
+
+		expect(file).toMatchObject({
+			index: String(indexId),
+			index_id: indexId,
+			name: ARTIFACT,
+			type: "json",
+		});
+		expect(file?.size).toBeGreaterThan(0);
+
+		// The key is minted, so it is derived from neither the row id nor the dead
+		// `indexes.storage_key` slug. Both are checked because a helper named for
+		// either would produce a key that reads nothing and orphans what it writes.
+		expect(file?.storage_key).toMatch(/^indexes\/\d+\/[0-9a-f]{32}$/);
+		expect(file?.storage_key).not.toContain(before?.slug);
+
+		// The whole bucket, so a write to a second key cannot go unnoticed.
+		expect(await listKeys(storage)).toEqual([file?.storage_key]);
+
+		const [row] = await db
+			.select({ ready: indexes.ready })
+			.from(indexes)
+			.where(eq(indexes.id, indexId));
+
+		expect(row?.ready).toBe(true);
+	});
+
+	it("writes the envelope and OTUs Python writes", async () => {
+		const storage = new MemoryStorage();
+		const userId = await seedNextUser();
+		const referenceId = await seedReference(db, userId, { name: "Plants" });
+
+		// Equal-length ids, so the JSONB manifest's key order — length, then
+		// bytewise — is the insertion order and the expectation can be written out.
+		await seedOtus(referenceId, [
+			{ id: "otualpha", version: 1 },
+			{ id: "otubetaa", version: 2 },
+		]);
+
+		const indexId = await seedBuild({
+			referenceId,
+			userId,
+			manifest: { otualpha: 1, otubetaa: 2 },
+		});
+
+		await generateTaskIndex(db, storage, testLogger, indexId);
+
+		const file = await readFileRow(indexId);
+		const artifact = await readArtifact(storage, file?.storage_key ?? "");
+
+		expect(artifact).toMatchObject({
+			_id: referenceId,
+			data_type: "genome",
+			name: "Plants",
+			organism: "virus",
+		});
+		expect(artifact.otus).toHaveLength(2);
+		expect(artifact.otus.map((otu) => otu._id)).toEqual([
+			"otualpha",
+			"otubetaa",
+		]);
+	});
+
+	// `JSON.parse` hoists array-index-like keys to the front of an object and
+	// sorts them numerically, and an eight-character id drawn from digits and
+	// lowercase letters is all digits often enough that a real reference has one.
+	// Python iterates the manifest in JSONB order, and the artifact's OTU order
+	// decides which isolate `cd-hit-est` keeps, so the two must agree.
+	it("orders OTUs by the manifest's stored order, not by parsed key order", async () => {
+		const storage = new MemoryStorage();
+		const userId = await seedNextUser();
+		const referenceId = await seedReference(db, userId);
+
+		await seedOtus(referenceId, [
+			{ id: "zzzzzzzz", version: 1 },
+			{ id: "12345678", version: 1 },
+			{ id: "aaaaaaaa", version: 1 },
+		]);
+
+		const indexId = await seedBuild({
+			referenceId,
+			userId,
+			manifest: { zzzzzzzz: 1, "12345678": 1, aaaaaaaa: 1 },
+		});
+
+		const [stored] = await db
+			.select({
+				order: sql<string[]>`array(select jsonb_object_keys(manifest))`,
+			})
+			.from(indexes)
+			.where(eq(indexes.id, indexId));
+
+		await generateTaskIndex(db, storage, testLogger, indexId);
+
+		const file = await readFileRow(indexId);
+		const artifact = await readArtifact(storage, file?.storage_key ?? "");
+
+		expect(artifact.otus.map((otu) => otu._id)).toEqual(stored?.order);
+
+		// The hazard itself: a parsed object puts the numeric id first, and the
+		// artifact must not.
+		expect(Object.keys({ zzzzzzzz: 1, "12345678": 1, aaaaaaaa: 1 })[0]).toBe(
+			"12345678",
+		);
+	});
+
+	// orjson writes six fractional digits or, with no microseconds, none.
+	// `Date.toISOString` always writes exactly three and has already truncated the
+	// other three, and postgres.js parses a naive timestamp as local time. The
+	// string is asserted rather than a parsed `Date` because it is the string that
+	// lands in a file workflows read.
+	it.each([
+		["2026-01-02 03:04:05.123456", "2026-01-02T03:04:05.123456Z"],
+		["2026-01-02 03:04:05", "2026-01-02T03:04:05Z"],
+		["2026-01-02 03:04:05.000900", "2026-01-02T03:04:05.000900Z"],
+	])("serializes created_at %s as %s", async (stored, expected) => {
+		const storage = new MemoryStorage();
+		const { indexId, referenceId } = await seedBuildable();
+
+		await db.execute(
+			sql`update legacy_references set created_at = ${stored}::timestamp where id = ${referenceId}`,
+		);
+
+		await generateTaskIndex(db, storage, testLogger, indexId);
+
+		const file = await readFileRow(indexId);
+
+		expect(
+			(await readArtifact(storage, file?.storage_key ?? "")).created_at,
+		).toBe(expected);
+	});
+
+	it("stamps last_indexed_version in the column and in data, across the chunk boundary", async () => {
+		const storage = new MemoryStorage();
+		const userId = await seedNextUser();
+		const referenceId = await seedReference(db, userId);
+
+		// 600 OTUs, so the patch loop runs two chunks and the stamp runs two
+		// statements. `OTU_ID_CHUNK_SIZE` is 500.
+		const otus = Array.from({ length: 600 }, (_, index) => ({
+			id: `otu${String(index).padStart(5, "0")}`,
+			version: 3,
+		}));
+
+		await seedOtus(referenceId, otus);
+
+		const manifest: Record<string, number> = {};
+
+		for (const otu of otus) {
+			manifest[otu.id] = otu.version;
+		}
+
+		const indexId = await seedBuild({ referenceId, userId, manifest });
+
+		await generateTaskIndex(db, storage, testLogger, indexId);
+
+		const rows = await db
+			.select({
+				column: legacyOtus.last_indexed_version,
+				inData: sql<string>`${legacyOtus.data} ->> 'last_indexed_version'`,
+			})
+			.from(legacyOtus)
+			.where(eq(legacyOtus.reference_id, referenceId));
+
+		expect(rows).toHaveLength(600);
+		expect(rows.every((row) => row.column === 3)).toBe(true);
+		expect(rows.every((row) => row.inData === "3")).toBe(true);
+	});
+
+	it("reports progress on chunk boundaries", async () => {
+		const storage = new MemoryStorage();
+		const userId = await seedNextUser();
+		const referenceId = await seedReference(db, userId);
+
+		const otus = Array.from({ length: 600 }, (_, index) => ({
+			id: `otu${String(index).padStart(5, "0")}`,
+			version: 1,
+		}));
+
+		await seedOtus(referenceId, otus);
+
+		const manifest: Record<string, number> = {};
+
+		for (const otu of otus) {
+			manifest[otu.id] = otu.version;
+		}
+
+		const indexId = await seedBuild({ referenceId, userId, manifest });
+
+		const reported: number[] = [];
+
+		await generateTaskIndex(
+			db,
+			storage,
+			testLogger,
+			indexId,
+			async (percent) => {
+				reported.push(percent);
+			},
+		);
+
+		expect(reported).toEqual([(500 / 600) * 100, 100]);
+	});
+
+	// A rebuild mints a new key rather than overwriting, so the row is repointed
+	// and the object it replaced is deleted once the write that orphaned it has
+	// committed.
+	it("upserts one file row across a rebuild and deletes the superseded object", async () => {
+		const storage = new MemoryStorage();
+		const { indexId } = await seedBuildable();
+
+		await generateTaskIndex(db, storage, testLogger, indexId);
+
+		const first = await readFileRow(indexId);
+
+		// A rebuild of the same build; the ready guard would otherwise no-op it.
+		await db
+			.update(indexes)
+			.set({ ready: false })
+			.where(eq(indexes.id, indexId));
+
+		await generateTaskIndex(db, storage, testLogger, indexId);
+
+		const second = await readFileRow(indexId);
+
+		const rows = await db
+			.select()
+			.from(indexFiles)
+			.where(eq(indexFiles.index_id, indexId));
+
+		expect(rows).toHaveLength(1);
+		expect(second?.id).toBe(first?.id);
+		expect(second?.storage_key).not.toBe(first?.storage_key);
+		expect(await listKeys(storage)).toEqual([second?.storage_key]);
+	});
+
+	// A claim is a lease, so a body may re-run from step zero after its work has
+	// already committed. Python raises here, which would fail the task and show an
+	// error against an index that is perfectly fine.
+	it("is a successful no-op when the build is already ready", async () => {
+		const storage = new MemoryStorage();
+		const { indexId } = await seedBuildable();
+
+		await generateTaskIndex(db, storage, testLogger, indexId);
+
+		const file = await readFileRow(indexId);
+
+		await expect(
+			generateTaskIndex(db, storage, testLogger, indexId),
+		).resolves.toBeUndefined();
+
+		expect(await readFileRow(indexId)).toEqual(file);
+		expect(await listKeys(storage)).toEqual([file?.storage_key]);
+	});
+
+	it("refuses a build that does not exist", async () => {
+		await expect(
+			generateTaskIndex(db, new MemoryStorage(), testLogger, 987654),
+		).rejects.toThrow(IndexNotFoundError);
+	});
+
+	it("refuses a job-backed build", async () => {
+		const userId = await seedNextUser();
+		const referenceId = await seedReference(db, userId);
+		const indexId = await seedBuild({
+			referenceId,
+			userId,
+			manifest: {},
+			backing: "job",
+		});
+
+		await expect(
+			generateTaskIndex(db, new MemoryStorage(), testLogger, indexId),
+		).rejects.toThrow("Index must be backed by a task build");
+	});
+
+	it("refuses a build backed by neither a job nor a task", async () => {
+		const userId = await seedNextUser();
+		const referenceId = await seedReference(db, userId);
+		const indexId = await seedBuild({
+			referenceId,
+			userId,
+			manifest: {},
+			backing: "neither",
+		});
+
+		await expect(
+			generateTaskIndex(db, new MemoryStorage(), testLogger, indexId),
+		).rejects.toThrow(IndexBuildTypeError);
+	});
+
+	// A manifest entry is proof the OTU existed at that version, so a null is a
+	// corrupted manifest. The build must fail rather than publish an artifact with
+	// a hole in it, and the half-written object must not be registered.
+	it("fails the build when a manifest entry cannot be patched", async () => {
+		const storage = new MemoryStorage();
+		const userId = await seedNextUser();
+		const referenceId = await seedReference(db, userId);
+
+		await seedOtus(referenceId, [{ id: "otualpha", version: 1 }]);
+
+		const indexId = await seedBuild({
+			referenceId,
+			userId,
+			manifest: { otualpha: 1, otughost: 2 },
+		});
+
+		await expect(
+			generateTaskIndex(db, storage, testLogger, indexId),
+		).rejects.toThrow(IndexManifestError);
+
+		expect(await readFileRow(indexId)).toBeUndefined();
+
+		const [row] = await db
+			.select({ ready: indexes.ready })
+			.from(indexes)
+			.where(eq(indexes.id, indexId));
+
+		expect(row?.ready).toBe(false);
+	});
+
+	// The bound on memory is the chunk size, not the reference. Asserted on the
+	// shape — one batched read per chunk, and bytes handed to storage as a stream
+	// rather than a buffer — because the bytes themselves cannot show it.
+	it("patches one chunk at a time and streams the artifact", async () => {
+		const storage = new MemoryStorage();
+		const write = vi.spyOn(storage, "write");
+
+		const userId = await seedNextUser();
+		const referenceId = await seedReference(db, userId);
+
+		const otus = Array.from({ length: 1200 }, (_, index) => ({
+			id: `otu${String(index).padStart(5, "0")}`,
+			version: 1,
+		}));
+
+		await seedOtus(referenceId, otus);
+
+		const manifest: Record<string, number> = {};
+
+		for (const otu of otus) {
+			manifest[otu.id] = otu.version;
+		}
+
+		const indexId = await seedBuild({ referenceId, userId, manifest });
+
+		const chunkSizes: number[] = [];
+
+		await generateTaskIndex(
+			db,
+			storage,
+			testLogger,
+			indexId,
+			async (percent) => {
+				chunkSizes.push(percent);
+			},
+		);
+
+		// Three chunks of 500, 500 and 200 rather than one read of 1200.
+		expect(chunkSizes).toHaveLength(3);
+
+		const data = write.mock.calls[0]?.[1];
+
+		expect(data).toBeDefined();
+		expect(Symbol.asyncIterator in Object(data)).toBe(true);
+		expect(Buffer.isBuffer(data)).toBe(false);
+
+		const artifact = await readArtifact(
+			storage,
+			(await readFileRow(indexId))?.storage_key ?? "",
+		);
+
+		expect(artifact.otus).toHaveLength(1200);
+	});
+});


### PR DESCRIPTION
## Summary
- Finish an index build from this side rather than leaving it to Python: patch the manifest's OTUs, stream `reference-v2.json.gz` to a minted storage key, register the `index_files` row, stamp `last_indexed_version`, and flip `ready`. Registered as the second task body, after `refresh_hmms`.
- Three deliberate divergences from Python, each recorded where it lands: an already-ready build is a successful no-op, because a reclaim re-runs a body from step zero; the artifact streams through `createGzip()` 500 OTUs at a time instead of being held in memory twice, with the chunk loop yielding so the heartbeat is not starved; and a failed build leaves its object to the orphan sweep, since a hard exit between the write and the commit orphans one regardless.
- Two ordering hazards closed: OTU order is read back with `jsonb_each ... with ordinality` rather than from the parsed column, because `JSON.parse` hoists array-index-like keys and an eight-character OTU id is all digits often enough to matter; and `reference.created_at` is rendered in SQL, because orjson writes six fractional digits or none while postgres.js parses a naive timestamp as local time.

Closes VIR-2895.