### PR TITLE
fix: restore sample deletion

### DIFF
--- a/apps/jobs-api/src/analyses/handlers.test.ts
+++ b/apps/jobs-api/src/analyses/handlers.test.ts
@@ -66,7 +66,7 @@ beforeEach(async () => {
 
 	const [reference] = await db
 		.insert(legacyReferences)
-		.values({ name: "Reference" })
+		.values({ name: "Reference", user_id: userId })
 		.returning({ id: legacyReferences.id });
 
 	referenceId = reference?.id as number;

--- a/apps/tasks/src/tasks/sweep-blast.test.ts
+++ b/apps/tasks/src/tasks/sweep-blast.test.ts
@@ -75,6 +75,7 @@ async function seedPendingBlast(): Promise<{
 			results: { hits: [{ index: 0, sequence: "ATGCATGC", orfs: [] }] },
 			sample: "0",
 			user_id: userId,
+			index_id: 1,
 		})
 		.returning({ id: analyses.id });
 

--- a/apps/web/src/server/analyses/functions.test.ts
+++ b/apps/web/src/server/analyses/functions.test.ts
@@ -118,7 +118,11 @@ async function seedReference(
 	return takeFirstOrThrow(
 		await db
 			.insert(legacyReferences)
-			.values({ name: `Reference ${Math.random()}`, ...overrides })
+			.values({
+				name: `Reference ${Math.random()}`,
+				user_id: ownerId,
+				...overrides,
+			})
 			.returning({ id: legacyReferences.id }),
 	).id;
 }

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -73,7 +73,6 @@ The columns, all `UNIQUE`:
 | --- | --- | --- |
 | `sample_reads` | `storage_key` | no |
 | `index_files` | `storage_key` | no |
-| `sample_artifacts` | `storage_key` | yes |
 | `subtraction_files` | `storage_key` | yes |
 | `analysis_files` | `storage_key` | yes |
 | `uploads` | `storage_key` | yes |

--- a/packages/data/src/analyses/data.test.ts
+++ b/packages/data/src/analyses/data.test.ts
@@ -80,7 +80,7 @@ async function seedReference(
 	return takeFirstOrThrow(
 		await db
 			.insert(legacyReferences)
-			.values({ name: "Reference", ...overrides })
+			.values({ name: "Reference", user_id: ownerId, ...overrides })
 			.returning({ id: legacyReferences.id }),
 	).id;
 }

--- a/packages/data/src/analyses/format.test.ts
+++ b/packages/data/src/analyses/format.test.ts
@@ -399,6 +399,8 @@ async function seedDetectedOtu(): Promise<void> {
 	);
 
 	await db.insert(legacyHistoryDiff).values({
+		// NOT NULL upstream, and unread here — the diff is what this test asserts.
+		change_id: `seed.${change.id}`,
 		history_id: change.id,
 		diff: [
 			["change", "name", [ANALYSED_NAME, CURRENT_NAME]],

--- a/packages/data/src/blast/data.test.ts
+++ b/packages/data/src/blast/data.test.ts
@@ -114,6 +114,7 @@ async function seedAnalysis(indices: number[] = [0]): Promise<number> {
 				},
 				sample: "0",
 				user_id: userId,
+				index_id: 1,
 			})
 			.returning({ id: analyses.id }),
 	).id;

--- a/packages/data/src/db/schema/analyses.ts
+++ b/packages/data/src/db/schema/analyses.ts
@@ -37,7 +37,7 @@ export const analyses = pgTable("analyses", {
 	sample: text("sample").notNull(),
 	sample_id: bigint("sample_id", { mode: "number" }),
 	reference_id: bigint("reference_id", { mode: "number" }),
-	index_id: bigint("index_id", { mode: "number" }),
+	index_id: bigint("index_id", { mode: "number" }).notNull(),
 	user_id: integer("user_id").notNull(),
 	job_id: integer("job_id"),
 });

--- a/packages/data/src/db/schema/history.ts
+++ b/packages/data/src/db/schema/history.ts
@@ -45,11 +45,11 @@ export const legacyHistoryDiff = pgTable("legacy_history_diff", {
 	// The change's public id, duplicating `legacy_history.legacy_id`. It predates
 	// `history_id` and Python still writes it, so an insert from here must too —
 	// the column is NOT NULL upstream.
-	change_id: text("change_id").unique(),
+	change_id: text("change_id").unique().notNull(),
 	history_id: bigint("history_id", { mode: "number" }).unique(),
 	// A dictdiffer diff: an array of `[action, path, changes]` triples, shaped by
 	// `@server/history/dictdiffer` and opaque to the database.
-	diff: jsonb("diff").$type<unknown>(),
+	diff: jsonb("diff").$type<unknown>().notNull(),
 });
 
 /** A row from the `legacy_history` table. */

--- a/packages/data/src/db/schema/hmms.ts
+++ b/packages/data/src/db/schema/hmms.ts
@@ -64,7 +64,9 @@ export const hmms = pgTable("hmms", {
 	length: integer("length").notNull(),
 	mean_entropy: doublePrecision("mean_entropy").notNull(),
 	total_entropy: doublePrecision("total_entropy").notNull(),
-	hidden: boolean("hidden").$defaultFn(() => false),
+	hidden: boolean("hidden")
+		.$defaultFn(() => false)
+		.notNull(),
 	names: jsonb("names").$type<string[]>().notNull(),
 	families: jsonb("families").$type<Record<string, number>>().notNull(),
 	genera: jsonb("genera").$type<Record<string, number>>().notNull(),

--- a/packages/data/src/db/schema/jobs.ts
+++ b/packages/data/src/db/schema/jobs.ts
@@ -5,9 +5,10 @@
 // The legacy Mongo `args` field is not a column. A job's resources are all
 // found on the owning rows via a reverse `job_id` foreign key —
 // `legacy_samples.job_id`, `indexes.job_id`, `subtractions.job_id`, and
-// `analyses.job_id` — and recombined into `args` when a job is read. There are
-// no `job_samples` / `job_indexes` junction tables: the sample and index are
-// resolved through those reverse foreign keys, not link rows.
+// `analyses.job_id` — and recombined into `args` when a job is read. The
+// `job_analyses` and `job_indexes` link tables upstream are vestigial and
+// deliberately unmirrored: the sample and index are resolved through those
+// reverse foreign keys, and nothing on this side reads or writes a link row.
 //
 // The two JSONB columns are typed with the `Stored*` shapes from
 // `@virtool/contracts`, which is where the mappers that publish them live. A
@@ -29,7 +30,10 @@ import {
 
 export const jobs = pgTable("jobs", {
 	id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-	acquired: boolean("acquired").$defaultFn(() => false),
+	// `.default()`, not `$defaultFn()`: this is the one column here that really
+	// does carry a server default upstream, so the generated test DDL has to
+	// carry it too or a raw insert omitting it fails only under test.
+	acquired: boolean("acquired").default(false).notNull(),
 	claim: jsonb("claim").$type<StoredJobClaim>(),
 	claimed_at: timestamp("claimed_at"),
 	created_at: timestamp("created_at").notNull(),

--- a/packages/data/src/db/schema/messages.ts
+++ b/packages/data/src/db/schema/messages.ts
@@ -35,9 +35,10 @@ export const instanceMessages = pgTable("instance_messages", {
 	message: text("message"),
 	createdAt: timestamp("created_at"),
 	updatedAt: timestamp("updated_at"),
-	userId: integer("user_id")
-		.notNull()
-		.references(() => users.id),
+	// Nullable upstream: a row migrated from Mongo carries its author in the
+	// legacy `"user"` column, and a trigger resolves `user_id` from it. Every
+	// read joins on it, so a row that predates the backfill is simply invisible.
+	userId: integer("user_id").references(() => users.id),
 });
 
 /** A row from the `instance_messages` table. */

--- a/packages/data/src/db/schema/references.ts
+++ b/packages/data/src/db/schema/references.ts
@@ -40,7 +40,7 @@ export const legacyReferences = pgTable("legacy_references", {
 		.$type<string[]>()
 		.$defaultFn(() => [])
 		.notNull(),
-	user_id: integer("user_id"),
+	user_id: integer("user_id").notNull(),
 	upload_id: integer("upload_id"),
 	cloned_from_id: bigint("cloned_from_id", { mode: "number" }),
 	task_id: integer("task_id"),

--- a/packages/data/src/db/schema/samples.ts
+++ b/packages/data/src/db/schema/samples.ts
@@ -92,22 +92,6 @@ export const legacySampleSubtractions = pgTable("legacy_sample_subtractions", {
 	subtraction_id: bigint("subtraction_id", { mode: "number" }).notNull(),
 });
 
-// Artifacts produced during sample creation.
-export const sampleArtifacts = pgTable("sample_artifacts", {
-	id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
-	sample: text("sample").notNull(),
-	sample_id: bigint("sample_id", { mode: "number" }),
-	name: text("name").notNull(),
-	name_on_disk: text("name_on_disk"),
-	size: bigint("size", { mode: "number" }),
-	// The artifact's complete object-storage key. Nullable because it was
-	// backfilled from `name_on_disk`, which is itself nullable: a row without one
-	// names no retrievable object.
-	storage_key: text("storage_key").unique(),
-	type: text("type").notNull(),
-	uploaded_at: timestamp("uploaded_at"),
-});
-
 // Reads files that make up a sample.
 export const sampleReads = pgTable("sample_reads", {
 	id: integer("id").primaryKey().generatedByDefaultAsIdentity(),

--- a/packages/data/src/history/data.test.ts
+++ b/packages/data/src/history/data.test.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { Db, DbOrTx } from "../db/pg";
 import { takeFirstOrThrow } from "../db/rows";
@@ -105,7 +106,11 @@ async function seedChange(values: {
 }
 
 async function seedDiff(historyId: number, diff: unknown): Promise<void> {
-	await db.insert(legacyHistoryDiff).values({ history_id: historyId, diff });
+	// `change_id` duplicates the history row's public id and is NOT NULL
+	// upstream, so a seed has to supply one even though nothing here reads it.
+	await db
+		.insert(legacyHistoryDiff)
+		.values({ change_id: `seed.${historyId}`, history_id: historyId, diff });
 }
 
 // The dictdiffer diff Python's `calculate_diff` writes for a rename, serialized
@@ -378,13 +383,16 @@ describe("patchOtusToVersions", () => {
 	});
 
 	it("throws when a remove change carries no document", async () => {
+		// JSON null, not SQL NULL: the column is NOT NULL upstream, so a row that
+		// carries no document holds a `null` inside the JSONB rather than an
+		// absent value. Both read back as `null` here.
 		await seedDiff(
 			await seedChange({
 				otu: "otu_gone",
 				otuVersion: null,
 				methodName: "remove",
 			}),
-			null,
+			sql`'null'::jsonb`,
 		);
 
 		await expect(

--- a/packages/data/src/jobs/data.test.ts
+++ b/packages/data/src/jobs/data.test.ts
@@ -145,6 +145,7 @@ describe("getJob", () => {
 				updated_at: now,
 				sample: "0",
 				user_id: 1,
+				index_id: 1,
 				job_id: jobId,
 				workflow: "nuvs",
 				ready: false,

--- a/packages/data/src/otus/mutations.test.ts
+++ b/packages/data/src/otus/mutations.test.ts
@@ -71,7 +71,7 @@ beforeEach(async () => {
 
 	const [reference] = await db
 		.insert(legacyReferences)
-		.values({ name: "Reference" })
+		.values({ name: "Reference", user_id: userId })
 		.returning({ id: legacyReferences.id });
 
 	referenceId = reference?.id as number;

--- a/packages/data/src/otus/queryCount.test.ts
+++ b/packages/data/src/otus/queryCount.test.ts
@@ -79,7 +79,7 @@ beforeEach(async () => {
 
 	const [reference] = await db
 		.insert(legacyReferences)
-		.values({ name: "Reference" })
+		.values({ name: "Reference", user_id: userId })
 		.returning({ id: legacyReferences.id });
 
 	referenceId = reference?.id as number;

--- a/packages/data/src/samples/data.test.ts
+++ b/packages/data/src/samples/data.test.ts
@@ -12,7 +12,6 @@ import {
 	legacySampleLabels,
 	legacySampleSubtractions,
 	legacySamples,
-	sampleArtifacts,
 	sampleReads,
 	sampleUploads,
 } from "../db/schema/samples";
@@ -62,7 +61,6 @@ beforeEach(async () => {
 	await db.delete(legacySampleLabels);
 	await db.delete(legacySampleSubtractions);
 	await db.delete(sampleUploads);
-	await db.delete(sampleArtifacts);
 	await db.delete(sampleReads);
 	await db.delete(legacySamples);
 	await db.delete(jobs);
@@ -104,9 +102,10 @@ async function seedAnalysis(
 			.values({
 				created_at: now,
 				updated_at: now,
-				// The legacy storage slug. Irrelevant to workflow tagging, but the
-				// column is NOT NULL upstream.
+				// The legacy storage slug and the owning build. Both irrelevant to
+				// workflow tagging, but NOT NULL upstream.
 				sample: String(overrides.sample_id ?? 0),
+				index_id: 1,
 				user_id: ownerId,
 				workflow: "nuvs",
 				ready: false,
@@ -663,13 +662,6 @@ describe("deleteSample", () => {
 			name_on_disk: "reads_1.fq.gz",
 			storage_key: `samples/${sampleId}/reads_1`,
 		});
-		await db.insert(sampleArtifacts).values({
-			sample: String(sampleId),
-			sample_id: sampleId,
-			name: "a.json",
-			type: "json",
-			storage_key: `samples/${sampleId}/artifact`,
-		});
 		await seedAnalysis({ sample_id: sampleId, workflow: "nuvs", ready: true });
 
 		const deleted = await deleteSample(
@@ -699,12 +691,6 @@ describe("deleteSample", () => {
 				.where(eq(sampleReads.sample_id, sampleId)),
 		).toHaveLength(0);
 		expect(
-			await db
-				.select()
-				.from(sampleArtifacts)
-				.where(eq(sampleArtifacts.sample_id, sampleId)),
-		).toHaveLength(0);
-		expect(
 			await db.select().from(analyses).where(eq(analyses.sample_id, sampleId)),
 		).toHaveLength(0);
 
@@ -729,13 +715,6 @@ describe("deleteSample", () => {
 			name_on_disk: "reads_1.fq.gz",
 			storage_key: "samples/reads",
 		});
-		await db.insert(sampleArtifacts).values({
-			sample: String(sampleId),
-			sample_id: sampleId,
-			name: "a.json",
-			type: "json",
-			storage_key: "samples/artifact",
-		});
 
 		const analysisId = await seedAnalysis({
 			sample_id: sampleId,
@@ -751,7 +730,6 @@ describe("deleteSample", () => {
 
 		for (const key of [
 			"samples/reads",
-			"samples/artifact",
 			"analyses/nuvs",
 			"samples/unrecorded",
 		]) {

--- a/packages/data/src/samples/data.ts
+++ b/packages/data/src/samples/data.ts
@@ -42,7 +42,6 @@ import {
 	legacySampleLabels,
 	legacySampleSubtractions,
 	legacySamples,
-	sampleArtifacts,
 	sampleReads,
 	sampleUploads,
 } from "../db/schema/samples";
@@ -1452,15 +1451,6 @@ export async function deleteSample(
 		// collected here rather than by `deleteAnalysis`.
 		const keyRows = await Promise.all([
 			tx
-				.select({ key: sampleArtifacts.storage_key })
-				.from(sampleArtifacts)
-				.where(
-					or(
-						eq(sampleArtifacts.sample_id, sampleId),
-						eq(sampleArtifacts.sample, storageId),
-					),
-				),
-			tx
 				.select({ key: sampleReads.storage_key })
 				.from(sampleReads)
 				.where(
@@ -1495,14 +1485,6 @@ export async function deleteSample(
 				or(
 					eq(sampleUploads.sample_id, sampleId),
 					eq(sampleUploads.sample, storageId),
-				),
-			);
-		await tx
-			.delete(sampleArtifacts)
-			.where(
-				or(
-					eq(sampleArtifacts.sample_id, sampleId),
-					eq(sampleArtifacts.sample, storageId),
 				),
 			);
 		await tx


### PR DESCRIPTION
## Summary

- `sample_artifacts` was dropped upstream in Python, but the Drizzle mirror still declared it and `deleteSample` still read storage keys from it and deleted its rows inside the delete transaction — so every sample deletion in production aborted with `42P01 undefined_table`. Nothing caught it because `createTestDatabase()` derives its DDL from the mirror, and the only writes to that table anywhere were the seeds in the test asserting the delete path cleared them.
- Comparing the mirror against a production schema dump also turned up nullability drift. `analyses.index_id`, `legacy_references.user_id`, `legacy_history_diff.change_id`, `legacy_history_diff.diff` and `hmms.hidden` are NOT NULL upstream and are now declared so; `jobs.acquired` carries a real server default, so it takes `.default()` rather than the `$defaultFn()` the other columns use; `instance_messages.user_id` goes the other way, being nullable upstream where a trigger resolves it from the legacy `"user"` column.
- Tightening `diff` surfaced a fixture seeding SQL NULL. The column is NOT NULL upstream, so a row carrying no document holds a JSON null instead — which is what the seed now writes, and a more faithful reproduction of the row that raises `UnbackfilledHistoryDiffError`.
- VIR-2974 tracks what this sweep deliberately left alone: the `spaces` administrator role, which the production CHECK constraint rejects but which reaches through `@virtool/contracts` into the SPA; the constraints and foreign keys the mirror omits; and a CI parity check, without which the next divergence is found the same way this one was.