### PR TITLE
fix: stop the orphan upload sweep reaping a running sample's reads

### DIFF
--- a/apps/tasks/src/tasks/reap-orphaned-uploads.ts
+++ b/apps/tasks/src/tasks/reap-orphaned-uploads.ts
@@ -15,7 +15,7 @@ import type { TaskContext } from "./registry";
 const payload = z.object({});
 
 /**
- * Delete reserved uploads that were never linked to a sample.
+ * Delete reserved uploads that no sample claims.
  *
  * The port of Python's `ReapOrphanedUploadsTask`, whose body is likewise one
  * call. Python jumps 0 to 100; the candidate count is known before the loop

--- a/packages/data/src/uploads/data.test.ts
+++ b/packages/data/src/uploads/data.test.ts
@@ -375,9 +375,34 @@ describe("reapOrphanedUploads", () => {
 		expect((await readRow(linked.id)).removed).toBe(false);
 	});
 
-	// A creation that died between the two rows has a `sample_uploads` row and no
-	// `sample_reads`, which is the orphan this sweep exists for.
-	it("reaps an upload only a sample_uploads row references", async () => {
+	/* A running sample has a `sample_uploads` row and no `sample_reads` row, which
+	   are only written at finalize. Reaping one deletes the reads the job is
+	   working from, and the cutoff is no defence: it is the age of the upload, so
+	   an upload reserved straight out of a user's list can be older than the
+	   window on the day the sample is created. */
+	it("leaves an upload a running sample reserved alone", async () => {
+		const userId = await seedUser(db);
+		const running = await seedStored(userId);
+		const key = running.storageKey ?? "";
+
+		await db.insert(sampleUploads).values({
+			sample: "sample-1",
+			upload_id: running.id,
+			index: 0,
+		});
+
+		await expect(reap()).resolves.toEqual({ found: 0, deleted: 0 });
+
+		const after = await readRow(running.id);
+
+		expect(after.removed).toBe(false);
+		expect(after.reserved).toBe(true);
+		await expect(storage.size(key)).resolves.toBeGreaterThan(0);
+	});
+
+	// `deleteSample` clears the link row in the transaction that releases the
+	// reservation, so a reservation no `sample_uploads` row names is the orphan.
+	it("reaps a reservation once its sample_uploads row is gone", async () => {
 		const userId = await seedUser(db);
 		const orphan = await seedStored(userId);
 
@@ -386,6 +411,12 @@ describe("reapOrphanedUploads", () => {
 			upload_id: orphan.id,
 			index: 0,
 		});
+
+		await expect(reap()).resolves.toEqual({ found: 0, deleted: 0 });
+
+		await db
+			.delete(sampleUploads)
+			.where(eq(sampleUploads.upload_id, orphan.id));
 
 		await expect(reap()).resolves.toEqual({ found: 1, deleted: 1 });
 		expect((await readRow(orphan.id)).removed).toBe(true);

--- a/packages/data/src/uploads/data.ts
+++ b/packages/data/src/uploads/data.ts
@@ -10,7 +10,7 @@ import { mintRootStorageKey } from "@virtool/storage";
 import { and, asc, count, desc, eq, inArray, lt, notExists } from "drizzle-orm";
 import type { Db, DbOrTx } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
-import { sampleReads } from "../db/schema/samples";
+import { sampleReads, sampleUploads } from "../db/schema/samples";
 import { type UploadRow, uploads as uploadsTable } from "../db/schema/uploads";
 import { users as usersTable } from "../db/schema/users";
 import { nowUtc, secondsAgo } from "../db/time";
@@ -298,7 +298,7 @@ export type ReapResult = {
 };
 
 /**
- * Delete reserved uploads that were never linked to a sample.
+ * Delete reserved uploads that no sample claims.
  *
  * The row goes before the object, unlike cache eviction: this is a soft delete,
  * so a refused delete leaves a row that still names the bytes. It emits no
@@ -324,14 +324,31 @@ export async function reapOrphanedUploads(
 				eq(uploadsTable.reserved, true),
 				eq(uploadsTable.removed, false),
 				lt(uploadsTable.createdAt, secondsAgo(olderThanSeconds)),
-				/* `sample_reads` alone. A `sample_uploads` row is written before any
-				   reads exist, so correlating on it too would exempt exactly the
-				   abandoned creations this sweep is for. */
 				notExists(
 					db
 						.select({ id: sampleReads.id })
 						.from(sampleReads)
 						.where(eq(sampleReads.upload, uploadsTable.id)),
+				),
+				/* `sample_reads` alone is not enough: those rows are written at
+				   finalize, so a sample that is still running looks exactly like an
+				   abandoned creation and has its inputs reaped out from under the
+				   workflow. The cutoff cannot rescue it — it measures the age of the
+				   upload rather than of the reservation, so an upload that sat in a
+				   user's list for a month is reapable the moment it is reserved.
+
+				   A `sample_uploads` row means a live sample claims the upload:
+				   `createSample` writes it in the transaction that reserves, and
+				   `deleteSample` clears it in the transaction that releases. What is
+				   left — a reservation no sample row names — is what this sweep is
+				   for. Python's `reap_orphaned` has to carry this term too; while both
+				   runners sweep the same table, the looser predicate is the one that
+				   decides what is reaped. */
+				notExists(
+					db
+						.select({ id: sampleUploads.id })
+						.from(sampleUploads)
+						.where(eq(sampleUploads.upload_id, uploadsTable.id)),
 				),
 			),
 		)


### PR DESCRIPTION
## Summary
- The sweep selected reserved uploads with no `sample_reads` row, and those rows are only written at finalize — so an upload a still-running sample job was reading from looked exactly like an abandoned creation and had its object deleted out from under the workflow. The thirty-day cutoff was no defence: it measures the age of the upload, not of the reservation, so an upload that sat in a user's list for a month was reapable the moment it was reserved.
- The predicate now also requires that no `sample_uploads` row names the upload. That row means a live sample claims it — `createSample` writes it in the transaction that reserves, `deleteSample` clears it in the transaction that releases — so reservations orphaned by a non-releasing delete path, a legacy path, or from before `sample_uploads` existed carry no such row and are still reaped.
- **Must not deploy ahead of the matching Python change.** `virtool/uploads/data.py`'s `reap_orphaned` still carries the looser predicate, and while both runners sweep the same table the looser one decides what is reaped.