### PR TITLE
fix: send logged-out users to the login wall instead of a 401

### DIFF
--- a/apps/web/src/server/auth/middleware.test.ts
+++ b/apps/web/src/server/auth/middleware.test.ts
@@ -52,6 +52,7 @@ const {
 	requireAdminRole,
 	requireAuthenticatedRequest,
 	requireSession,
+	serverFnIdFromUrl,
 	UnauthorizedError,
 } = await import("./middleware");
 const { createFirstUserFn, loginFn, logoutFn, resetPasswordFn } = await import(
@@ -85,12 +86,20 @@ beforeEach(async () => {
 /** The middleware's server handler, which `createMiddleware` stores verbatim. */
 type ServerHandler = (options: {
 	next: (options?: unknown) => Promise<unknown>;
+	serverFnMeta: { id: string };
 }) => Promise<unknown>;
 
 function serverHandler(exceptions: ReadonlyArray<{ url: string }>) {
 	const middleware = createAuthenticationMiddleware(async () => exceptions);
 	return (middleware as unknown as { options: { server: ServerHandler } })
 		.options.server;
+}
+
+// The metadata Start hands a function middleware. It is not on the public type
+// of a server-function reference, which is why the middleware derives the id
+// from `url` instead — and why the test below pins the two against each other.
+function metaFor(fn: { url: string }): { id: string } {
+	return (fn as unknown as { serverFnMeta: { id: string } }).serverFnMeta;
 }
 
 function cookieHeader(sessionId: string, token: string): string {
@@ -130,6 +139,18 @@ describe("authenticationExceptions", () => {
 	});
 });
 
+// The middleware builds its exception set from each fn's `url`, but matches
+// against the `serverFnMeta.id` Start hands it. Nothing in the type system ties
+// those together, so pin it: if Start changes either, the exceptions silently
+// stop matching and every public endpoint starts refusing anonymous callers.
+describe("serverFnIdFromUrl", () => {
+	it.each(
+		authenticationExceptions.map((fn) => [metaFor(fn).id, fn.url] as const),
+	)("recovers %s from its url", (id, url) => {
+		expect(serverFnIdFromUrl(url)).toBe(id);
+	});
+});
+
 describe("createAuthenticationMiddleware", () => {
 	it.each([
 		["createFirstUserFn", () => createFirstUserFn],
@@ -142,10 +163,29 @@ describe("createAuthenticationMiddleware", () => {
 		getRequest.mockReturnValue(requestFor(get().url));
 		const next = vi.fn().mockResolvedValue("result");
 
-		await serverHandler(authenticationExceptions)({ next });
+		await serverHandler(authenticationExceptions)({
+			next,
+			serverFnMeta: metaFor(get()),
+		});
 
 		expect(next).toHaveBeenCalledWith({ context: { session: null } });
 		expect(setUser).not.toHaveBeenCalled();
+	});
+
+	// A server function invoked during SSR runs in-process, so the incoming
+	// request is the page being rendered, not the function's own URL. Identifying
+	// the call by that URL exempted nothing at all on the SSR path, and a
+	// logged-out hard load rendered a 401 in place of the login wall (VIR-2941).
+	it("exempts a call made while rendering a page", async () => {
+		getRequest.mockReturnValue(requestFor("/"));
+		const next = vi.fn().mockResolvedValue("result");
+
+		await serverHandler(authenticationExceptions)({
+			next,
+			serverFnMeta: metaFor(getRootFn),
+		});
+
+		expect(next).toHaveBeenCalledWith({ context: { session: null } });
 	});
 
 	it("rejects an unauthenticated call to a fn that is not excepted", async () => {
@@ -153,7 +193,10 @@ describe("createAuthenticationMiddleware", () => {
 		const next = vi.fn();
 
 		await expect(
-			serverHandler(authenticationExceptions)({ next }),
+			serverHandler(authenticationExceptions)({
+				next,
+				serverFnMeta: { id: "somethingElse" },
+			}),
 		).rejects.toBeInstanceOf(UnauthorizedError);
 
 		expect(setResponseStatus).toHaveBeenCalledWith(401);
@@ -169,7 +212,10 @@ describe("createAuthenticationMiddleware", () => {
 		);
 		const next = vi.fn().mockResolvedValue("result");
 
-		await serverHandler(authenticationExceptions)({ next });
+		await serverHandler(authenticationExceptions)({
+			next,
+			serverFnMeta: { id: "somethingElse" },
+		});
 
 		expect(next).toHaveBeenCalledWith({ context: { session: { userId } } });
 	});
@@ -184,6 +230,7 @@ describe("createAuthenticationMiddleware", () => {
 
 		await serverHandler(authenticationExceptions)({
 			next: vi.fn().mockResolvedValue("result"),
+			serverFnMeta: { id: "somethingElse" },
 		});
 
 		expect(setUser).toHaveBeenCalledWith({ id: userId });
@@ -198,34 +245,35 @@ describe("createAuthenticationMiddleware", () => {
 		);
 
 		await expect(
-			serverHandler(authenticationExceptions)({ next: vi.fn() }),
+			serverHandler(authenticationExceptions)({
+				next: vi.fn(),
+				serverFnMeta: { id: "somethingElse" },
+			}),
 		).rejects.toBeInstanceOf(UnauthorizedError);
 	});
 
 	it("authenticates every call when there are no exceptions", async () => {
 		getRequest.mockReturnValue(requestFor(loginFn.url));
 
-		await expect(serverHandler([])({ next: vi.fn() })).rejects.toBeInstanceOf(
-			UnauthorizedError,
-		);
+		await expect(
+			serverHandler([])({
+				next: vi.fn(),
+				serverFnMeta: metaFor(loginFn),
+			}),
+		).rejects.toBeInstanceOf(UnauthorizedError);
 	});
 
-	// The path is compared as a pathname, so a query string must not defeat the
-	// match and turn a public endpoint into a 401.
-	it("matches an exception carrying a query string", async () => {
-		getRequest.mockReturnValue(requestFor(`${loginFn.url}?createServerFn`));
-		const next = vi.fn().mockResolvedValue("result");
-
-		await serverHandler(authenticationExceptions)({ next });
-
-		expect(next).toHaveBeenCalledWith({ context: { session: null } });
-	});
-
-	it("does not treat a path that merely extends an exception as excepted", async () => {
-		getRequest.mockReturnValue(requestFor(`${loginFn.url}Extra`));
+	// The id is matched exactly, so an id that merely extends an exempt one — the
+	// shape a compiler-generated id takes when two exports share a prefix — must
+	// not inherit its exemption.
+	it("does not treat an id that merely extends an exception as excepted", async () => {
+		getRequest.mockReturnValue(requestFor(loginFn.url));
 
 		await expect(
-			serverHandler(authenticationExceptions)({ next: vi.fn() }),
+			serverHandler(authenticationExceptions)({
+				next: vi.fn(),
+				serverFnMeta: { id: `${metaFor(loginFn).id}Extra` },
+			}),
 		).rejects.toBeInstanceOf(UnauthorizedError);
 	});
 });

--- a/apps/web/src/server/auth/middleware.ts
+++ b/apps/web/src/server/auth/middleware.ts
@@ -120,6 +120,14 @@ export type LoadAuthenticationExceptions = () => Promise<
 	ReadonlyArray<{ url: string }>
 >;
 
+// A server function's `url` is the server-fn base with its id appended, and an
+// id is base64url, so the last segment is the id `serverFnMeta` carries.
+// `middleware.test.ts` pins that against the metadata Start actually hands the
+// middleware.
+export function serverFnIdFromUrl(url: string): string {
+	return url.slice(url.lastIndexOf("/") + 1);
+}
+
 // The exception list holds server-function references, and reaching them means
 // reaching their modules — which carry zod validators and the auth request
 // layer. `start.ts` is part of the browser program (routeTree.gen.ts imports
@@ -141,31 +149,35 @@ const loadAuthenticationExceptions = createServerOnlyFn(
  * `loadExceptions` exists so tests can supply their own list; production passes
  * nothing and gets the real one.
  */
-// Server fn IDs are unique per fn and each fn binds to exactly one method, so
-// matching on pathname alone is sufficient to identify the call.
+// Never identify the call from `getRequest()`. That is the *incoming* request,
+// which is the function's own URL only for an RPC call from the browser: during
+// SSR a server function is invoked in-process, so the incoming request is the
+// page being rendered and no exception matches. `serverFnMeta` names the
+// function on both paths.
 export function createAuthenticationMiddleware(
 	loadExceptions: LoadAuthenticationExceptions = loadAuthenticationExceptions,
 ) {
-	// Resolved on the first call and cached: the paths never change.
-	let exceptionPaths: Set<string> | null = null;
+	// Resolved on the first call and cached: the ids never change.
+	let exceptionIds: Set<string> | null = null;
 
-	return createMiddleware({ type: "function" }).server(async ({ next }) => {
-		exceptionPaths ??= new Set(
-			(await loadExceptions()).map(
-				(fn) => new URL(fn.url, "http://x").pathname,
-			),
-		);
+	return createMiddleware({ type: "function" }).server(
+		async ({ next, serverFnMeta }) => {
+			exceptionIds ??= new Set(
+				(await loadExceptions()).map((fn) => serverFnIdFromUrl(fn.url)),
+			);
 
-		const pathname = new URL(getRequest().url).pathname;
-		const session: AuthenticatedSession | null = exceptionPaths.has(pathname)
-			? null
-			: await requireSession();
-		// Attach the user to the request's isolation scope so errors and logs
-		// from this handler are tied to the acting user. Id-only here — the
-		// handle isn't on the session and isn't worth a per-request lookup.
-		if (session) {
-			Sentry.setUser({ id: session.userId });
-		}
-		return next({ context: { session } });
-	});
+			const session: AuthenticatedSession | null = exceptionIds.has(
+				serverFnMeta.id,
+			)
+				? null
+				: await requireSession();
+			// Attach the user to the request's isolation scope so errors and logs
+			// from this handler are tied to the acting user. Id-only here — the
+			// handle isn't on the session and isn't worth a per-request lookup.
+			if (session) {
+				Sentry.setUser({ id: session.userId });
+			}
+			return next({ context: { session } });
+		},
+	);
 }

--- a/apps/web/src/server/error-logging.ts
+++ b/apps/web/src/server/error-logging.ts
@@ -18,17 +18,27 @@ import { logger } from "./logger";
  */
 export const errorLoggingMiddleware = createMiddleware({
 	type: "function",
-}).server(async ({ next }) => {
+}).server(async ({ next, serverFnMeta }) => {
 	try {
 		return await next();
 	} catch (err) {
 		const status = getResponseStatus();
+		// `path` is the incoming request, which during SSR is the page being
+		// rendered rather than the function's own URL. `serverFn` is what names the
+		// failing handler on both paths.
 		const path = new URL(getRequest().url).pathname;
+		const serverFn = serverFnMeta.name;
 
 		if (status >= 400 && status < 500) {
-			logger.debug({ err, path, status }, "server function rejected request");
+			logger.debug(
+				{ err, path, serverFn, status },
+				"server function rejected request",
+			);
 		} else {
-			logger.error({ err, path, status }, "unhandled server function error");
+			logger.error(
+				{ err, path, serverFn, status },
+				"unhandled server function error",
+			);
 		}
 
 		throw err;

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -97,9 +97,17 @@ parameter exists only so tests can supply their own list.
 
 Every server function is gated by default. Public endpoints opt out by
 being listed in the `exceptions` array — passed as **server-function
-references**, not URL strings. The middleware derives the path from
-each fn's bound `url`, so the exception list can't drift out of sync
-with a rename.
+references**, not URL strings, so the list can't drift out of sync with
+a rename.
+
+**A call is identified by the `serverFnMeta` Start hands the
+middleware, never from `getRequest()`.** That is the *incoming*
+request, which is the function's own `/_serverFn/...` URL only for an
+RPC call from the browser: during SSR a server function is invoked
+in-process, so the incoming request is the page being rendered and no
+exception matches. `serverFnIdFromUrl` bridges the two — the exception
+list carries `url`, which is the id with the server-fn base in front —
+and `middleware.test.ts` pins that against the real metadata.
 
 The list is a standalone module rather than an inline array so it can
 be asserted on: `middleware.test.ts` pins its exact contents, and a fn


### PR DESCRIPTION
## Summary

- The global authentication middleware identified a call by `new URL(getRequest().url).pathname`, which is the *incoming* request. Over RPC that is the server function's own URL, but a function invoked during SSR runs in-process — so the incoming request is the page being rendered and nothing in `authenticationExceptions` ever matched. Every `open()` function was authenticated on the SSR path.
- A logged-out hard load therefore ran `_authenticated`'s guard, whose first call is `getRootFn` and sits outside the try/catch that redirects, and the layout rendered a 401 one line before the account check would have bounced to `/login`. `/login` lost its configured password policy the same way, silently falling back to the default minimum length.
- Match on the `serverFnMeta.id` Start hands the middleware instead. `serverFnIdFromUrl` bridges that to the exception list, which keeps `url` because `serverFnMeta` is not on Start's public type for a server-function reference; a test pins the two against each other so a Start upgrade fails loudly rather than silently un-exempting every public endpoint. `errorLoggingMiddleware` carried the same misidentification and logged every SSR-side failure against the page path.