### PR TITLE
chore: add the cleanup_sessions task to delete expired sessions

### DIFF
--- a/apps/tasks/src/tasks/cleanup-sessions.test.ts
+++ b/apps/tasks/src/tasks/cleanup-sessions.test.ts
@@ -1,0 +1,155 @@
+import { seedSession, seedUser } from "@virtool/data/auth/test/fixtures";
+import type { Db } from "@virtool/data/db/pg";
+import { sessions } from "@virtool/data/db/schema/sessions";
+import { tasks } from "@virtool/data/db/schema/tasks";
+import { users } from "@virtool/data/db/schema/users";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import { acquireTask, type ClaimedTask } from "@virtool/data/tasks/data";
+import { createLogger, type Logger } from "@virtool/logger";
+import { MemoryStorage } from "@virtool/storage";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { runTask } from "../framework/run";
+import { cleanupSessionsTask } from "./cleanup-sessions";
+import type { TaskContext } from "./registry";
+
+const RUNNER = "ts-runner-a-1";
+
+const logger: Logger = createLogger({ name: "test", level: "silent" });
+
+let database: TestDatabase;
+let db: Db;
+let ctx: TaskContext;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(sessions);
+	await db.delete(users);
+	await db.delete(tasks);
+
+	ctx = { db, storage: new MemoryStorage() };
+});
+
+function minutesFromNow(minutes: number): Date {
+	return new Date(Date.now() + minutes * 60 * 1000);
+}
+
+/**
+ * Insert a `cleanup_sessions` row and claim it, as the spawner and the runner
+ * will once the cutover registers it.
+ *
+ * Written directly rather than through `createTask`, whose `TaskType` lists only
+ * the four the web app spawns.
+ */
+async function claim(): Promise<ClaimedTask> {
+	await db.insert(tasks).values({
+		complete: false,
+		context: {},
+		count: 0,
+		created_at: new Date(),
+		progress: 0,
+		step: cleanupSessionsTask.type,
+		type: cleanupSessionsTask.type,
+	});
+
+	const claimed = await acquireTask(db, {
+		runnerId: RUNNER,
+		allowedTypes: [cleanupSessionsTask.type],
+	});
+
+	if (claimed === null) {
+		throw new Error("the task under test was not claimable");
+	}
+
+	return claimed;
+}
+
+function readRow(taskId: number) {
+	return db
+		.select()
+		.from(tasks)
+		.where(eq(tasks.id, taskId))
+		.then(([row]) => row);
+}
+
+async function remainingSessionIds(): Promise<string[]> {
+	const rows = await db
+		.select({ sessionId: sessions.sessionId })
+		.from(sessions)
+		.orderBy(sessions.id);
+
+	return rows.map((row) => row.sessionId);
+}
+
+describe("cleanupSessionsTask", () => {
+	it("deletes the expired sessions and completes", async () => {
+		const userId = await seedUser(db);
+
+		await seedSession(db, userId, { expiresAt: minutesFromNow(-30) });
+		await seedSession(db, userId, { expiresAt: minutesFromNow(-1) });
+		const live = await seedSession(db, userId, {
+			expiresAt: minutesFromNow(30),
+		});
+
+		const task = await claim();
+
+		const outcome = await runTask({
+			db,
+			def: cleanupSessionsTask,
+			task,
+			ctx,
+			logger,
+			signal: new AbortController().signal,
+		});
+
+		expect(outcome).toEqual({ status: "completed" });
+
+		expect(await readRow(task.id)).toMatchObject({
+			complete: true,
+			error: null,
+			progress: 100,
+			step: "cleanup_expired_sessions",
+		});
+
+		expect(await remainingSessionIds()).toEqual([live.sessionId]);
+	});
+
+	it("completes without deleting when nothing has expired", async () => {
+		const userId = await seedUser(db);
+		const live = await seedSession(db, userId, {
+			expiresAt: minutesFromNow(30),
+		});
+
+		const task = await claim();
+
+		const outcome = await runTask({
+			db,
+			def: cleanupSessionsTask,
+			task,
+			ctx,
+			logger,
+			signal: new AbortController().signal,
+		});
+
+		expect(outcome).toEqual({ status: "completed" });
+
+		expect(await readRow(task.id)).toMatchObject({
+			complete: true,
+			error: null,
+			progress: 100,
+		});
+
+		expect(await remainingSessionIds()).toEqual([live.sessionId]);
+	});
+});

--- a/apps/tasks/src/tasks/cleanup-sessions.ts
+++ b/apps/tasks/src/tasks/cleanup-sessions.ts
@@ -1,0 +1,31 @@
+import { deleteExpiredSessions } from "@virtool/data/auth/session";
+import { z } from "zod";
+import { defineTask } from "../framework/define";
+import type { TaskContext } from "./registry";
+
+/**
+ * `cleanup_sessions` carries nothing.
+ */
+const payload = z.object({});
+
+/**
+ * Delete expired session rows.
+ *
+ * It is idempotent as a reclaim requires: a re-run deletes whatever is expired
+ * when it runs, which is nothing if the first attempt got there.
+ *
+ */
+export const cleanupSessionsTask = defineTask<typeof payload, TaskContext>({
+	type: "cleanup_sessions",
+	payload,
+	steps: ["cleanup_expired_sessions"],
+	async run({ ctx, helpers, logger, signal }) {
+		await helpers.runStep("cleanup_expired_sessions", async () => {
+			const deleted = await deleteExpiredSessions(ctx.db, { signal });
+
+			if (deleted > 0) {
+				logger.info({ count: deleted }, "cleaned up expired sessions");
+			}
+		});
+	},
+});

--- a/apps/tasks/src/tasks/registry.ts
+++ b/apps/tasks/src/tasks/registry.ts
@@ -1,6 +1,7 @@
 import type { Db } from "@virtool/data/db/pg";
 import type { StorageBackend } from "@virtool/storage";
 import type { TaskRegistry } from "../framework/define";
+import { cleanupSessionsTask } from "./cleanup-sessions";
 import { createIndexTask } from "./create-index";
 import { evictCachesLruTask } from "./evict-caches-lru";
 import { refreshHmmsTask } from "./refresh-hmms";
@@ -32,6 +33,7 @@ export type TaskContext = {
  * another; `registry.test.ts` fails on any that do.
  */
 export const taskRegistry: TaskRegistry<TaskContext> = {
+	cleanup_sessions: cleanupSessionsTask,
 	create_index: createIndexTask,
 	evict_caches_lru: evictCachesLruTask,
 	refresh_hmms: refreshHmmsTask,

--- a/packages/contracts/src/tasks.ts
+++ b/packages/contracts/src/tasks.ts
@@ -3,11 +3,6 @@ import { z } from "zod";
 /**
  * A task the spawner inserts on a schedule.
  *
- * These are the five Python's `startup_periodic_tasks` carries, spelled with
- * the `name` of the task class rather than its Python identifier, because the
- * `name` is what lands in `tasks.type`. Their intervals are the spawner's, not
- * this union's.
- *
  * Kept apart from {@link TaskName} because the spawn-outcome counter's label
  * set *is* the schedule: a series for a type nothing ever spawns would sit at
  * zero forever and read as a task that never runs.
@@ -23,17 +18,12 @@ export const PeriodicTaskName = z.enum([
 export type PeriodicTaskName = z.infer<typeof PeriodicTaskName>;
 
 /**
- * Every task name Virtool runs — the five periodic ones plus the four created
- * in response to a request.
- *
- * **This bounds a metric label, not a row.** `tasks.type` is a plain `text`
- * column with no CHECK constraint on either side, so a row may legitimately
- * carry a name this union has never heard of — a typo, or a task a future
- * Python release adds. Anything reading the column keeps it typed `string` and
- * folds an unrecognised value onto `other` at the point it becomes a label.
+ * Every task name Virtool runs — the five periodic ones, the four created in
+ * response to a request, and `cleanup_sessions`.
  */
 export const TaskName = z.enum([
 	...PeriodicTaskName.options,
+	"cleanup_sessions",
 	"clone_reference",
 	"create_index",
 	"import_reference",

--- a/packages/data/src/auth/session.test.ts
+++ b/packages/data/src/auth/session.test.ts
@@ -8,14 +8,13 @@ import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
 import {
 	createAuthenticatedSession,
 	createResetSession,
+	deleteExpiredSessions,
 	invalidateSession,
 	invalidateUserSessions,
 } from "./session";
 import { seedSession, seedUser } from "./test/fixtures";
 import { hashToken } from "./tokens";
 
-// The Python lifetimes in `virtool/sessions/data.py`, which these rows must be
-// indistinguishable from.
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 const SIXTY_MINUTES_MS = 60 * 60 * 1000;
 const TEN_MINUTES_MS = 10 * 60 * 1000;
@@ -210,5 +209,136 @@ describe("invalidateUserSessions", () => {
 		expect(
 			await db.select({ id: users.id }).from(users).where(eq(users.id, userId)),
 		).toEqual([{ id: userId }]);
+	});
+});
+
+describe("deleteExpiredSessions", () => {
+	const FIVE_MINUTES_MS = 5 * 60 * 1000;
+
+	function minutesFromNow(minutes: number): Date {
+		return new Date(Date.now() + minutes * 60 * 1000);
+	}
+
+	async function remainingSessionIds(): Promise<string[]> {
+		const rows = await db
+			.select({ sessionId: sessions.sessionId })
+			.from(sessions)
+			.orderBy(sessions.id);
+
+		return rows.map((row) => row.sessionId);
+	}
+
+	it("deletes an expired session and leaves a live one", async () => {
+		const userId = await seedUser(db);
+
+		await seedSession(db, userId, { expiresAt: minutesFromNow(-30) });
+		const live = await seedSession(db, userId, {
+			expiresAt: minutesFromNow(30),
+		});
+
+		expect(await deleteExpiredSessions(db)).toBe(1);
+		expect(await remainingSessionIds()).toEqual([live.sessionId]);
+	});
+
+	// `expires_at` is `timestamp without time zone` holding naive UTC. A cutoff
+	// bound as a `Date` casts through the session `TimeZone`, which is unset here,
+	// so a wrong cutoff is out by whole hours rather than by seconds. Five minutes
+	// either side of now catches that in both directions: an hour early would keep
+	// the expired row, an hour late would take the live one.
+	it("puts the cutoff at now, not an hour either side of it", async () => {
+		const userId = await seedUser(db);
+
+		await seedSession(db, userId, {
+			expiresAt: new Date(Date.now() - FIVE_MINUTES_MS),
+		});
+		const live = await seedSession(db, userId, {
+			expiresAt: new Date(Date.now() + FIVE_MINUTES_MS),
+		});
+
+		expect(await deleteExpiredSessions(db)).toBe(1);
+		expect(await remainingSessionIds()).toEqual([live.sessionId]);
+	});
+
+	it("deletes every session type", async () => {
+		const userId = await seedUser(db);
+
+		for (const sessionType of [
+			"anonymous",
+			"authenticated",
+			"reset",
+		] as const) {
+			await seedSession(db, userId, {
+				expiresAt: minutesFromNow(-30),
+				sessionType,
+			});
+		}
+
+		expect(await deleteExpiredSessions(db)).toBe(3);
+		expect(await remainingSessionIds()).toEqual([]);
+	});
+
+	it("loops past the batch size until nothing expired is left", async () => {
+		const userId = await seedUser(db);
+
+		for (let index = 0; index < 7; index++) {
+			await seedSession(db, userId, { expiresAt: minutesFromNow(-30) });
+		}
+
+		const live = await seedSession(db, userId, {
+			expiresAt: minutesFromNow(30),
+		});
+
+		expect(await deleteExpiredSessions(db, { batchSize: 2 })).toBe(7);
+		expect(await remainingSessionIds()).toEqual([live.sessionId]);
+	});
+
+	it("returns zero when nothing has expired", async () => {
+		const userId = await seedUser(db);
+		await seedSession(db, userId, { expiresAt: minutesFromNow(30) });
+
+		expect(await deleteExpiredSessions(db)).toBe(0);
+		expect(await remainingSessionIds()).toHaveLength(1);
+	});
+
+	// Deleting a live session logs a user out early, which is the only harm this
+	// can do — so the surviving row is compared whole rather than counted.
+	it("leaves a live session's row untouched", async () => {
+		const userId = await seedUser(db);
+
+		const live = await seedSession(db, userId, {
+			expiresAt: minutesFromNow(30),
+		});
+
+		const before = await db
+			.select()
+			.from(sessions)
+			.where(eq(sessions.sessionId, live.sessionId));
+
+		await seedSession(db, userId, { expiresAt: minutesFromNow(-30) });
+
+		await deleteExpiredSessions(db);
+
+		expect(
+			await db
+				.select()
+				.from(sessions)
+				.where(eq(sessions.sessionId, live.sessionId)),
+		).toEqual(before);
+	});
+
+	// The signal is checked between batches, so a run on a table that has never
+	// been cleared cannot outlive the drain. Whatever earlier batches committed
+	// stands: each is its own transaction.
+	it("throws and deletes nothing when the signal is already aborted", async () => {
+		const userId = await seedUser(db);
+		const expired = await seedSession(db, userId, {
+			expiresAt: minutesFromNow(-30),
+		});
+
+		await expect(
+			deleteExpiredSessions(db, { signal: AbortSignal.abort() }),
+		).rejects.toThrow();
+
+		expect(await remainingSessionIds()).toEqual([expired.sessionId]);
 	});
 });

--- a/packages/data/src/auth/session.test.ts
+++ b/packages/data/src/auth/session.test.ts
@@ -1,5 +1,14 @@
+import { setTimeout as delay } from "node:timers/promises";
 import { eq } from "drizzle-orm";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	onTestFinished,
+} from "vitest";
 
 import type { Db } from "../db/pg";
 import { sessions } from "../db/schema/sessions";
@@ -324,6 +333,80 @@ describe("deleteExpiredSessions", () => {
 				.from(sessions)
 				.where(eq(sessions.sessionId, live.sessionId)),
 		).toEqual(before);
+	});
+
+	/**
+	 * The refresh race the outer `where`'s repeated expiry test exists for.
+	 *
+	 * A second session extends the row and holds its lock, so the delete's
+	 * subquery still sees it expired and the delete itself parks on the lock.
+	 * Once that commits, Postgres re-checks the outer predicate alone — a
+	 * predicate naming only the id would pass, and the refreshed session would
+	 * go.
+	 */
+	it("spares a session refreshed between the select and the delete", async () => {
+		const refresher = database.connect();
+		const observer = database.connect();
+
+		onTestFinished(async () => {
+			await Promise.all([refresher.close(), observer.close()]);
+		});
+
+		const userId = await seedUser(db);
+		const refreshed = await seedSession(db, userId, {
+			expiresAt: minutesFromNow(-30),
+		});
+
+		let commit: () => void = () => undefined;
+		const committed = new Promise<void>((resolve) => {
+			commit = resolve;
+		});
+
+		let extended: () => void = () => undefined;
+		const holds = new Promise<void>((resolve) => {
+			extended = resolve;
+		});
+
+		const holding = refresher.client.begin(async (tx) => {
+			await tx`
+				update sessions
+				set expires_at = timezone('utc', clock_timestamp()) + interval '30 minutes'
+				where session_id = ${refreshed.sessionId}
+			`;
+
+			extended();
+
+			await committed;
+		});
+
+		await holds;
+
+		const deleting = deleteExpiredSessions(db);
+
+		for (let attempt = 0; attempt < 100; attempt++) {
+			const rows = await observer.client.unsafe(
+				`select 1 from pg_stat_activity
+				 where datname = current_database() and wait_event_type = 'Lock'`,
+			);
+
+			if (rows.length > 0) {
+				break;
+			}
+
+			await delay(25);
+		}
+
+		commit();
+		await holding;
+
+		expect(await deleting).toBe(0);
+		expect(await remainingSessionIds()).toEqual([refreshed.sessionId]);
+	}, 15_000);
+
+	it("rejects a batch size that would never advance the loop", async () => {
+		await expect(deleteExpiredSessions(db, { batchSize: 0 })).rejects.toThrow(
+			RangeError,
+		);
 	});
 
 	// The signal is checked between batches, so a run on a table that has never

--- a/packages/data/src/auth/session.ts
+++ b/packages/data/src/auth/session.ts
@@ -184,10 +184,18 @@ export type DeleteExpiredSessionsOptions = {
  * unset in this pool, so the offset is silent and hour-scale. Deleting a live
  * session logs a user out early, which is the only harm this can do.
  *
+ * **The expiry test is repeated on the outer `delete`**, where it looks
+ * redundant against the subquery that already applied it. Under Read Committed
+ * a row updated by a transaction that commits mid-statement is re-checked
+ * against the outer `where` alone — the subquery is not re-run — so a predicate
+ * naming only the id passes on a row whose `expires_at` has since moved
+ * forward, and a session Python's sliding refresh just extended is deleted out
+ * from under its user.
+ *
  * The loop stops on a batch shorter than the limit. A concurrent logout that
- * removes an expired row between the select and the delete can end a run one
- * batch early; the next run takes what is left, and no run deletes a row it
- * should not have.
+ * removes an expired row between the select and the delete, or a refresh the
+ * re-check then spares, can end a run one batch early; the next run takes what
+ * is left, and no run deletes a row it should not have.
  */
 export async function deleteExpiredSessions(
 	db: DbOrTx,
@@ -196,6 +204,12 @@ export async function deleteExpiredSessions(
 		signal,
 	}: DeleteExpiredSessionsOptions = {},
 ): Promise<number> {
+	if (!Number.isInteger(batchSize) || batchSize < 1) {
+		throw new RangeError(
+			`batchSize must be a positive integer, got ${batchSize}`,
+		);
+	}
+
 	let total = 0;
 
 	for (;;) {
@@ -204,7 +218,7 @@ export async function deleteExpiredSessions(
 		const deleted = await db
 			.delete(sessions)
 			.where(
-				sql`${sessions.id} in (
+				sql`${sessions.expiresAt} < ${nowUtc()} and ${sessions.id} in (
 					select id from ${sessions}
 					where expires_at < ${nowUtc()}
 					limit ${batchSize}

--- a/packages/data/src/auth/session.ts
+++ b/packages/data/src/auth/session.ts
@@ -1,20 +1,26 @@
 import { randomBytes } from "node:crypto";
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import type { DbOrTx } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
 import { type SessionRow, sessions } from "../db/schema/sessions";
+import { nowUtc } from "../db/time";
 import { hashToken, newSessionId, newSessionToken } from "./tokens";
 
-// Python lifetimes in `virtool/sessions/data.py`:
-//   - authenticated + remember: 30 days
-//   - authenticated, no remember: 60 minutes
-//   - reset: 10 minutes
-// We mirror them so a row written here is indistinguishable from one written
-// by the Python backend.
+/**
+ * How long an authenticated session lasts when the user ticked "remember me".
+ */
 const SESSION_LIFETIME_REMEMBER_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * How long an authenticated session lasts when the user did not.
+ */
 const SESSION_LIFETIME_NO_REMEMBER_MS = 60 * 60 * 1000;
+
+/**
+ * How long a forced-reset session lasts.
+ */
 const RESET_LIFETIME_MS = 10 * 60 * 1000;
 
 /** Inputs to mint an authenticated session row. */
@@ -140,4 +146,76 @@ export async function invalidateUserSessions(
 	userId: number,
 ): Promise<void> {
 	await db.delete(sessions).where(eq(sessions.userId, userId));
+}
+
+/**
+ * How many expired sessions one statement removes.
+ *
+ * Low thousands, so a single pass is short enough that nothing else waiting on
+ * a `sessions` row waits long, and few enough passes are needed that the loop
+ * is not itself the cost. The first production run clears years of accumulated
+ * rows, which is the run this bound exists for.
+ */
+const SESSION_CLEANUP_BATCH_SIZE = 2_000;
+
+/** What {@link deleteExpiredSessions} accepts. */
+export type DeleteExpiredSessionsOptions = {
+	/** Rows removed per statement. Defaults to {@link SESSION_CLEANUP_BATCH_SIZE}. */
+	batchSize?: number;
+	/** Aborts the loop between batches. Committed batches stand. */
+	signal?: AbortSignal;
+};
+
+/**
+ * Delete every session row whose `expires_at` has passed, and report how many
+ * went.
+ *
+ * **The delete is batched, and each batch is its own transaction.** A single
+ * statement covering years of accumulated rows would hold every one of their
+ * locks and pin `xmin` for its whole duration, stalling autovacuum across the
+ * database rather than just this table. Nothing here opens a transaction, so a
+ * `db` handle runs each statement autocommitted; passing a transaction instead
+ * folds the whole loop into it and gives back exactly the long-running delete
+ * being avoided.
+ *
+ * **The cutoff is Postgres's clock, never a `Date` bound from here.**
+ * `expires_at` is `timestamp without time zone` holding naive UTC, and a
+ * JavaScript `Date` bound against it casts through the session `TimeZone` —
+ * unset in this pool, so the offset is silent and hour-scale. Deleting a live
+ * session logs a user out early, which is the only harm this can do.
+ *
+ * The loop stops on a batch shorter than the limit. A concurrent logout that
+ * removes an expired row between the select and the delete can end a run one
+ * batch early; the next run takes what is left, and no run deletes a row it
+ * should not have.
+ */
+export async function deleteExpiredSessions(
+	db: DbOrTx,
+	{
+		batchSize = SESSION_CLEANUP_BATCH_SIZE,
+		signal,
+	}: DeleteExpiredSessionsOptions = {},
+): Promise<number> {
+	let total = 0;
+
+	for (;;) {
+		signal?.throwIfAborted();
+
+		const deleted = await db
+			.delete(sessions)
+			.where(
+				sql`${sessions.id} in (
+					select id from ${sessions}
+					where expires_at < ${nowUtc()}
+					limit ${batchSize}
+				)`,
+			)
+			.returning({ id: sessions.id });
+
+		total += deleted.length;
+
+		if (deleted.length < batchSize) {
+			return total;
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Adds `deleteExpiredSessions` to `@virtool/data`, batch-deleting rows past `expires_at` (one transaction per batch, cutoff read from Postgres's own clock rather than a JS `Date`) so a first run clearing years of accumulated sessions can't hold every lock or pin `xmin` and stall autovacuum database-wide.
- Ports Python's `SessionCleanupTask` — never spawned, and since deleted outright — as a one-step task body over that helper, registered in the runner's registry.
- Registered but **not spawned**: `PERIODIC_TASKS` gains the type at 3600 s in the cutover issue, since Python's runner is the only runner until then and strands a type it cannot name. `cleanup_sessions` is therefore added to `TaskName`, which the registry's keys are pinned to, but not to `PeriodicTaskName`, whose members label the spawn-outcome counter.