### PR TITLE
fix: show new references without a page reload

### DIFF
--- a/apps/web/src/references/components/__tests__/ReferenceList.test.tsx
+++ b/apps/web/src/references/components/__tests__/ReferenceList.test.tsx
@@ -160,16 +160,8 @@ describe("<ReferenceList />", () => {
 			mockGetAccount(createFakeAccount({ permissions }));
 
 			const created = createFakeReferenceMinimal({ name: "Fresh Reference" });
-			let items = [references];
 
-			referenceServerFnMocks.findReferencesFn.mockImplementation(async () => ({
-				foundCount: items.length,
-				totalCount: items.length,
-				page: 1,
-				pageCount: 1,
-				perPage: 25,
-				items,
-			}));
+			mockFindReferences([references]);
 			mockCreateReference(createFakeReference({ name: created.name }));
 
 			await renderWithRouter(<ReferenceListHarness />);
@@ -187,7 +179,10 @@ describe("<ReferenceList />", () => {
 				created.name,
 			);
 
-			items = [references, created];
+			// The list the invalidated query will refetch. Nothing but a refetch
+			// can put this reference on screen.
+			mockFindReferences([references, created]);
+
 			await userEvent.click(
 				within(dialog).getByRole("button", { name: "Create" }),
 			);
@@ -202,16 +197,8 @@ describe("<ReferenceList />", () => {
 			mockGetAccount(createFakeAccount({ permissions }));
 
 			const clone = createFakeReferenceMinimal({ name: "Cloned Reference" });
-			let items = [references];
 
-			referenceServerFnMocks.findReferencesFn.mockImplementation(async () => ({
-				foundCount: items.length,
-				totalCount: items.length,
-				page: 1,
-				pageCount: 1,
-				perPage: 25,
-				items,
-			}));
+			mockFindReferences([references]);
 			mockCreateReference(createFakeReference({ name: clone.name }));
 
 			await renderWithRouter(<ReferenceListHarness />);
@@ -223,7 +210,10 @@ describe("<ReferenceList />", () => {
 				await screen.findByRole("button", { name: "clone" }),
 			);
 
-			items = [references, clone];
+			// The list the invalidated query will refetch. Nothing but a refetch
+			// can put this reference on screen.
+			mockFindReferences([references, clone]);
+
 			await userEvent.click(screen.getByRole("button", { name: "Clone" }));
 
 			expect(await screen.findByText(clone.name)).toBeInTheDocument();

--- a/apps/web/src/references/components/__tests__/ReferenceList.test.tsx
+++ b/apps/web/src/references/components/__tests__/ReferenceList.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createFakeAccount } from "@tests/fake/account";
 import { createFakePermissions } from "@tests/fake/permissions";
@@ -154,7 +154,81 @@ describe("<ReferenceList />", () => {
 		});
 	});
 
+	describe("<CreateReference />", () => {
+		it("should show a newly created reference without a reload", async () => {
+			const permissions = createFakePermissions({ create_ref: true });
+			mockGetAccount(createFakeAccount({ permissions }));
+
+			const created = createFakeReferenceMinimal({ name: "Fresh Reference" });
+			let items = [references];
+
+			referenceServerFnMocks.findReferencesFn.mockImplementation(async () => ({
+				foundCount: items.length,
+				totalCount: items.length,
+				page: 1,
+				pageCount: 1,
+				perPage: 25,
+				items,
+			}));
+			mockCreateReference(createFakeReference({ name: created.name }));
+
+			await renderWithRouter(<ReferenceListHarness />);
+
+			expect(await screen.findByText("References")).toBeInTheDocument();
+			expect(screen.queryByText(created.name)).not.toBeInTheDocument();
+
+			await userEvent.click(
+				await screen.findByRole("button", { name: "Create" }),
+			);
+
+			const dialog = await screen.findByRole("dialog");
+			await userEvent.type(
+				within(dialog).getByRole("textbox", { name: "Name" }),
+				created.name,
+			);
+
+			items = [references, created];
+			await userEvent.click(
+				within(dialog).getByRole("button", { name: "Create" }),
+			);
+
+			expect(await screen.findByText(created.name)).toBeInTheDocument();
+		});
+	});
+
 	describe("<CloneReference />", () => {
+		it("should show the clone without a reload", async () => {
+			const permissions = createFakePermissions({ create_ref: true });
+			mockGetAccount(createFakeAccount({ permissions }));
+
+			const clone = createFakeReferenceMinimal({ name: "Cloned Reference" });
+			let items = [references];
+
+			referenceServerFnMocks.findReferencesFn.mockImplementation(async () => ({
+				foundCount: items.length,
+				totalCount: items.length,
+				page: 1,
+				pageCount: 1,
+				perPage: 25,
+				items,
+			}));
+			mockCreateReference(createFakeReference({ name: clone.name }));
+
+			await renderWithRouter(<ReferenceListHarness />);
+
+			expect(await screen.findByText("References")).toBeInTheDocument();
+			expect(screen.queryByText(clone.name)).not.toBeInTheDocument();
+
+			await userEvent.click(
+				await screen.findByRole("button", { name: "clone" }),
+			);
+
+			items = [references, clone];
+			await userEvent.click(screen.getByRole("button", { name: "Clone" }));
+
+			expect(await screen.findByText(clone.name)).toBeInTheDocument();
+		});
+
 		it("handleSubmit() should mutate with correct input", async () => {
 			const permissions = createFakePermissions({ create_ref: true });
 			const account = createFakeAccount({ permissions: permissions });

--- a/apps/web/src/references/queries.ts
+++ b/apps/web/src/references/queries.ts
@@ -86,6 +86,8 @@ export function useSuspenseReferences(
  * @returns A mutator for cloning a reference
  */
 export function useCloneReference() {
+	const queryClient = useQueryClient();
+
 	return useMutation<
 		Reference,
 		Error,
@@ -95,6 +97,11 @@ export function useCloneReference() {
 			createReferenceFn({
 				data: { name, description, cloneFrom: refId },
 			}) as Promise<Reference>,
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: referenceQueryKeys.lists(),
+			});
+		},
 	});
 }
 
@@ -104,6 +111,8 @@ export function useCloneReference() {
  * @returns A mutator for importing a reference
  */
 export function useImportReference() {
+	const queryClient = useQueryClient();
+
 	return useMutation<
 		Reference,
 		Error,
@@ -113,6 +122,11 @@ export function useImportReference() {
 			createReferenceFn({
 				data: { name, description, importFrom },
 			}) as Promise<Reference>,
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: referenceQueryKeys.lists(),
+			});
+		},
 	});
 }
 
@@ -150,6 +164,8 @@ export function useUploadReference() {
  * @returns A mutator for creating an empty reference
  */
 export function useCreateReference() {
+	const queryClient = useQueryClient();
+
 	return useMutation<
 		Reference,
 		Error,
@@ -159,6 +175,11 @@ export function useCreateReference() {
 			createReferenceFn({
 				data: { name, description, organism },
 			}) as Promise<Reference>,
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: referenceQueryKeys.lists(),
+			});
+		},
 	});
 }
 

--- a/packages/data/src/references/data.test.ts
+++ b/packages/data/src/references/data.test.ts
@@ -1,0 +1,201 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { seedUser } from "../auth/test/fixtures";
+import type { Db, PgClient } from "../db/pg";
+import { takeFirstOrThrow } from "../db/rows";
+import { groups, userGroups } from "../db/schema/groups";
+import {
+	legacyReferenceGroups,
+	legacyReferences,
+	legacyReferenceUsers,
+} from "../db/schema/references";
+import { settings } from "../db/schema/settings";
+import { tasks } from "../db/schema/tasks";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { collectFrames } from "../test/frames";
+import {
+	addReferenceGroup,
+	addReferenceUser,
+	createReference,
+	removeReferenceGroup,
+	removeReferenceUser,
+	setReferenceArchived,
+	updateReference,
+	updateReferenceGroup,
+	updateReferenceUser,
+} from "./data";
+
+let database: TestDatabase;
+let db: Db;
+let client: PgClient;
+
+let userId: number;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+	client = database.client;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(legacyReferenceUsers);
+	await db.delete(legacyReferenceGroups);
+	await db.delete(legacyReferences);
+	await db.delete(tasks);
+	await db.delete(userGroups);
+	await db.delete(groups);
+	await db.delete(users);
+	await db.delete(settings);
+
+	userId = await seedUser(db);
+});
+
+async function seedReference(): Promise<number> {
+	const reference = await createReference(db, {
+		name: "Reference",
+		description: "",
+		organism: "virus",
+		userId,
+	});
+
+	return reference.id;
+}
+
+async function seedGroup(): Promise<number> {
+	const group = takeFirstOrThrow(
+		await db
+			.insert(groups)
+			.values({ name: "Team", permissions: {} as never })
+			.returning({ id: groups.id }),
+	);
+
+	return group.id;
+}
+
+describe("createReference", () => {
+	it("publishes a create frame once the transaction has committed", async () => {
+		let referenceId: number | undefined;
+
+		const frames = await collectFrames(client, async () => {
+			const reference = await createReference(db, {
+				name: "Reference",
+				description: "",
+				organism: "virus",
+				userId,
+			});
+
+			referenceId = reference.id;
+		});
+
+		expect(frames).toEqual([
+			{ domain: "references", resource_id: referenceId, operation: "create" },
+		]);
+	});
+
+	it("publishes nothing when the clone source is missing", async () => {
+		const frames = await collectFrames(client, async () => {
+			await expect(
+				createReference(db, {
+					name: "Clone",
+					description: "",
+					organism: "",
+					cloneFrom: 404,
+					userId,
+				}),
+			).rejects.toThrow();
+		});
+
+		expect(frames).toEqual([]);
+	});
+});
+
+describe("updateReference", () => {
+	it("publishes an update frame", async () => {
+		const referenceId = await seedReference();
+
+		const frames = await collectFrames(client, async () => {
+			await updateReference(db, referenceId, { name: "Renamed" });
+		});
+
+		expect(frames).toEqual([
+			{ domain: "references", resource_id: referenceId, operation: "update" },
+		]);
+	});
+
+	// Nothing was written, so every connected browser would refetch the
+	// reference for a change that did not happen.
+	it("publishes nothing when the patch is empty", async () => {
+		const referenceId = await seedReference();
+
+		const frames = await collectFrames(client, async () => {
+			await updateReference(db, referenceId, {});
+		});
+
+		expect(frames).toEqual([]);
+	});
+});
+
+describe("setReferenceArchived", () => {
+	it("publishes an update frame", async () => {
+		const referenceId = await seedReference();
+
+		const frames = await collectFrames(client, async () => {
+			await setReferenceArchived(db, referenceId, true);
+		});
+
+		expect(frames).toEqual([
+			{ domain: "references", resource_id: referenceId, operation: "update" },
+		]);
+	});
+});
+
+describe("membership", () => {
+	it("publishes an update frame for each user change", async () => {
+		const referenceId = await seedReference();
+		const memberId = await seedUser(db, { handle: "bob" });
+
+		const frames = await collectFrames(client, async () => {
+			await addReferenceUser(db, referenceId, memberId, { modify: true });
+			await updateReferenceUser(db, referenceId, memberId, { build: true });
+			await removeReferenceUser(db, referenceId, memberId);
+		});
+
+		expect(frames).toEqual([
+			{ domain: "references", resource_id: referenceId, operation: "update" },
+			{ domain: "references", resource_id: referenceId, operation: "update" },
+			{ domain: "references", resource_id: referenceId, operation: "update" },
+		]);
+	});
+
+	it("publishes an update frame for each group change", async () => {
+		const referenceId = await seedReference();
+		const groupId = await seedGroup();
+
+		const frames = await collectFrames(client, async () => {
+			await addReferenceGroup(db, referenceId, groupId, { modify: true });
+			await updateReferenceGroup(db, referenceId, groupId, { build: true });
+			await removeReferenceGroup(db, referenceId, groupId);
+		});
+
+		expect(frames).toEqual([
+			{ domain: "references", resource_id: referenceId, operation: "update" },
+			{ domain: "references", resource_id: referenceId, operation: "update" },
+			{ domain: "references", resource_id: referenceId, operation: "update" },
+		]);
+	});
+
+	it("publishes nothing when the member does not exist", async () => {
+		const referenceId = await seedReference();
+
+		const frames = await collectFrames(client, async () => {
+			await expect(removeReferenceUser(db, referenceId, 404)).rejects.toThrow();
+		});
+
+		expect(frames).toEqual([]);
+	});
+});

--- a/packages/data/src/references/data.ts
+++ b/packages/data/src/references/data.ts
@@ -40,6 +40,7 @@ import { tasks } from "../db/schema/tasks";
 import { uploads } from "../db/schema/uploads";
 import { users } from "../db/schema/users";
 import { AppError } from "../errors";
+import { emit } from "../events/emit";
 import { getSettings } from "../settings/data";
 import { createTask, type TaskType } from "../tasks/data";
 
@@ -709,6 +710,8 @@ export async function createReference(
 		return reference.id;
 	});
 
+	await emit("references", newId, "create");
+
 	return getReference(db, newId);
 }
 
@@ -745,6 +748,8 @@ export async function updateReference(
 			.update(legacyReferences)
 			.set(patch)
 			.where(eq(legacyReferences.id, referenceId));
+
+		await emit("references", referenceId, "update");
 	}
 
 	return getReference(db, referenceId);
@@ -761,6 +766,8 @@ export async function setReferenceArchived(
 		.update(legacyReferences)
 		.set({ archived })
 		.where(eq(legacyReferences.id, referenceId));
+
+	await emit("references", referenceId, "update");
 
 	return getReference(db, referenceId);
 }
@@ -811,6 +818,8 @@ export async function addReferenceUser(
 		modify: resolved.modify,
 		modify_otu: resolved.modifyOtu,
 	});
+
+	await emit("references", referenceId, "update");
 
 	return {
 		id: user.id,
@@ -866,6 +875,8 @@ export async function addReferenceGroup(
 		modify: resolved.modify,
 		modify_otu: resolved.modifyOtu,
 	});
+
+	await emit("references", referenceId, "update");
 
 	return {
 		id: group.id,
@@ -925,6 +936,8 @@ export async function updateReferenceUser(
 			),
 		);
 
+	await emit("references", referenceId, "update");
+
 	return {
 		id: userId,
 		handle: row.handle,
@@ -982,6 +995,8 @@ export async function updateReferenceGroup(
 			),
 		);
 
+	await emit("references", referenceId, "update");
+
 	return {
 		id: groupId,
 		name: row.name,
@@ -1008,6 +1023,8 @@ export async function removeReferenceUser(
 	if (removed.length === 0) {
 		throw new ReferenceMemberNotFoundError();
 	}
+
+	await emit("references", referenceId, "update");
 }
 
 export async function removeReferenceGroup(
@@ -1028,4 +1045,6 @@ export async function removeReferenceGroup(
 	if (removed.length === 0) {
 		throw new ReferenceMemberNotFoundError();
 	}
+
+	await emit("references", referenceId, "update");
 }


### PR DESCRIPTION
## Summary

- Create, clone and import were the only reference mutations with no cache invalidation, so a new reference stayed invisible until a hard reload. The `/refs` loader uses `ensureQueryData`, which returns the cached page rather than refetching, and `ReferenceList` reads the same list key through `useSuspenseQuery` without remounting — nothing in the flow triggered a refetch. All three now invalidate `referenceQueryKeys.lists()` on success, matching `useArchiveReference`/`useUnarchiveReference`.
- The `references` domain was fully wired on the SSE path but `packages/data/src/references/data.ts` published no `client_events` frames at all, so a reference created, renamed, archived or reassigned by one user stayed invisible to everyone else until they reloaded. `createReference` now emits a `create` frame after its transaction commits; `updateReference`, `setReferenceArchived` and the six membership mutations emit an `update` frame. A no-op update and a mutation that threw both stay silent.
- Regression tests cover both halves — the empty-create and clone paths in `ReferenceList.test.tsx`, and the published frames in a new `packages/data/src/references/data.test.ts` — each verified to fail against the unfixed code.

Closes VIR-2943.