### PR TITLE
chore: publish the web image under both ui and web names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -602,21 +602,30 @@ jobs:
             # release. Keep in step with the matrix in the build job.
             matrix:
                 include:
+                    # Published under both names while the cluster migrates off
+                    # `ui` — drop the first line once nothing pulls it.
                     - image: ui
                       target: dist
                       workspace: apps/web
+                      images: |
+                          ${{ env.REGISTRY }}/virtool/ui
+                          ${{ env.REGISTRY }}/virtool/web
                     - image: jobs-api
                       target: jobs-api
                       workspace: apps/jobs-api
+                      images: ${{ env.REGISTRY }}/virtool/jobs-api
                     - image: tasks
                       target: tasks
                       workspace: apps/tasks
+                      images: ${{ env.REGISTRY }}/virtool/tasks
                     - image: ts-create-sample
                       target: create-sample
                       workspace: apps/create-sample
+                      images: ${{ env.REGISTRY }}/virtool/ts-create-sample
                     - image: ts-create-subtraction
                       target: create-subtraction
                       workspace: apps/create-subtraction
+                      images: ${{ env.REGISTRY }}/virtool/ts-create-subtraction
         steps:
             - name: Checkout
               uses: actions/checkout@v7
@@ -639,7 +648,7 @@ jobs:
               uses: docker/metadata-action@v6
               with:
                   context: git
-                  images: ${{ env.REGISTRY }}/virtool/${{ matrix.image }}
+                  images: ${{ matrix.images }}
             - name: Build & Push
               uses: docker/build-push-action@v7
               with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -603,29 +603,31 @@ jobs:
             matrix:
                 include:
                     # Published under both names while the cluster migrates off
-                    # `ui` — drop the first line once nothing pulls it.
+                    # `ui` — drop the first line once nothing pulls it. Matrix
+                    # values are evaluated before the job's `env` context
+                    # exists, so these are literal `ghcr.io`, not `${{ env.REGISTRY }}`.
                     - image: ui
                       target: dist
                       workspace: apps/web
                       images: |
-                          ${{ env.REGISTRY }}/virtool/ui
-                          ${{ env.REGISTRY }}/virtool/web
+                          ghcr.io/virtool/ui
+                          ghcr.io/virtool/web
                     - image: jobs-api
                       target: jobs-api
                       workspace: apps/jobs-api
-                      images: ${{ env.REGISTRY }}/virtool/jobs-api
+                      images: ghcr.io/virtool/jobs-api
                     - image: tasks
                       target: tasks
                       workspace: apps/tasks
-                      images: ${{ env.REGISTRY }}/virtool/tasks
+                      images: ghcr.io/virtool/tasks
                     - image: ts-create-sample
                       target: create-sample
                       workspace: apps/create-sample
-                      images: ${{ env.REGISTRY }}/virtool/ts-create-sample
+                      images: ghcr.io/virtool/ts-create-sample
                     - image: ts-create-subtraction
                       target: create-subtraction
                       workspace: apps/create-subtraction
-                      images: ${{ env.REGISTRY }}/virtool/ts-create-subtraction
+                      images: ghcr.io/virtool/ts-create-subtraction
         steps:
             - name: Checkout
               uses: actions/checkout@v7

--- a/apps/site/src/pages/releases/[id].json.ts
+++ b/apps/site/src/pages/releases/[id].json.ts
@@ -2,7 +2,6 @@ import { getRepoReleases } from "@utils/releases";
 
 const repoMap = {
   hmms: ["virtool-hmm"],
-  ml: ["ml-plant-viruses"],
   references: ["ref-plant-viruses"],
   virtool: ["virtool"],
 };
@@ -22,7 +21,6 @@ export async function GET({ params }): Promise<Response> {
 export function getStaticPaths() {
   return [
     { params: { id: "hmms" } },
-    { params: { id: "ml" } },
     { params: { id: "references" } },
     { params: { id: "virtool" } },
   ];

--- a/docs/images.md
+++ b/docs/images.md
@@ -7,7 +7,7 @@ manifest.
 
 | Target | Image | App |
 | --- | --- | --- |
-| `dist` | `ghcr.io/virtool/ui` | `apps/web` |
+| `dist` | `ghcr.io/virtool/ui`, `ghcr.io/virtool/web` | `apps/web` |
 | `jobs-api` | `ghcr.io/virtool/jobs-api` | `apps/jobs-api` |
 | `tasks` | `ghcr.io/virtool/tasks` | `apps/tasks` |
 | `create-sample` | `ghcr.io/virtool/ts-create-sample` | `apps/create-sample` |
@@ -18,6 +18,11 @@ manifest.
 `dist` is named that rather than `web` because tooling outside this repo
 targets it. There is also a `dev` stage carrying `apps/web` on the
 install layer, which ships nothing.
+
+`dist` is released under both `ghcr.io/virtool/ui` and
+`ghcr.io/virtool/web` — one build, tagged twice by `release-ghcr`'s
+`docker/metadata-action` step — while the cluster migrates off the
+`ui` name. Drop the `ui` tag once nothing pulls it.
 
 ## Every runtime stage is `node:24-bookworm-slim`
 


### PR DESCRIPTION
## Summary
- The `dist` build (`apps/web`) now publishes to both `ghcr.io/virtool/ui` and `ghcr.io/virtool/web` from a single build, via `docker/metadata-action`'s multi-image support in the `release-ghcr` job.
- Documents the dual publish in `docs/images.md` as a transitional state, to be dropped once nothing pulls `ui`.