### PR TITLE
chore: port the clone_reference task body

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1351,6 +1351,45 @@ own:
   taking none, so a run holding hundreds of objects cannot outlive the
   drain and delete rows for a runner that has already released the claim.
 
+`clone_reference` is the fourth, and the first whose failure destroys
+something. Its body is one call to `populateClonedReference`
+(`@virtool/data/references/populate`), which lives beside `references/data.ts`
+rather than in it — everything it does reads OTUs and writes history, and
+`otus/data.ts` already imports this domain's errors, so folding it in would
+close a cycle. It is also the layer `import_reference` (VIR-2898) will
+stand on. Five rules are its own:
+
+- **A failure deletes the reference**, its OTUs, sequences, history,
+  diffs and membership rows, in one transaction, before the error is
+  rethrown. The user watches a clone vanish with nothing to retry. That
+  is Python's `_rollback_insert_only_reference` and both runners are live
+  until the cutover, so it is not this side's to soften. An **abort** is
+  the exception and rolls back nothing: the process is going away, the
+  task will be released and re-run, and destroying a reference because a
+  pod restarted is not a cleanup.
+- **A re-run clears before it writes.** Ids are minted fresh every time,
+  so nothing would stop a reclaimed attempt landing a second complete set
+  of OTUs beside the first — silently, since neither set is malformed. The
+  clear is the rollback's deletions minus the reference row itself.
+- **A chunk is patched, prepared and committed before the next is read**,
+  a thousand OTUs at a time, so peak memory is bounded by the chunk and
+  not by the reference. A chunk carries **whole OTUs**: `position` counts
+  a sequence within its OTU, so splitting one across two inserts would
+  start its second half at zero and reorder it. The prepare loop yields
+  between chunks — a deep copy and reshape of a thousand documents is a
+  synchronous stretch long enough to starve the heartbeat.
+- **The progress split is Python's**, patching running to 1/1.3 of the bar
+  and the insert covering the rest. The two runners' progress is compared
+  during the cutover; do not round it off.
+- **Ids are minted without a collision check**, as Python's are, and the
+  unique constraints are what a collision fails on. They stay the
+  mixed-case 62-character alphabet every id written from this side uses,
+  where Python's `random_alphanumeric` defaults to lowercase-only —
+  nothing keys on the case, and the wider alphabet is the safer of the two
+  against the collision neither side checks for. `randomId(length)` in
+  `otus/data.ts` is the one generator; the OTU takes 8 characters and its
+  isolates and sequences 12.
+
 See [docs/tasks.md](docs/tasks.md) for the full config table, the
 `AppContext` contract, the shutdown ordering and its guarantees, the
 probe and metrics surface including the five task series and their

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1351,45 +1351,6 @@ own:
   taking none, so a run holding hundreds of objects cannot outlive the
   drain and delete rows for a runner that has already released the claim.
 
-`clone_reference` is the fourth, and the first whose failure destroys
-something. Its body is one call to `populateClonedReference`
-(`@virtool/data/references/populate`), which lives beside `references/data.ts`
-rather than in it — everything it does reads OTUs and writes history, and
-`otus/data.ts` already imports this domain's errors, so folding it in would
-close a cycle. It is also the layer `import_reference` (VIR-2898) will
-stand on. Five rules are its own:
-
-- **A failure deletes the reference**, its OTUs, sequences, history,
-  diffs and membership rows, in one transaction, before the error is
-  rethrown. The user watches a clone vanish with nothing to retry. That
-  is Python's `_rollback_insert_only_reference` and both runners are live
-  until the cutover, so it is not this side's to soften. An **abort** is
-  the exception and rolls back nothing: the process is going away, the
-  task will be released and re-run, and destroying a reference because a
-  pod restarted is not a cleanup.
-- **A re-run clears before it writes.** Ids are minted fresh every time,
-  so nothing would stop a reclaimed attempt landing a second complete set
-  of OTUs beside the first — silently, since neither set is malformed. The
-  clear is the rollback's deletions minus the reference row itself.
-- **A chunk is patched, prepared and committed before the next is read**,
-  a thousand OTUs at a time, so peak memory is bounded by the chunk and
-  not by the reference. A chunk carries **whole OTUs**: `position` counts
-  a sequence within its OTU, so splitting one across two inserts would
-  start its second half at zero and reorder it. The prepare loop yields
-  between chunks — a deep copy and reshape of a thousand documents is a
-  synchronous stretch long enough to starve the heartbeat.
-- **The progress split is Python's**, patching running to 1/1.3 of the bar
-  and the insert covering the rest. The two runners' progress is compared
-  during the cutover; do not round it off.
-- **Ids are minted without a collision check**, as Python's are, and the
-  unique constraints are what a collision fails on. They stay the
-  mixed-case 62-character alphabet every id written from this side uses,
-  where Python's `random_alphanumeric` defaults to lowercase-only —
-  nothing keys on the case, and the wider alphabet is the safer of the two
-  against the collision neither side checks for. `randomId(length)` in
-  `otus/data.ts` is the one generator; the OTU takes 8 characters and its
-  isolates and sequences 12.
-
 See [docs/tasks.md](docs/tasks.md) for the full config table, the
 `AppContext` contract, the shutdown ordering and its guarantees, the
 probe and metrics surface including the five task series and their

--- a/apps/tasks/src/tasks/clone-reference.test.ts
+++ b/apps/tasks/src/tasks/clone-reference.test.ts
@@ -1,0 +1,251 @@
+import { seedUser } from "@virtool/data/auth/test/fixtures";
+import type { Db } from "@virtool/data/db/pg";
+import {
+	legacyHistory,
+	legacyHistoryDiff,
+} from "@virtool/data/db/schema/history";
+import { legacyOtus, legacySequences } from "@virtool/data/db/schema/otus";
+import {
+	legacyReferences,
+	legacyReferenceUsers,
+} from "@virtool/data/db/schema/references";
+import { tasks } from "@virtool/data/db/schema/tasks";
+import { users } from "@virtool/data/db/schema/users";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import type { ClaimedTask } from "@virtool/data/tasks/data";
+import { createLogger, type Logger } from "@virtool/logger";
+import { MemoryStorage } from "@virtool/storage";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { runTask } from "../framework/run";
+import { acquireOrThrow, readTaskRow, seedTaskRow } from "../testing/tasks";
+import { cloneReferenceTask } from "./clone-reference";
+import type { TaskContext } from "./registry";
+
+const logger: Logger = createLogger({ name: "test", level: "silent" });
+
+let database: TestDatabase;
+let db: Db;
+let ctx: TaskContext;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(legacyHistoryDiff);
+	await db.delete(legacyHistory);
+	await db.delete(legacySequences);
+	await db.delete(legacyOtus);
+	await db.delete(legacyReferenceUsers);
+	await db.delete(legacyReferences);
+	await db.delete(tasks);
+	await db.delete(users);
+
+	ctx = { db, storage: new MemoryStorage() };
+});
+
+async function seedReference(userId: number, name: string): Promise<number> {
+	const [row] = await db
+		.insert(legacyReferences)
+		.values({
+			name,
+			description: "",
+			organism: "virus",
+			created_at: new Date("2021-06-01T00:00:00.000Z"),
+			archived: false,
+			restrict_source_types: false,
+			source_types: [],
+			user_id: userId,
+		})
+		.returning({ id: legacyReferences.id });
+
+	if (row === undefined) {
+		throw new Error("failed to seed a reference");
+	}
+
+	return row.id;
+}
+
+/**
+ * Seed a source reference with `count` OTUs and the clone the task is to fill,
+ * then claim the task the way the runner will.
+ */
+async function claimClone(
+	count = 2,
+	manifestOverride?: Record<string, number>,
+) {
+	const userId = await seedUser(db, { handle: "curator" });
+	const sourceId = await seedReference(userId, "Source");
+	const cloneId = await seedReference(userId, "Clone of Source");
+
+	const manifest: Record<string, number> = {};
+
+	for (let index = 0; index < count; index += 1) {
+		const otuId = `src_otu_${index}`;
+		const isolateId = `src_iso_${index}`;
+
+		await db.insert(legacyOtus).values({
+			id: otuId,
+			data: {
+				_id: otuId,
+				name: `OTU ${index}`,
+				abbreviation: "",
+				lower_name: `otu ${index}`,
+				isolates: [
+					{
+						id: isolateId,
+						default: true,
+						source_type: "isolate",
+						source_name: isolateId,
+					},
+				],
+				last_indexed_version: null,
+				reference: { id: sourceId },
+				schema: [],
+				verified: true,
+				version: 0,
+			},
+			name: `OTU ${index}`,
+			abbreviation: "",
+			reference_id: sourceId,
+			verified: true,
+			version: 0,
+		});
+
+		await db.insert(legacySequences).values({
+			id: `src_seq_${index}`,
+			data: {
+				_id: `src_seq_${index}`,
+				accession: `ACC${index}`,
+				definition: "A definition",
+				host: "",
+				otu_id: otuId,
+				isolate_id: isolateId,
+				reference: { id: sourceId },
+				segment: "",
+				sequence: "ATGC",
+			},
+			otu_id: otuId,
+			isolate_id: isolateId,
+			segment: "",
+			position: 0,
+		});
+
+		manifest[otuId] = 0;
+	}
+
+	const taskId = await seedTaskRow(db, cloneReferenceTask.type, {
+		manifest: manifestOverride ?? manifest,
+		ref_id: cloneId,
+		user_id: userId,
+	});
+
+	return {
+		task: await acquireOrThrow(db, cloneReferenceTask.type),
+		cloneId,
+		sourceId,
+		taskId,
+	};
+}
+
+function run(task: ClaimedTask, signal = new AbortController().signal) {
+	return runTask({ db, def: cloneReferenceTask, task, ctx, logger, signal });
+}
+
+describe("cloneReferenceTask", () => {
+	it("runs a claimed task through to complete and fills the reference", async () => {
+		const { task, cloneId } = await claimClone();
+
+		expect(await run(task)).toEqual({ status: "completed" });
+
+		expect(await readTaskRow(db, task.id)).toMatchObject({
+			complete: true,
+			error: null,
+			progress: 100,
+			step: "clone",
+		});
+
+		expect(
+			await db
+				.select({ id: legacyOtus.id })
+				.from(legacyOtus)
+				.where(eq(legacyOtus.reference_id, cloneId)),
+		).toHaveLength(2);
+
+		expect(
+			await db
+				.select({ id: legacyHistory.id })
+				.from(legacyHistory)
+				.where(eq(legacyHistory.reference_id, cloneId)),
+		).toHaveLength(2);
+	});
+
+	// A reclaim re-runs a body from step zero, and the ids are minted fresh every
+	// time. Without the clear the second attempt would double the reference.
+	it("is idempotent across a re-run", async () => {
+		const { task, cloneId } = await claimClone();
+
+		expect(await run(task)).toEqual({ status: "completed" });
+
+		await db
+			.update(tasks)
+			.set({ complete: false, runner_id: null, acquired_at: null })
+			.where(eq(tasks.id, task.id));
+
+		const second = await acquireOrThrow(db, cloneReferenceTask.type);
+
+		expect(await run(second)).toEqual({ status: "completed" });
+
+		expect(
+			await db
+				.select({ id: legacyOtus.id })
+				.from(legacyOtus)
+				.where(eq(legacyOtus.reference_id, cloneId)),
+		).toHaveLength(2);
+	});
+
+	// The reference is gone rather than left half-built, which is what Python
+	// does and what the two runners must agree on until the cutover.
+	it("fails the task and deletes the reference when the manifest is unpatchable", async () => {
+		const { task, cloneId } = await claimClone(1, { src_otu_missing: 0 });
+
+		const outcome = await run(task);
+
+		expect(outcome.status).toBe("failed");
+
+		expect(await readTaskRow(db, task.id)).toMatchObject({
+			complete: true,
+			step: "clone",
+		});
+
+		expect(
+			await db
+				.select({ id: legacyReferences.id })
+				.from(legacyReferences)
+				.where(eq(legacyReferences.id, cloneId)),
+		).toHaveLength(0);
+	});
+
+	it("refuses a payload without the manifest the clone was frozen against", async () => {
+		const userId = await seedUser(db, { handle: "curator" });
+		const cloneId = await seedReference(userId, "Clone of Source");
+
+		await seedTaskRow(db, cloneReferenceTask.type, {
+			ref_id: cloneId,
+			user_id: userId,
+		});
+
+		const task = await acquireOrThrow(db, cloneReferenceTask.type);
+
+		expect((await run(task)).status).toBe("failed");
+	});
+});

--- a/apps/tasks/src/tasks/clone-reference.ts
+++ b/apps/tasks/src/tasks/clone-reference.ts
@@ -1,0 +1,57 @@
+import { populateClonedReference } from "@virtool/data/references/populate";
+import { z } from "zod";
+import { defineTask } from "../framework/define";
+import type { TaskContext } from "./registry";
+
+/**
+ * `clone_reference` carries the manifest the clone was frozen against.
+ *
+ * `createReference` writes it when the clone is requested: every OTU the source
+ * reference held at that moment, mapped to the version it stood at. The clone is
+ * built from that snapshot rather than from the source as it stands now, so
+ * editing the source while the task runs cannot change what lands.
+ */
+const payload = z.object({
+	manifest: z.record(z.string(), z.number().int().nonnegative()),
+	ref_id: z.number().int().positive(),
+	user_id: z.number().int().positive(),
+});
+
+/**
+ * Fill a cloned reference with the OTUs of the reference it was cloned from.
+ *
+ * The port of Python's `CloneReferenceTask`, whose body is likewise one call.
+ * Python reports a position within the step and so does this: the manifest gives
+ * the OTU count up front, and a real reference is tens of thousands of them.
+ * `report` takes a fraction where the data layer publishes percent.
+ *
+ * A failure takes the reference with it — the rollback inside
+ * `populateClonedReference` deletes the half-built reference and its rows, so
+ * the user sees it disappear rather than sitting there empty with no way to
+ * finish it. That is Python's behaviour and both runners are live until the
+ * cutover, so it is not this side's to soften.
+ */
+export const cloneReferenceTask = defineTask<typeof payload, TaskContext>({
+	type: "clone_reference",
+	payload,
+	// Python's method name, which `BaseTask.run` writes to the column. Both
+	// runners write `clone` for the same work until the cutover completes.
+	steps: ["clone"],
+	async run({ ctx, helpers, logger, payload, signal }) {
+		await helpers.runStep("clone", async (report) => {
+			await populateClonedReference(
+				ctx.db,
+				logger,
+				{
+					manifest: payload.manifest,
+					referenceId: payload.ref_id,
+					userId: payload.user_id,
+				},
+				async (percent) => {
+					report(percent / 100);
+				},
+				signal,
+			);
+		});
+	},
+});

--- a/apps/tasks/src/tasks/registry.ts
+++ b/apps/tasks/src/tasks/registry.ts
@@ -2,6 +2,7 @@ import type { Db } from "@virtool/data/db/pg";
 import type { StorageBackend } from "@virtool/storage";
 import type { TaskRegistry } from "../framework/define";
 import { cleanupSessionsTask } from "./cleanup-sessions";
+import { cloneReferenceTask } from "./clone-reference";
 import { createIndexTask } from "./create-index";
 import { evictCachesLruTask } from "./evict-caches-lru";
 import { reapOrphanedUploadsTask } from "./reap-orphaned-uploads";
@@ -36,6 +37,7 @@ export type TaskContext = {
  */
 export const taskRegistry: TaskRegistry<TaskContext> = {
 	cleanup_sessions: cleanupSessionsTask,
+	clone_reference: cloneReferenceTask,
 	create_index: createIndexTask,
 	evict_caches_lru: evictCachesLruTask,
 	reap_orphaned_uploads: reapOrphanedUploadsTask,

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -988,6 +988,102 @@ Idempotency comes free: a re-run selects whatever is still over budget, and
 `storage.delete` is idempotent on its own, so an interrupted run is finished by
 the next one rather than repaired by it.
 
+### `clone_reference`, the fourth body
+
+`clone_reference` fills a newly created reference with the OTUs of the one it
+was cloned from. Its body is one call to `populateClonedReference`
+(`@virtool/data/references/populate`) inside one step, `clone` — Python's method
+name — and it reports a position: the manifest gives the OTU count up front, and
+a real reference is tens of thousands of them.
+
+**The work lives beside `references/data.ts`, not in it.** Everything the
+populate does reads OTUs and writes history, and `otus/data.ts` already imports
+this domain's errors, so folding it into `data.ts` would close that arrow into a
+cycle. The module is also the layer `import_reference` (VIR-2898) will stand on:
+`prepareOtuInsertion`, the chunked bulk insert and the rollback are the port of
+Python's `alot.py` and `populate_insert_only_reference`, which both tasks share,
+and only the clone-specific driver on top of them is this task's.
+
+**The manifest is a snapshot, not a pointer.** `createReference` writes every
+OTU the source held at the moment the clone was requested, mapped to the version
+it stood at, and each OTU is reconstructed to that version through
+`patchOtusToVersions`. Editing the source while the task runs cannot change what
+lands. An OTU the manifest names that history cannot produce is a
+`ReferenceManifestError` and fails the task — the entry is proof the OTU existed
+at that version, so a miss is corrupted history rather than a routine absence,
+and skipping it would publish a reference silently short of an OTU.
+
+**A failure deletes the reference.** Everything the run committed goes in one
+transaction — diffs, history, sequences, OTUs, the membership rows, and the
+`legacy_references` row itself — before the error is rethrown. The user sees the
+clone disappear from the list with nothing to retry. That is Python's
+`_rollback_insert_only_reference`, both runners are live until the cutover, and
+the two must not disagree about what a failed clone leaves behind. It is
+deliberate, not an oversight to be softened into "leave it empty and let them
+retry".
+
+**An abort rolls back nothing.** A drain-time abort means the process is going
+away; the runner releases the claim and another runner re-runs the body from
+step zero. Rolling back there would destroy a user's reference because a pod
+restarted. The signal is checked between chunks and rethrown untranslated.
+
+**A re-run clears before it writes.** The ids are minted fresh on every attempt,
+so a reclaimed run would otherwise land a second complete set of OTUs beside the
+first — silently, since neither set is malformed and nothing links the two. The
+clear is the rollback's deletions minus the reference row. The two paths it has
+to cover fall out of that: a rollback took the reference with it, so a re-run
+after an accepted failure finds nothing to clone into and fails immediately;
+an ungraceful exit left the reference, and the clear is what makes the re-run
+land exactly one copy.
+
+**A chunk is patched, prepared and committed before the next is read**, a
+thousand OTUs at a time, so peak memory is bounded by the chunk rather than by
+the reference. A chunk carries whole OTUs: `position` counts a sequence within
+its OTU, and splitting one across two inserts would start its second half's
+count at zero and reorder it — which misapplies every diff that addresses an
+isolate's sequence list by index. The prepare loop yields the event loop between
+chunks, because a deep copy and reshape of a thousand documents is a synchronous
+stretch long enough to starve the heartbeat and get the task reclaimed out from
+under itself.
+
+**The progress split is Python's.** Patching runs to `1/1.3` of the bar and the
+insert covers the remaining ~23%, which is what Python's `headroom = int(count *
+0.3)` leaves. The two runners' progress is compared during the cutover, so the
+ratio is reproduced rather than rounded off.
+
+**Ids are minted without a collision check**, exactly as Python's are: the unique
+constraints on `legacy_otus.id` and `legacy_sequences.id` are what a collision
+fails the task on, and a check would cost a query per id against a table this
+path is writing tens of thousands of rows into. They stay the mixed-case
+62-character alphabet every id written from this side uses, where Python's
+`random_alphanumeric` defaults to lowercase-only 36. Nothing keys on the case —
+the columns are `VARCHAR` and the ids Mongo held were mixed-case — and the wider
+alphabet is the safer of the two against the collision neither side checks for.
+`randomId(length)` in `otus/data.ts` is the one generator: 8 characters for the
+OTU, 12 for its isolates and sequences.
+
+The reshaping is Python's, term for term. Each cloned OTU takes the reference's
+own `created_at` rather than the instant the task ran, `imported: true`,
+`version: 0`, a `remote.id` naming the OTU it came from, and a `lower_name`
+derived from its name. Each isolate is pruned to `default`, `id`, `sequences`,
+`source_type` and `source_name`, dropping whatever an older Virtool wrote onto
+it. Each sequence keeps its accession, takes a `remote.id` naming its source, and
+the sequences are then lifted out of their isolates — `legacy_otus.data` never
+holds them. `verify` runs while they are still embedded, and its report is stored
+on the document as `issues` alongside `verified`. That stored report is this
+side's camelCase `OtuIssueReport` where Python's is snake_case; nothing on either
+side reads it, both recompute `verify` at read time, so the divergence is inert
+and a second snake_case report would be a second declaration of a shape the
+contract already owns.
+
+The history is one `legacy_history` row per OTU with `method_name = "clone"`,
+`otu_version = "0"` and a NULL `index_id`, and one `legacy_history_diff` row
+holding `diff(null, document)` — a dictdiffer diff against nothing, not the bare
+document. The diff is composed against the OTU as it will be stored, isolates
+already emptied of their sequences, which is what Python does; a diff taken from
+the joined document would describe a document no row holds. The rows are paired
+to their diffs by `legacy_id` rather than by the order the insert returned.
+
 ### Frames are the framework's, never a body's
 
 A body never emits. `updateTaskProgress`, `completeTask` and `failTask` publish

--- a/packages/data/src/history/add.ts
+++ b/packages/data/src/history/add.ts
@@ -37,24 +37,45 @@ export type HistoryValues = {
 	userId: number;
 };
 
-/** The description of a change that created an OTU. */
-export function composeCreateDescription(document: OtuDocument): string {
-	return withAbbreviation(`Created ${String(document.name)}`, document);
-}
-
-/** The description of a change that removed an OTU. */
-export function composeRemoveDescription(document: OtuDocument): string {
-	return withAbbreviation(`Removed ${String(document.name)}`, document);
-}
-
-function withAbbreviation(description: string, document: OtuDocument): string {
-	const abbreviation = document.abbreviation;
+/**
+ * The description of a change, as its past-tense method name applied to the OTU.
+ *
+ * Python appends the `d` and, unless the method already ends in one, the `e`
+ * before it — `clone` becomes `Cloned` and `import` becomes `Imported`. Only the
+ * methods the bulk paths record are described this way; every other method has
+ * its own composer, because the generic phrasing reads badly for them.
+ */
+export function composeHistoryDescription(
+	methodName: HistoryMethod,
+	name: string,
+	abbreviation: unknown,
+): string {
+	const suffix = methodName.endsWith("e") ? "d" : "ed";
+	const description = `${methodName.charAt(0).toUpperCase()}${methodName.slice(1)}${suffix} ${name}`;
 
 	if (typeof abbreviation === "string" && abbreviation) {
 		return `${description} (${abbreviation})`;
 	}
 
 	return description;
+}
+
+/** The description of a change that created an OTU. */
+export function composeCreateDescription(document: OtuDocument): string {
+	return composeHistoryDescription(
+		"create",
+		String(document.name),
+		document.abbreviation,
+	);
+}
+
+/** The description of a change that removed an OTU. */
+export function composeRemoveDescription(document: OtuDocument): string {
+	return composeHistoryDescription(
+		"remove",
+		String(document.name),
+		document.abbreviation,
+	);
 }
 
 /**
@@ -123,9 +144,15 @@ function deriveOtuInformation(
 	};
 }
 
-// A create stores the whole new document and a remove the whole old one; there
-// is no other side to diff against. Everything else stores a dictdiffer diff.
-function composeDiff(values: HistoryValues): unknown {
+/**
+ * The diff a change stores.
+ *
+ * A create stores the whole new document and a remove the whole old one; there
+ * is no other side to diff against. Everything else stores a dictdiffer diff —
+ * including the `clone` and `import` a bulk insertion records, whose `old` is
+ * `null` and whose diff is therefore built against nothing.
+ */
+export function composeDiff(values: HistoryValues): unknown {
 	if (values.methodName === "create") {
 		return values.new;
 	}

--- a/packages/data/src/otus/data.ts
+++ b/packages/data/src/otus/data.ts
@@ -63,7 +63,7 @@ import {
 export type OtuDocument = Record<string, unknown>;
 
 /** A sequence document, recovered verbatim from the `data` JSONB column. */
-type SequenceDocument = Record<string, unknown>;
+export type SequenceDocument = Record<string, unknown>;
 
 /** Thrown when no OTU holds the requested id. */
 export class OtuNotFoundError extends AppError {}
@@ -99,8 +99,22 @@ const ID_ALPHABET =
 
 const ID_LENGTH = 8;
 
-function randomId(): string {
-	const bytes = crypto.getRandomValues(new Uint8Array(ID_LENGTH));
+/**
+ * Draw a random id of `length` characters.
+ *
+ * Isolate and sequence ids minted by the bulk reference-insertion paths are
+ * twelve characters where an OTU's is eight, which is the only reason the
+ * length is a parameter.
+ *
+ * The alphabet stays the mixed-case 62 characters every id written from this
+ * side uses, where Python's `random_alphanumeric` defaults to lowercase-only 36.
+ * Nothing keys on the case: the columns are `VARCHAR`, and the ids Mongo held
+ * were mixed-case, so a lowercase-only draw here would be the odd one out rather
+ * than the faithful one. The wider alphabet is also the safer of the two against
+ * the collision this path does not check for.
+ */
+export function randomId(length: number = ID_LENGTH): string {
+	const bytes = crypto.getRandomValues(new Uint8Array(length));
 
 	return Array.from(
 		bytes,
@@ -388,7 +402,7 @@ async function readOtuWithReference(
 	};
 }
 
-function isolatesOf(document: OtuDocument): Record<string, unknown>[] {
+export function isolatesOf(document: OtuDocument): Record<string, unknown>[] {
 	const isolates = document.isolates;
 
 	if (!Array.isArray(isolates)) {
@@ -419,7 +433,7 @@ function findIsolate(
 
 // Every promoted column is recomputed from the document, so the same values
 // serve an insert and an update and the row stays in sync on each write.
-function otuRowValues(document: OtuDocument, referenceId: number) {
+export function otuRowValues(document: OtuDocument, referenceId: number) {
 	const abbreviation = document.abbreviation;
 
 	return {
@@ -517,7 +531,7 @@ function nextSequencePosition(otuId: string) {
 	return sql<number>`(select coalesce(max(${legacySequences.position}) + 1, 0) from ${legacySequences} where ${legacySequences.otu_id} = ${otuId})`;
 }
 
-function sequenceRowValues(document: SequenceDocument) {
+export function sequenceRowValues(document: SequenceDocument) {
 	const segment = document.segment;
 
 	return {
@@ -605,7 +619,7 @@ async function updateLegacySequenceSegments(
  * is `false` rather than an empty list — the shape Python's `verify` returns.
  * `verified` on the row is exactly `verify(...) === null`.
  */
-function verify(joined: OtuDocument): OtuIssueReport | null {
+export function verify(joined: OtuDocument): OtuIssueReport | null {
 	const isolates = isolatesOf(joined);
 
 	const emptyIsolate: string[] = [];

--- a/packages/data/src/references/populate.test.ts
+++ b/packages/data/src/references/populate.test.ts
@@ -1,0 +1,634 @@
+import { createLogger, type Logger } from "@virtool/logger";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { seedUser } from "../auth/test/fixtures";
+import type { Db } from "../db/pg";
+import { legacyHistory, legacyHistoryDiff } from "../db/schema/history";
+import { legacyOtus, legacySequences } from "../db/schema/otus";
+import {
+	legacyReferences,
+	legacyReferenceUsers,
+} from "../db/schema/references";
+import { users } from "../db/schema/users";
+import { createTestDatabase, type TestDatabase } from "../db/test/fixtures";
+import { diff } from "../history/dictdiffer";
+import { type OtuDocument, verify } from "../otus/data";
+import { populateClonedReference, ReferenceManifestError } from "./populate";
+
+const logger: Logger = createLogger({ name: "test", level: "silent" });
+
+let database: TestDatabase;
+let db: Db;
+let userId: number;
+let sourceId: number;
+let cloneId: number;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+const CLONE_CREATED_AT = new Date("2024-03-01T12:00:00.000Z");
+
+beforeEach(async () => {
+	await db.delete(legacyHistoryDiff);
+	await db.delete(legacyHistory);
+	await db.delete(legacySequences);
+	await db.delete(legacyOtus);
+	await db.delete(legacyReferenceUsers);
+	await db.delete(legacyReferences);
+	await db.delete(users);
+
+	userId = await seedUser(db, { handle: "curator" });
+	sourceId = await seedSourceReference("Source", new Date("2020-01-01"));
+	cloneId = await seedSourceReference("Clone of Source", CLONE_CREATED_AT);
+});
+
+async function seedSourceReference(
+	name: string,
+	createdAt: Date,
+): Promise<number> {
+	const [row] = await db
+		.insert(legacyReferences)
+		.values({
+			name,
+			description: "",
+			organism: "virus",
+			created_at: createdAt,
+			archived: false,
+			restrict_source_types: false,
+			source_types: [],
+			user_id: userId,
+		})
+		.returning({ id: legacyReferences.id });
+
+	if (row === undefined) {
+		throw new Error("failed to seed a reference");
+	}
+
+	return row.id;
+}
+
+type SeededSequence = {
+	id: string;
+	accession?: string;
+	sequence?: string;
+	segment?: string;
+};
+
+type SeededIsolate = {
+	id: string;
+	sequences: SeededSequence[];
+	extra?: Record<string, unknown>;
+};
+
+/**
+ * Insert a source OTU and its sequences the way the write paths hold them: the
+ * document in `legacy_otus.data` with its isolates carrying no sequences, and
+ * one `legacy_sequences` row per sequence, numbered within the OTU.
+ */
+async function seedOtu(
+	referenceId: number,
+	{
+		id,
+		name = `OTU ${id}`,
+		abbreviation = "",
+		isolates = [],
+		version = 0,
+	}: {
+		id: string;
+		name?: string;
+		abbreviation?: string;
+		isolates?: SeededIsolate[];
+		version?: number;
+	},
+): Promise<void> {
+	await db.insert(legacyOtus).values({
+		id,
+		data: {
+			_id: id,
+			name,
+			abbreviation,
+			lower_name: name.toLowerCase(),
+			isolates: isolates.map((isolate) => ({
+				id: isolate.id,
+				default: true,
+				source_type: "isolate",
+				source_name: isolate.id,
+				...isolate.extra,
+			})),
+			last_indexed_version: null,
+			reference: { id: referenceId },
+			schema: [],
+			verified: true,
+			version,
+		},
+		name,
+		abbreviation,
+		reference_id: referenceId,
+		verified: true,
+		version,
+	});
+
+	let position = 0;
+
+	for (const isolate of isolates) {
+		for (const sequence of isolate.sequences) {
+			await db.insert(legacySequences).values({
+				id: sequence.id,
+				data: {
+					_id: sequence.id,
+					accession: sequence.accession ?? `ACC${sequence.id}`,
+					definition: "A definition",
+					host: "",
+					otu_id: id,
+					isolate_id: isolate.id,
+					reference: { id: referenceId },
+					segment: sequence.segment ?? "",
+					sequence: sequence.sequence ?? "ATGC",
+				},
+				otu_id: id,
+				isolate_id: isolate.id,
+				segment: sequence.segment ?? "",
+				position,
+			});
+
+			position += 1;
+		}
+	}
+}
+
+async function readClonedOtus(): Promise<
+	{ id: string; data: OtuDocument; verified: boolean; version: number }[]
+> {
+	return db
+		.select({
+			id: legacyOtus.id,
+			data: legacyOtus.data,
+			verified: legacyOtus.verified,
+			version: legacyOtus.version,
+		})
+		.from(legacyOtus)
+		.where(eq(legacyOtus.reference_id, cloneId));
+}
+
+function takeOne<T>(items: T[]): T {
+	expect(items).toHaveLength(1);
+
+	const [item] = items;
+
+	if (item === undefined) {
+		throw new Error("expected exactly one item");
+	}
+
+	return item;
+}
+
+describe("populateClonedReference", () => {
+	it("clones every OTU in the manifest under fresh ids", async () => {
+		await seedOtu(sourceId, {
+			id: "src_otu_1",
+			name: "Tobacco mosaic virus",
+			abbreviation: "TMV",
+			isolates: [{ id: "src_iso_1", sequences: [{ id: "src_seq_1" }] }],
+		});
+
+		await populateClonedReference(db, logger, {
+			manifest: { src_otu_1: 0 },
+			referenceId: cloneId,
+			userId,
+		});
+
+		const cloned = takeOne(await readClonedOtus());
+
+		expect(cloned.id).not.toBe("src_otu_1");
+		expect(cloned.id).toHaveLength(8);
+		expect(cloned.version).toBe(0);
+		expect(cloned.verified).toBe(true);
+
+		expect(cloned.data).toMatchObject({
+			_id: cloned.id,
+			imported: true,
+			last_indexed_version: null,
+			lower_name: "tobacco mosaic virus",
+			name: "Tobacco mosaic virus",
+			reference: { id: cloneId },
+			remote: { id: "src_otu_1" },
+			user: { id: userId },
+			verified: true,
+			version: 0,
+		});
+
+		// The OTUs are stamped with the reference's own creation time, not the
+		// instant the task happened to run.
+		expect(cloned.data.created_at).toBe(CLONE_CREATED_AT.toISOString());
+
+		const [isolate] = cloned.data.isolates as Record<string, unknown>[];
+
+		expect(isolate?.id).not.toBe("src_iso_1");
+		expect(isolate?.id).toHaveLength(12);
+
+		const clonedSequence = takeOne(
+			await db
+				.select()
+				.from(legacySequences)
+				.where(eq(legacySequences.otu_id, cloned.id)),
+		);
+
+		expect(clonedSequence.id).not.toBe("src_seq_1");
+		expect(clonedSequence.id).toHaveLength(12);
+		expect(clonedSequence.data).toMatchObject({
+			isolate_id: isolate?.id,
+			otu_id: cloned.id,
+			reference: { id: cloneId },
+			remote: { id: "src_seq_1" },
+		});
+
+		// The source is untouched.
+		expect(
+			await db
+				.select({ id: legacyOtus.id })
+				.from(legacyOtus)
+				.where(eq(legacyOtus.reference_id, sourceId)),
+		).toHaveLength(1);
+	});
+
+	it("clones an OTU at the version the manifest pins it to", async () => {
+		const isolate = {
+			id: "src_iso_1",
+			default: true,
+			source_type: "isolate",
+			source_name: "src_iso_1",
+		};
+
+		const firstSequence = {
+			_id: "src_seq_1",
+			accession: "ACCsrc_seq_1",
+			definition: "A definition",
+			host: "",
+			otu_id: "src_otu_1",
+			isolate_id: "src_iso_1",
+			reference: { id: sourceId },
+			segment: "",
+			sequence: "ATGC",
+		};
+
+		const secondSequence = { ...firstSequence, _id: "src_seq_2" };
+
+		await seedOtu(sourceId, {
+			id: "src_otu_1",
+			name: "Tobacco mosaic virus",
+			isolates: [
+				{
+					id: "src_iso_1",
+					sequences: [{ id: "src_seq_1" }, { id: "src_seq_2" }],
+				},
+			],
+			version: 2,
+		});
+
+		const atVersionOne = {
+			_id: "src_otu_1",
+			name: "Tobacco mosaic virus",
+			abbreviation: "",
+			lower_name: "tobacco mosaic virus",
+			isolates: [{ ...isolate, sequences: [firstSequence] }],
+			last_indexed_version: null,
+			reference: { id: sourceId },
+			schema: [],
+			verified: true,
+			version: 1,
+		};
+
+		const atVersionTwo = {
+			...atVersionOne,
+			isolates: [{ ...isolate, sequences: [firstSequence, secondSequence] }],
+			version: 2,
+		};
+
+		const [change] = await db
+			.insert(legacyHistory)
+			.values({
+				legacy_id: "src_otu_1.2",
+				created_at: new Date(),
+				description: "Created new sequence",
+				method_name: "create_sequence",
+				user_id: userId,
+				otu: "src_otu_1",
+				otu_name: "Tobacco mosaic virus",
+				otu_version: "2",
+				reference_id: sourceId,
+			})
+			.returning({ id: legacyHistory.id });
+
+		await db.insert(legacyHistoryDiff).values({
+			change_id: "src_otu_1.2",
+			history_id: change?.id,
+			diff: diff(atVersionOne, atVersionTwo),
+		});
+
+		await populateClonedReference(db, logger, {
+			manifest: { src_otu_1: 1 },
+			referenceId: cloneId,
+			userId,
+		});
+
+		const cloned = takeOne(await readClonedOtus());
+
+		expect(
+			await db
+				.select({ id: legacySequences.id })
+				.from(legacySequences)
+				.where(eq(legacySequences.otu_id, cloned.id)),
+		).toHaveLength(1);
+	});
+
+	it("numbers each OTU's sequences from zero however the chunks fall", async () => {
+		for (const index of [1, 2, 3]) {
+			await seedOtu(sourceId, {
+				id: `src_otu_${index}`,
+				isolates: [
+					{
+						id: `src_iso_${index}`,
+						sequences: [
+							{ id: `src_seq_${index}a` },
+							{ id: `src_seq_${index}b` },
+							{ id: `src_seq_${index}c` },
+						],
+					},
+				],
+			});
+		}
+
+		await populateClonedReference(db, logger, {
+			manifest: { src_otu_1: 0, src_otu_2: 0, src_otu_3: 0 },
+			referenceId: cloneId,
+			userId,
+			// Two OTUs then one, so the second chunk starts its numbering afresh.
+			chunkSize: 2,
+		});
+
+		const cloned = await readClonedOtus();
+
+		expect(cloned).toHaveLength(3);
+
+		for (const otu of cloned) {
+			const rows = await db
+				.select({ position: legacySequences.position })
+				.from(legacySequences)
+				.where(eq(legacySequences.otu_id, otu.id))
+				.orderBy(legacySequences.position);
+
+			expect(rows.map((row) => row.position)).toEqual([0, 1, 2]);
+		}
+	});
+
+	it("prunes an isolate to the keys a clone keeps and lifts its sequences out", async () => {
+		await seedOtu(sourceId, {
+			id: "src_otu_1",
+			isolates: [
+				{
+					id: "src_iso_1",
+					sequences: [{ id: "src_seq_1" }],
+					extra: { restrict_source_types: true, legacy_note: "drop me" },
+				},
+			],
+		});
+
+		await populateClonedReference(db, logger, {
+			manifest: { src_otu_1: 0 },
+			referenceId: cloneId,
+			userId,
+		});
+
+		const cloned = takeOne(await readClonedOtus());
+		const [isolate] = cloned.data.isolates as Record<string, unknown>[];
+
+		expect(Object.keys(isolate ?? {}).sort()).toEqual([
+			"default",
+			"id",
+			"source_name",
+			"source_type",
+		]);
+	});
+
+	it("records the issues and verified flag verify reports", async () => {
+		await seedOtu(sourceId, {
+			id: "src_otu_1",
+			isolates: [{ id: "src_iso_1", sequences: [] }],
+		});
+
+		await populateClonedReference(db, logger, {
+			manifest: { src_otu_1: 0 },
+			referenceId: cloneId,
+			userId,
+		});
+
+		const cloned = takeOne(await readClonedOtus());
+		const [isolate] = cloned.data.isolates as Record<string, unknown>[];
+
+		expect(cloned.verified).toBe(false);
+		expect(cloned.data.verified).toBe(false);
+		expect(cloned.data.issues).toEqual(
+			verify({
+				...cloned.data,
+				isolates: [{ ...isolate, sequences: [] }],
+			}),
+		);
+		expect(cloned.data.issues).toMatchObject({
+			emptyIsolate: [isolate?.id],
+			emptyOtu: false,
+		});
+	});
+
+	it("records one clone change per OTU, diffed from nothing", async () => {
+		await seedOtu(sourceId, {
+			id: "src_otu_1",
+			name: "Tobacco mosaic virus",
+			abbreviation: "TMV",
+			isolates: [{ id: "src_iso_1", sequences: [{ id: "src_seq_1" }] }],
+		});
+
+		await populateClonedReference(db, logger, {
+			manifest: { src_otu_1: 0 },
+			referenceId: cloneId,
+			userId,
+		});
+
+		const cloned = takeOne(await readClonedOtus());
+
+		const change = takeOne(
+			await db
+				.select()
+				.from(legacyHistory)
+				.where(eq(legacyHistory.reference_id, cloneId)),
+		);
+
+		expect(change).toMatchObject({
+			legacy_id: `${cloned.id}.0`,
+			description: "Cloned Tobacco mosaic virus (TMV)",
+			method_name: "clone",
+			otu: cloned.id,
+			otu_name: "Tobacco mosaic virus",
+			otu_version: "0",
+			// Nothing has built the clone into an index yet.
+			index_id: null,
+			user_id: userId,
+		});
+
+		// The change is stamped when it is written; the OTU carries the reference's
+		// own creation time.
+		expect(change.created_at.toISOString()).not.toBe(
+			CLONE_CREATED_AT.toISOString(),
+		);
+
+		const stored = takeOne(
+			await db
+				.select()
+				.from(legacyHistoryDiff)
+				.where(eq(legacyHistoryDiff.history_id, change.id)),
+		);
+
+		expect(stored.change_id).toBe(`${cloned.id}.0`);
+		// A dictdiffer diff against nothing, not the bare document.
+		expect(stored.diff).toEqual(diff(null, cloned.data));
+	});
+
+	it("deletes the reference and everything committed when a chunk fails", async () => {
+		await seedOtu(sourceId, {
+			id: "src_otu_1",
+			isolates: [{ id: "src_iso_1", sequences: [{ id: "src_seq_1" }] }],
+		});
+
+		await expect(
+			populateClonedReference(db, logger, {
+				manifest: { src_otu_1: 0, src_otu_missing: 0 },
+				referenceId: cloneId,
+				userId,
+				// The first OTU commits before the second is found to be unpatchable.
+				chunkSize: 1,
+			}),
+		).rejects.toBeInstanceOf(ReferenceManifestError);
+
+		expect(await readClonedOtus()).toHaveLength(0);
+
+		expect(
+			await db
+				.select({ id: legacySequences.id })
+				.from(legacySequences)
+				.where(eq(legacySequences.otu_id, "src_seq_1")),
+		).toHaveLength(0);
+
+		expect(
+			await db
+				.select({ id: legacyHistory.id })
+				.from(legacyHistory)
+				.where(eq(legacyHistory.reference_id, cloneId)),
+		).toHaveLength(0);
+
+		expect(await db.select().from(legacyHistoryDiff)).toHaveLength(0);
+
+		expect(
+			await db
+				.select({ id: legacyReferences.id })
+				.from(legacyReferences)
+				.where(eq(legacyReferences.id, cloneId)),
+		).toHaveLength(0);
+
+		// Only the clone goes; the reference it was cloned from is untouched.
+		expect(
+			await db
+				.select({ id: legacyOtus.id })
+				.from(legacyOtus)
+				.where(eq(legacyOtus.reference_id, sourceId)),
+		).toHaveLength(1);
+	});
+
+	it("does not double up when it runs again over a populated reference", async () => {
+		await seedOtu(sourceId, {
+			id: "src_otu_1",
+			isolates: [{ id: "src_iso_1", sequences: [{ id: "src_seq_1" }] }],
+		});
+
+		await seedOtu(sourceId, {
+			id: "src_otu_2",
+			isolates: [{ id: "src_iso_2", sequences: [{ id: "src_seq_2" }] }],
+		});
+
+		const values = {
+			manifest: { src_otu_1: 0, src_otu_2: 0 },
+			referenceId: cloneId,
+			userId,
+		};
+
+		await populateClonedReference(db, logger, values);
+		await populateClonedReference(db, logger, values);
+
+		expect(await readClonedOtus()).toHaveLength(2);
+
+		expect(
+			await db
+				.select({ id: legacyHistory.id })
+				.from(legacyHistory)
+				.where(eq(legacyHistory.reference_id, cloneId)),
+		).toHaveLength(2);
+
+		expect(await db.select().from(legacyHistoryDiff)).toHaveLength(2);
+
+		expect(
+			await db.select({ id: legacySequences.id }).from(legacySequences),
+		).toHaveLength(4);
+	});
+
+	it("reports progress that only rises, giving the insert the last quarter", async () => {
+		const manifest: Record<string, number> = {};
+
+		for (let index = 0; index < 10; index += 1) {
+			const id = `src_otu_${index}`;
+
+			await seedOtu(sourceId, {
+				id,
+				isolates: [
+					{ id: `src_iso_${index}`, sequences: [{ id: `s${index}` }] },
+				],
+			});
+
+			manifest[id] = 0;
+		}
+
+		const reported: number[] = [];
+
+		await populateClonedReference(
+			db,
+			logger,
+			{ manifest, referenceId: cloneId, userId },
+			async (percent) => {
+				reported.push(percent);
+			},
+		);
+
+		expect(reported.length).toBeGreaterThan(1);
+
+		for (const [index, percent] of reported.entries()) {
+			expect(percent).toBeGreaterThanOrEqual(reported[index - 1] ?? 0);
+		}
+
+		// Patching runs to 1/1.3 of the bar, as Python's headroom leaves it.
+		expect(reported[0]).toBeCloseTo((10 / 13) * 100, 5);
+		expect(reported.at(-1)).toBe(100);
+	});
+
+	it("fails rather than cloning a reference that does not exist", async () => {
+		await expect(
+			populateClonedReference(db, logger, {
+				manifest: {},
+				referenceId: cloneId + 1000,
+				userId,
+			}),
+		).rejects.toThrow();
+	});
+});

--- a/packages/data/src/references/populate.ts
+++ b/packages/data/src/references/populate.ts
@@ -321,8 +321,11 @@ async function insertPreparedOtus(
 		const diffRows = insertions.map(({ history }) => {
 			const historyId = historyIds.get(history.changeId);
 
+			/* Not a manifest failure: the ids are minted in this function and the
+			   insert above is what wrote them, so a miss here is this side's own
+			   invariant breaking rather than anything the manifest said. */
 			if (historyId === undefined) {
-				throw new ReferenceManifestError(
+				throw new Error(
 					`no history row was written for change ${history.changeId}`,
 				);
 			}
@@ -528,6 +531,13 @@ export async function populateClonedReference(
 			   timer. Without a macrotask boundary here a large reference starves it
 			   and the task is reclaimed out from under itself. */
 			await setImmediate();
+
+			/* Checked again on this side of the yield, and not only at the top of
+			   the loop: the yield is exactly where a lost lease is noticed, and the
+			   last chunk has no next iteration to notice it in. Another runner may
+			   already have cleared the reference and started rebuilding it, and this
+			   insert is fenced on nothing. */
+			signal?.throwIfAborted();
 
 			await insertPreparedOtus(db, referenceId, insertions);
 

--- a/packages/data/src/references/populate.ts
+++ b/packages/data/src/references/populate.ts
@@ -1,0 +1,558 @@
+// Bulk-populating a brand new reference with OTUs, sequences and history.
+//
+// A port of `virtool.references.alot` and `populate_insert_only_reference`, plus
+// the `populate_cloned_reference` that drives them for a clone. It is the body
+// of the `clone_reference` task, and the layer the `import_reference` task will
+// stand on.
+//
+// Kept out of `./data.ts` because everything here reads OTUs and writes history,
+// and `otus/data.ts` already imports this domain's errors — folding it in would
+// close that into a cycle.
+
+import { setImmediate } from "node:timers/promises";
+import type { HistoryMethod } from "@virtool/contracts";
+import type { Logger } from "@virtool/logger";
+import { eq, inArray } from "drizzle-orm";
+import type { Db, DbOrTx } from "../db/pg";
+import { legacyHistory, legacyHistoryDiff } from "../db/schema/history";
+import { legacyOtus, legacySequences } from "../db/schema/otus";
+import {
+	legacyReferenceGroups,
+	legacyReferences,
+	legacyReferenceUsers,
+} from "../db/schema/references";
+import { AppError } from "../errors";
+import { emit } from "../events/emit";
+import { composeDiff, composeHistoryDescription } from "../history/add";
+import { otuSpecifierKey, patchOtusToVersions } from "../history/data";
+import {
+	isolatesOf,
+	type OtuDocument,
+	otuRowValues,
+	randomId,
+	type SequenceDocument,
+	sequenceRowValues,
+	verify,
+} from "../otus/data";
+import { ReferenceNotFoundError } from "./data";
+
+/**
+ * Thrown when the manifest names an OTU version history cannot produce.
+ *
+ * A manifest entry is proof the OTU existed at that version when the clone was
+ * requested, so this is corrupted history rather than a routine miss. The task
+ * fails and the half-built reference is rolled back, where skipping the OTU
+ * would publish a reference silently missing it.
+ */
+export class ReferenceManifestError extends AppError {}
+
+/** The values {@link populateClonedReference} works from. */
+export type PopulateClonedReferenceValues = {
+	/** Every source OTU id mapped to the version to clone it at */
+	manifest: Record<string, number>;
+
+	/** The primary key of the reference being populated */
+	referenceId: number;
+
+	/** The user the cloned OTUs and their history are attributed to */
+	userId: number;
+
+	/**
+	 * OTUs patched, prepared and inserted per transaction. Present so a test can
+	 * drive the chunking at a size it can seed; production takes the default.
+	 */
+	chunkSize?: number;
+};
+
+/**
+ * OTUs written per transaction.
+ *
+ * A reference runs to tens of thousands of OTUs and hundreds of thousands of
+ * sequences. Chunking bounds both the transaction and the peak heap: a chunk is
+ * patched, prepared and committed before the next is read, so nothing ever holds
+ * the whole reference.
+ */
+const OTU_CHUNK_SIZE = 1000;
+
+// The most bind parameters a statement may carry. postgres.js allows rather more
+// than this, but the figure is Python's and the two write the same rows.
+const MAX_BIND_PARAMETERS = 32767;
+
+// Each row binds the columns its `*RowValues` mapper produces, so the row count a
+// statement can carry is that divided into the ceiling. Only the sequence rows
+// can exceed a chunk on their own — an OTU chunk of a thousand carries a
+// thousand OTU rows and a thousand history rows, but as many sequence rows as
+// those OTUs happen to hold.
+const OTU_ROW_CHUNK_SIZE = Math.floor(MAX_BIND_PARAMETERS / 8);
+const SEQUENCE_ROW_CHUNK_SIZE = Math.floor(MAX_BIND_PARAMETERS / 6);
+const HISTORY_ROW_CHUNK_SIZE = Math.floor(MAX_BIND_PARAMETERS / 9);
+const HISTORY_DIFF_ROW_CHUNK_SIZE = Math.floor(MAX_BIND_PARAMETERS / 3);
+
+/** The length of an OTU id, and of the isolate and sequence ids under it. */
+const OTU_ID_LENGTH = 8;
+const NESTED_ID_LENGTH = 12;
+
+// The only keys an isolate keeps. A source isolate may carry anything a previous
+// Virtool wrote onto it, and a clone is a fresh document rather than a copy of an
+// old one.
+const ISOLATE_KEYS = new Set([
+	"default",
+	"id",
+	"sequences",
+	"source_type",
+	"source_name",
+]);
+
+/** An OTU, its sequences and its creating history row, ready to be written. */
+type PreparedInsertion = {
+	otu: OtuDocument;
+	sequences: SequenceDocument[];
+	history: {
+		changeId: string;
+		description: string;
+		diff: unknown;
+		methodName: HistoryMethod;
+		otuId: string;
+		otuName: string;
+		otuVersion: string;
+		userId: number;
+	};
+};
+
+function* chunked<T>(items: T[], size: number): Generator<T[]> {
+	for (let start = 0; start < items.length; start += size) {
+		yield items.slice(start, start + size);
+	}
+}
+
+/**
+ * Reshape a source OTU into the one a bulk insertion writes, with fresh ids
+ * throughout and its sequences lifted out of its isolates.
+ *
+ * The source document is never touched: the caller's copy comes out of
+ * `patchOtusToVersions`, which hands back documents that may share structure
+ * with one another, so a mutation in place would corrupt the OTU next to it.
+ *
+ * `issues` is stored on the document because Python stores it, but the shape is
+ * this side's camelCase `OtuIssueReport` rather than Python's snake_case one.
+ * Nothing reads the stored field on either side — both recompute `verify` at
+ * read time — so the divergence is inert, and reproducing a second, snake_case
+ * report here would be a second declaration of a shape the contract already owns.
+ */
+function prepareOtuInsertion(
+	createdAt: Date,
+	historyMethod: HistoryMethod,
+	source: OtuDocument,
+	referenceId: number,
+	userId: number,
+): PreparedInsertion {
+	const otuId = randomId(OTU_ID_LENGTH);
+	const otu = structuredClone(source);
+
+	Object.assign(otu, {
+		_id: otuId,
+		created_at: createdAt,
+		imported: true,
+		last_indexed_version: null,
+		lower_name: String(source.name).toLowerCase(),
+		reference: { id: referenceId },
+		remote: { id: source._id },
+		schema: source.schema ?? [],
+		user: { id: userId },
+		version: 0,
+	});
+
+	for (const isolate of isolatesOf(otu)) {
+		const isolateId = randomId(NESTED_ID_LENGTH);
+
+		isolate.id = isolateId;
+
+		for (const sequence of sequencesOf(isolate)) {
+			const remote = sequence.remote as { id?: unknown } | undefined;
+
+			Object.assign(sequence, {
+				_id: randomId(NESTED_ID_LENGTH),
+				isolate_id: isolateId,
+				otu_id: otuId,
+				// Python's `.get("segment", "")`: an absent segment becomes the empty
+				// string, where an explicit null stays null.
+				segment: "segment" in sequence ? sequence.segment : "",
+				reference: { id: referenceId },
+				remote: {
+					id:
+						remote && typeof remote === "object" && remote.id !== undefined
+							? remote.id
+							: sequence._id,
+				},
+			});
+		}
+
+		for (const key of Object.keys(isolate)) {
+			if (!ISOLATE_KEYS.has(key)) {
+				delete isolate[key];
+			}
+		}
+	}
+
+	// Verified while the sequences are still embedded — `verify` reads an isolate's
+	// sequence list, and the next loop takes it away.
+	const issues = verify(otu);
+
+	Object.assign(otu, { issues, verified: issues === null });
+
+	const sequences: SequenceDocument[] = [];
+
+	for (const isolate of isolatesOf(otu)) {
+		sequences.push(...sequencesOf(isolate));
+
+		delete isolate.sequences;
+	}
+
+	const otuName = String(otu.name);
+	const otuVersion = String(otu.version);
+
+	return {
+		otu,
+		sequences,
+		history: {
+			changeId: `${otuId}.${otuVersion}`,
+			description: composeHistoryDescription(
+				historyMethod,
+				otuName,
+				otu.abbreviation,
+			),
+			// Composed against the OTU as it will be stored, isolates already emptied
+			// of their sequences. Python does the same, and a diff taken from the
+			// joined document instead would describe a document no row holds.
+			diff: composeDiff({
+				description: "",
+				methodName: historyMethod,
+				old: null,
+				new: otu,
+				referenceId,
+				userId,
+			}),
+			methodName: historyMethod,
+			otuId,
+			otuName,
+			otuVersion,
+			userId,
+		},
+	};
+}
+
+function sequencesOf(isolate: Record<string, unknown>): SequenceDocument[] {
+	const sequences = isolate.sequences;
+
+	return Array.isArray(sequences) ? (sequences as SequenceDocument[]) : [];
+}
+
+/**
+ * Write a chunk of prepared OTUs, their sequences and their history in one
+ * transaction.
+ *
+ * `position` counts each OTU's sequences off from zero in the order they were
+ * flattened out of its isolates, which is the order a joined read must give them
+ * back in. A chunk therefore has to carry whole OTUs — splitting one across two
+ * calls would start its second half's count at zero again and reorder it.
+ */
+async function insertPreparedOtus(
+	db: Db,
+	referenceId: number,
+	insertions: PreparedInsertion[],
+): Promise<void> {
+	if (insertions.length === 0) {
+		return;
+	}
+
+	const otuRows = insertions.map((insertion) =>
+		otuRowValues(insertion.otu, referenceId),
+	);
+
+	const sequenceRows = insertions.flatMap((insertion) =>
+		insertion.sequences.map((sequence, position) => ({
+			...sequenceRowValues(sequence),
+			position,
+		})),
+	);
+
+	// One instant for the whole chunk, and a different one from the OTUs' own
+	// `created_at` — which is the reference's. Python stamps each row as it
+	// prepares it; a chunk is prepared in a single synchronous stretch, so the
+	// two differ by nothing a reader could see.
+	const now = new Date();
+
+	const historyRows = insertions.map(({ history }) => ({
+		legacy_id: history.changeId,
+		created_at: now,
+		description: history.description,
+		method_name: history.methodName,
+		user_id: history.userId,
+		otu: history.otuId,
+		otu_name: history.otuName,
+		otu_version: history.otuVersion,
+		reference_id: referenceId,
+	}));
+
+	await db.transaction(async (tx) => {
+		for (const rows of chunked(otuRows, OTU_ROW_CHUNK_SIZE)) {
+			await tx.insert(legacyOtus).values(rows);
+		}
+
+		for (const rows of chunked(sequenceRows, SEQUENCE_ROW_CHUNK_SIZE)) {
+			await tx.insert(legacySequences).values(rows);
+		}
+
+		const historyIds = new Map<string, number>();
+
+		for (const rows of chunked(historyRows, HISTORY_ROW_CHUNK_SIZE)) {
+			const written = await tx
+				.insert(legacyHistory)
+				.values(rows)
+				.returning({ id: legacyHistory.id, legacyId: legacyHistory.legacy_id });
+
+			for (const row of written) {
+				historyIds.set(String(row.legacyId), row.id);
+			}
+		}
+
+		// Paired by `legacy_id` rather than by the order the insert returned, so a
+		// diff can never be attached to the wrong change.
+		const diffRows = insertions.map(({ history }) => {
+			const historyId = historyIds.get(history.changeId);
+
+			if (historyId === undefined) {
+				throw new ReferenceManifestError(
+					`no history row was written for change ${history.changeId}`,
+				);
+			}
+
+			return {
+				change_id: history.changeId,
+				history_id: historyId,
+				diff: history.diff,
+			};
+		});
+
+		for (const rows of chunked(diffRows, HISTORY_DIFF_ROW_CHUNK_SIZE)) {
+			await tx.insert(legacyHistoryDiff).values(rows);
+		}
+	});
+}
+
+/**
+ * Delete every OTU, sequence, history row and diff the reference carries.
+ *
+ * Sequences are deleted explicitly rather than left to the cascade from their
+ * OTUs. The cascade is real upstream, but it is a database constraint the
+ * Drizzle mirror does not declare, so relying on it would make this correct in
+ * production and silently wrong anywhere the schema is materialised from the
+ * mirror.
+ */
+async function clearReferenceContents(
+	tx: DbOrTx,
+	referenceId: number,
+): Promise<void> {
+	await tx
+		.delete(legacyHistoryDiff)
+		.where(
+			inArray(
+				legacyHistoryDiff.history_id,
+				tx
+					.select({ id: legacyHistory.id })
+					.from(legacyHistory)
+					.where(eq(legacyHistory.reference_id, referenceId)),
+			),
+		);
+
+	await tx
+		.delete(legacyHistory)
+		.where(eq(legacyHistory.reference_id, referenceId));
+
+	await tx
+		.delete(legacySequences)
+		.where(
+			inArray(
+				legacySequences.otu_id,
+				tx
+					.select({ id: legacyOtus.id })
+					.from(legacyOtus)
+					.where(eq(legacyOtus.reference_id, referenceId)),
+			),
+		);
+
+	await tx.delete(legacyOtus).where(eq(legacyOtus.reference_id, referenceId));
+}
+
+/**
+ * Undo a partially completed populate, taking the reference with it.
+ *
+ * Everything the populate committed goes in one transaction, so the cleanup is
+ * atomic and every delete is scoped to the reference's own primary key. The
+ * reference row goes last, and it does go: a clone that failed has nothing a
+ * user could retry, so Python removes it from the list rather than leaving a
+ * half-populated one behind, and the two runners must not disagree about that
+ * while both are live.
+ */
+async function rollbackPopulatedReference(
+	db: Db,
+	referenceId: number,
+): Promise<void> {
+	await db.transaction(async (tx) => {
+		await clearReferenceContents(tx, referenceId);
+
+		await tx
+			.delete(legacyReferenceUsers)
+			.where(eq(legacyReferenceUsers.reference_id, referenceId));
+
+		await tx
+			.delete(legacyReferenceGroups)
+			.where(eq(legacyReferenceGroups.reference_id, referenceId));
+
+		await tx
+			.delete(legacyReferences)
+			.where(eq(legacyReferences.id, referenceId));
+	});
+}
+
+async function readReferenceCreatedAt(
+	db: Db,
+	referenceId: number,
+): Promise<Date> {
+	const [row] = await db
+		.select({ createdAt: legacyReferences.created_at })
+		.from(legacyReferences)
+		.where(eq(legacyReferences.id, referenceId))
+		.limit(1);
+
+	if (row === undefined) {
+		throw new ReferenceNotFoundError("Reference does not exist");
+	}
+
+	return row.createdAt;
+}
+
+/**
+ * Fill a newly created reference with the OTUs of the one it was cloned from.
+ *
+ * Every OTU in the manifest is reconstructed at the version the manifest pins
+ * it to, given fresh ids, and written with the history row that records its
+ * creation. The reference's own `created_at` stamps every OTU, matching Python.
+ *
+ * Work runs a chunk at a time — patch, prepare, commit — so peak memory is
+ * bounded by the chunk rather than by the size of the reference, and the event
+ * loop is yielded between chunks so the runner's heartbeat survives a large one.
+ *
+ * It is idempotent, as a reclaimed task requires. A re-run clears whatever a
+ * previous attempt committed before writing anything, because the ids are freshly
+ * minted every time and nothing would otherwise stop a second complete set of
+ * OTUs landing beside the first.
+ *
+ * Any failure rolls the whole reference back — its rows and the reference itself
+ * — and rethrows. An abort does not: the process is going away, the task will be
+ * released and re-run from step zero, and destroying a user's reference because
+ * a pod restarted is not a cleanup.
+ */
+export async function populateClonedReference(
+	db: Db,
+	logger: Logger,
+	values: PopulateClonedReferenceValues,
+	onProgress?: (percent: number) => Promise<void>,
+	signal?: AbortSignal,
+): Promise<void> {
+	const { manifest, referenceId, userId, chunkSize = OTU_CHUNK_SIZE } = values;
+
+	const createdAt = await readReferenceCreatedAt(db, referenceId);
+
+	const specifiers = Object.entries(manifest).map(([otuId, version]) => ({
+		otuId,
+		version,
+	}));
+
+	const count = specifiers.length;
+
+	/* Python gives the insert a thirtieth of the bar for every ten OTUs patched,
+	   so patching runs to 1/1.3 of it and inserting covers the rest. The split is
+	   reproduced rather than rounded off because the two runners' progress is
+	   compared during the cutover. */
+	const headroom = Math.floor(count * 0.3);
+	const total = count + headroom;
+
+	let patched = 0;
+	let inserted = 0;
+
+	async function report(): Promise<void> {
+		if (total === 0) {
+			await onProgress?.(100);
+
+			return;
+		}
+
+		const done = patched + (headroom * inserted) / count;
+
+		await onProgress?.((done / total) * 100);
+	}
+
+	await db.transaction((tx) => clearReferenceContents(tx, referenceId));
+
+	try {
+		for (const slice of chunked(specifiers, chunkSize)) {
+			signal?.throwIfAborted();
+
+			const documents = await patchOtusToVersions(db, slice);
+
+			const insertions = slice.map(({ otuId, version }) => {
+				const document = documents.get(otuSpecifierKey(otuId, version));
+
+				if (!document) {
+					throw new ReferenceManifestError(
+						`OTU ${otuId} could not be patched to version ${version}`,
+					);
+				}
+
+				return prepareOtuInsertion(
+					createdAt,
+					"clone",
+					document,
+					referenceId,
+					userId,
+				);
+			});
+
+			patched += slice.length;
+
+			await report();
+
+			/* Preparing a chunk is a long synchronous stretch — a deep copy and a
+			   reshape of every document in it — and the runner's heartbeat is a
+			   timer. Without a macrotask boundary here a large reference starves it
+			   and the task is reclaimed out from under itself. */
+			await setImmediate();
+
+			await insertPreparedOtus(db, referenceId, insertions);
+
+			inserted += slice.length;
+
+			await report();
+		}
+	} catch (err) {
+		if (signal?.aborted) {
+			throw err;
+		}
+
+		/* The task id is not this layer's to know; `runTask` logs the failure with
+		   it, and this line carries the reference the rollback is about to take. */
+		logger.error(
+			{ err, reference_id: referenceId },
+			"failed to populate a cloned reference; rolling it back",
+		);
+
+		await rollbackPopulatedReference(db, referenceId);
+
+		throw err;
+	}
+
+	await onProgress?.(100);
+
+	await emit("references", referenceId, "update");
+}


### PR DESCRIPTION
## Summary

- Adds `populateClonedReference` (`@virtool/data/references/populate`) and the `clone_reference` body that calls it, registered under the runner. The module is the port of Python's `alot.py` and `populate_insert_only_reference` as well as the clone driver on top of them, so `import_reference` (VIR-2898) stands on the same layer. It sits beside `references/data.ts` rather than in it — everything it does reads OTUs and writes history, and `otus/data.ts` already imports this domain's errors, so folding it in would close that arrow into a cycle.
- **A failure deletes the reference** — diffs, history, sequences, OTUs, membership rows and the `legacy_references` row, in one transaction, before the error is rethrown. That is Python's `_rollback_insert_only_reference`, and both runners are live until the cutover, so the two must not disagree about what a failed clone leaves behind. An **abort** is the exception and rolls back nothing: the process is going away, the task will be released and re-run, and destroying a user's reference because a pod restarted is not a cleanup. A re-run therefore clears before it writes — ids are minted fresh on every attempt, so a reclaimed run would otherwise land a second complete set of OTUs beside the first, silently, since neither set is malformed.
- Two departures from the issue's stated contract: the signature is `(db, logger, values, onProgress?, signal?)` — the shape `generateTaskIndex` already takes — because the issue also asks for an `error` log before the rollback and AGENTS requires a body to forward its `signal`; and ids keep the mixed-case 62-character alphabet every id written from this side uses, where Python's `random_alphanumeric` defaults to lowercase-only 36. Nothing keys on the case, and the wider alphabet is the safer of the two against the collision neither side checks for.