### PR TITLE
fix: start deleting expired session rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1163,9 +1163,10 @@ The periodic spawner is `createTaskSpawner`
 (`apps/tasks/src/tasks/periodic.ts`) and `createPeriodicTask`
 (`@virtool/data/tasks/data`). It **only ever inserts**, and it ships to
 production **beside** Python's `PeriodicTaskSpawner` rather than
-replacing it — both write the same five types into the same table, and
-nothing but a shared advisory lock keeps them from spawning everything
-twice. The failure is silent: no error, no log, no alert. Six rules:
+replacing it — both write into the same table, five of the six types in
+common, and nothing but a shared advisory lock keeps them from spawning
+everything twice. The failure is silent: no error, no log, no alert.
+Six rules:
 
 - **The key is `pg_try_advisory_xact_lock(hashtext('<task name>'))`,
   computed in SQL**, matching what Python's
@@ -1176,7 +1177,7 @@ twice. The failure is silent: no error, no log, no alert. Six rules:
   same shape `createIndex` already takes for `index_build:{id}`, and
   `hashtext`'s int4 keyspace is accepted, not fixed.
 - **Transaction-scoped, never session-level**, and one transaction per
-  task name per tick — never one spanning all five. `try_` never
+  task name per tick — never one spanning them all. `try_` never
   blocks; `false` is `skipped_locked`, logged at debug, and is never
   retried or escalated.
 - **A spawn is gated on outstanding work as well as on the window.** An
@@ -1194,10 +1195,13 @@ twice. The failure is silent: no error, no log, no alert. Six rules:
   window**, so a type's effective period is `max(30, interval)`. A
   per-task timer would open its window at a different moment than
   Python's tick.
-- **`PERIODIC_TASKS` holds exactly five types**, with Python's
-  intervals, and a test pins the list. Do not register a sixth before
-  the cutover: Python's runner strands a name it does not recognise,
-  leaving a row claimed and incomplete forever.
+- **`PERIODIC_TASKS` holds exactly six types**, and a test pins the
+  list. Five carry Python's intervals; `cleanup_sessions` is hourly and
+  is the one type Python never spawned. A type belongs there only once
+  `taskRegistry` carries a handler for it — the runner filters its claim
+  on the registry's keys, so a registration without one spawns a row
+  that is never acquired and never fails, and sits queued instead. A
+  test checks the two lists against each other.
 - **A failure on one type stops neither the tick nor the loop**, and a
   non-positive interval is rejected at construction rather than per
   tick. The spawner holds no work, so its shutdown hook declares no

--- a/apps/tasks/src/spawner.test.ts
+++ b/apps/tasks/src/spawner.test.ts
@@ -25,6 +25,7 @@ import {
 	type PeriodicTaskRegistration,
 	SPAWN_TICK_INTERVAL_MS,
 } from "./tasks/periodic";
+import { taskRegistry } from "./tasks/registry";
 import { waitFor } from "./testing/waitFor";
 
 const logger: Logger = createLogger({ name: "test", level: "silent" });
@@ -83,20 +84,33 @@ function build(
 
 describe("PERIODIC_TASKS", () => {
 	/**
-	 * Python's runner is the only runner until the cutover, and it strands a task
-	 * name it does not recognise — the row keeps `acquired_at` with no error and
-	 * no completion, and nothing can ever clear it. Pinning the list means adding
-	 * a sixth type breaks a test and forces that rule to be read.
+	 * Pinning the list means adding a seventh type breaks a test, and so stays a
+	 * deliberate act rather than a line someone appends.
 	 */
-	it("registers exactly the five names Python spawns", () => {
+	it("registers exactly the six periodic names", () => {
 		expect(PERIODIC_TASKS.map(({ type }) => type).toSorted()).toEqual(
 			[...PeriodicTaskName.options].toSorted(),
 		);
 	});
 
-	// Asserted against Python's own figures rather than against the constants
+	/**
+	 * A registration the registry has no handler for spawns a row the runner
+	 * never claims — its claim filters on the registry's keys — so the row is
+	 * never acquired and never fails. It sits queued instead, counted against the
+	 * queue gauges, with nothing logging why.
+	 */
+	it("registers nothing the runner cannot claim", () => {
+		expect(
+			PERIODIC_TASKS.map(({ type }) => type).filter(
+				(type) => !(type in taskRegistry),
+			),
+		).toEqual([]);
+	});
+
+	// Asserted against the intervals themselves rather than against the constants
 	// this module exports, which would only prove the module agrees with itself.
-	// While both spawners run, the shorter of the two intervals sets the rate.
+	// Every figure but `cleanup_sessions` is Python's, so replacing that spawner
+	// does not move the cadence a deployment already sees.
 	it("carries Python's intervals", () => {
 		expect(
 			Object.fromEntries(
@@ -110,6 +124,7 @@ describe("PERIODIC_TASKS", () => {
 			refresh_hmms: 600,
 			timeout_jobs: 600,
 			evict_caches_lru: 3600,
+			cleanup_sessions: 3600,
 			reap_orphaned_uploads: 86400,
 		});
 	});

--- a/apps/tasks/src/tasks/periodic.ts
+++ b/apps/tasks/src/tasks/periodic.ts
@@ -16,9 +16,9 @@ export type PeriodicTaskRegistration = {
 	 * {@link SPAWN_TICK_INTERVAL_MS} regardless, so a type's effective period is
 	 * `max(tick, intervalSeconds)` quantised to tick boundaries — and a floor
 	 * rather than a period, since a spawn also waits on the last run of the type
-	 * to finish. Must match Python's interval in `virtool/startup.py` while both
-	 * spawners run: the shorter of the two sets the effective rate, so a
-	 * divergence silently changes production cadence rather than failing.
+	 * to finish. Every type Python also spawns carries Python's interval from
+	 * `virtool/startup.py`, so the cadence a deployment sees does not move when
+	 * this process replaces that one.
 	 */
 	intervalSeconds: number;
 };
@@ -36,15 +36,17 @@ export type PeriodicTaskRegistration = {
 export const SPAWN_TICK_INTERVAL_MS = 30_000;
 
 /**
- * Every periodic task this process spawns, with Python's intervals.
+ * Every periodic task this process spawns.
  *
- * **Do not add a type here.** Python's runner is the only runner until the
- * cutover, and it *strands* a task name it does not recognise — it acquires the
- * row, logs a warning and returns, leaving `acquired_at` set, no error and no
- * completion, so the row is counted as running forever and nothing can clear
- * it. New types are registered in the cutover issue, once this process's runner
- * is the one claiming. A test pins this list to exactly these five so a sixth
- * is a deliberate act.
+ * A type belongs here only once `taskRegistry` carries a handler for it, and a
+ * test checks the two against each other. A registration without a handler
+ * spawns a row nothing claims: the runner filters its claim on the registry's
+ * keys, so the row is never acquired, never fails, and sits queued counting
+ * against the queue gauges. The outstanding-work gate holds that at one row per
+ * type rather than a backlog, which is what makes the mistake survivable rather
+ * than invisible.
+ *
+ * A test pins this list to exactly these six, so a seventh is a deliberate act.
  *
  * The order is the order each tick walks.
  */
@@ -53,5 +55,20 @@ export const PERIODIC_TASKS: PeriodicTaskRegistration[] = [
 	{ type: "refresh_hmms", intervalSeconds: 600 },
 	{ type: "timeout_jobs", intervalSeconds: 600 },
 	{ type: "evict_caches_lru", intervalSeconds: 3600 },
+	/*
+	 * Hourly, and the one interval here Python does not set — `SessionCleanupTask`
+	 * was written, never registered, and has since been deleted from that repo, so
+	 * expired `sessions` rows have never been deleted in production.
+	 *
+	 * Correctness never waits on this: `verify.ts` and the reset path in `core.ts`
+	 * both reject an expired row on sight, so a row lingering between sweeps is
+	 * inert and the sweep is harmless when late. That removes the usual argument
+	 * for a short interval. Hourly keeps the shortest-lived rows — 10 minute reset
+	 * sessions, 60 minute no-remember ones — from outliving their expiry by much,
+	 * without running an indexed scan that finds nothing dozens of times an hour.
+	 * Daily is the defensible alternative and is rejected because a day's
+	 * accumulation makes each run a larger delete for no benefit.
+	 */
+	{ type: "cleanup_sessions", intervalSeconds: 3600 },
 	{ type: "reap_orphaned_uploads", intervalSeconds: 86_400 },
 ];

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1438,8 +1438,10 @@ the runner's half of this process.
 ### It runs beside Python's spawner, and the lock is the whole design
 
 This is the half that goes to production *first*, while Python's API replicas
-are still running `PeriodicTaskSpawner`. Both insert the same five types into
-the same `tasks` table. There are already several Python spawners racing each
+are still running `PeriodicTaskSpawner`. Both insert into the same `tasks`
+table, five of the six types in common — `cleanup_sessions` is this side's
+alone, Python having deleted the class. There are already several Python
+spawners racing each
 other across replicas — the advisory lock is what makes that safe, and this
 process joins as one more participant in a protocol that already exists.
 
@@ -1462,7 +1464,7 @@ So the lock is not an implementation detail to be improved:
   do not exclude each other, and PgBouncer lists it as never supported under
   transaction pooling.
 - **The lock, the recency check and the insert are one transaction**, and it is
-  one transaction *per task name per tick* — not one spanning all five, which
+  one transaction *per task name per tick* — not one spanning them all, which
   would hold every lock for the length of the whole tick.
 - **`try_` never blocks.** `false` means another spawner is handling this name
   this tick: record `skipped_locked`, log at debug, move on. No retry, no
@@ -1471,7 +1473,7 @@ So the lock is not an implementation detail to be improved:
 `hashtext` returns a signed **int4**, so the real keyspace is 2³² rather than
 the 2⁶⁴ the advisory-lock signature implies, and the function is undocumented
 by deliberate policy and has changed behaviour across major versions. At
-Virtool's key population — five task names plus one `index_build:{id}` per
+Virtool's key population — six task names plus one `index_build:{id}` per
 reference, sharing one namespace — a collision is ~10⁻⁵, and every call site is
 a `try_` lock, so it degrades to a spurious skip rather than to corruption.
 Widening the hash would break exclusion with Python, which is the entire point.
@@ -1527,7 +1529,20 @@ transaction's age.
 | `refresh_hmms` | 600 s |
 | `timeout_jobs` | 600 s |
 | `evict_caches_lru` | 3600 s |
+| `cleanup_sessions` | 3600 s |
 | `reap_orphaned_uploads` | 86400 s |
+
+Every figure but `cleanup_sessions` is Python's. That one is the only free
+choice on the list — `SessionCleanupTask` was written, never registered, and
+has since been deleted from the Python repo, so no expired `sessions` row has
+ever been deleted in production and there is no cadence to match. Hourly,
+because correctness never waits on the sweep: `verify.ts` and the reset path in
+`core.ts` both reject an expired row on sight, so a row lingering between
+sweeps is inert and the sweep is harmless when late. That removes the usual
+argument for a short interval, and hourly still keeps the shortest-lived rows —
+10 minute reset sessions, 60 minute no-remember ones — from outliving their
+expiry by much. Daily is the defensible alternative, rejected because a day's
+accumulation makes each run a larger delete for no benefit.
 
 Python walks every registered task and then sleeps a hardcoded 30 s, whatever
 the intervals are. So a type's effective period is `max(30, interval)`,
@@ -1544,12 +1559,17 @@ boundary where a `created_at`-only dedup can admit a concurrent duplicate. The
 outstanding-work gate above closes that on this side; Python's spawner keeps
 the defect until it is deleted.
 
-**Do not register a sixth type.** Python's runner is the only runner until the
-cutover, and it *strands* a name it does not recognise — it acquires the row,
-logs a warning and returns, leaving `acquired_at` set with no error and no
-completion, so the row is counted as running forever and nothing can clear it.
-`PERIODIC_TASKS` is pinned by a test to exactly the five, so adding one is a
-deliberate act. New types are registered at cutover.
+**Register nothing the runner cannot claim.** A type belongs on this list only
+once `taskRegistry` carries a handler for it. The runner filters its claim on
+the registry's keys, so a registration without one spawns a row that is never
+acquired, never fails and never completes: it sits queued, counted against the
+queue gauges, with nothing logging why. The outstanding-work gate holds that at
+one row per type rather than a backlog, which makes the mistake survivable
+rather than invisible — but a test checks the two lists against each other so
+it does not happen at all.
+
+`PERIODIC_TASKS` is pinned by a second test to exactly these six, so a seventh
+is a deliberate act rather than a line someone appends.
 
 ### The loop
 

--- a/packages/contracts/src/tasks.ts
+++ b/packages/contracts/src/tasks.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
  * zero forever and read as a task that never runs.
  */
 export const PeriodicTaskName = z.enum([
+	"cleanup_sessions",
 	"evict_caches_lru",
 	"reap_orphaned_uploads",
 	"refresh_hmms",
@@ -18,12 +19,11 @@ export const PeriodicTaskName = z.enum([
 export type PeriodicTaskName = z.infer<typeof PeriodicTaskName>;
 
 /**
- * Every task name Virtool runs — the five periodic ones, the four created in
- * response to a request, and `cleanup_sessions`.
+ * Every task name Virtool runs — the six periodic ones and the four created in
+ * response to a request.
  */
 export const TaskName = z.enum([
 	...PeriodicTaskName.options,
-	"cleanup_sessions",
 	"clone_reference",
 	"create_index",
 	"import_reference",


### PR DESCRIPTION
## Summary

- Registers `cleanup_sessions` with the periodic spawner at 3600 s, the interval VIR-2896 chose. The task body and its handler landed in VIR-2896 but the spawner registration was deliberately held back, so `deleteExpiredSessions` has never run — no expired `sessions` row has ever been deleted in production. This is the change that starts it.
- Registration required moving `cleanup_sessions` into `PeriodicTaskName`, which `PeriodicTaskRegistration.type` and `createPeriodicTask` both take; its standalone `TaskName` entry goes, since it now arrives via the spread. `TaskType` is untouched — this type is spawner-created, not `createTask`-created.
- Both `PERIODIC_TASKS` pins move to six rather than being deleted or weakened to a `contains` check, and a third test asserts every registered type has a `taskRegistry` handler.

## On the precondition

VIR-2968 says not to land this before the runner cutover, because Python's runner would claim a `cleanup_sessions` row, fail to recognise it, and strand it with `acquired_at` set. That hazard no longer exists:

- `virtool/tasks/registry.py` is now an explicit nine-class `TASK_REGISTRY` rather than `BaseTask.__subclasses__()`, and `acquire()` filters `type = ANY(:allowed_types)` in SQL. An unrecognised type is never acquired, so it cannot be stranded.
- `SessionCleanupTask` has been deleted from the Python repo outright — `cleanup_sessions` appears nowhere in it.

The failure mode that remains is an unhandled registration spawning a row nothing acquires, which sits queued against the queue gauges. The outstanding-work gate caps that at one row per type, and the new registry-coverage test closes it. The comments and docs built on the old stranding rationale are rewritten where this change forced the line.