### PR TITLE
chore: port the import_reference task body

### DIFF
--- a/apps/tasks/package.json
+++ b/apps/tasks/package.json
@@ -20,6 +20,7 @@
 		"@virtool/logger": "workspace:*",
 		"@virtool/sentry": "workspace:*",
 		"@virtool/service": "workspace:*",
+		"@virtool/sqlite": "workspace:*",
 		"@virtool/storage": "workspace:*",
 		"pino": "^10.1.0",
 		"postgres": "^3.4.9",

--- a/apps/tasks/src/tasks/import-reference.test.ts
+++ b/apps/tasks/src/tasks/import-reference.test.ts
@@ -1,0 +1,454 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+import { seedUser } from "@virtool/data/auth/test/fixtures";
+import type { Db } from "@virtool/data/db/pg";
+import {
+	legacyHistory,
+	legacyHistoryDiff,
+} from "@virtool/data/db/schema/history";
+import { legacyOtus, legacySequences } from "@virtool/data/db/schema/otus";
+import {
+	legacyReferences,
+	legacyReferenceUsers,
+} from "@virtool/data/db/schema/references";
+import { tasks } from "@virtool/data/db/schema/tasks";
+import { uploads } from "@virtool/data/db/schema/uploads";
+import { users } from "@virtool/data/db/schema/users";
+import {
+	createTestDatabase,
+	type TestDatabase,
+} from "@virtool/data/db/test/fixtures";
+import type { ClaimedTask } from "@virtool/data/tasks/data";
+import { createLogger, type Logger } from "@virtool/logger";
+import { createIndexArtifact } from "@virtool/sqlite";
+import { MemoryStorage } from "@virtool/storage";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { runTask } from "../framework/run";
+import { acquireOrThrow, readTaskRow, seedTaskRow } from "../testing/tasks";
+import { importReferenceTask } from "./import-reference";
+import type { TaskContext } from "./registry";
+
+const logger: Logger = createLogger({ name: "test", level: "silent" });
+
+const NAME_ON_DISK = "8f3c-reference.json.gz";
+
+const STORAGE_KEY = "uploads/deadbeef";
+
+let database: TestDatabase;
+let db: Db;
+let storage: MemoryStorage;
+let ctx: TaskContext;
+let userId: number;
+let referenceId: number;
+
+beforeAll(async () => {
+	database = await createTestDatabase();
+	db = database.db;
+}, 60_000);
+
+afterAll(async () => {
+	await database.drop();
+});
+
+beforeEach(async () => {
+	await db.delete(legacyHistoryDiff);
+	await db.delete(legacyHistory);
+	await db.delete(legacySequences);
+	await db.delete(legacyOtus);
+	await db.delete(legacyReferenceUsers);
+	await db.delete(legacyReferences);
+	await db.delete(tasks);
+	await db.delete(uploads);
+	await db.delete(users);
+
+	storage = new MemoryStorage();
+	ctx = { db, storage };
+
+	userId = await seedUser(db, { handle: "curator" });
+	referenceId = await seedReference(userId);
+});
+
+async function seedReference(owner: number): Promise<number> {
+	const [row] = await db
+		.insert(legacyReferences)
+		.values({
+			name: "Imported",
+			description: "",
+			organism: "",
+			created_at: new Date("2021-06-01T00:00:00.000Z"),
+			archived: false,
+			restrict_source_types: false,
+			source_types: [],
+			user_id: owner,
+		})
+		.returning({ id: legacyReferences.id });
+
+	if (row === undefined) {
+		throw new Error("failed to seed a reference");
+	}
+
+	return row.id;
+}
+
+async function seedUpload(nameOnDisk: string): Promise<void> {
+	await db.insert(uploads).values({
+		name: "reference.json.gz",
+		nameOnDisk,
+		ready: true,
+		removed: false,
+		reserved: false,
+		storageKey: STORAGE_KEY,
+		type: "reference",
+		userId,
+	});
+}
+
+async function* once(bytes: Uint8Array): AsyncIterable<Uint8Array> {
+	yield bytes;
+}
+
+function sourceOtu(overrides: Record<string, unknown> = {}) {
+	return {
+		_id: "otu_source",
+		abbreviation: "ABTV",
+		name: "Abaca bunchy top virus",
+		isolates: [
+			{
+				id: "iso_a",
+				default: true,
+				source_type: "isolate",
+				source_name: "A1",
+				sequences: [
+					{
+						_id: "seq_a1",
+						accession: "NC_010315",
+						definition: "Abaca bunchy top virus DNA A",
+						sequence: "CCCCAAAATT",
+					},
+				],
+			},
+		],
+		...overrides,
+	};
+}
+
+function sourceData(otus: unknown[] = [sourceOtu()]) {
+	return { data_type: "genome", organism: "virus", otus };
+}
+
+async function seedGzippedUpload(
+	data: unknown,
+	nameOnDisk = NAME_ON_DISK,
+): Promise<void> {
+	await seedUpload(nameOnDisk);
+	await storage.write(
+		STORAGE_KEY,
+		once(gzipSync(Buffer.from(JSON.stringify(data), "utf8"))),
+	);
+}
+
+async function claim(nameOnDisk = NAME_ON_DISK): Promise<ClaimedTask> {
+	await seedTaskRow(db, importReferenceTask.type, {
+		name_on_disk: nameOnDisk,
+		ref_id: referenceId,
+		user_id: userId,
+	});
+
+	return acquireOrThrow(db, importReferenceTask.type);
+}
+
+function run(task: ClaimedTask, signal = new AbortController().signal) {
+	return runTask({ db, def: importReferenceTask, task, ctx, logger, signal });
+}
+
+describe("import_reference", () => {
+	it("imports a gzipped JSON reference", async () => {
+		await seedGzippedUpload(sourceData());
+
+		const task = await claim();
+
+		expect(await run(task)).toEqual({ status: "completed" });
+
+		expect(await readTaskRow(db, task.id)).toMatchObject({
+			complete: true,
+			error: null,
+			progress: 100,
+			step: "import_reference",
+		});
+
+		const otuRows = await db
+			.select()
+			.from(legacyOtus)
+			.where(eq(legacyOtus.reference_id, referenceId));
+
+		expect(otuRows).toHaveLength(1);
+
+		const otu = otuRows[0];
+
+		expect(otu?.name).toBe("Abaca bunchy top virus");
+		expect(otu?.version).toBe(0);
+
+		// A fresh id is minted and the source id is kept on `remote`, so a
+		// re-import never collides with what a previous one wrote.
+		expect(otu?.id).not.toBe("otu_source");
+		expect(otu?.data).toMatchObject({
+			imported: true,
+			remote: { id: "otu_source" },
+			version: 0,
+		});
+	});
+
+	it("updates the reference's organism from the file", async () => {
+		await seedGzippedUpload(sourceData());
+
+		expect(await run(await claim())).toEqual({ status: "completed" });
+
+		const [row] = await db
+			.select({ organism: legacyReferences.organism })
+			.from(legacyReferences)
+			.where(eq(legacyReferences.id, referenceId));
+
+		expect(row?.organism).toBe("virus");
+	});
+
+	it("records one creating history row per OTU", async () => {
+		await seedGzippedUpload(sourceData());
+
+		expect(await run(await claim())).toEqual({ status: "completed" });
+
+		const rows = await db
+			.select()
+			.from(legacyHistory)
+			.where(eq(legacyHistory.reference_id, referenceId));
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			description: "Imported Abaca bunchy top virus (ABTV)",
+			method_name: "import",
+			otu_version: "0",
+		});
+	});
+
+	it("lifts sequences out of their isolates", async () => {
+		await seedGzippedUpload(sourceData());
+
+		expect(await run(await claim())).toEqual({ status: "completed" });
+
+		const sequences = await db.select().from(legacySequences);
+
+		expect(sequences).toHaveLength(1);
+		expect(sequences[0]?.position).toBe(0);
+
+		const [otu] = await db.select().from(legacyOtus);
+
+		if (otu === undefined) {
+			throw new Error("the import wrote no OTU");
+		}
+
+		const { isolates } = otu.data as {
+			isolates: Record<string, unknown>[];
+		};
+
+		expect(isolates[0]).not.toHaveProperty("sequences");
+	});
+
+	it("is idempotent across a re-run", async () => {
+		await seedGzippedUpload(sourceData());
+
+		expect(await run(await claim())).toEqual({ status: "completed" });
+
+		await db.delete(tasks);
+
+		expect(await run(await claim())).toEqual({ status: "completed" });
+
+		expect(await db.select().from(legacyOtus)).toHaveLength(1);
+		expect(await db.select().from(legacySequences)).toHaveLength(1);
+		expect(await db.select().from(legacyHistory)).toHaveLength(1);
+	});
+
+	it("fails without reading storage when the upload is gone", async () => {
+		const task = await claim();
+
+		expect(await run(task)).toMatchObject({
+			status: "failed",
+			error: expect.stringContaining("could not be found"),
+		});
+	});
+
+	it("reports a file that is not gzipped the way Python does", async () => {
+		await seedUpload(NAME_ON_DISK);
+		await storage.write(STORAGE_KEY, once(Buffer.from("not gzip at all")));
+
+		expect(await run(await claim())).toMatchObject({
+			status: "failed",
+			error: expect.stringContaining("Not a gzipped file"),
+		});
+	});
+
+	it("refuses a suffix neither reader understands", async () => {
+		await seedGzippedUpload(sourceData(), "reference.tar.gz");
+
+		expect(await run(await claim("reference.tar.gz"))).toMatchObject({
+			status: "failed",
+			error: expect.stringContaining("Unsupported reference file name"),
+		});
+	});
+
+	it("names the duplicated ids when a file repeats an OTU id", async () => {
+		await seedGzippedUpload(
+			sourceData([
+				sourceOtu(),
+				sourceOtu({
+					name: "Another virus",
+					isolates: sourceOtu({}).isolates.map((isolate) => ({
+						...isolate,
+						id: "iso_b",
+						sequences: [
+							{
+								_id: "seq_b1",
+								accession: "NC_000002",
+								definition: "Another",
+								sequence: "TTTTGGGGCC",
+							},
+						],
+					})),
+				}),
+			]),
+		);
+
+		expect(await run(await claim())).toMatchObject({
+			status: "failed",
+			error: expect.stringContaining("Duplicate OTU ids"),
+		});
+	});
+
+	it("rejects a sequence shorter than ten bases", async () => {
+		await seedGzippedUpload(
+			sourceData([
+				sourceOtu({
+					isolates: [
+						{
+							id: "iso_a",
+							default: true,
+							source_type: "isolate",
+							source_name: "A1",
+							sequences: [
+								{
+									_id: "seq_a1",
+									accession: "NC_010315",
+									definition: "Too short",
+									sequence: "ACGT",
+								},
+							],
+						},
+					],
+				}),
+			]),
+		);
+
+		expect(await run(await claim())).toMatchObject({
+			status: "failed",
+			error: expect.stringContaining("Invalid reference data"),
+		});
+	});
+
+	it("leaves the reference in place when the file is unusable", async () => {
+		await seedUpload(NAME_ON_DISK);
+		await storage.write(STORAGE_KEY, once(Buffer.from("not gzip at all")));
+
+		expect(await run(await claim())).toMatchObject({ status: "failed" });
+
+		expect(
+			await db
+				.select()
+				.from(legacyReferences)
+				.where(eq(legacyReferences.id, referenceId)),
+		).toHaveLength(1);
+	});
+
+	it("imports a .v1.sqlite snapshot", async () => {
+		const nameOnDisk = "8f3c-reference.v1.sqlite";
+		const workPath = await mkdtemp(join(tmpdir(), "vt-import-test-"));
+		const path = join(workPath, "snapshot.v1.sqlite");
+
+		try {
+			await createIndexArtifact(
+				path,
+				{
+					created_at: "2021-06-01T00:00:00.000Z",
+					data_type: "genome",
+					id: "reference_1",
+					name: "Plant Viruses",
+					organism: "virus",
+				},
+				[
+					{
+						abbreviation: "ABTV",
+						id: "otu_source",
+						isolates: [
+							{
+								default: true,
+								id: "iso_a",
+								sequences: [
+									{
+										accession: "NC_010315",
+										definition: "Abaca bunchy top virus DNA A",
+										host: null,
+										id: "seq_a1",
+										segment: null,
+										sequence: "CCCCAAAATT",
+									},
+								],
+								source_name: "A1",
+								source_type: "isolate",
+							},
+						],
+						name: "Abaca bunchy top virus",
+						schema: [],
+						taxid: null,
+						version: 0,
+					},
+				],
+			);
+
+			await seedUpload(nameOnDisk);
+			await storage.write(STORAGE_KEY, once(await readFile(path)));
+		} finally {
+			await rm(workPath, { force: true, recursive: true });
+		}
+
+		expect(await run(await claim(nameOnDisk))).toEqual({ status: "completed" });
+
+		const otuRows = await db
+			.select()
+			.from(legacyOtus)
+			.where(eq(legacyOtus.reference_id, referenceId));
+
+		expect(otuRows).toHaveLength(1);
+		expect(otuRows[0]?.name).toBe("Abaca bunchy top virus");
+
+		// The snapshot reader yields `id` where the JSON export writes `_id`;
+		// both must reach the populate as the same document.
+		expect(otuRows[0]?.data).toMatchObject({
+			imported: true,
+			remote: { id: "otu_source" },
+		});
+
+		expect(await db.select().from(legacySequences)).toHaveLength(1);
+	});
+
+	it("fails a payload the schema rejects", async () => {
+		await seedTaskRow(db, importReferenceTask.type, {
+			name_on_disk: "",
+			ref_id: referenceId,
+			user_id: userId,
+		});
+
+		const task = await acquireOrThrow(db, importReferenceTask.type);
+
+		expect(await run(task)).toMatchObject({ status: "failed" });
+	});
+});

--- a/apps/tasks/src/tasks/import-reference.test.ts
+++ b/apps/tasks/src/tasks/import-reference.test.ts
@@ -440,6 +440,45 @@ describe("import_reference", () => {
 		expect(await db.select().from(legacySequences)).toHaveLength(1);
 	});
 
+	it("reports an abort during the read as aborted, not failed", async () => {
+		await seedGzippedUpload(sourceData());
+
+		const controller = new AbortController();
+		const task = await claim();
+
+		controller.abort();
+
+		// An abort is the process going away, so the task is released rather
+		// than failed against a file that is perfectly good.
+		expect(await run(task, controller.signal)).toEqual({ status: "aborted" });
+
+		expect(await readTaskRow(db, task.id)).toMatchObject({
+			complete: false,
+			error: null,
+		});
+	});
+
+	it("surfaces a storage failure instead of hanging on the gunzip stream", async () => {
+		await seedUpload(NAME_ON_DISK);
+
+		// `.pipe()` would leave the consumer waiting on a gunzip stream nothing
+		// ends; the source's rejection has to reach it.
+		storage.read = () => {
+			async function* fail(): AsyncIterable<Uint8Array> {
+				yield gzipSync(Buffer.from("{"));
+
+				throw new Error("storage went away mid-download");
+			}
+
+			return fail();
+		};
+
+		expect(await run(await claim())).toMatchObject({
+			status: "failed",
+			error: expect.stringContaining("storage went away mid-download"),
+		});
+	});
+
 	it("fails a payload the schema rejects", async () => {
 		await seedTaskRow(db, importReferenceTask.type, {
 			name_on_disk: "",

--- a/apps/tasks/src/tasks/import-reference.ts
+++ b/apps/tasks/src/tasks/import-reference.ts
@@ -149,30 +149,36 @@ async function readGzippedJson(
 	key: string,
 	signal: AbortSignal,
 ): Promise<unknown> {
-	const stream = Readable.from(storage.read(key), { signal }).pipe(
-		createGunzip(),
-	);
-
 	const chunks: Buffer[] = [];
 
 	let inflated = 0;
 
 	try {
-		for await (const chunk of stream) {
-			inflated += chunk.length;
+		/* Assembled with `pipeline` rather than `.pipe()`. A source that rejects
+		   part-way — storage failing mid-download, or the signal aborting — does
+		   not reach a `.pipe()`d destination, so the consumer would wait on a
+		   gunzip stream nothing is going to end and the source's error would go
+		   unhandled. `pipeline` destroys every stage with it and rethrows here. */
+		await pipeline(
+			Readable.from(storage.read(key)),
+			createGunzip(),
+			async (source: AsyncIterable<Buffer>) => {
+				for await (const chunk of source) {
+					inflated += chunk.length;
 
-			if (inflated > MAX_INFLATED_BYTES) {
-				stream.destroy();
+					if (inflated > MAX_INFLATED_BYTES) {
+						throw new ReferenceImportError(
+							`Reference file exceeds the ${MAX_INFLATED_BYTES / (1024 * 1024)} MB decompressed limit`,
+						);
+					}
 
-				throw new ReferenceImportError(
-					`Reference file exceeds the ${MAX_INFLATED_BYTES / (1024 * 1024)} MB decompressed limit`,
-				);
-			}
-
-			chunks.push(chunk);
-		}
+					chunks.push(chunk);
+				}
+			},
+			{ signal },
+		);
 	} catch (err) {
-		throw describeDecompressionFailure(err);
+		throw describeDecompressionFailure(err, signal);
 	}
 
 	try {
@@ -200,10 +206,9 @@ async function readSqliteSnapshot(
 	const path = join(workPath, "reference-snapshot.v1.sqlite");
 
 	try {
-		await pipeline(
-			Readable.from(storage.read(key), { signal }),
-			createWriteStream(path),
-		);
+		await pipeline(Readable.from(storage.read(key)), createWriteStream(path), {
+			signal,
+		});
 
 		const snapshot = openWorkflowIndex({ id: referenceId, path });
 
@@ -232,14 +237,27 @@ async function readSqliteSnapshot(
 }
 
 /**
- * Name a decompression failure the way Python's caller does.
+ * Name a decompression failure the way Python's caller does, leaving an abort
+ * alone.
  *
  * Python matches `"Not a gzipped file"` out of the text `zlib` raises; Node's
  * message for the same condition is `incorrect header check`, so the check is
  * on the condition rather than on the wording, and the string is reproduced so
  * both runners put the same sentence in front of a user.
  */
-function describeDecompressionFailure(err: unknown): Error {
+function describeDecompressionFailure(
+	err: unknown,
+	signal: AbortSignal,
+): Error {
+	/* An abort is the process going away, not a bad upload, and it is returned
+	   untranslated so `runTask` reports `aborted` and the task is released for
+	   another runner to re-run from step zero. Calling it a decompression
+	   failure would fail the task and record an error against a file that is
+	   perfectly good. */
+	if (signal.aborted || (err instanceof Error && err.name === "AbortError")) {
+		return err instanceof Error ? err : new Error(String(err));
+	}
+
 	if (err instanceof ReferenceImportError) {
 		return err;
 	}

--- a/apps/tasks/src/tasks/import-reference.ts
+++ b/apps/tasks/src/tasks/import-reference.ts
@@ -1,0 +1,282 @@
+import { createWriteStream } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { createGunzip } from "node:zlib";
+import {
+	type ReferenceSourceData,
+	ReferenceSourceDataSchema,
+} from "@virtool/contracts";
+import { populateImportedReference } from "@virtool/data/references/populate";
+import { getUploadFileByNameOnDisk } from "@virtool/data/uploads/data";
+import { openWorkflowIndex } from "@virtool/sqlite";
+import type { StorageBackend } from "@virtool/storage";
+import { z } from "zod";
+import { defineTask } from "../framework/define";
+import type { TaskContext } from "./registry";
+
+/**
+ * `import_reference` carries the upload it is to read and the reference it is
+ * to fill.
+ *
+ * `name_on_disk` rather than the upload's id, because that is what
+ * `createReference` writes onto the context and what Python's task reads. It
+ * does not locate the object — the storage key is resolved from the row.
+ */
+const payload = z.object({
+	name_on_disk: z.string().min(1),
+	ref_id: z.number().int().positive(),
+	user_id: z.number().int().positive(),
+});
+
+/**
+ * The most decompressed bytes an uploaded JSON reference may expand to.
+ *
+ * The file is parsed with `JSON.parse`, so the whole document is held as one
+ * string and then again as objects — peak resident memory runs three to five
+ * times the decompressed size. 512 MiB therefore needs a runner with a couple
+ * of gigabytes, which the pod has, while still refusing a gzip bomb long before
+ * V8 raises `ERR_STRING_TOO_LONG` and buries the real cause.
+ *
+ * Measured against a real export: 6.15 MB gzipped inflates to 24.9 MB, so this
+ * is roughly twenty times the largest reference seen in production.
+ */
+const MAX_INFLATED_BYTES = 512 * 1024 * 1024;
+
+const JSON_SUFFIX = ".json.gz";
+
+const SQLITE_SUFFIX = ".v1.sqlite";
+
+/** Thrown when an upload cannot be read as the reference it claims to be. */
+class ReferenceImportError extends Error {
+	constructor(message: string, options?: ErrorOptions) {
+		super(message, options);
+		this.name = "ReferenceImportError";
+	}
+}
+
+export const importReferenceTask = defineTask<typeof payload, TaskContext>({
+	type: "import_reference",
+	payload,
+	// Python names its step after the bound method it runs, `BaseTask.run`
+	// writing `func.__name__` into the column. Both runners write
+	// `import_reference` for the same work until the cutover completes.
+	steps: ["import_reference"],
+	async run({ ctx, helpers, payload, signal }) {
+		await helpers.runStep("import_reference", async (report) => {
+			const upload = await getUploadFileByNameOnDisk(
+				ctx.db,
+				payload.name_on_disk,
+			);
+
+			if (upload === null) {
+				throw new ReferenceImportError(
+					"The uploaded reference file could not be found",
+				);
+			}
+
+			const data = await loadSourceData(
+				ctx.storage,
+				upload.key,
+				payload.name_on_disk,
+				payload.ref_id,
+				signal,
+			);
+
+			await populateImportedReference(
+				ctx.db,
+				{
+					data,
+					referenceId: payload.ref_id,
+					userId: payload.user_id,
+				},
+				async (percent) => {
+					report(percent / 100);
+				},
+				signal,
+			);
+		});
+	},
+});
+
+/**
+ * Read and validate the upload, dispatching on the suffix as Python does.
+ *
+ * The suffix is the only thing that distinguishes the two formats — an upload
+ * has no recorded content type — and an unrecognised one is refused rather than
+ * guessed at, because opening a JSON export as SQLite fails with a message
+ * about a corrupt database.
+ */
+async function loadSourceData(
+	storage: StorageBackend,
+	key: string,
+	nameOnDisk: string,
+	referenceId: number,
+	signal: AbortSignal,
+): Promise<ReferenceSourceData> {
+	let raw: unknown;
+
+	if (nameOnDisk.endsWith(JSON_SUFFIX)) {
+		raw = await readGzippedJson(storage, key, signal);
+	} else if (nameOnDisk.endsWith(SQLITE_SUFFIX)) {
+		raw = await readSqliteSnapshot(storage, key, referenceId, signal);
+	} else {
+		throw new ReferenceImportError(
+			`Unsupported reference file name; expected a ${JSON_SUFFIX} or ${SQLITE_SUFFIX} suffix`,
+		);
+	}
+
+	const parsed = ReferenceSourceDataSchema.safeParse(raw);
+
+	if (!parsed.success) {
+		throw new ReferenceImportError(describeInvalidData(parsed.error));
+	}
+
+	return parsed.data;
+}
+
+/**
+ * Inflate the upload and parse it, refusing anything past the size cap.
+ *
+ * The count is of bytes leaving the gunzip stream, never `storage.size`, which
+ * reports the compressed figure and so says nothing about what the file expands
+ * to.
+ */
+async function readGzippedJson(
+	storage: StorageBackend,
+	key: string,
+	signal: AbortSignal,
+): Promise<unknown> {
+	const stream = Readable.from(storage.read(key), { signal }).pipe(
+		createGunzip(),
+	);
+
+	const chunks: Buffer[] = [];
+
+	let inflated = 0;
+
+	try {
+		for await (const chunk of stream) {
+			inflated += chunk.length;
+
+			if (inflated > MAX_INFLATED_BYTES) {
+				stream.destroy();
+
+				throw new ReferenceImportError(
+					`Reference file exceeds the ${MAX_INFLATED_BYTES / (1024 * 1024)} MB decompressed limit`,
+				);
+			}
+
+			chunks.push(chunk);
+		}
+	} catch (err) {
+		throw describeDecompressionFailure(err);
+	}
+
+	try {
+		return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+	} catch (err) {
+		throw new ReferenceImportError((err as Error).message, { cause: err });
+	}
+}
+
+/**
+ * Spool the upload to disk and read it as a reference snapshot.
+ *
+ * `node:sqlite` opens a path and has no streaming reader, so the object has to
+ * land on the filesystem first. The OTUs are collected rather than streamed
+ * because the duplicate checks span the whole file and the populate needs a
+ * count before it can report progress.
+ */
+async function readSqliteSnapshot(
+	storage: StorageBackend,
+	key: string,
+	referenceId: number,
+	signal: AbortSignal,
+): Promise<unknown> {
+	const workPath = await mkdtemp(join(tmpdir(), "vt-import-reference-"));
+	const path = join(workPath, "reference-snapshot.v1.sqlite");
+
+	try {
+		await pipeline(
+			Readable.from(storage.read(key), { signal }),
+			createWriteStream(path),
+		);
+
+		const snapshot = openWorkflowIndex({ id: referenceId, path });
+
+		try {
+			const metadata = await snapshot.getReferenceMetadata();
+
+			const otus = [];
+
+			for await (const otu of snapshot.iterOtus()) {
+				signal.throwIfAborted();
+
+				otus.push(otu);
+			}
+
+			return {
+				data_type: metadata.data_type,
+				organism: metadata.organism,
+				otus,
+			};
+		} finally {
+			snapshot.close();
+		}
+	} finally {
+		await rm(workPath, { force: true, recursive: true });
+	}
+}
+
+/**
+ * Name a decompression failure the way Python's caller does.
+ *
+ * Python matches `"Not a gzipped file"` out of the text `zlib` raises; Node's
+ * message for the same condition is `incorrect header check`, so the check is
+ * on the condition rather than on the wording, and the string is reproduced so
+ * both runners put the same sentence in front of a user.
+ */
+function describeDecompressionFailure(err: unknown): Error {
+	if (err instanceof ReferenceImportError) {
+		return err;
+	}
+
+	const message = err instanceof Error ? err.message : String(err);
+
+	if (message.includes("incorrect header check")) {
+		return new ReferenceImportError("Not a gzipped file", { cause: err });
+	}
+
+	return new ReferenceImportError(message, { cause: err });
+}
+
+/** The most schema problems named before the message is truncated. */
+const MAX_REPORTED_ISSUES = 3;
+
+/**
+ * Summarise a validation failure into something a popover can hold.
+ *
+ * `tasks.error` is rendered to the user, and a raw `ZodError` dump over a file
+ * with thousands of OTUs is both unreadable and unbounded. Each problem is
+ * located by its path, which for a source file names the offending OTU by
+ * index.
+ */
+function describeInvalidData(error: z.ZodError): string {
+	const issues = error.issues.map((issue) => {
+		const path = issue.path.join(".");
+
+		return path ? `${path}: ${issue.message}` : issue.message;
+	});
+
+	const shown = issues.slice(0, MAX_REPORTED_ISSUES).join("; ");
+
+	const summary =
+		issues.length > MAX_REPORTED_ISSUES
+			? `${shown} and ${issues.length - MAX_REPORTED_ISSUES} more`
+			: shown;
+
+	return `Invalid reference data: ${summary}`;
+}

--- a/apps/tasks/src/tasks/registry.ts
+++ b/apps/tasks/src/tasks/registry.ts
@@ -5,6 +5,7 @@ import { cleanupSessionsTask } from "./cleanup-sessions";
 import { cloneReferenceTask } from "./clone-reference";
 import { createIndexTask } from "./create-index";
 import { evictCachesLruTask } from "./evict-caches-lru";
+import { importReferenceTask } from "./import-reference";
 import { installHmmsTask } from "./install-hmms";
 import { reapOrphanedUploadsTask } from "./reap-orphaned-uploads";
 import { refreshHmmsTask } from "./refresh-hmms";
@@ -41,6 +42,7 @@ export const taskRegistry: TaskRegistry<TaskContext> = {
 	clone_reference: cloneReferenceTask,
 	create_index: createIndexTask,
 	evict_caches_lru: evictCachesLruTask,
+	import_reference: importReferenceTask,
 	install_hmms: installHmmsTask,
 	reap_orphaned_uploads: reapOrphanedUploadsTask,
 	refresh_hmms: refreshHmmsTask,

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1023,7 +1023,7 @@ a real reference is tens of thousands of them.
 **The work lives beside `references/data.ts`, not in it.** Everything the
 populate does reads OTUs and writes history, and `otus/data.ts` already imports
 this domain's errors, so folding it into `data.ts` would close that arrow into a
-cycle. The module is also the layer `import_reference` (VIR-2898) will stand on:
+cycle. The module is also the layer `import_reference` stands on:
 `prepareOtuInsertion`, the chunked bulk insert and the rollback are the port of
 Python's `alot.py` and `populate_insert_only_reference`, which both tasks share,
 and only the clone-specific driver on top of them is this task's.
@@ -1107,6 +1107,71 @@ document. The diff is composed against the OTU as it will be stored, isolates
 already emptied of their sequences, which is what Python does; a diff taken from
 the joined document would describe a document no row holds. The rows are paired
 to their diffs by `legacy_id` rather than by the order the insert returned.
+
+### `import_reference`, the fifth body
+
+`import_reference` fills a newly created reference with the OTUs of a file the
+user uploaded. Its body is one step, `import_reference` — Python's method name —
+which resolves the upload, parses it, and hands the documents to
+`populateImportedReference` (`@virtool/data/references/populate`). It reports a
+position: the parsed file gives the OTU count up front.
+
+**The body reads the file; the data layer only writes rows.** `install_hmms`
+established this and the import follows it — gzip, SQLite and the two upload
+formats live in `apps/tasks`, and `populateImportedReference` takes an
+already-parsed `ReferenceSourceData`. Pushing the parsing down would put
+`node:sqlite` and a decompression budget inside the package the web server
+imports, for a format only this task reads.
+
+**Two formats, dispatched on the suffix, because Python dispatches on the
+suffix.** A `.json.gz` upload is inflated and `JSON.parse`d; a `.v1.sqlite` one
+is spooled to a temp file and read through `openWorkflowIndex`
+(`@virtool/sqlite`), whose reader and DDL are shared with the workflow index
+artifact. Anything else is refused with Python's sentence rather than guessed
+at — opening a JSON export as SQLite fails with a message about a corrupt
+database, which tells a user nothing.
+
+**An upload is located by `name_on_disk`, and that resolves to a key.**
+`createReference` writes `name_on_disk` onto the task context rather than the
+upload's id, so it is the only handle the task has;
+`getUploadFileByNameOnDisk` turns it into the recorded `storage_key`, filtering
+removed rows exactly as Python's `get_storage_key_by_name_on_disk` does. The
+string does not locate an object and nothing composes a key from it.
+
+**The inflation guard counts decompressed bytes.** `storage.size` reports the
+compressed figure and so says nothing about what a file expands to. The count is
+of bytes leaving the gunzip stream, capped at 512 MiB — twenty times the largest
+reference seen in production, and low enough that a gzip bomb is named as one
+rather than surfacing as `ERR_STRING_TOO_LONG` from a `JSON.parse` that got that
+far.
+
+**Both `_id` and `id` are accepted for an OTU and a sequence.** The JSON export
+spells them `_id`; the SQLite reader yields `id`. Python reconciles the two with
+a pydantic alias plus `allow_population_by_field_name`, and
+`ReferenceSourceDataSchema` (`@virtool/contracts`) reproduces that, normalising
+onto `_id` because the stored document is Mongo-shaped. An isolate's id is
+plain `id` on both sides and needs no alias.
+
+**The four duplicate checks run in one pass, where Python runs four
+validators.** Pydantic stops at the first that raises, so a file with two
+problems is fixed and re-uploaded only to fail on the next; reporting all four
+at once is strictly more useful and changes no predicate. The quirks are
+inherited deliberately — the name check compares case-insensitively but reports
+the name as written, isolate ids collide only within their own OTU, and sequence
+ids collide across the whole file. `data_type` admits `genome` alone, because
+Python's `ReferenceDataType` has one member and the looser side would accept a
+file the other refuses while both runners are live.
+
+**A validation failure is summarised, never dumped.** `tasks.error` is rendered
+into a popover, and a raw `ZodError` over a file with thousands of OTUs is
+unbounded. The message names the first few problems and counts off the rest.
+
+**Nothing is rolled back.** A failed import leaves whatever it committed, and
+the reference with it, as `create_index` and every workflow leave their
+half-built resources. `populateImportedReference` clears the reference's
+contents at the top of every run, which is what makes a reclaimed task's re-run
+from step zero clean, so a rollback would buy nothing the clearing does not
+already give.
 
 ### Frames are the framework's, never a body's
 

--- a/packages/contracts/src/references.ts
+++ b/packages/contracts/src/references.ts
@@ -107,3 +107,193 @@ export const ReferenceUpdateRequest = z.object({
 });
 
 export type ReferenceUpdateRequest = z.infer<typeof ReferenceUpdateRequest>;
+
+/*
+ * The shape of an uploaded reference file, and the port of Python's
+ * `ReferenceSourceData` and the models under it.
+ *
+ * Two upload formats parse to this one shape: a gzipped JSON export, which
+ * spells an OTU's and a sequence's id `_id`, and a `.v1.sqlite` snapshot, whose
+ * reader yields the same documents keyed `id`. Python reconciles the two with a
+ * pydantic alias plus `allow_population_by_field_name`; `withUnderscoreId`
+ * below is that reconciliation, and it normalises onto `_id` because
+ * `prepareOtuInsertion` reads the document Mongo-side.
+ *
+ * Every object is loose. A reference carries keys neither implementation reads
+ * — `schema`, `taxid`, `remote` — and the OTU document is stored verbatim, so
+ * stripping them would silently drop data on the way through.
+ */
+
+/**
+ * Accept an `id` where the schema wants `_id`, as Python's alias does.
+ *
+ * Only fills `_id` in; an object that already has one is untouched, so a
+ * document carrying both keeps whichever the JSON export wrote.
+ */
+function withUnderscoreId(value: unknown): unknown {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return value;
+	}
+
+	const record = value as Record<string, unknown>;
+
+	if ("_id" in record || !("id" in record)) {
+		return value;
+	}
+
+	const { id, ...rest } = record;
+
+	return { _id: id, ...rest };
+}
+
+const referenceSourceSequenceSchema = z.preprocess(
+	withUnderscoreId,
+	z.looseObject({
+		_id: z.string().min(1),
+		accession: z.string().min(1),
+		definition: z.string(),
+		sequence: z.string().min(10),
+	}),
+);
+
+const referenceSourceIsolateSchema = z.looseObject({
+	// No alias here, and none in Python either: both readers spell an isolate's
+	// id `id` already.
+	id: z.string(),
+	default: z.boolean(),
+	source_type: z.string(),
+	source_name: z.string(),
+	sequences: z.array(referenceSourceSequenceSchema).min(1),
+});
+
+const referenceSourceOtuSchema = z.preprocess(
+	withUnderscoreId,
+	z.looseObject({
+		_id: z.string(),
+		abbreviation: z.string().default(""),
+		name: z.string(),
+		isolates: z.array(referenceSourceIsolateSchema).min(1),
+	}),
+);
+
+/** One OTU of an uploaded reference, with its isolates and their sequences. */
+export type ReferenceSourceOtu = z.infer<typeof referenceSourceOtuSchema>;
+
+/**
+ * The most duplicates of one kind named before the message is truncated.
+ *
+ * A file whose ids are all identical would otherwise put one entry per OTU into
+ * `tasks.error`, which is read back into a popover.
+ */
+const MAX_REPORTED_DUPLICATES = 5;
+
+/**
+ * Every duplicate check Python runs, in one pass over the OTUs.
+ *
+ * Python spreads these across four `@validator("otus")` functions, which stop
+ * at the first that raises, so a file with two problems is fixed and
+ * re-uploaded only to fail on the next. Running them together reports all four
+ * at once; the predicates themselves are unchanged, quirks included — the name
+ * check compares case-insensitively but reports the name as written, isolate
+ * ids collide only within their own OTU, and sequence ids collide across the
+ * whole file.
+ */
+function checkForDuplicates(
+	data: { otus: ReferenceSourceOtu[] },
+	ctx: z.RefinementCtx,
+): void {
+	const seenNames = new Set<string>();
+	const duplicateNames = new Set<string>();
+
+	const seenOtuIds = new Set<string>();
+	const duplicateOtuIds = new Set<string>();
+
+	const seenSequenceIds = new Set<string>();
+	const duplicateSequenceIds = new Set<string>();
+
+	const otusWithDuplicateIsolates: string[] = [];
+
+	for (const otu of data.otus) {
+		const lowered = otu.name.toLowerCase();
+
+		if (seenNames.has(lowered)) {
+			duplicateNames.add(otu.name);
+		} else {
+			seenNames.add(lowered);
+		}
+
+		if (seenOtuIds.has(otu._id)) {
+			duplicateOtuIds.add(otu._id);
+		} else {
+			seenOtuIds.add(otu._id);
+		}
+
+		const isolateIds = new Set<string>();
+		let hasDuplicateIsolate = false;
+
+		for (const isolate of otu.isolates) {
+			if (isolateIds.has(isolate.id)) {
+				hasDuplicateIsolate = true;
+			}
+
+			isolateIds.add(isolate.id);
+
+			for (const sequence of isolate.sequences) {
+				if (seenSequenceIds.has(sequence._id)) {
+					duplicateSequenceIds.add(sequence._id);
+				} else {
+					seenSequenceIds.add(sequence._id);
+				}
+			}
+		}
+
+		if (hasDuplicateIsolate) {
+			otusWithDuplicateIsolates.push(`${otu.name} (${otu._id})`);
+		}
+	}
+
+	const problems: Array<[string, Iterable<string>]> = [
+		["Duplicate OTU names", duplicateNames],
+		["Duplicate OTU ids", duplicateOtuIds],
+		["OTUs with duplicate isolate ids", otusWithDuplicateIsolates],
+		["Duplicate sequence ids", duplicateSequenceIds],
+	];
+
+	for (const [label, found] of problems) {
+		const items = [...found];
+
+		if (items.length > 0) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["otus"],
+				message: `${label}: ${summarize(items)}`,
+			});
+		}
+	}
+}
+
+/** Name the first few of `items`, counting off however many are left. */
+function summarize(items: string[]): string {
+	const shown = items.slice(0, MAX_REPORTED_DUPLICATES).join(", ");
+
+	return items.length > MAX_REPORTED_DUPLICATES
+		? `${shown} and ${items.length - MAX_REPORTED_DUPLICATES} more`
+		: shown;
+}
+
+export const ReferenceSourceDataSchema = z
+	.object({
+		/*
+		 * Python's `ReferenceDataType` has one member, so a barcode reference is
+		 * rejected there and must be rejected here too — both runners claim these
+		 * tasks until the cutover, and the looser side would accept a file the
+		 * other refuses.
+		 */
+		data_type: z.enum(["genome"]).default("genome"),
+		organism: z.string().default("Unknown"),
+		otus: z.array(referenceSourceOtuSchema).min(1),
+	})
+	.superRefine(checkForDuplicates);
+
+/** A parsed reference upload, ready to be written to a reference. */
+export type ReferenceSourceData = z.infer<typeof ReferenceSourceDataSchema>;

--- a/packages/data/src/references/populate.ts
+++ b/packages/data/src/references/populate.ts
@@ -1,16 +1,20 @@
 // Bulk-populating a brand new reference with OTUs, sequences and history.
 //
 // A port of `virtool.references.alot` and `populate_insert_only_reference`, plus
-// the `populate_cloned_reference` that drives them for a clone. It is the body
-// of the `clone_reference` task, and the layer the `import_reference` task will
-// stand on.
+// the `populate_cloned_reference` and `populate_imported_reference` that drive
+// them for a clone and an import. It is the layer under both the
+// `clone_reference` and `import_reference` tasks.
+//
+// Neither entry point reads a file. An import's upload is parsed and validated
+// by the task body, which hands the documents down; that keeps gzip, SQLite and
+// the two upload formats out of a module whose job is writing rows.
 //
 // Kept out of `./data.ts` because everything here reads OTUs and writes history,
 // and `otus/data.ts` already imports this domain's errors — folding it in would
 // close that into a cycle.
 
 import { setImmediate } from "node:timers/promises";
-import type { HistoryMethod } from "@virtool/contracts";
+import type { HistoryMethod, ReferenceSourceData } from "@virtool/contracts";
 import type { Logger } from "@virtool/logger";
 import { eq, inArray } from "drizzle-orm";
 import type { Db, DbOrTx } from "../db/pg";
@@ -563,6 +567,104 @@ export async function populateClonedReference(
 	}
 
 	await onProgress?.(100);
+
+	await emit("references", referenceId, "update");
+}
+
+/** The values {@link populateImportedReference} works from. */
+export type PopulateImportedReferenceValues = {
+	/** The parsed contents of the uploaded reference file */
+	data: ReferenceSourceData;
+
+	/** The primary key of the reference being populated */
+	referenceId: number;
+
+	/** The user the imported OTUs and their history are attributed to */
+	userId: number;
+
+	/**
+	 * OTUs prepared and inserted per transaction. Present so a test can drive
+	 * the chunking at a size it can seed; production takes the default.
+	 */
+	chunkSize?: number;
+};
+
+/**
+ * Fill a newly created reference with the OTUs of an uploaded file.
+ *
+ * The file is parsed and validated before it reaches here — this layer takes
+ * documents, never bytes, so neither gzip nor SQLite appears in it. Every OTU
+ * is given fresh ids and written with the history row recording its creation,
+ * stamped with the reference's own `created_at` as Python does.
+ *
+ * It is idempotent, as a reclaimed task requires. A re-run clears whatever a
+ * previous attempt committed before writing anything, because the ids are
+ * minted afresh every time and nothing would otherwise stop a second complete
+ * set of OTUs landing beside the first.
+ *
+ * Nothing is rolled back on failure. A half-populated reference is left for the
+ * user to delete or retry against, the clearing above being what makes the
+ * retry clean.
+ */
+export async function populateImportedReference(
+	db: Db,
+	values: PopulateImportedReferenceValues,
+	onProgress?: (percent: number) => Promise<void>,
+	signal?: AbortSignal,
+): Promise<void> {
+	const { data, referenceId, userId, chunkSize = OTU_CHUNK_SIZE } = values;
+
+	const createdAt = await readReferenceCreatedAt(db, referenceId);
+
+	await db.transaction(async (tx) => {
+		await clearReferenceContents(tx, referenceId);
+
+		/* Python updates `organism` in its own transaction before inserting
+		   anything. Folded into the clearing transaction here so a re-entry
+		   cannot leave the column updated against contents it then fails to
+		   write. */
+		await tx
+			.update(legacyReferences)
+			.set({ organism: data.organism })
+			.where(eq(legacyReferences.id, referenceId));
+	});
+
+	const count = data.otus.length;
+
+	let inserted = 0;
+
+	for (const slice of chunked(data.otus, chunkSize)) {
+		signal?.throwIfAborted();
+
+		const insertions = slice.map((otu) =>
+			prepareOtuInsertion(
+				createdAt,
+				"import",
+				otu as OtuDocument,
+				referenceId,
+				userId,
+			),
+		);
+
+		/* Preparing a chunk is a long synchronous stretch — a deep copy and a
+		   reshape of every document in it — and the runner's heartbeat is a
+		   timer. Without a macrotask boundary here a large reference starves it
+		   and the task is reclaimed out from under itself. */
+		await setImmediate();
+
+		/* Checked again on this side of the yield, and not only at the top of
+		   the loop: the yield is exactly where a lost lease is noticed, and the
+		   last chunk has no next iteration to notice it in. Another runner may
+		   already have cleared the reference and started rebuilding it, and this
+		   insert is fenced on nothing. */
+		signal?.throwIfAborted();
+
+		await insertPreparedOtus(db, referenceId, insertions);
+
+		inserted += slice.length;
+
+		await onProgress?.((inserted / count) * 100);
+	}
 
 	await emit("references", referenceId, "update");
 }

--- a/packages/data/src/uploads/data.ts
+++ b/packages/data/src/uploads/data.ts
@@ -198,6 +198,39 @@ export async function getUploadFile(
 }
 
 /**
+ * The same, resolved from `name_on_disk` rather than the row's primary key.
+ *
+ * `createReference` puts `name_on_disk` on an `import_reference` task's context
+ * instead of the upload's id, so that string is the only handle the task has.
+ * The column is unique, which makes the lookup exact, and Python resolves it
+ * the same way for the same reason.
+ *
+ * Nothing else should reach for this: `name_on_disk` does not locate an object
+ * and is kept only because Python's task context is spelled in terms of it.
+ */
+export async function getUploadFileByNameOnDisk(
+	db: DbOrTx,
+	nameOnDisk: string,
+): Promise<UploadFile | null> {
+	const [row] = await db
+		.select({ name: uploadsTable.name, storageKey: uploadsTable.storageKey })
+		.from(uploadsTable)
+		.where(
+			and(
+				eq(uploadsTable.nameOnDisk, nameOnDisk),
+				eq(uploadsTable.removed, false),
+			),
+		)
+		.limit(1);
+
+	if (!row?.name || !row.storageKey) {
+		return null;
+	}
+
+	return { key: row.storageKey, name: row.name };
+}
+
+/**
  * Reserve the given uploads so they cannot be used for another sample.
  *
  * Only a visible reads upload is a valid sample input, so every id must resolve

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,6 +393,9 @@ importers:
       '@virtool/service':
         specifier: workspace:*
         version: link:../../packages/service
+      '@virtool/sqlite':
+        specifier: workspace:*
+        version: link:../../packages/sqlite
       '@virtool/storage':
         specifier: workspace:*
         version: link:../../packages/storage


### PR DESCRIPTION
## Summary

- Ports Python's `ImportReferenceTask` as the sixth TypeScript task body, filling a newly created reference with the OTUs of an uploaded file. The body reads the file and the data layer only writes rows, following `install_hmms` — gzip, SQLite and the two upload formats stay in `apps/tasks`, and `populateImportedReference` takes an already-parsed `ReferenceSourceData`, reusing the `prepareOtuInsertion` and chunked bulk insert that `clone_reference` already stands on.
- Accepts both upload formats Python does, dispatched on the suffix: a gzipped JSON export and a `.v1.sqlite` snapshot, the latter read through `@virtool/sqlite` so its DDL and format validation are not duplicated. The two spell an OTU's and a sequence's id differently, so `ReferenceSourceDataSchema` reproduces Python's pydantic alias and normalises onto `_id`; its four duplicate checks run in one pass rather than as four validators that stop at the first failure.
- Three of the issue's claims were stale — Python moved in `45a7c0176`. There is one step, `import_reference`, because `load_file` no longer exists; the upload is located by `name_on_disk` and resolved to its recorded `storage_key` rather than a key composed from the filename; and `data_type` admits `genome` alone, matching Python's one-member enum, so the looser side cannot accept a file the other refuses while both runners are live.
- Nothing is rolled back on failure, as with `create_index` and the workflows. `populateImportedReference` clears the reference's contents at the top of every run, which is what makes a reclaimed task's re-run from step zero clean.