### PR TITLE
fix: open HMM annotations linked from older NuVs analyses

### DIFF
--- a/apps/web/src/hmm/components/HmmDetail.tsx
+++ b/apps/web/src/hmm/components/HmmDetail.tsx
@@ -20,9 +20,18 @@ const routeApi = getRouteApi("/_authenticated/hmms/$hmmId");
  */
 export default function HmmDetail() {
 	const { hmmId } = routeApi.useParams();
-	const { data, isPending, isError } = useFetchHmm(Number(hmmId));
+	const id = Number(hmmId);
 
-	if (isError) {
+	/*
+	 * The path segment is whatever the URL carried, so it need not be a row id
+	 * at all. Fetching on a `NaN` reaches the server function's validator, which
+	 * rejects it as an unhandled 500 rather than the not-found this is.
+	 */
+	const isRowId = Number.isSafeInteger(id) && id > 0;
+
+	const { data, isPending, isError } = useFetchHmm(id, isRowId);
+
+	if (!isRowId || isError) {
 		return <NotFound />;
 	}
 

--- a/apps/web/src/hmm/components/HmmDetail.tsx
+++ b/apps/web/src/hmm/components/HmmDetail.tsx
@@ -15,23 +15,10 @@ import { HmmTaxonomy } from "./HmmTaxonomy";
 
 const routeApi = getRouteApi("/_authenticated/hmms/$hmmId");
 
-/**
- * The HMM detailed view
- */
-export default function HmmDetail() {
-	const { hmmId } = routeApi.useParams();
-	const id = Number(hmmId);
+function HmmDetailView({ hmmId }: { hmmId: number }) {
+	const { data, isPending, isError } = useFetchHmm(hmmId);
 
-	/*
-	 * The path segment is whatever the URL carried, so it need not be a row id
-	 * at all. Fetching on a `NaN` reaches the server function's validator, which
-	 * rejects it as an unhandled 500 rather than the not-found this is.
-	 */
-	const isRowId = Number.isSafeInteger(id) && id > 0;
-
-	const { data, isPending, isError } = useFetchHmm(id, isRowId);
-
-	if (!isRowId || isError) {
+	if (isError) {
 		return <NotFound />;
 	}
 
@@ -138,4 +125,23 @@ export default function HmmDetail() {
 			</section>
 		</div>
 	);
+}
+
+/**
+ * The HMM detailed view
+ */
+export default function HmmDetail() {
+	const { hmmId } = routeApi.useParams();
+	const id = Number(hmmId);
+
+	/*
+	 * The path segment is whatever the URL carried, so it need not be a row id
+	 * at all. Fetching on a `NaN` reaches the server function's validator, which
+	 * rejects it as an unhandled 500 rather than the not-found this is.
+	 */
+	if (!Number.isSafeInteger(id) || id < 1) {
+		return <NotFound />;
+	}
+
+	return <HmmDetailView hmmId={id} />;
 }

--- a/apps/web/src/hmm/components/__tests__/HmmDetail.test.tsx
+++ b/apps/web/src/hmm/components/__tests__/HmmDetail.test.tsx
@@ -21,6 +21,13 @@ describe("<HmmDetail />", () => {
 			expect(screen.getByText("Not found")).toBeInTheDocument();
 		});
 
+		it("should render not found when the path carries a non-numeric id", async () => {
+			await renderRoute("/hmms/abc123");
+
+			expect(await screen.findByText("404")).toBeInTheDocument();
+			expect(screen.getByText("Not found")).toBeInTheDocument();
+		});
+
 		it("should render loading when props.detail = null", async () => {
 			await renderRoute(path);
 

--- a/apps/web/src/hmm/components/__tests__/HmmDetail.test.tsx
+++ b/apps/web/src/hmm/components/__tests__/HmmDetail.test.tsx
@@ -21,12 +21,20 @@ describe("<HmmDetail />", () => {
 			expect(screen.getByText("Not found")).toBeInTheDocument();
 		});
 
-		it("should render not found when the path carries a non-numeric id", async () => {
-			await renderRoute("/hmms/abc123");
+		it.each([
+			["a legacy Mongo id", "abc123"],
+			["zero", "0"],
+			["a negative id", "-1"],
+			["an id beyond the safe integer range", "9007199254740993"],
+		])(
+			"should render not found when the path carries %s",
+			async (_label, segment) => {
+				await renderRoute(`/hmms/${segment}`);
 
-			expect(await screen.findByText("404")).toBeInTheDocument();
-			expect(screen.getByText("Not found")).toBeInTheDocument();
-		});
+				expect(await screen.findByText("404")).toBeInTheDocument();
+				expect(screen.getByText("Not found")).toBeInTheDocument();
+			},
+		);
 
 		it("should render loading when props.detail = null", async () => {
 			await renderRoute(path);

--- a/apps/web/src/hmm/queries.ts
+++ b/apps/web/src/hmm/queries.ts
@@ -55,12 +55,14 @@ export function useSuspenseHmms(page: number, perPage: number, term?: string) {
  * Fetches a single HMM
  *
  * @param hmmId - The id of the hmm to fetch
+ * @param enabled - Whether to fetch at all
  * @returns A single HMM
  */
-export function useFetchHmm(hmmId: number) {
+export function useFetchHmm(hmmId: number, enabled = true) {
 	return useQuery({
 		queryKey: hmmQueryKeys.detail(hmmId),
 		queryFn: () => getHmmFn({ data: { hmmId } }),
+		enabled,
 	});
 }
 

--- a/apps/web/src/hmm/queries.ts
+++ b/apps/web/src/hmm/queries.ts
@@ -55,14 +55,12 @@ export function useSuspenseHmms(page: number, perPage: number, term?: string) {
  * Fetches a single HMM
  *
  * @param hmmId - The id of the hmm to fetch
- * @param enabled - Whether to fetch at all
  * @returns A single HMM
  */
-export function useFetchHmm(hmmId: number, enabled = true) {
+export function useFetchHmm(hmmId: number) {
 	return useQuery({
 		queryKey: hmmQueryKeys.detail(hmmId),
 		queryFn: () => getHmmFn({ data: { hmmId } }),
-		enabled,
 	});
 }
 

--- a/packages/contracts/src/nuvs.ts
+++ b/packages/contracts/src/nuvs.ts
@@ -64,7 +64,11 @@ export type NuvsOrfHit = {
 	full_e: number;
 	full_score: number;
 
-	/** The id of the matched annotation */
+	/**
+	 * The row id of the matched annotation, resolved by the formatter from
+	 * whatever id the stored blob names it by — which for an analysis predating
+	 * the Postgres migration is a legacy Mongo string
+	 */
 	hit: number;
 
 	/** The annotation's names, merged in from the annotation */

--- a/packages/data/src/analyses/format.test.ts
+++ b/packages/data/src/analyses/format.test.ts
@@ -117,7 +117,7 @@ describe("formatAnalysis for nuvs", () => {
 	});
 
 	it("resolves an annotation by its legacy Mongo string id", async () => {
-		await seedHmm({
+		const hmmId = await seedHmm({
 			cluster: 7,
 			families: { Virgaviridae: 2 },
 			legacyId: "abc123",
@@ -126,8 +126,10 @@ describe("formatAnalysis for nuvs", () => {
 
 		const results = await formatAnalysis(db, "nuvs", nuvsResults("abc123"));
 
+		// The published `hit` is the row id, not the legacy string the blob
+		// stores, because the client links an annotated ORF to `/hmms/{hit}`.
 		expect(firstOrfHit(results)).toMatchObject({
-			hit: "abc123",
+			hit: hmmId,
 			cluster: 7,
 			names: ["Movement protein"],
 		});
@@ -166,7 +168,7 @@ describe("formatAnalysis for nuvs", () => {
 	it("resolves a legacy Mongo string id made only of digits", async () => {
 		// A Mongo id is alphanumeric, so it can come out all digits and be
 		// indistinguishable from a modern integer id.
-		await seedHmm({
+		const hmmId = await seedHmm({
 			cluster: 9,
 			families: {},
 			legacyId: "80412357",
@@ -176,7 +178,7 @@ describe("formatAnalysis for nuvs", () => {
 		const results = await formatAnalysis(db, "nuvs", nuvsResults("80412357"));
 
 		expect(firstOrfHit(results)).toMatchObject({
-			hit: "80412357",
+			hit: hmmId,
 			cluster: 9,
 			names: ["All digits"],
 		});

--- a/packages/data/src/analyses/format.ts
+++ b/packages/data/src/analyses/format.ts
@@ -563,8 +563,19 @@ async function annotateNuvsOrfs(
 
 	const annotations = new Map<string, Record<string, unknown>>();
 
+	/*
+	 * `hit` is rewritten to the row id rather than passed through. The stored
+	 * value may be a legacy Mongo string, and the client links an annotated ORF
+	 * to `/hmms/{hit}`, which addresses a row by its integer id — so a string
+	 * reaching the client sends it to a route that cannot resolve.
+	 */
 	function annotationOf(row: (typeof rows)[number]) {
-		return { cluster: row.cluster, families: row.families, names: row.names };
+		return {
+			cluster: row.cluster,
+			families: row.families,
+			hit: row.id,
+			names: row.names,
+		};
 	}
 
 	// Legacy ids are keyed first so that an all-digit one cannot shadow the


### PR DESCRIPTION
## Summary

- A NuVs analysis predating the Postgres migration references its HMM annotations by their legacy Mongo string id. `annotateNuvsOrfs` resolved those correctly but passed `hit` through verbatim, so the client received a string where `NuvsOrfHit.hit` is typed `number` — the ORF label linked to `/hmms/{mongoId}`, `HmmDetail` coerced it to `NaN`, and `getHmmFn`'s validator rejected it as an unhandled 500 (VIR-2955).
- The formatter now publishes the resolved row id as `hit`. It already has the row in hand, so this costs nothing and makes the contract's declared type true rather than aspirational. Two tests pinned the old passthrough and are updated.
- `HmmDetail` also stops fetching on a path segment that is not a row id, rendering not-found instead of reporting an incident for what is plainly a bad URL.