### PR TITLE
fix: stop periodic tasks piling up while the runner is down

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1179,10 +1179,17 @@ twice. The failure is silent: no error, no log, no alert. Six rules:
   task name per tick — never one spanning all five. `try_` never
   blocks; `false` is `skipped_locked`, logged at debug, and is never
   retried or escalated.
-- **The recency predicate is Python's**: any row of the type with
+- **A spawn is gated on outstanding work as well as on the window.** An
+  **active** row of the type — `complete = false AND error IS NULL` —
+  suppresses it whatever its age, which holds the backlog at one row per
+  type when the runner is down; *active* rather than *incomplete*,
+  because a Python failure leaves `complete` false and would block the
+  type forever. Python gates on recency alone, and diverging in this
+  direction cannot duplicate: it only declines spawns Python would have
+  made. The window itself stays Python's — any row with
   `created_at > clock_timestamp() - interval`, **complete and errored
-  rows included**. A stricter rule here loses to Python's looser one
-  and spawns the duplicate the lock exists to prevent.
+  rows included** — because narrowing *that* spawns where Python would
+  not, which is the duplicate the lock exists to prevent.
 - **The tick is a hardcoded 30 s and the interval is only a suppression
   window**, so a type's effective period is `max(30, interval)`. A
   per-task timer would open its window at a different moment than

--- a/apps/tasks/src/spawner.test.ts
+++ b/apps/tasks/src/spawner.test.ts
@@ -240,7 +240,7 @@ describe("createTaskSpawner", () => {
 		await expect(spawner.stop()).resolves.toBeUndefined();
 	});
 
-	it("spawns again once the window has closed", async () => {
+	it("spawns again once the window has closed and the run has finished", async () => {
 		const { spawner } = build([{ type: "sweep_blast", intervalSeconds: 30 }]);
 
 		spawner.start();
@@ -253,6 +253,16 @@ describe("createTaskSpawner", () => {
 			.set({
 				created_at: sql`timezone('utc', clock_timestamp()) - make_interval(secs => 31)`,
 			})
+			.where(eq(tasks.type, "sweep_blast"));
+
+		// An aged row is not on its own enough: it is still outstanding work, and
+		// respawning alongside it is the backlog this gate exists to bound.
+		await delay(200);
+		expect(await countTasks("sweep_blast")).toBe(1);
+
+		await db
+			.update(tasks)
+			.set({ complete: true })
 			.where(eq(tasks.type, "sweep_blast"));
 
 		await waitFor(async () => (await countTasks("sweep_blast")) === 2);

--- a/apps/tasks/src/spawner.ts
+++ b/apps/tasks/src/spawner.ts
@@ -51,7 +51,8 @@ export type TaskSpawnerOptions = {
  * `create_periodic`, which is per call; this checks once, at construction, so a
  * bad schedule fails the process at startup rather than every thirty seconds
  * forever. An interval of zero would leave the suppression window permanently
- * open and spawn the task on every tick.
+ * open, so nothing but `createPeriodicTask`'s outstanding-work gate would pace
+ * the type and it would respawn the moment each run finished.
  */
 function checkSchedule(schedule: PeriodicTaskRegistration[]): void {
 	for (const { type, intervalSeconds } of schedule) {

--- a/apps/tasks/src/tasks/periodic.ts
+++ b/apps/tasks/src/tasks/periodic.ts
@@ -14,10 +14,11 @@ export type PeriodicTaskRegistration = {
 	 *
 	 * A suppression window, not a schedule: the loop ticks at
 	 * {@link SPAWN_TICK_INTERVAL_MS} regardless, so a type's effective period is
-	 * `max(tick, intervalSeconds)` quantised to tick boundaries. Must match
-	 * Python's interval in `virtool/startup.py` while both spawners run — the
-	 * shorter of the two sets the effective rate, so a divergence silently
-	 * changes production cadence rather than failing.
+	 * `max(tick, intervalSeconds)` quantised to tick boundaries — and a floor
+	 * rather than a period, since a spawn also waits on the last run of the type
+	 * to finish. Must match Python's interval in `virtool/startup.py` while both
+	 * spawners run: the shorter of the two sets the effective rate, so a
+	 * divergence silently changes production cadence rather than failing.
 	 */
 	intervalSeconds: number;
 };

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1413,13 +1413,37 @@ a `try_` lock, so it degrades to a spurious skip rather than to corruption.
 Widening the hash would break exclusion with Python, which is the entire point.
 Accept the keyspace.
 
-### The recency check is Python's predicate, not a better one
+### A spawn waits on outstanding work as well as on the window
 
-Any row of the type with `created_at > now - interval` suppresses the spawn,
-**whatever its state** — complete, errored, or neither. Filtering to incomplete
-rows or excluding errored ones is not an improvement: a stricter rule here
-loses to Python's looser one, and the pair then produces exactly the duplicate
-the lock exists to prevent.
+Two things suppress a spawn, and a row satisfying either is enough:
+
+- **A row of the type that is still active** — `complete = false AND error IS
+  NULL` — **whatever its age.** This is the gate that bounds the backlog.
+- **Any row of the type with `created_at > now - interval`**, whatever its
+  state: complete, errored, or neither. This is the window, and it paces a type
+  whose runs finish quickly.
+
+The first is a deliberate divergence from Python, which gates on recency alone.
+Python's rule keeps inserting once the last row ages out of the window however
+wedged the runner is — `sweep_blast` alone is a row every thirty seconds — so a
+fleet that comes back from an outage finds a pile of identical periodic tasks
+to drain instead of one. Gating on outstanding work holds it at one row per
+type, and the recovering runner drains one task per type.
+
+**Active, not merely incomplete, is what blocks.** A Python failure writes
+`error` and leaves `complete` false, so a rule reading `complete` alone would
+leave every type Python has ever failed blocked for good, silently — a
+suppressed spawn is the ordinary steady state and looks like nothing at all. A
+stale claim *does* block, because a reclaim will run it and a second row
+alongside would be the duplicate the gate exists to avoid.
+
+**Diverging this way cannot produce a duplicate while Python's spawner is
+live.** The direction is what matters: this side only ever declines a spawn
+Python's rule would have made, so Python's looser predicate sets the effective
+rate until its spawner is deleted, and the pile-up it is responsible for goes
+with it. The reverse — narrowing what counts as suppressing, so this side
+spawns where Python would not — is what produces duplicates, and is why the
+window still counts complete and errored rows.
 
 The window is `timezone('utc', clock_timestamp()) - make_interval(...)`, and
 the rows are inserted with `timezone('utc', clock_timestamp())` too. The
@@ -1452,10 +1476,9 @@ While both spawners run the shorter of the two intervals sets the effective
 rate, so a divergence changes production cadence rather than failing.
 
 This also puts `sweep_blast` — a 30 s interval on a 30 s tick — right on the
-boundary where a `created_at`-only dedup can admit a concurrent duplicate. That
-is a known, accepted defect of Python's design, and the stricter rule that
-fixes it lands when Python's spawner is deleted. A stricter rule now would lose
-to Python's looser one.
+boundary where a `created_at`-only dedup can admit a concurrent duplicate. The
+outstanding-work gate above closes that on this side; Python's spawner keeps
+the defect until it is deleted.
 
 **Do not register a sixth type.** Python's runner is the only runner until the
 cutover, and it *strands* a name it does not recognise — it acquires the row,

--- a/packages/data/src/tasks/data.ts
+++ b/packages/data/src/tasks/data.ts
@@ -109,6 +109,25 @@ export async function createTask(
 }
 
 /**
+ * A task that is neither finished nor failed: outstanding work, whether it is
+ * queued, running, or claimed by a runner that has stopped renewing its lease.
+ *
+ * The two terms are both required and neither implies the other. A Python
+ * failure writes `error` and leaves `complete` false, so `complete = false`
+ * alone would count a row Python has already given up on; `error IS NULL`
+ * alone would count every row that ever succeeded.
+ *
+ * It is Python's `TasksData.get_counts` predicate term for term, which is what
+ * makes the pre- and post-cutover comparison apples-to-apples, and it is the
+ * predicate of Python's `idx_tasks_active` partial index, so a read under it is
+ * served by that index rather than scanning a table whose completed rows
+ * accumulate without bound.
+ */
+function isActive(): SQL | undefined {
+	return and(eq(tasksTable.complete, false), isNull(tasksTable.error));
+}
+
+/**
  * How a spawn attempt for one periodic task type ended.
  *
  * `skipped_locked` and `not_due` are told apart rather than folded into one
@@ -135,7 +154,7 @@ export type PeriodicSpawnResult =
  * nothing but that lock, and the failure mode is silent: diverge on the key and
  * both spawn, every periodic task runs twice, and nothing errors or logs.
  *
- * Three rules make the exclusion hold, and none of them is a preference:
+ * Two rules make the exclusion hold, and neither is a preference:
  *
  * - **The key is `hashtext` of the bare task name, computed in SQL.** Python
  *   emits `pg_try_advisory_xact_lock(hashtext($1))` from
@@ -148,10 +167,6 @@ export type PeriodicSpawnResult =
  *   pooler-safe one: session locks survive rollback, are reentrant so two
  *   logical spawners sharing a pooled connection do *not* exclude each other,
  *   and PgBouncer lists them as never supported under transaction pooling.
- * - **The recency check matches Python's predicate exactly** — *any* row of the
- *   type inside the window, complete or errored or neither. A stricter rule
- *   here loses to Python's looser one and spawns the duplicate this whole
- *   design exists to prevent.
  *
  * `hashtext` returns a signed **int4**, so the real keyspace is 2³² rather than
  * the 2⁶⁴ the advisory-lock signature implies, and the function is undocumented
@@ -164,6 +179,26 @@ export type PeriodicSpawnResult =
  * `try_` never blocks: `false` means another spawner is handling this type this
  * tick, and the caller moves on without retrying or escalating.
  *
+ * **The spawn is gated on outstanding work as well as on recency**, and this is
+ * a deliberate divergence from Python, which gates on recency alone. A row of
+ * the type that is still {@link isActive} suppresses the spawn *whatever its
+ * age*, so a type has at most one outstanding row at a time. Python's rule
+ * keeps inserting once the last row ages out of the window however wedged the
+ * runner is, and a fleet that comes back after an outage finds a pile of
+ * identical periodic tasks to drain rather than one.
+ *
+ * That an active row is what blocks — rather than an incomplete one — is what
+ * keeps a failure from blocking the type forever: a Python failure writes
+ * `error` and leaves `complete` false, and such a row re-arms on the ordinary
+ * interval like any other finished one. A row whose lease has gone stale
+ * *does* block, because a reclaim will run it and a second row would then be
+ * the duplicate this gate exists to avoid.
+ *
+ * Diverging this way cannot produce a duplicate while Python's spawner is
+ * live, because it only ever declines a spawn Python's rule would have made:
+ * Python's looser predicate sets the effective rate until its spawner is
+ * deleted, and the pile-up it is responsible for goes with it.
+ *
  * The lock, the check and the insert are one transaction; the event is emitted
  * after it commits, so a rolled-back insert cannot announce a row that does not
  * exist. `Db` rather than `DbOrTx` for that reason — this function has to own
@@ -171,7 +206,8 @@ export type PeriodicSpawnResult =
  *
  * `intervalSeconds` must be positive. It is validated where the schedule is
  * registered, at startup, rather than on every tick; zero here would leave the
- * window permanently open and spawn on every tick forever.
+ * window permanently open, so nothing but the outstanding-work gate would pace
+ * the type and it would respawn the moment each run finished.
  */
 export async function createPeriodicTask(
 	db: Db,
@@ -188,18 +224,21 @@ export async function createPeriodicTask(
 				return { outcome: "skipped_locked", task: null };
 			}
 
-			const [recent] = await tx
+			const [blocking] = await tx
 				.select({ id: tasksTable.id })
 				.from(tasksTable)
 				.where(
 					and(
 						eq(tasksTable.type, type),
-						gt(tasksTable.created_at, secondsAgo(intervalSeconds)),
+						or(
+							isActive(),
+							gt(tasksTable.created_at, secondsAgo(intervalSeconds)),
+						),
 					),
 				)
 				.limit(1);
 
-			if (recent !== undefined) {
+			if (blocking !== undefined) {
 				return { outcome: "not_due", task: null };
 			}
 
@@ -641,24 +680,6 @@ export async function releaseRunnerClaims(
 		.returning({ id: tasksTable.id });
 
 	return rows.map((row) => row.id);
-}
-
-/**
- * The predicate Python's `TasksData.get_counts` counts under: a task that is
- * neither finished nor failed.
- *
- * Reproduced term for term, because the pre- and post-cutover comparison is
- * only apples-to-apples if both sides count the same rows. It is also the
- * predicate of Python's `idx_tasks_active` partial index, so the reads below
- * are served by it rather than scanning a table whose completed rows accumulate
- * without bound.
- *
- * Note that `error IS NULL` and `complete = false` are *both* required. A
- * Python failure writes `error` and leaves `complete` false, so neither term
- * implies the other on rows Python wrote.
- */
-function isActive(): SQL | undefined {
-	return and(eq(tasksTable.complete, false), isNull(tasksTable.error));
 }
 
 /** Active tasks of one type, split the way Python's `get_counts` splits them. */

--- a/packages/data/src/tasks/periodic.test.ts
+++ b/packages/data/src/tasks/periodic.test.ts
@@ -49,11 +49,19 @@ beforeEach(async () => {
 async function seedTask(
 	type: string,
 	ageSeconds: number,
-	values: { complete?: boolean; error?: string } = {},
+	values: {
+		acquiredSecondsAgo?: number;
+		complete?: boolean;
+		error?: string;
+	} = {},
 ): Promise<number> {
 	const [row] = await db
 		.insert(tasks)
 		.values({
+			acquired_at:
+				values.acquiredSecondsAgo === undefined
+					? null
+					: sql`timezone('utc', clock_timestamp()) - make_interval(secs => ${values.acquiredSecondsAgo}::double precision)`,
 			complete: values.complete ?? false,
 			context: {},
 			count: 0,
@@ -195,7 +203,7 @@ describe("the recency window", () => {
 	});
 
 	it("spawns when the newest task of the type is older than it", async () => {
-		await seedTask("sweep_blast", 31);
+		await seedTask("sweep_blast", 31, { complete: true });
 
 		const result = await createPeriodicTask(db, "sweep_blast", 30);
 
@@ -211,9 +219,9 @@ describe("the recency window", () => {
 		expect(result.outcome).toBe("spawned");
 	});
 
-	// Python selects any row of the type inside the window, whatever its state.
-	// A stricter rule here would lose to Python's looser one every time the two
-	// spawners raced, which is the duplicate the advisory lock exists to prevent.
+	// The window is not narrowed to the rows the outstanding-work gate misses.
+	// A run that finished — successfully or not — still paces the type, so a
+	// task that fails in a second does not respawn on every tick.
 	it("counts a completed task inside it", async () => {
 		await seedTask("sweep_blast", 10, { complete: true });
 
@@ -256,11 +264,90 @@ describe("the recency window", () => {
 		});
 
 		await db.delete(tasks);
-		await seedTask("sweep_blast", 31);
+		await seedTask("sweep_blast", 31, { complete: true });
 
 		expect(
 			(await createPeriodicTask(skewed.db, "sweep_blast", 30)).outcome,
 		).toBe("spawned");
+	});
+});
+
+/**
+ * The regression guard for the backlog. Python gates on recency alone, so a
+ * wedged or absent runner leaves it inserting a fresh row every time the last
+ * one ages out of the window, and the fleet comes back to a pile of identical
+ * periodic tasks. Nothing here may depend on how *old* the outstanding row is.
+ */
+describe("the outstanding-work gate", () => {
+	it("suppresses a spawn while a queued task of the type is outstanding", async () => {
+		await seedTask("sweep_blast", 3600);
+
+		expect(await createPeriodicTask(db, "sweep_blast", 30)).toEqual({
+			outcome: "not_due",
+			task: null,
+		});
+
+		expect(await countTasks("sweep_blast")).toBe(1);
+	});
+
+	/**
+	 * A claim whose lease has run out is work a reclaim will pick up and run,
+	 * not work that is gone. Spawning alongside it is the duplicate the gate is
+	 * here to avoid.
+	 */
+	it("suppresses a spawn while a claim of the type has gone stale", async () => {
+		await seedTask("sweep_blast", 3600, { acquiredSecondsAgo: 3600 });
+
+		expect((await createPeriodicTask(db, "sweep_blast", 30)).outcome).toBe(
+			"not_due",
+		);
+	});
+
+	it("holds the backlog at one row however many ticks pass", async () => {
+		await seedTask("sweep_blast", 3600);
+
+		for (let tick = 0; tick < 5; tick++) {
+			expect((await createPeriodicTask(db, "sweep_blast", 30)).outcome).toBe(
+				"not_due",
+			);
+		}
+
+		expect(await countTasks("sweep_blast")).toBe(1);
+	});
+
+	it("re-arms once the outstanding task completes", async () => {
+		const taskId = await seedTask("sweep_blast", 3600);
+
+		expect((await createPeriodicTask(db, "sweep_blast", 30)).outcome).toBe(
+			"not_due",
+		);
+
+		await db.update(tasks).set({ complete: true }).where(eq(tasks.id, taskId));
+
+		expect((await createPeriodicTask(db, "sweep_blast", 30)).outcome).toBe(
+			"spawned",
+		);
+	});
+
+	/**
+	 * A Python failure writes `error` and leaves `complete` false, so gating on
+	 * `complete` alone would leave every type Python has ever failed blocked for
+	 * good — silently, since a suppressed spawn is the ordinary steady state.
+	 */
+	it("re-arms after a failure Python recorded without completing the row", async () => {
+		await seedTask("sweep_blast", 3600, { error: "boom" });
+
+		expect((await createPeriodicTask(db, "sweep_blast", 30)).outcome).toBe(
+			"spawned",
+		);
+	});
+
+	it("ignores outstanding tasks of other types", async () => {
+		await seedTask("refresh_hmms", 3600);
+
+		expect((await createPeriodicTask(db, "sweep_blast", 30)).outcome).toBe(
+			"spawned",
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary

- The periodic spawner gated only on recency, so a wedged or absent runner left it inserting a fresh row for each type every time the last one aged out of its window — a `sweep_blast` every thirty seconds — and a fleet coming back from an outage found a pile of identical tasks to drain. A spawn now also waits on outstanding work: an active row of the type suppresses it whatever its age, holding the backlog at one row per type.
- **Active** — `complete = false AND error IS NULL` — rather than merely incomplete, because a Python failure writes `error` and leaves `complete` false, so gating on that column alone would block every type Python has ever failed for good, silently. A stale claim does block, since a reclaim will run it. The window itself stays Python's, counting complete and errored rows: narrowing *it* would spawn where Python would not, which is the duplicate the advisory lock exists to prevent, whereas widening what suppresses cannot — this side only ever declines a spawn Python would have made. The lock key derivation is untouched.
- Note this is inert on a live fleet until Python's spawner is deleted: when this side declines, Python takes the next tick and inserts anyway, so the backlog still accrues at Python's rate until the cutover.

Closes VIR-2966.