### PR TITLE
ci: gate the workflow image builds on everything base copies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,10 +62,13 @@ jobs:
                   # **Every path a build stage COPYs must appear under that
                   # image's filter.** A missing one skips the build on the PR
                   # that breaks it and fails on the subsequent push to main,
-                  # where nothing gates it. The two image filters are nearly
-                  # identical and are still written out separately: nuvs copies
-                  # packages/bio and pathoscope copies packages/pathoscope-core,
-                  # and folding them into one would rebuild each image for the
+                  # where nothing gates it. Both image filters therefore carry
+                  # everything the shared `base` stage copies — including
+                  # packages neither app imports today, because `base` copies
+                  # them regardless of which target is requested. The two are
+                  # still written out separately rather than folded into one:
+                  # pathoscope copies packages/pathoscope-core and nuvs does
+                  # not, and one shared filter would rebuild each image for the
                   # other's inputs.
                   #
                   # This file is in all three so that a change to the jobs
@@ -85,8 +88,10 @@ jobs:
                         - 'packages/archive/**'
                         - 'packages/bio/**'
                         - 'packages/contracts/**'
+                        - 'packages/data/**'
                         - 'packages/logger/**'
                         - 'packages/sentry/**'
+                        - 'packages/service/**'
                         - 'packages/sqlite/**'
                         - 'packages/storage/**'
                         - 'packages/workflow/**'
@@ -94,6 +99,7 @@ jobs:
                         - 'apps/tsconfig.node.json'
                         - 'apps/*/package.json'
                         - 'packages/*/package.json'
+                        - 'biome.json'
                         - 'package.json'
                         - 'pnpm-workspace.yaml'
                         - 'pnpm-lock.yaml'
@@ -106,25 +112,29 @@ jobs:
                         - '.github/workflows/ci.yaml'
                         - 'Dockerfile'
                       pathoscope-image:
-                        - 'packages/pathoscope-core/**'
                         - '.github/workflows/ci.yaml'
                         - 'apps/pathoscope/**'
                         - 'packages/archive/**'
+                        - 'packages/bio/**'
                         - 'packages/contracts/**'
+                        - 'packages/data/**'
                         - 'packages/logger/**'
+                        - 'packages/pathoscope-core/**'
                         - 'packages/sentry/**'
+                        - 'packages/service/**'
                         - 'packages/sqlite/**'
                         - 'packages/storage/**'
                         - 'packages/workflow/**'
                         - 'packages/tsconfig.base.json'
                         - 'apps/tsconfig.node.json'
                         - 'apps/*/package.json'
+                        - 'packages/*/package.json'
+                        - 'biome.json'
                         - 'package.json'
                         - 'pnpm-workspace.yaml'
                         - 'pnpm-lock.yaml'
                         - 'Dockerfile'
                         - '.dockerignore'
-                        - '.github/workflows/ci.yaml'
                       # No `Dockerfile` here, unlike pathoscope-crate. That job
                       # builds bowtie2 out of it to run its goldens against;
                       # this one builds nothing at all — quality-core's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,10 @@ This is a **pnpm monorepo**:
   would leave two candidates for what the cluster runs. Don't add a publish job
   until that repo retires; note that `publish-ghcr` is also what stamps a real
   version, so until then `APP_VERSION` is `0.0.0` in every built image and the
-  `workflow_version` in its cache keys with it.
+  `workflow_version` in its cache keys with it. **`ghcr.io/virtool/ts-pathoscope`
+  nonetheless has tags, `:latest` among them** — a short-lived publish job left
+  them behind before the port landed, so they carry the tools and no workflow
+  code. They are not evidence this image is published.
 - `apps/nuvs/` — `@virtool/nuvs`, the NuVs workflow executor and its image
   (`ghcr.io/virtool/ts-nuvs`). Ten steps and five external tools — skewer,
   bowtie2, SPAdes, `hmmpress` and `hmmscan`. It finds viruses the reference
@@ -256,12 +259,15 @@ their inputs differ: the crate jobs run cargo and read no TypeScript, while
 each image build bundles its own app and so depends on every workspace package
 its Dockerfile copies. One shared filter would run the libclang-and-cargo job
 on any `packages/workflow` change, and would rebuild each image for the other's
-inputs — `nuvs-image` carries `packages/bio` and `pathoscope-image` carries
-`packages/pathoscope-core`. Extend the `changes` job's filters in the same
+inputs — `pathoscope-image` carries `packages/pathoscope-core` and `nuvs-image`
+does not. Extend the `changes` job's filters in the same
 commit as anything that gives a job a new input — in
 particular, **every path a workflow Dockerfile `COPY`s must appear under that
 image's filter**, or the build is skipped on the pull request that breaks it
-and fails on the push to `main`, where nothing gates it.
+and fails on the push to `main`, where nothing gates it. That covers everything
+the shared `base` stage copies, packages the app does not import among them:
+`base` copies `packages/data`, `packages/service` and `packages/bio` whichever
+target was requested, so both image filters list all three.
 
 `pnpm build` builds **every app but `apps/site`**, which is gated by its own
 `site-build` CI job. `pnpm check` and `pnpm format` run biome over `apps` and

--- a/docs/images.md
+++ b/docs/images.md
@@ -146,16 +146,46 @@ Adding an app to the repo needs no Dockerfile edit until it needs an
 image; adding an *image* needs a stage here and an entry in both
 matrices.
 
+### The four workflow images
+
+The workflow images are in two states, and the split is deliberate. Which
+one an image is in turns on a single question: does a Python repo still
+release that workflow?
+
+| Image | Built | Published | Blocked on |
+| --- | --- | --- | --- |
+| `ts-create-sample` | ✅ | ✅ | — |
+| `ts-create-subtraction` | ✅ | ✅ | — |
+| `ts-pathoscope` | ✅ | ❌ | `virtool/workflow-pathoscope` retiring |
+| `ts-nuvs` | ✅ | ❌ | `virtool/workflow-nuvs` retiring |
+
+`virtool/workflow-create-sample` and `virtool/workflow-create-subtraction`
+are still live too, but they publish `ghcr.io/virtool/create-sample` and
+`ghcr.io/virtool/create-subtraction` — different names from the `ts-`
+images here, so the cluster picks one by the image it pulls and there is
+no ambiguity to resolve. The same is true of the two unpublished images
+and would be true if they published tomorrow; what stops them is not a
+name collision but that **two pipelines shipping the same workflow leaves
+two candidates for what the cluster runs**, and that has to be settled
+deliberately rather than by whichever released last.
+
 **Pathoscope and nuvs are the odd two, and both are built but
 deliberately not published.** Each has its own build job
-(`build-pathoscope`, `build-nuvs`) with no publish counterpart, because
-`virtool/workflow-pathoscope` and `virtool/workflow-nuvs` still release
-those workflows, and a second pipeline shipping either from here would
-leave two candidates for what the cluster runs. Restore a publish job for
-one when its Python repo retires. Note that `release-ghcr` is also what
-stamps a real version, so until then `APP_VERSION` is `0.0.0` in every
-built pathoscope or nuvs image, and the `workflow_version` in their cache
-keys with it.
+(`build-pathoscope`, `build-nuvs`) with no publish counterpart. Restore a
+publish job for one when its Python repo retires, and settle which image
+name the cluster pulls in the same change. Note that `release-ghcr` is
+also what stamps a real version, so until then `APP_VERSION` is `0.0.0`
+in every built pathoscope or nuvs image, and the `workflow_version` in
+their cache keys with it.
+
+**`ghcr.io/virtool/ts-pathoscope` already exists in the registry, and
+nothing here produced it.** A `publish-pathoscope` job lived in `ci.yaml`
+briefly and was removed once the two-pipeline problem was recognised; it
+left three versions behind, `:latest` among them. They predate the
+workflow port, so that tag is a tools-only image with no workflow code in
+it — a pull of `ts-pathoscope:latest` gets something that cannot run a
+job. Do not treat those tags as evidence the image is published, and do
+not read `:latest` as current.
 
 Both build jobs, plus `pathoscope-test` and `quality-test`, are the only
 path-filtered jobs in `ci.yaml`, and they take a filter each because
@@ -167,11 +197,13 @@ while `build-pathoscope` and `build-nuvs` bundle their app on the shared
 
 **Everything a build stage `COPY`s must appear under that image's
 filter** — a missing path skips the build on the pull request that breaks
-it and fails on the push to `main`, where nothing gates it. The two image
-filters are nearly identical and are kept separate rather than merged,
-because nuvs copies `packages/bio` and pathoscope copies
-`packages/pathoscope-core`, and folding them into one would rebuild each
-image for the other's inputs.
+it and fails on the push to `main`, where nothing gates it. That includes
+everything `base` copies, packages the app does not import among them:
+`base` is shared, so it copies `packages/data`, `packages/service` and
+`packages/bio` whichever target was requested. The two image filters are
+therefore nearly identical, and are kept separate rather than merged
+because pathoscope copies `packages/pathoscope-core` and nuvs does not —
+folding them into one would rebuild each image for the other's inputs.
 
 Build a single image locally by naming its target:
 


### PR DESCRIPTION
## Summary

- Both workflow-image path filters listed only the packages their app imports, but `build-nuvs` and `build-pathoscope` are `FROM base`, which copies `packages/data`, `packages/service` and `packages/bio` whichever target was requested. A change confined to one of those skipped the build on the PR that could break it and ran unguarded on the push to `main`. Both filters now carry everything `base` takes, `biome.json` and `packages/*/package.json` included; `pathoscope-image` also loses a duplicate `ci.yaml` entry, and the comment claiming the two differ over `packages/bio` is corrected — they differ over `packages/pathoscope-core` alone.
- Records the VIR-2975 audit in `docs/images.md`: `ts-create-sample` and `ts-create-subtraction` are built and published, `ts-pathoscope` and `ts-nuvs` are built and deliberately not. Nothing is paused — the latest run on `main` is green across all 26 jobs. Each unpublished image is blocked on its Python repo retiring rather than on a name collision; `virtool/workflow-create-sample` and `-create-subtraction` are live too and publish under different names, which is why those two can ship from here.
- Warns that `ghcr.io/virtool/ts-pathoscope` already carries tags, `:latest` among them, left by a `publish-pathoscope` job that lived in `ci.yaml` briefly and was removed once the two-pipeline problem was recognised. They predate the workflow port, so that tag is a tools-only image that cannot run a job — not evidence the image is published.

Two follow-ups are deliberately not in here: whether to delete the stale `ts-pathoscope` versions from GHCR, and Linear issues tracking the two Python repo retirements.