### PR TITLE
chore: port the reap_orphaned_uploads task body

### DIFF
--- a/apps/tasks/src/tasks/reap-orphaned-uploads.test.ts
+++ b/apps/tasks/src/tasks/reap-orphaned-uploads.test.ts
@@ -1,0 +1,226 @@
+import { seedUser } from "@virtool/data/auth/test/fixtures";
+import type { Db } from "@virtool/data/db/pg";
+import { sampleReads, sampleUploads } from "@virtool/data/db/schema/samples";
+import { tasks } from "@virtool/data/db/schema/tasks";
+import { uploads } from "@virtool/data/db/schema/uploads";
+import { users } from "@virtool/data/db/schema/users";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import { ORPHAN_AGE_SECONDS } from "@virtool/data/uploads/data";
+import { createLogger, type Logger } from "@virtool/logger";
+import type { StorageBackend } from "@virtool/storage";
+import { MemoryStorage } from "@virtool/storage";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { runTask } from "../framework/run";
+import { claimTask, readTaskRow } from "../testing/tasks";
+import { reapOrphanedUploadsTask } from "./reap-orphaned-uploads";
+import type { TaskContext } from "./registry";
+
+const logger: Logger = createLogger({ name: "test", level: "silent" });
+
+let database: TestDatabase;
+let db: Db;
+let storage: MemoryStorage;
+let ctx: TaskContext;
+let userId: number;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(sampleReads);
+	await db.delete(sampleUploads);
+	await db.delete(uploads);
+	await db.delete(users);
+	await db.delete(tasks);
+
+	storage = new MemoryStorage();
+	ctx = { db, storage };
+	userId = await seedUser(db);
+});
+
+async function* body(text: string): AsyncIterable<Uint8Array> {
+	yield new TextEncoder().encode(text);
+}
+
+/**
+ * Seed a reserved upload with an object behind it, aged past the body's own
+ * {@link ORPHAN_AGE_SECONDS}. The window is only an argument at the data layer,
+ * which `data.test.ts` drives directly.
+ */
+async function seedOrphan(index: number): Promise<{ id: number; key: string }> {
+	const key = `uploads/orphan-${index}`;
+
+	await storage.write(key, body(key));
+
+	const [row] = await db
+		.insert(uploads)
+		.values({
+			createdAt: new Date(Date.now() - (ORPHAN_AGE_SECONDS + 3600) * 1000),
+			name: `reads-${index}.fq.gz`,
+			nameOnDisk: `disk-${index}`,
+			ready: true,
+			removed: false,
+			reserved: true,
+			size: 10,
+			storageKey: key,
+			type: "reads",
+			uploadedAt: new Date(),
+			userId,
+		})
+		.returning({ id: uploads.id });
+
+	if (row === undefined) {
+		throw new Error("failed to seed an orphaned upload");
+	}
+
+	return { id: row.id, key };
+}
+
+async function readUpload(uploadId: number) {
+	const [row] = await db.select().from(uploads).where(eq(uploads.id, uploadId));
+
+	if (row === undefined) {
+		throw new Error(`no upload row with id ${uploadId}`);
+	}
+
+	return row;
+}
+
+describe("reapOrphanedUploadsTask", () => {
+	it("reaps every orphan and finishes the task", async () => {
+		const first = await seedOrphan(0);
+		const second = await seedOrphan(1);
+
+		const task = await claimTask(db, reapOrphanedUploadsTask);
+
+		const outcome = await runTask({
+			db,
+			def: reapOrphanedUploadsTask,
+			task,
+			ctx,
+			logger,
+			signal: new AbortController().signal,
+		});
+
+		expect(outcome).toEqual({ status: "completed" });
+
+		expect(await readTaskRow(db, task.id)).toMatchObject({
+			complete: true,
+			error: null,
+			progress: 100,
+			step: "reap",
+		});
+
+		for (const orphan of [first, second]) {
+			expect(await readUpload(orphan.id)).toMatchObject({
+				removed: true,
+				reserved: false,
+			});
+			await expect(storage.size(orphan.key)).rejects.toThrow();
+		}
+	});
+
+	it("completes with nothing to reap", async () => {
+		const task = await claimTask(db, reapOrphanedUploadsTask);
+
+		const outcome = await runTask({
+			db,
+			def: reapOrphanedUploadsTask,
+			task,
+			ctx,
+			logger,
+			signal: new AbortController().signal,
+		});
+
+		expect(outcome).toEqual({ status: "completed" });
+
+		expect(await readTaskRow(db, task.id)).toMatchObject({
+			complete: true,
+			error: null,
+			progress: 100,
+		});
+	});
+
+	// A refused delete leaks bytes but must not fail the sweep, and the soft
+	// delete keeps the key naming them.
+	it("completes when storage refuses a delete", async () => {
+		const orphan = await seedOrphan(0);
+
+		const refusing: StorageBackend = {
+			read: (key) => storage.read(key),
+			write: (key, data) => storage.write(key, data),
+			list: (prefix) => storage.list(prefix),
+			size: (key) => storage.size(key),
+			delete: async () => {
+				throw new Error("bucket refused the delete");
+			},
+		};
+
+		const outcome = await runTask({
+			db,
+			def: reapOrphanedUploadsTask,
+			task: await claimTask(db, reapOrphanedUploadsTask),
+			ctx: { db, storage: refusing },
+			logger,
+			signal: new AbortController().signal,
+		});
+
+		expect(outcome).toEqual({ status: "completed" });
+
+		expect(await readUpload(orphan.id)).toMatchObject({
+			removed: true,
+			reserved: false,
+			storageKey: orphan.key,
+		});
+	});
+
+	// `runTask` awaits the body rather than racing it, so a sweep that ignored the
+	// signal would hold the drain open and write on past the claim's release.
+	it("stops sweeping when the run is aborted", async () => {
+		const first = await seedOrphan(0);
+		const second = await seedOrphan(1);
+
+		const controller = new AbortController();
+
+		// Aborts as the first object goes, so the check between iterations is what
+		// stops the sweep. Aborting up front would never reach the body at all.
+		const abortingOnDelete: StorageBackend = {
+			read: (key) => storage.read(key),
+			write: (key, data) => storage.write(key, data),
+			list: (prefix) => storage.list(prefix),
+			size: (key) => storage.size(key),
+			delete: async (key) => {
+				await storage.delete(key);
+				controller.abort();
+			},
+		};
+
+		const outcome = await runTask({
+			db,
+			def: reapOrphanedUploadsTask,
+			task: await claimTask(db, reapOrphanedUploadsTask),
+			ctx: { db, storage: abortingOnDelete },
+			logger,
+			signal: controller.signal,
+		});
+
+		expect(outcome).toEqual({ status: "aborted" });
+
+		expect(await readUpload(first.id)).toMatchObject({ removed: true });
+		expect(await readUpload(second.id)).toMatchObject({
+			removed: false,
+			reserved: true,
+		});
+		await expect(storage.size(second.key)).resolves.toBeGreaterThan(0);
+	});
+});

--- a/apps/tasks/src/tasks/reap-orphaned-uploads.ts
+++ b/apps/tasks/src/tasks/reap-orphaned-uploads.ts
@@ -1,0 +1,50 @@
+import {
+	ORPHAN_AGE_SECONDS,
+	reapOrphanedUploads,
+} from "@virtool/data/uploads/data";
+import { z } from "zod";
+import { defineTask } from "../framework/define";
+import type { TaskContext } from "./registry";
+
+/**
+ * `reap_orphaned_uploads` is spawned on a schedule and carries nothing.
+ *
+ * `z.object` strips unknown keys, so a row Python wrote carrying one this side
+ * does not read still runs.
+ */
+const payload = z.object({});
+
+/**
+ * Delete reserved uploads that were never linked to a sample.
+ *
+ * The port of Python's `ReapOrphanedUploadsTask`, whose body is likewise one
+ * call. Python jumps 0 to 100; the candidate count is known before the loop
+ * starts and each iteration costs a round trip to object storage, so this
+ * reports a position. `report` takes a fraction where the data layer publishes
+ * percent.
+ */
+export const reapOrphanedUploadsTask = defineTask<typeof payload, TaskContext>({
+	type: "reap_orphaned_uploads",
+	payload,
+	// Python's method name, which `BaseTask.run` writes to the column. Both
+	// runners write `reap` for the same work until the cutover completes.
+	steps: ["reap"],
+	async run({ ctx, helpers, logger, signal }) {
+		await helpers.runStep("reap", async (report) => {
+			const { found, deleted } = await reapOrphanedUploads(
+				ctx.db,
+				ctx.storage,
+				logger,
+				ORPHAN_AGE_SECONDS,
+				async (percent) => {
+					report(percent / 100);
+				},
+				signal,
+			);
+
+			if (found > 0) {
+				logger.info({ found, deleted }, "reaped orphaned reserved uploads");
+			}
+		});
+	},
+});

--- a/apps/tasks/src/tasks/registry.ts
+++ b/apps/tasks/src/tasks/registry.ts
@@ -4,6 +4,7 @@ import type { TaskRegistry } from "../framework/define";
 import { cleanupSessionsTask } from "./cleanup-sessions";
 import { createIndexTask } from "./create-index";
 import { evictCachesLruTask } from "./evict-caches-lru";
+import { reapOrphanedUploadsTask } from "./reap-orphaned-uploads";
 import { refreshHmmsTask } from "./refresh-hmms";
 import { timeoutJobsTask } from "./timeout-jobs";
 
@@ -37,6 +38,7 @@ export const taskRegistry: TaskRegistry<TaskContext> = {
 	cleanup_sessions: cleanupSessionsTask,
 	create_index: createIndexTask,
 	evict_caches_lru: evictCachesLruTask,
+	reap_orphaned_uploads: reapOrphanedUploadsTask,
 	refresh_hmms: refreshHmmsTask,
 	timeout_jobs: timeoutJobsTask,
 };

--- a/packages/data/src/uploads/data.test.ts
+++ b/packages/data/src/uploads/data.test.ts
@@ -1,17 +1,30 @@
 import type { UploadType } from "@virtool/contracts";
 import { MemoryStorage } from "@virtool/storage";
 import { eq } from "drizzle-orm";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 import { seedUser } from "../auth/test/fixtures";
-import type { Db } from "../db/pg";
+import type { Db, PgClient } from "../db/pg";
+import { sampleReads, sampleUploads } from "../db/schema/samples";
 import { type UploadRow, uploads as uploadsTable } from "../db/schema/uploads";
 import { users } from "../db/schema/users";
 import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { createEmitter } from "../events/emit";
 import { testLogger } from "../test/logger";
 import {
 	createUpload,
 	deleteUpload,
 	findUploads,
+	ORPHAN_AGE_SECONDS,
+	reapOrphanedUploads,
 	UploadNotFoundError,
 	UploadReservedError,
 } from "./data";
@@ -29,6 +42,8 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
+	await db.delete(sampleReads);
+	await db.delete(sampleUploads);
 	await db.delete(uploadsTable);
 	await db.delete(users);
 });
@@ -223,5 +238,262 @@ describe("deleteUpload", () => {
 		await expect(
 			deleteUpload(db, new MemoryStorage(), testLogger, reserved.id),
 		).rejects.toBeInstanceOf(UploadReservedError);
+	});
+});
+
+describe("reapOrphanedUploads", () => {
+	// A minute-wide window rather than production's thirty days, which is what
+	// the age being an argument buys.
+	const WINDOW_SECONDS = 60;
+
+	let notify: ReturnType<typeof vi.fn>;
+	let storage: MemoryStorage;
+
+	beforeEach(() => {
+		// The fixture's emitter really NOTIFYs, so a published frame would be
+		// invisible. Restored in `afterEach` for the rest of the file.
+		notify = vi.fn().mockResolvedValue(undefined);
+		createEmitter({
+			client: { notify } as unknown as PgClient,
+			logger: testLogger,
+		});
+
+		storage = new MemoryStorage();
+	});
+
+	afterEach(() => {
+		createEmitter({ client: database.client, logger: testLogger });
+	});
+
+	function secondsAgoDate(seconds: number): Date {
+		return new Date(Date.now() - seconds * 1000);
+	}
+
+	/** Seed an upload with an object behind it, and return the row and its key. */
+	async function seedStored(
+		userId: number,
+		overrides: SeedOverrides = {},
+	): Promise<UploadRow> {
+		const row = await seedUpload(userId, {
+			createdAt: secondsAgoDate(WINDOW_SECONDS * 2),
+			reserved: true,
+			...overrides,
+		});
+
+		if (row.storageKey) {
+			await storage.write(row.storageKey, bodyOf("reads"));
+		}
+
+		return row;
+	}
+
+	function reap(
+		onProgress?: (percent: number) => Promise<void>,
+		backend: MemoryStorage = storage,
+	) {
+		return reapOrphanedUploads(
+			db,
+			backend,
+			testLogger,
+			WINDOW_SECONDS,
+			onProgress,
+		);
+	}
+
+	async function readRow(uploadId: number): Promise<UploadRow> {
+		const [row] = await db
+			.select()
+			.from(uploadsTable)
+			.where(eq(uploadsTable.id, uploadId));
+
+		if (row === undefined) {
+			throw new Error(`no upload row with id ${uploadId}`);
+		}
+
+		return row;
+	}
+
+	// Both runners sweep the same table until the cutover, so the shorter of the
+	// two ages would be the real one.
+	it("reaps at Python's thirty days", () => {
+		expect(ORPHAN_AGE_SECONDS).toBe(30 * 24 * 60 * 60);
+	});
+
+	it("releases, soft-deletes and removes the object of a genuine orphan", async () => {
+		const userId = await seedUser(db);
+		const orphan = await seedStored(userId);
+		const key = orphan.storageKey ?? "";
+
+		await expect(reap()).resolves.toEqual({ found: 1, deleted: 1 });
+
+		const after = await readRow(orphan.id);
+
+		expect(after.removed).toBe(true);
+		expect(after.reserved).toBe(false);
+		expect(after.removedAt).not.toBeNull();
+		await expect(storage.size(key)).rejects.toThrow();
+	});
+
+	it("leaves a reservation younger than the window alone", async () => {
+		const userId = await seedUser(db);
+		const fresh = await seedStored(userId, { createdAt: secondsAgoDate(5) });
+
+		await expect(reap()).resolves.toEqual({ found: 0, deleted: 0 });
+		expect((await readRow(fresh.id)).removed).toBe(false);
+	});
+
+	it("leaves an unreserved upload alone", async () => {
+		const userId = await seedUser(db);
+		const unreserved = await seedStored(userId, { reserved: false });
+
+		await expect(reap()).resolves.toEqual({ found: 0, deleted: 0 });
+		expect((await readRow(unreserved.id)).removed).toBe(false);
+	});
+
+	it("leaves an already-removed upload alone", async () => {
+		const userId = await seedUser(db);
+		const removed = await seedStored(userId, { removed: true });
+		const key = removed.storageKey ?? "";
+
+		await expect(reap()).resolves.toEqual({ found: 0, deleted: 0 });
+		await expect(storage.size(key)).resolves.toBeGreaterThan(0);
+	});
+
+	it("leaves an upload a sample_reads row references alone", async () => {
+		const userId = await seedUser(db);
+		const linked = await seedStored(userId);
+
+		await db.insert(sampleReads).values({
+			sample: "sample-1",
+			name: "reads_1.fq.gz",
+			name_on_disk: "reads_1.fq.gz",
+			storage_key: "samples/sample-1/reads_1.fq.gz",
+			upload: linked.id,
+		});
+
+		await expect(reap()).resolves.toEqual({ found: 0, deleted: 0 });
+		expect((await readRow(linked.id)).removed).toBe(false);
+	});
+
+	// A creation that died between the two rows has a `sample_uploads` row and no
+	// `sample_reads`, which is the orphan this sweep exists for.
+	it("reaps an upload only a sample_uploads row references", async () => {
+		const userId = await seedUser(db);
+		const orphan = await seedStored(userId);
+
+		await db.insert(sampleUploads).values({
+			sample: "sample-1",
+			upload_id: orphan.id,
+			index: 0,
+		});
+
+		await expect(reap()).resolves.toEqual({ found: 1, deleted: 1 });
+		expect((await readRow(orphan.id)).removed).toBe(true);
+	});
+
+	it("splits uploads either side of the window boundary", async () => {
+		const userId = await seedUser(db);
+		const outside = await seedStored(userId, {
+			createdAt: secondsAgoDate(WINDOW_SECONDS + 30),
+		});
+		const inside = await seedStored(userId, {
+			createdAt: secondsAgoDate(WINDOW_SECONDS - 30),
+		});
+
+		await expect(reap()).resolves.toEqual({ found: 1, deleted: 1 });
+
+		expect((await readRow(outside.id)).removed).toBe(true);
+		expect((await readRow(inside.id)).removed).toBe(false);
+	});
+
+	// The regression the port exists for: Python's release-then-loop leaves the
+	// rest `reserved = false, removed = false`, which no later sweep matches.
+	it("soft-deletes an upload whose object refuses to delete, and continues", async () => {
+		const userId = await seedUser(db);
+		const first = await seedStored(userId);
+		const failing = await seedStored(userId);
+		const last = await seedStored(userId);
+
+		const failingKey = failing.storageKey ?? "";
+		const remove = storage.delete.bind(storage);
+
+		vi.spyOn(storage, "delete").mockImplementation(async (key: string) => {
+			if (key === failingKey) {
+				throw new Error("bucket refused the key");
+			}
+
+			await remove(key);
+		});
+
+		await expect(reap()).resolves.toEqual({ found: 3, deleted: 3 });
+
+		for (const id of [first.id, failing.id, last.id]) {
+			const row = await readRow(id);
+
+			expect(row.removed).toBe(true);
+			expect(row.reserved).toBe(false);
+		}
+
+		// The row survives, so the key naming the leaked object is still recorded.
+		expect((await readRow(failing.id)).storageKey).toBe(failingKey);
+		await expect(reap()).resolves.toEqual({ found: 0, deleted: 0 });
+	});
+
+	it("is idempotent across runs", async () => {
+		const userId = await seedUser(db);
+		const orphan = await seedStored(userId);
+
+		await reap();
+		const first = await readRow(orphan.id);
+
+		await expect(reap()).resolves.toEqual({ found: 0, deleted: 0 });
+
+		const second = await readRow(orphan.id);
+
+		expect(second.removedAt).toEqual(first.removedAt);
+		expect(second.removed).toBe(true);
+	});
+
+	it("reports no progress and returns zero when nothing is orphaned", async () => {
+		const onProgress = vi.fn().mockResolvedValue(undefined);
+
+		await expect(reap(onProgress)).resolves.toEqual({ found: 0, deleted: 0 });
+		expect(onProgress).not.toHaveBeenCalled();
+	});
+
+	it("reports progress across the delete loop, ending at 100", async () => {
+		const userId = await seedUser(db);
+
+		for (let index = 0; index < 4; index++) {
+			await seedStored(userId);
+		}
+
+		const reported: number[] = [];
+
+		await reap(async (percent) => {
+			reported.push(percent);
+		});
+
+		expect(reported).toEqual([25, 50, 75, 100]);
+	});
+
+	it("soft-deletes an upload with no storage_key without touching storage", async () => {
+		const userId = await seedUser(db);
+		const keyless = await seedStored(userId, { storageKey: null });
+
+		const remove = vi.spyOn(storage, "delete");
+
+		await expect(reap()).resolves.toEqual({ found: 1, deleted: 1 });
+
+		expect(remove).not.toHaveBeenCalled();
+		expect((await readRow(keyless.id)).removed).toBe(true);
+	});
+
+	it("publishes no uploads frame", async () => {
+		const userId = await seedUser(db);
+		await seedStored(userId);
+
+		await expect(reap()).resolves.toEqual({ found: 1, deleted: 1 });
+		expect(notify).not.toHaveBeenCalled();
 	});
 });

--- a/packages/data/src/uploads/data.ts
+++ b/packages/data/src/uploads/data.ts
@@ -7,13 +7,20 @@ import type {
 import type { Logger } from "@virtool/logger";
 import type { StorageBackend } from "@virtool/storage";
 import { mintRootStorageKey } from "@virtool/storage";
-import { and, count, desc, eq, inArray } from "drizzle-orm";
-import type { DbOrTx } from "../db/pg";
+import { and, asc, count, desc, eq, inArray, lt, notExists } from "drizzle-orm";
+import type { Db, DbOrTx } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
+import { sampleReads } from "../db/schema/samples";
 import { type UploadRow, uploads as uploadsTable } from "../db/schema/uploads";
 import { users as usersTable } from "../db/schema/users";
+import { nowUtc, secondsAgo } from "../db/time";
 import { AppError } from "../errors";
 import { emit } from "../events/emit";
+
+/**
+ * How old a reserved upload must be before the sweep may reap it.
+ */
+export const ORPHAN_AGE_SECONDS = 30 * 24 * 60 * 60;
 
 /** Fields needed to create an upload; `body` streams straight to storage. */
 export type UploadCreateValues = {
@@ -68,7 +75,7 @@ export async function findUploads(
 	userId?: number,
 ): Promise<UploadSearchResult> {
 	// A visible upload is finished, not deleted, and not held for a sample that
-	// is mid-creation. Python applies the same three base filters unconditionally.
+	// is mid-creation.
 	const baseFilters = [
 		eq(uploadsTable.ready, true),
 		eq(uploadsTable.removed, false),
@@ -130,8 +137,7 @@ export async function createUpload(
 	const nameOnDisk = `${crypto.randomUUID()}-${values.name}`;
 
 	// Minted before the write, so the bytes land under a key the row then records
-	// verbatim. `name_on_disk` no longer locates anything; Python still reads it
-	// to identify the upload a reference-import task was queued against.
+	// verbatim. `name_on_disk` no longer locates anything.
 	const storageKey = mintRootStorageKey("uploads");
 
 	const size = await storage.write(storageKey, values.body);
@@ -173,10 +179,6 @@ export type UploadFile = {
  * `storage_key` locates the object and `name` is what the user chose and what
  * the download is named. Both columns are nullable at the database level, so a
  * row missing either has no downloadable file.
- *
- * A removed upload is excluded, matching Python. `ready` is deliberately not
- * filtered on: Python does not either, and an upload created from this side is
- * only inserted once its bytes are written.
  */
 export async function getUploadFile(
 	db: DbOrTx,
@@ -285,4 +287,110 @@ export async function deleteUpload(
 	}
 
 	await emit("uploads", uploadId, "delete");
+}
+
+/** What one sweep of {@link reapOrphanedUploads} selected and what it removed. */
+export type ReapResult = {
+	/** Orphans the predicate selected. */
+	found: number;
+	/** Orphans this run flipped to `removed`. */
+	deleted: number;
+};
+
+/**
+ * Delete reserved uploads that were never linked to a sample.
+ *
+ * The row goes before the object, unlike cache eviction: this is a soft delete,
+ * so a refused delete leaves a row that still names the bytes. It emits no
+ * frame, where `deleteUpload` does — every row it touches is `reserved`, which
+ * `findUploads` filters out, so no client list held one.
+ */
+export async function reapOrphanedUploads(
+	db: Db,
+	storage: StorageBackend,
+	logger: Logger,
+	olderThanSeconds: number,
+	onProgress?: (percent: number) => Promise<void>,
+	signal?: AbortSignal,
+): Promise<ReapResult> {
+	/* The cutoff is Postgres's clock, not a bound `Date`, so the sweep selects
+	   against the same instant it stamps `removed_at` with. A NULL `created_at`
+	   is never selected, matching Python. */
+	const orphans = await db
+		.select({ id: uploadsTable.id })
+		.from(uploadsTable)
+		.where(
+			and(
+				eq(uploadsTable.reserved, true),
+				eq(uploadsTable.removed, false),
+				lt(uploadsTable.createdAt, secondsAgo(olderThanSeconds)),
+				/* `sample_reads` alone. A `sample_uploads` row is written before any
+				   reads exist, so correlating on it too would exempt exactly the
+				   abandoned creations this sweep is for. */
+				notExists(
+					db
+						.select({ id: sampleReads.id })
+						.from(sampleReads)
+						.where(eq(sampleReads.upload, uploadsTable.id)),
+				),
+			),
+		)
+		.orderBy(asc(uploadsTable.id));
+
+	const found = orphans.length;
+
+	if (found === 0) {
+		return { found, deleted: 0 };
+	}
+
+	let deleted = 0;
+
+	for (const [index, orphan] of orphans.entries()) {
+		signal?.throwIfAborted();
+
+		/* Release and soft-delete in one statement. Never split these: Python
+		   releases the batch and then loops its ordinary delete, so anything
+		   interrupting that loop leaves the rest `reserved = false, removed =
+		   false` — which no later sweep matches, its predicate being
+		   `reserved = true`, and which no list shows. The guard is also what makes
+		   a reclaimed run a no-op against a sweep that committed. */
+		const [reaped] = await db
+			.update(uploadsTable)
+			.set({ reserved: false, removed: true, removedAt: nowUtc() })
+			.where(
+				and(eq(uploadsTable.id, orphan.id), eq(uploadsTable.removed, false)),
+			)
+			.returning({ storageKey: uploadsTable.storageKey });
+
+		// Removed by another writer since the select, so its object is that
+		// writer's to delete.
+		if (reaped === undefined) {
+			await onProgress?.(((index + 1) / found) * 100);
+			continue;
+		}
+
+		deleted += 1;
+
+		if (reaped.storageKey) {
+			try {
+				await storage.delete(reaped.storageKey);
+			} catch (err) {
+				logger.warn(
+					{ err, uploadId: orphan.id, storageKey: reaped.storageKey },
+					"failed to delete reaped upload object; object orphaned",
+				);
+			}
+		} else {
+			// Predates keys being recorded, as in `deleteUpload`. A composed key
+			// could reach another row's bytes.
+			logger.warn(
+				{ uploadId: orphan.id },
+				"reaped upload has no storage_key to delete",
+			);
+		}
+
+		await onProgress?.(((index + 1) / found) * 100);
+	}
+
+	return { found, deleted };
 }


### PR DESCRIPTION
## Summary

- Adds `reapOrphanedUploads` to `@virtool/data/uploads/data` and the `reap_orphaned_uploads` body that calls it, registered under the runner. `PERIODIC_TASKS` already carried the type at 86400 s.
- **Release and soft-delete are one conditional statement per upload**, where Python bulk-releases the batch and then loops its ordinary delete. Anything interrupting that loop leaves the rest `reserved = false, removed = false`, which no later sweep matches — its predicate being `reserved = true` — and which no list shows, so those uploads are unreachable forever. That matters more on this side than in Python: a reclaimed task re-runs from step zero as routine behaviour.
- The cutoff is Postgres's clock rather than a bound `Date`, the predicate correlates on `sample_reads` alone (a `sample_uploads` row is written before any reads exist, so it would exempt exactly the abandoned creations this sweep is for), and the sweep emits no `uploads` frame — every row it touches is `reserved`, which `findUploads` filters out.

Two notes on the issue's stated contract, which was written against an older tree:

- The uploads `data.ts` has moved into `@virtool/data`, so the function lives at `packages/data/src/uploads/data.ts` rather than `apps/web/src/server/uploads/data.ts`.
- The storage key is read from `uploads.storage_key` and returned by the `UPDATE`, not derived as `files/{name_on_disk}` — that column is recorded now, and `deleteUpload` already reads it.