### PR TITLE
chore: fold the tilt/minikube dev cluster into the repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,11 @@
 .idea
 data
+# The Tilt/Minikube dev cluster. The Tiltfile builds these images with the repo
+# root as the context, and Tilt reads this file to decide what it watches — so
+# without these rules, editing a manifest or the Tiltfile itself would rebuild
+# every live-edited image.
+Tiltfile
+dev
 **/dist
 docker
 docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,11 @@ carries `--tries` and `--timeout`** — the defaults are 20 tries at a
 900-second read timeout, so an unreachable mirror hangs the job for
 hours instead of failing it.
 
+**The local Tilt/Minikube cluster is the root `Tiltfile` plus `dev/`**, which
+holds the Kustomize `manifests/` and the cluster `scripts/`. Neither is a
+workspace and neither holds TypeScript; see **The dev cluster is the root
+`Tiltfile` and `dev/`** under **Tooling**, and [dev/README.md](dev/README.md).
+
 Use `pnpm` for all install, run, and exec commands — not `npm` or `bun`.
 
 ## Tooling
@@ -269,8 +274,33 @@ and fails on the push to `main`, where nothing gates it.
 without an edit; `apps/site` is excluded once, in `biome.json`'s
 `files.includes`.
 
-Don't use the dev server. Live development is done using Tilt and Minikube and is
-currently configured in another repository.
+Don't use the dev server. Live development is done using Tilt and Minikube,
+configured in the root `Tiltfile` — see below.
+
+### The dev cluster is the root `Tiltfile` and `dev/`
+
+The `Tiltfile` is at the repo root, where `tilt up` looks for it. `dev/` holds
+everything it reads: the Kustomize `manifests/` and the `scripts/` that create,
+update and wipe the cluster. Every service and workflow it deploys builds from
+the root `Dockerfile`, at the stage named after the live-edit flag
+(`tilt up -- --web` builds the `dev` stage, `--nuvs` the `nuvs` stage). See
+[dev/README.md](dev/README.md).
+
+Three rules it carries:
+
+- **A `docker_build` context is `'.'`, the repo root.** Everything else the
+  Tiltfile names is relative to the root too, so a manifest is
+  `'dev/manifests/ingress.yaml'` and a script `'dev/scripts/pull.sh'`.
+- **`.dockerignore` excludes both `Tiltfile` and `dev`.** The Tiltfile builds
+  with the repo root as its context and Tilt reads that file to decide what it
+  watches, so without those rules an edit to a manifest rebuilds every
+  live-edited image.
+- **There is no migration target.** Migrations are Python's; the migration Job
+  runs the published `ghcr.io/virtool/virtool` image and nothing builds it here.
+
+It is YAML, Bash and Starlark, so `dev/` is not a pnpm workspace and is
+invisible to `pnpm build`, `pnpm test` and `pnpm knip`. `biome.json`'s
+`files.includes` carves it out the same way it carves out `apps/site`.
 
 ### When to run checks
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,254 @@
+local(['bash', 'dev/scripts/ensure-minikube.sh'], quiet=False)
+
+# Configuration
+#
+# Each live-edit target is a bool flag with a long and short form (e.g.
+# `--web` / `-w`). Tilt's flag parser only matches on the exact name given to
+# config.define_bool, so the short form has to be defined and checked
+# separately.
+config.define_bool("web", usage="live edit the web app")
+config.define_bool("w")
+config.define_bool("jobs-api", usage="live edit jobs-api")
+config.define_bool("j")
+config.define_bool("tasks", usage="live edit tasks")
+config.define_bool("t")
+config.define_bool("create-sample", usage="live edit the create-sample workflow")
+config.define_bool("m")
+config.define_bool("create-subtraction", usage="live edit the create-subtraction workflow")
+config.define_bool("b")
+config.define_bool("nuvs", usage="live edit the nuvs workflow")
+config.define_bool("n")
+config.define_bool("pathoscope", usage="live edit the pathoscope workflow")
+config.define_bool("p")
+
+cfg = config.parse()
+
+def flag(long, short=None):
+    return cfg.get(long, False) or (short != None and cfg.get(short, False))
+
+edit_web = flag("web", "w")
+edit_jobs_api = flag("jobs-api", "j")
+edit_tasks = flag("tasks", "t")
+edit_create_sample = flag("create-sample", "m")
+edit_create_subtraction = flag("create-subtraction", "b")
+edit_nuvs = flag("nuvs", "n")
+edit_pathoscope = flag("pathoscope", "p")
+
+load('ext://helm_resource', 'helm_resource', 'helm_repo')
+load('ext://uibutton', 'cmd_button', 'location')
+
+cmd_button('pull',
+    argv=['bash', 'dev/scripts/pull.sh'],
+    icon_name="cloud_download",
+    location=location.NAV,
+    text='Pull',
+)
+
+cmd_button('wipe',
+    argv=['bash', 'dev/scripts/wipe.sh'],
+    icon_name="delete_forever",
+    location=location.NAV,
+    text='Wipe',
+    requires_confirmation=True,
+)
+
+helm_repo('kedacore', 'https://kedacore.github.io/charts', labels=['k8s'])
+
+helm_resource(
+    'keda',
+    'kedacore/keda',
+    labels=['k8s'],
+    resource_deps=['kedacore']
+)
+
+k8s_yaml('dev/manifests/data/azurite.yaml')
+k8s_yaml('dev/manifests/data/postgres.yaml')
+
+k8s_resource("azurite", labels=['data'])
+k8s_resource("postgres", labels=['data'])
+
+# The migration Job runs the published `ghcr.io/virtool/virtool` image and is
+# never built here. Migrations are Python's, and the repository that used to
+# hold them as a live-edit target no longer exists.
+k8s_yaml('dev/manifests/ingress.yaml')
+k8s_yaml('dev/manifests/migration.yaml')
+
+docker_prune_settings(max_age_mins=1)
+
+# Anything in the build context that no sync below covers forces a full image
+# rebuild, which replaces the pod and costs a cold start. These paths are all
+# either generated or irrelevant to the image, so a change to one must never do
+# that. Shared across every docker_build below.
+#
+# `_tmp_*` is the important one: every host-side pnpm invocation writes
+# `_tmp_<pid>_<hash>` into a folder it is about to write atomically, so a
+# bare `pnpm exec ...` at the repo root drops one here and rebuilds every
+# live-edited image.
+#
+# This file and `dev/` are excluded by `.dockerignore`, which both the daemon
+# and Tilt's file watcher read, so editing the Tiltfile or a manifest does not
+# rebuild seven images.
+ui_monorepo_ignore = [
+  '**/_tmp_*',
+  '.claude/',
+  '.tanstack/',
+  'apps/web/.nitro/',
+  'apps/web/.output/',
+  'coverage/',
+  '*.md',
+]
+
+# Actual Virtool stuff.
+if edit_web:
+    docker_build(
+      'ghcr.io/virtool/ui',
+      '.',
+      entrypoint='pnpm --filter @virtool/web exec vite --host 0.0.0.0 --port 9900',
+      target='dev',
+      ignore=ui_monorepo_ignore,
+      live_update=[
+        fall_back_on([
+          './pnpm-lock.yaml',
+          './pnpm-workspace.yaml',
+          './package.json',
+          './apps/web/package.json',
+          './apps/web/vite.config.js',
+        ]),
+        sync('./apps/web/src', '/repo/apps/web/src'),
+        sync('./packages', '/repo/packages'),
+      ]
+    )
+
+if edit_jobs_api:
+    docker_build(
+      'ghcr.io/virtool/jobs-api',
+      '.',
+      target='jobs-api',
+      ignore=ui_monorepo_ignore,
+    )
+
+if edit_tasks:
+    docker_build(
+      'ghcr.io/virtool/tasks',
+      '.',
+      target='tasks',
+      ignore=ui_monorepo_ignore,
+    )
+
+k8s_yaml(kustomize('dev/manifests/web'))
+k8s_yaml(kustomize('dev/manifests/virtool'))
+
+k8s_resource(
+    'virtool-jobs-api',
+    labels=['virtool'],
+    port_forwards=["9960:9950"],
+    new_name="jobs-api",
+    resource_deps=["migration"],
+    trigger_mode=TRIGGER_MODE_MANUAL
+)
+
+k8s_resource(
+    labels=['k8s'],
+    new_name='ingress',
+    objects=['ingress', 'ingress-uploads'],
+    resource_deps=["web"]
+)
+
+k8s_resource(
+    'virtool-migration',
+    labels=['virtool'],
+    new_name="migration",
+    resource_deps=["azurite", "postgres"],
+    trigger_mode=TRIGGER_MODE_MANUAL
+)
+
+k8s_resource(
+    'virtool-tasks',
+    labels=['virtool'],
+    new_name="tasks",
+    port_forwards=["9970:9900"],
+    resource_deps=["migration"],
+    trigger_mode=TRIGGER_MODE_MANUAL
+)
+
+k8s_resource(
+    'virtool-web',
+    labels=['virtool'],
+    new_name="web",
+    port_forwards=[9900],
+    resource_deps=["postgres"]
+)
+
+"""Workflows"""
+if edit_create_sample:
+    docker_build(
+        'ghcr.io/virtool/create-sample',
+        '.',
+        target='create-sample',
+        ignore=ui_monorepo_ignore,
+    )
+
+if edit_create_subtraction:
+    docker_build(
+        'ghcr.io/virtool/create-subtraction',
+        '.',
+        target='create-subtraction',
+        ignore=ui_monorepo_ignore,
+    )
+
+if edit_nuvs:
+    docker_build(
+        'ghcr.io/virtool/nuvs',
+        '.',
+        target='nuvs',
+        ignore=ui_monorepo_ignore,
+    )
+
+if edit_pathoscope:
+    docker_build(
+        'ghcr.io/virtool/pathoscope',
+        '.',
+        target='pathoscope',
+        ignore=ui_monorepo_ignore,
+    )
+
+k8s_kind(
+    'ScaledJob',
+    image_json_path='{.spec.jobTargetRef.template.spec.containers[0].image}'
+)
+
+k8s_yaml(kustomize('dev/manifests/workflows'))
+
+scaled_job_deps = ['keda', 'jobs-api']
+
+k8s_resource(
+    'virtool-workflow-create-sample',
+    labels=["workflows"],
+    new_name="create-sample",
+    resource_deps=scaled_job_deps
+)
+
+
+k8s_resource(
+    'virtool-workflow-create-subtraction',
+    labels=["workflows"],
+    new_name="create-subtraction",
+    resource_deps=scaled_job_deps
+)
+
+
+
+k8s_resource(
+    'virtool-workflow-nuvs',
+    labels=["workflows"],
+    new_name="nuvs",
+    resource_deps=scaled_job_deps
+)
+
+k8s_resource(
+    'virtool-workflow-pathoscope',
+    labels=["workflows"],
+    new_name="pathoscope",
+    resource_deps=scaled_job_deps,
+    trigger_mode=TRIGGER_MODE_MANUAL
+)

--- a/biome.json
+++ b/biome.json
@@ -11,6 +11,7 @@
 			"!packages/pathoscope-core",
 			"!packages/quality-core/tests/fixtures/*.json",
 			"!apps/site/**",
+			"!dev/**",
 			"!packages/sqlite/src/fixtures/**",
 			"!**/routeTree.gen.ts",
 			"!**/node_modules",

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,119 @@
+# Dev cluster
+
+The local Kubernetes development environment, run with Tilt on Minikube. Every
+service and workflow it deploys builds from this repository, which is why the
+tooling lives here rather than in a repository of its own.
+
+The `Tiltfile` is at the **repo root**, where `tilt up` looks for it; this
+directory holds everything it reads. Run every command below from the repo
+root.
+
+## Requirements
+
+Docker Engine, `git`, Helm, `jq`, `kubectl`, `mkcert`, Minikube and Tilt.
+
+## Stack
+
+- **Tilt** — orchestrates the cluster; the root `Tiltfile` is the entry point
+- **Minikube** — the cluster itself
+- **KEDA** — scales workflow pods off a `metrics-api` trigger pointing at
+  `jobs-api`'s `/jobs/counts`
+- **PostgreSQL** — persisted across `tilt up` / `tilt down` by a PVC
+- **Azurite** — Azure Blob Storage emulator, on the well-known dev account
+  `devstoreaccount1`, persisting blobs at `/data` by a PVC
+
+## Layout
+
+```
+Tiltfile                  at the repo root: resources, buttons, live-edit flags
+dev/
+  manifests/              Kustomize manifests for every cluster resource
+    data/                 PostgreSQL, Azurite
+    ingress.yaml
+    migration.yaml
+    web/
+    virtool/              jobs-api, tasks
+    workflows/            a ScaledJob per workflow
+  scripts/
+    ensure-minikube.sh    Start the cluster if it is not already running
+    init.sh               Create or reset the cluster
+    pull.sh               Point the manifests at the latest released image tags
+    wipe.sh               Delete the StatefulSets and their PVCs
+```
+
+## Getting started
+
+1. Create the cluster:
+
+   ```shell
+   bash dev/scripts/init.sh
+   ```
+
+   This deletes any existing cluster, creates one with preset resource limits,
+   enables the `ingress` and `metrics-server` addons, issues an mkcert
+   certificate for `virtool.local` and installs it as the ingress controller's
+   default, and writes the cluster IP to `/etc/hosts` — which needs `sudo`.
+
+   Run `mkcert -install` once beforehand so the certificate is trusted.
+
+2. Start Tilt:
+
+   ```shell
+   tilt up
+   ```
+
+   Virtool is then at <https://virtool.local>.
+
+`tilt down` brings the resources back down; run it before `minikube stop` or
+the cluster does not stop cleanly. The `Tiltfile` calls
+`dev/scripts/ensure-minikube.sh` as it loads, so `tilt up` starts a stopped cluster
+on its own.
+
+## Live editing
+
+Every live-edit target builds from this repository's root `Dockerfile`, at the
+stage named after the target. Pass a flag to turn one on. Each has a long form
+and a short, double-dash form — Tilt's flag parser has no single-dash
+shorthand, so `--w` is as short as it gets:
+
+| Flag | Short | Image | Dockerfile stage |
+| --- | --- | --- | --- |
+| `--web` | `--w` | `ghcr.io/virtool/ui` | `dev` |
+| `--jobs-api` | `--j` | `ghcr.io/virtool/jobs-api` | `jobs-api` |
+| `--tasks` | `--t` | `ghcr.io/virtool/tasks` | `tasks` |
+| `--create-sample` | `--m` | `ghcr.io/virtool/create-sample` | `create-sample` |
+| `--create-subtraction` | `--b` | `ghcr.io/virtool/create-subtraction` | `create-subtraction` |
+| `--nuvs` | `--n` | `ghcr.io/virtool/nuvs` | `nuvs` |
+| `--pathoscope` | `--p` | `ghcr.io/virtool/pathoscope` | `pathoscope` |
+
+Flags combine: `tilt up -- --w --j`.
+
+`--web` runs Vite in the pod and syncs `apps/web/src` and `packages` into it,
+so an edit shows up without a rebuild. The rest rebuild the image on change,
+and `jobs-api` and `tasks` are on manual trigger — update them from the Tilt UI
+when you want the build.
+
+There is no migration target. Migrations are Python's, and the migration Job
+runs the published `ghcr.io/virtool/virtool` image.
+
+## Updating images
+
+`dev/scripts/pull.sh` rewrites the manifests to the latest released tags — the
+`virtool/virtool-ui` release for everything built here, and the
+`virtool/virtool` release for the migration Job. Run it directly or click
+**Pull** in the Tilt UI.
+
+## Wiping data
+
+`dev/scripts/wipe.sh` deletes the `postgres` and `azurite` StatefulSets and their
+PVCs; Tilt recreates them on the next trigger. It refuses to run unless
+`kubectl`'s current context is `minikube`. Run it directly or click **Wipe** in
+the Tilt UI.
+
+## Why none of this is linted or bundled
+
+It is YAML, Bash and Starlark and no TypeScript, so nothing here is a pnpm
+workspace and nothing here is built. `biome.json`'s `files.includes` carves
+`dev/` out the way it carves out `apps/site`, and `.dockerignore` excludes both
+`dev` and `Tiltfile` — without that, editing a manifest would land in the build
+context and rebuild every live-edited image.

--- a/dev/manifests/data/azurite.yaml
+++ b/dev/manifests/data/azurite.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: azurite
+  labels:
+    app: azurite
+spec:
+  serviceName: azurite
+  replicas: 1
+  selector:
+    matchLabels:
+      app: azurite
+  template:
+    metadata:
+      labels:
+        app: azurite
+    spec:
+      initContainers:
+        - name: azurite-init
+          image: mcr.microsoft.com/azure-cli:latest
+          restartPolicy: Always
+          env:
+            - name: AZURE_STORAGE_CONNECTION_STRING
+              value: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              until az storage container create --name virtool --output none 2>/dev/null; do sleep 2; done
+              touch /tmp/ready
+              exec sleep infinity
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          readinessProbe:
+            exec:
+              command: ["test", "-f", "/tmp/ready"]
+            periodSeconds: 2
+      containers:
+        - name: azurite
+          image: mcr.microsoft.com/azure-storage/azurite
+          args:
+            - azurite
+            - --blobHost
+            - 0.0.0.0
+            - --queueHost
+            - 0.0.0.0
+            - --tableHost
+            - 0.0.0.0
+            - --location
+            - /data
+            - --skipApiVersionCheck
+            - --disableProductStyleUrl
+          ports:
+            - containerPort: 10000
+              name: blob
+            - containerPort: 10001
+              name: queue
+            - containerPort: 10002
+              name: table
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          readinessProbe:
+            tcpSocket:
+              port: 10000
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 10000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: azurite
+spec:
+  selector:
+    app: azurite
+  ports:
+    - name: blob
+      protocol: TCP
+      port: 10000
+      targetPort: 10000
+    - name: queue
+      protocol: TCP
+      port: 10001
+      targetPort: 10001
+    - name: table
+      protocol: TCP
+      port: 10002
+      targetPort: 10002

--- a/dev/manifests/data/postgres.yaml
+++ b/dev/manifests/data/postgres.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - image: postgres:18
+          name: postgres
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+            limits:
+              cpu: 375m
+              memory: 1Gi
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - virtool
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - virtool
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql
+          env:
+            - name: POSTGRES_USER
+              value: "virtool"
+            - name: POSTGRES_DB
+              value: virtool
+            - name: POSTGRES_PASSWORD
+              value: virtool
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432

--- a/dev/manifests/ingress.yaml
+++ b/dev/manifests/ingress.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-body-size: "10000m"
+    # The Vite HMR socket and the /events SSE stream are long-lived and mostly
+    # idle. nginx's 60s defaults would cut them.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+spec:
+  tls:
+    - hosts:
+        - virtool.local
+      secretName: mkcert
+  rules:
+    - host: virtool.local
+      http:
+        paths:
+          - path: /(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: virtool-web-service
+                port:
+                  number: 80
+---
+# Uploads (POST /uploads) get their own Ingress so request buffering can be
+# turned off just for them. With buffering off, nginx streams the request body
+# straight to the UI instead of absorbing it first, so client-side upload
+# progress reflects the true blob-store write speed rather than jumping to 100%
+# and then stalling on a silent second hop. Buffering stays on everywhere else
+# (see the `ingress` object) so slow clients don't pin connections.
+# ingress-nginx merges this into the same virtool.local server block and orders
+# locations longest-path-first, so this rule wins for /uploads requests.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-uploads
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-body-size: "10000m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+spec:
+  tls:
+    - hosts:
+        - virtool.local
+      secretName: mkcert
+  rules:
+    - host: virtool.local
+      http:
+        paths:
+          - path: /(uploads.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: virtool-web-service
+                port:
+                  number: 80

--- a/dev/manifests/migration.yaml
+++ b/dev/manifests/migration.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: virtool-migration
+  labels:
+    app: virtool-migration
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: virtool-migration
+    spec:
+      restartPolicy: Never
+      containers:
+        - image: ghcr.io/virtool/virtool:41.19.0
+          name: virtool-migration
+          command: ["virtool", "migration", "apply"]
+          env:
+            - name: VT_DATA_PATH
+              value: "/data"
+            - name: VT_DEV
+              value: "true"
+            - name: VT_HOST
+              value: "0.0.0.0"
+            - name: VT_POSTGRES_CONNECTION_STRING
+              value: "postgresql+asyncpg://virtool@postgres.default.svc.cluster.local?password=virtool"
+            - name: VT_STORAGE_BACKEND
+              value: "azure"
+            - name: VT_STORAGE_AZURE_ACCOUNT
+              value: "devstoreaccount1"
+            - name: VT_STORAGE_AZURE_CONTAINER
+              value: "virtool"
+            - name: VT_STORAGE_AZURE_ACCESS_KEY
+              value: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+            - name: VT_STORAGE_AZURE_ENDPOINT
+              value: "http://azurite.default.svc.cluster.local:10000/devstoreaccount1"
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 800m
+              memory: 2Gi
+            requests:
+              cpu: 200m
+              memory: 1Gi

--- a/dev/manifests/virtool/jobs-api/deployment.yaml
+++ b/dev/manifests/virtool/jobs-api/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jobs-api
+  labels:
+    app: virtool-jobs-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: virtool-jobs-api
+  template:
+    metadata:
+      labels:
+        app: virtool-jobs-api
+    spec:
+      containers:
+        - name: jobs-api
+          image: ghcr.io/virtool/jobs-api:latest
+          env:
+            - name: VT_POSTGRES_URL
+              value: "postgres://virtool:virtool@postgres.default.svc.cluster.local:5432/virtool"
+            - name: VT_STORAGE_BACKEND
+              value: "azure"
+            - name: VT_STORAGE_AZURE_ACCOUNT
+              value: "devstoreaccount1"
+            - name: VT_STORAGE_AZURE_CONTAINER
+              value: "virtool"
+            - name: VT_STORAGE_AZURE_ACCESS_KEY
+              value: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+            - name: VT_STORAGE_AZURE_ENDPOINT
+              value: "http://azurite.default.svc.cluster.local:10000/devstoreaccount1"
+          ports:
+            - containerPort: 9950
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 600m
+              memory: 800M
+            requests:
+              cpu: 400m
+              memory: 400M

--- a/dev/manifests/virtool/jobs-api/kustomization.yaml
+++ b/dev/manifests/virtool/jobs-api/kustomization.yaml
@@ -1,0 +1,14 @@
+images:
+  - name: ghcr.io/virtool/jobs-api
+    newTag: latest
+
+labels:
+  - pairs:
+      component: jobs-api
+      part-of: virtool
+
+namePrefix: virtool-
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/dev/manifests/virtool/jobs-api/service.yaml
+++ b/dev/manifests/virtool/jobs-api/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jobs-api-service
+spec:
+  type: ClusterIP
+  selector:
+    app: virtool-jobs-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: 9950

--- a/dev/manifests/virtool/kustomization.yaml
+++ b/dev/manifests/virtool/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - jobs-api
+  - tasks

--- a/dev/manifests/virtool/tasks/deployment.yaml
+++ b/dev/manifests/virtool/tasks/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tasks
+  labels:
+    app: virtool-tasks
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: virtool-tasks
+  template:
+    metadata:
+      labels:
+        app: virtool-tasks
+    spec:
+      containers:
+        - name: tasks
+          image: ghcr.io/virtool/tasks:latest
+          env:
+            - name: VT_POSTGRES_URL
+              value: "postgres://virtool:virtool@postgres.default.svc.cluster.local:5432/virtool"
+            - name: VT_STORAGE_BACKEND
+              value: "azure"
+            - name: VT_STORAGE_AZURE_ACCOUNT
+              value: "devstoreaccount1"
+            - name: VT_STORAGE_AZURE_CONTAINER
+              value: "virtool"
+            - name: VT_STORAGE_AZURE_ACCESS_KEY
+              value: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+            - name: VT_STORAGE_AZURE_ENDPOINT
+              value: "http://azurite.default.svc.cluster.local:10000/devstoreaccount1"
+          ports:
+            - containerPort: 9900
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 600m
+              memory: 1Gi

--- a/dev/manifests/virtool/tasks/kustomization.yaml
+++ b/dev/manifests/virtool/tasks/kustomization.yaml
@@ -1,0 +1,13 @@
+images:
+  - name: ghcr.io/virtool/tasks
+    newTag: latest
+
+labels:
+  - pairs:
+      component: tasks
+      part-of: virtool
+
+namePrefix: virtool-
+
+resources:
+  - deployment.yaml

--- a/dev/manifests/web/deployment.yaml
+++ b/dev/manifests/web/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  template:
+    spec:
+      containers:
+        - image: ghcr.io/virtool/ui:latest
+          name: virtool-web
+          command: ["npm", "start"]
+          env:
+            - name: VT_UI_PORT
+              value: "9900"
+            - name: VT_UI_HOST
+              value: "0.0.0.0"
+            - name: VT_POSTGRES_URL
+              value: "postgres://virtool:virtool@postgres.default.svc.cluster.local:5432/virtool"
+            - name: VT_STORAGE_BACKEND
+              value: "azure"
+            - name: VT_STORAGE_AZURE_ACCOUNT
+              value: "devstoreaccount1"
+            - name: VT_STORAGE_AZURE_CONTAINER
+              value: "virtool"
+            - name: VT_STORAGE_AZURE_ACCESS_KEY
+              value: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+            - name: VT_STORAGE_AZURE_ENDPOINT
+              value: "http://azurite.default.svc.cluster.local:10000/devstoreaccount1"
+          ports:
+            - containerPort: 9900
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 4000m
+              memory: 3200M
+            requests:
+              cpu: 2000m
+              memory: 3200M

--- a/dev/manifests/web/kustomization.yaml
+++ b/dev/manifests/web/kustomization.yaml
@@ -1,0 +1,15 @@
+images:
+  - name: ghcr.io/virtool/ui
+    newTag: 7.79.7
+
+labels:
+  - pairs:
+      app: virtool-web
+    includeSelectors: true
+    includeTemplates: true
+
+namePrefix: virtool-
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/dev/manifests/web/service.yaml
+++ b/dev/manifests/web/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-service
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 9900

--- a/dev/manifests/workflows/create-sample.yaml
+++ b/dev/manifests/workflows/create-sample.yaml
@@ -1,0 +1,38 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  labels:
+    app.virtool.ca/workflow-name: create-sample
+    app.virtool.ca/workflow-size: small
+  name: create-sample
+spec:
+  jobTargetRef:
+    template:
+      metadata:
+        labels:
+          app: workflow-create-sample
+      spec:
+        containers:
+          - name: workflow-create-sample
+            image: ghcr.io/virtool/create-sample:7.79.7
+            env:
+              - name: VT_PROC
+                value: "2"
+              - name: VT_MEM
+                value: "4"
+              - name: VT_WORKFLOW
+                value: create_sample
+            resources:
+              limits:
+                cpu: 2700m
+                memory: 5Gi
+              requests:
+                cpu: 2700m
+                memory: 5Gi
+  triggers:
+    - type: metrics-api
+      metadata:
+        url: "http://virtool-jobs-api-service.default.svc.cluster.local/jobs/counts"
+        valueLocation: "pending.create_sample"
+        targetValue: "1"
+        activationTargetValue: "0"

--- a/dev/manifests/workflows/create-subtraction.yaml
+++ b/dev/manifests/workflows/create-subtraction.yaml
@@ -1,0 +1,38 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  labels:
+    app.virtool.ca/workflow-name: create-subtraction
+    app.virtool.ca/workflow-size: small
+  name: create-subtraction
+spec:
+  jobTargetRef:
+    template:
+      metadata:
+        labels:
+          app: workflow-create-subtraction
+      spec:
+        containers:
+          - name: workflow-create-subtraction
+            image: ghcr.io/virtool/create-subtraction:7.79.7
+            env:
+              - name: VT_PROC
+                value: "2"
+              - name: VT_MEM
+                value: "2"
+              - name: VT_WORKFLOW
+                value: create_subtraction
+            resources:
+              limits:
+                cpu: "3"
+                memory: 5Gi
+              requests:
+                cpu: "3"
+                memory: 5Gi
+  triggers:
+    - type: metrics-api
+      metadata:
+        url: "http://virtool-jobs-api-service.default.svc.cluster.local/jobs/counts"
+        valueLocation: "pending.create_subtraction"
+        targetValue: "1"
+        activationTargetValue: "0"

--- a/dev/manifests/workflows/kustomization.yaml
+++ b/dev/manifests/workflows/kustomization.yaml
@@ -1,0 +1,22 @@
+namePrefix: virtool-workflow-
+
+labels:
+  - pairs:
+      app.kubernetes.io/component: workflow
+      app.kubernetes.io/part-of: virtool
+    includeSelectors: true
+    includeTemplates: true
+
+patches:
+  - path: patches/patch-strategic.yaml
+    target:
+      kind: ScaledJob
+  - path: patches/patch-json.yaml
+    target:
+      kind: ScaledJob
+
+resources:
+  - create-sample.yaml
+  - create-subtraction.yaml
+  - nuvs.yaml
+  - pathoscope.yaml

--- a/dev/manifests/workflows/nuvs.yaml
+++ b/dev/manifests/workflows/nuvs.yaml
@@ -1,0 +1,35 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  name: nuvs
+  labels:
+    app.virtool.ca/workflow-size: large
+    app.virtool.ca/workflow-name: nuvs
+spec:
+  jobTargetRef:
+    template:
+      spec:
+        containers:
+          - name: workflow-nuvs
+            image: ghcr.io/virtool/nuvs:7.79.7
+            env:
+              - name: VT_PROC
+                value: "4"
+              - name: VT_MEM
+                value: "10"
+              - name: VT_WORKFLOW
+                value: nuvs
+            resources:
+              limits:
+                cpu: "5"
+                memory: 11Gi
+              requests:
+                cpu: "4"
+                memory: 10Gi
+  triggers:
+    - type: metrics-api
+      metadata:
+        url: "http://virtool-jobs-api-service.default.svc.cluster.local/jobs/counts"
+        valueLocation: "pending.nuvs"
+        targetValue: "1"
+        activationTargetValue: "0"

--- a/dev/manifests/workflows/patches/patch-json.yaml
+++ b/dev/manifests/workflows/patches/patch-json.yaml
@@ -1,0 +1,47 @@
+- op: add
+  path: /spec/jobTargetRef/template/spec/containers/0/env/-1
+  value:
+    name: VT_JOBS_API_URL
+    value: http://virtool-jobs-api-service.default.svc.cluster.local
+
+- op: add
+  path: /spec/jobTargetRef/template/spec/containers/0/env/-1
+  value:
+    name: VT_TIMEOUT
+    value: "120"
+
+- op: add
+  path: /spec/jobTargetRef/template/spec/containers/0/env/-1
+  value:
+    name: VT_WORK_PATH
+    value: /work
+
+- op: add
+  path: /spec/jobTargetRef/template/spec/containers/0/env/-1
+  value:
+    name: VT_STORAGE_BACKEND
+    value: azure
+
+- op: add
+  path: /spec/jobTargetRef/template/spec/containers/0/env/-1
+  value:
+    name: VT_STORAGE_AZURE_ACCOUNT
+    value: devstoreaccount1
+
+- op: add
+  path: /spec/jobTargetRef/template/spec/containers/0/env/-1
+  value:
+    name: VT_STORAGE_AZURE_CONTAINER
+    value: virtool
+
+- op: add
+  path: /spec/jobTargetRef/template/spec/containers/0/env/-1
+  value:
+    name: VT_STORAGE_AZURE_ACCESS_KEY
+    value: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+
+- op: add
+  path: /spec/jobTargetRef/template/spec/containers/0/env/-1
+  value:
+    name: VT_STORAGE_AZURE_ENDPOINT
+    value: http://azurite.default.svc.cluster.local:10000/devstoreaccount1

--- a/dev/manifests/workflows/patches/patch-strategic.yaml
+++ b/dev/manifests/workflows/patches/patch-strategic.yaml
@@ -1,0 +1,13 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  name: ignored
+spec:
+  failedJobsHistoryLimit: 3
+  jobTargetRef:
+    backoffLimit: 1
+    completions: 1
+    parallelism: 1
+  rollout:
+    strategy: gradual
+  successfulJobsHistoryLimit: 1

--- a/dev/manifests/workflows/pathoscope.yaml
+++ b/dev/manifests/workflows/pathoscope.yaml
@@ -1,0 +1,35 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  name: pathoscope
+  labels:
+    app.virtool.ca/workflow-name: pathoscope
+    app.virtool.ca/workflow-size: large
+spec:
+  jobTargetRef:
+    template:
+      spec:
+        containers:
+          - name: workflow-pathoscope
+            image: ghcr.io/virtool/pathoscope:7.79.7
+            env:
+              - name: VT_MEM
+                value: "8"
+              - name: VT_PROC
+                value: "4"
+              - name: VT_WORKFLOW
+                value: pathoscope
+            resources:
+              limits:
+                cpu: "5"
+                memory: 10Gi
+              requests:
+                cpu: "5"
+                memory: 10Gi
+  triggers:
+    - type: metrics-api
+      metadata:
+        url: "http://virtool-jobs-api-service.default.svc.cluster.local/jobs/counts"
+        valueLocation: "pending.pathoscope"
+        targetValue: "1"
+        activationTargetValue: "0"

--- a/dev/scripts/ensure-minikube.sh
+++ b/dev/scripts/ensure-minikube.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+if minikube status >/dev/null 2>&1; then
+    echo "Minikube is already running."
+else
+    echo "Minikube is not running. Starting..."
+    minikube start --cpus 8 --memory 16000
+fi

--- a/dev/scripts/init.sh
+++ b/dev/scripts/init.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+echo "Deleting any existing Minikube cluster..."
+minikube delete --purge=true
+
+echo "Starting Minikube for first time..."
+minikube start --cpus 8 --memory 16000
+
+echo "Enabling Minikube addons..."
+minikube addons enable metrics-server
+
+echo "Generating TLS certificate for virtool.local..."
+CERT_DIR=$(mktemp -d)
+mkcert -key-file "$CERT_DIR/key.pem" -cert-file "$CERT_DIR/cert.pem" virtool.local
+
+echo "Creating TLS secrets..."
+kubectl -n kube-system create secret tls mkcert \
+    --key "$CERT_DIR/key.pem" \
+    --cert "$CERT_DIR/cert.pem"
+kubectl create secret tls mkcert \
+    --key "$CERT_DIR/key.pem" \
+    --cert "$CERT_DIR/cert.pem"
+
+echo "Cleaning up temporary certificate files..."
+rm -rf "$CERT_DIR"
+
+echo "Configuring ingress addon to use custom certificate..."
+minikube addons configure ingress <<< "kube-system/mkcert"
+minikube addons enable ingress
+
+echo "Verifying ingress configuration..."
+kubectl -n ingress-nginx get deployment ingress-nginx-controller -o yaml | grep "kube-system"
+
+echo "Configuring /etc/hosts..."
+MINIKUBE_IP=$(minikube ip)
+sudo sed -i '/virtool.local/d' /etc/hosts
+echo -e "$MINIKUBE_IP\tvirtool.local" | sudo tee -a /etc/hosts

--- a/dev/scripts/pull.sh
+++ b/dev/scripts/pull.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Manifest paths are resolved from this script's own location rather than the
+# working directory. Tilt's Pull button runs it from dev/, a person running it
+# by hand is as likely to be at the repo root.
+MANIFESTS="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/manifests"
+
+# Ensure jq is installed
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is not installed. Please install jq to use this script."
+    exit 1
+fi
+
+fetch_latest_tag() {
+    local repo=$1
+    local url="https://api.github.com/repos/${repo}/releases/latest"
+    curl -s "$url" | jq -r '.tag_name' | sed 's/^v//'
+}
+
+update_tag() {
+    local file=$1
+    local prefix=$2
+    local tag=$3
+
+    if [[ -f "$file" ]]; then
+        sed -i.bak "s|${prefix}[0-9.]\+|${prefix}${tag}|" "$file" && rm "${file}.bak"
+        echo "Using tag '$tag' for $file"
+    else
+        echo "Error: File $file not found."
+        exit 1
+    fi
+}
+
+echo "Server"
+echo ""
+
+# migration hasn't been ported to the virtool-ui monorepo yet, so it still
+# versions off the virtool python monolith's releases.
+virtool_tag=$(fetch_latest_tag "virtool/virtool")
+update_tag "$MANIFESTS/migration.yaml" "ghcr.io/virtool/virtool:" "$virtool_tag"
+
+# web, jobs-api, tasks, and all four workflows now build from virtool-ui, so
+# one release tag covers all of them.
+ui_tag=$(fetch_latest_tag "virtool/virtool-ui")
+update_tag "$MANIFESTS/web/kustomization.yaml" "newTag: " "$ui_tag"
+update_tag "$MANIFESTS/virtool/jobs-api/kustomization.yaml" "newTag: " "$ui_tag"
+update_tag "$MANIFESTS/virtool/tasks/kustomization.yaml" "newTag: " "$ui_tag"
+
+echo ""
+echo "Workflows"
+echo ""
+
+for workflow in "create-sample" "create-subtraction" "nuvs" "pathoscope"; do
+    update_tag "$MANIFESTS/workflows/${workflow}.yaml" "${workflow}:" "$ui_tag"
+done

--- a/dev/scripts/pull.sh
+++ b/dev/scripts/pull.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Without pipefail a failing curl is masked by the jq and sed that follow it,
+# and the tag check below reports a missing release where the truth is a dead
+# network or a spent rate limit.
+set -o pipefail
+
 # Manifest paths are resolved from this script's own location rather than the
 # working directory. Tilt's Pull button runs it from dev/, a person running it
 # by hand is as likely to be at the repo root.
@@ -11,24 +16,50 @@ if ! command -v jq &> /dev/null; then
     exit 1
 fi
 
+# The API is called unauthenticated, so it is rate limited at 60 requests an
+# hour and answers a spent budget with a JSON error object and a 403. `curl -s`
+# reports that as success and `.tag_name` comes back `null`, so without `-f` and
+# the checks below a rate-limited run rewrites every manifest to `null`.
 fetch_latest_tag() {
     local repo=$1
     local url="https://api.github.com/repos/${repo}/releases/latest"
-    curl -s "$url" | jq -r '.tag_name' | sed 's/^v//'
+    local tag
+
+    if ! tag=$(curl -fsS "$url" | jq -r '.tag_name' | sed 's/^v//'); then
+        echo "Error: could not fetch the latest release of $repo." >&2
+        exit 1
+    fi
+
+    if [[ -z "$tag" || "$tag" == "null" ]]; then
+        echo "Error: $repo reported no latest release tag." >&2
+        exit 1
+    fi
+
+    echo "$tag"
 }
 
+# The old tag is matched as a run of non-space characters rather than as
+# `[0-9.]+`. jobs-api and tasks ship pinned to `latest`, which has no digits in
+# it, so a numeric pattern left them there while still reporting success — and
+# the whole point of this script is that every service runs one release.
 update_tag() {
     local file=$1
     local prefix=$2
     local tag=$3
 
-    if [[ -f "$file" ]]; then
-        sed -i.bak "s|${prefix}[0-9.]\+|${prefix}${tag}|" "$file" && rm "${file}.bak"
-        echo "Using tag '$tag' for $file"
-    else
-        echo "Error: File $file not found."
+    if [[ ! -f "$file" ]]; then
+        echo "Error: File $file not found." >&2
         exit 1
     fi
+
+    sed -i.bak "s|${prefix}[^[:space:]]\+|${prefix}${tag}|" "$file" && rm "${file}.bak"
+
+    if ! grep -qF "${prefix}${tag}" "$file"; then
+        echo "Error: no '${prefix}' tag to rewrite in $file." >&2
+        exit 1
+    fi
+
+    echo "Using tag '$tag' for $file"
 }
 
 echo "Server"

--- a/dev/scripts/wipe.sh
+++ b/dev/scripts/wipe.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+current_context=$(kubectl config current-context 2>/dev/null || true)
+if [[ "$current_context" != "minikube" ]]; then
+    echo "Refusing to wipe: kubectl current-context is '${current_context:-<none>}', expected 'minikube'."
+    echo "Switch contexts with: kubectl config use-context minikube"
+    exit 1
+fi
+
+if ! minikube status >/dev/null 2>&1; then
+    echo "Refusing to wipe: Minikube is not running."
+    exit 1
+fi
+
+echo "Deleting StatefulSets..."
+kubectl delete statefulset azurite postgres --ignore-not-found
+
+echo "Deleting PVCs..."
+kubectl delete pvc \
+    data-azurite-0 \
+    data-postgres-0 \
+    --ignore-not-found
+
+echo "Done. Tilt will recreate resources on next trigger."


### PR DESCRIPTION
## Summary

- Every live-edit target in the `virtool/dev` Tiltfile — `web`, `jobs-api`, `tasks` and the four workflows — already built from this repository, so the separate repo only bought a sibling-path dependency and a second place to look. The `Tiltfile` now sits at the repo root, where `tilt up` looks for it, and `dev/` holds the Kustomize manifests and cluster scripts it reads. Build contexts are `'.'` rather than `'../virtool-ui/'`.
- The `--migration` flag is gone along with the repository behind it; the migration Job keeps running the published `ghcr.io/virtool/virtool` image. `scripts/update_workflows.py` did not come along either — it bumps `virtool-workflow` in the Python `workflow-*` repos this monorepo replaced.
- `.dockerignore` excludes `Tiltfile` and `dev`, without which an edit to a manifest would land in the build context and rebuild every live-edited image, and `biome.json` carves `dev/` out the way it carves out `apps/site`. `AGENTS.md` drops the "configured in another repository" line for a section covering those rules.

Verified `pnpm check` and `pnpm knip`, that all three kustomizations build, and that the Tiltfile parses. `tilt up` itself is unverified — evaluating the Tiltfile runs its `local()` call and starts Minikube.

Note for whoever runs this next: the workflow manifests point at `ghcr.io/virtool/{create-sample,nuvs,pathoscope}`, but this repo publishes create-sample as `ts-create-sample` and deliberately publishes neither nuvs nor pathoscope, so those ScaledJobs will `ImagePullBackOff` without a live-edit flag. Pre-existing, and VIR-2975's territory.

Closes VIR-2967.