### PR TITLE
fix: remove the unassignable Spaces administrator role

### DIFF
--- a/apps/web/src/server/auth/middleware.test.ts
+++ b/apps/web/src/server/auth/middleware.test.ts
@@ -378,7 +378,7 @@ describe("requireAdminRole", () => {
 		).rejects.toBeInstanceOf(ForbiddenError);
 	});
 
-	it.each(["full", "settings", "spaces", "users", "base"] as const)(
+	it.each(["full", "settings", "users", "base"] as const)(
 		"allows a full administrator to satisfy a %s requirement",
 		async (requiredRole) => {
 			const userId = await seedUser(db, { administratorRole: "full" });

--- a/apps/web/src/server/users/functions.ts
+++ b/apps/web/src/server/users/functions.ts
@@ -1,6 +1,9 @@
 import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
 import { setResponseStatus } from "@tanstack/react-start/server";
-import { PasswordTooShortError } from "@virtool/contracts";
+import {
+	ADMINISTRATOR_ROLE_NAMES,
+	PasswordTooShortError,
+} from "@virtool/contracts";
 import {
 	changePassword,
 	createUser,
@@ -28,7 +31,7 @@ import { db } from "../composition";
 import { ClientError } from "../errors";
 import { pageSchema, perPageSchema, rowIdSchema } from "../validation";
 
-const administratorRoleSchema = z.enum(["full", "settings", "users", "base"]);
+const administratorRoleSchema = z.enum(ADMINISTRATOR_ROLE_NAMES);
 
 const userIdSchema = z.object({
 	userId: rowIdSchema,

--- a/apps/web/src/server/users/functions.ts
+++ b/apps/web/src/server/users/functions.ts
@@ -28,13 +28,7 @@ import { db } from "../composition";
 import { ClientError } from "../errors";
 import { pageSchema, perPageSchema, rowIdSchema } from "../validation";
 
-const administratorRoleSchema = z.enum([
-	"full",
-	"settings",
-	"spaces",
-	"users",
-	"base",
-]);
+const administratorRoleSchema = z.enum(["full", "settings", "users", "base"]);
 
 const userIdSchema = z.object({
 	userId: rowIdSchema,

--- a/apps/web/src/tests/fake/administrator.ts
+++ b/apps/web/src/tests/fake/administrator.ts
@@ -13,18 +13,13 @@ export const administratorRoles: AdministratorRole[] = [
 		name: "Settings",
 	},
 	{
-		description: "Manage users in any space. Delete any space.",
-		id: "spaces",
-		name: "Spaces",
-	},
-	{
 		description: "Create user accounts. Control activation of user accounts.",
 		id: "users",
 		name: "Users",
 	},
 	{
 		description:
-			"Provides ability to:\n    - Create new spaces even if the `Free Spaces` setting is not enabled.\n    - Manage HMMs and common references.\n    - View all running jobs.\n    - Cancel any job.",
+			"Provides ability to:\n    - Manage HMMs and common references.\n    - View all running jobs.\n    - Cancel any job.",
 		id: "base",
 		name: "Base",
 	},

--- a/packages/contracts/src/administrators.ts
+++ b/packages/contracts/src/administrators.ts
@@ -3,34 +3,22 @@ import type { Permission } from "./permissions";
 /**
  * All administrator roles, ordered from most to least privileged.
  *
- * The five values are the Postgres `administratorrole` enum's. `spaces` is
- * obsolete in product terms but stays a valid value because Python still writes
- * it; dropping it needs a Python-side migration first.
+ * The four values are the ones the `administrator_role_valid` CHECK constraint
+ * on `users.administrator_role` permits.
  */
-export type AdministratorRoleName =
-	| "full"
-	| "settings"
-	| "spaces"
-	| "users"
-	| "base";
+export type AdministratorRoleName = "full" | "settings" | "users" | "base";
 
 /**
  * The permissions level of each administrator role.
  *
  * A strict ranking, `full` strongest through `base` weakest, so requiring
- * `base` means "any administrator". Python's
- * `virtool/users/data.py::check_administrator_role` is not a total order — it
- * scores `base` = 1, `users` / `settings` / `spaces` as level-2 **peers**, and
- * `full` = 3 — so a `users` administrator clears a `settings` requirement there
- * and not here. Every requirement declared in this repo is `base`, `users`,
- * `settings` or `full`, and only the `settings` ones sit where the two differ.
+ * `base` means "any administrator".
  */
 const AdministratorPermissionsLevel: Record<AdministratorRoleName, number> = {
 	full: 0,
 	settings: 1,
-	spaces: 2,
-	users: 3,
-	base: 4,
+	users: 2,
+	base: 3,
 };
 
 /**

--- a/packages/contracts/src/administrators.ts
+++ b/packages/contracts/src/administrators.ts
@@ -1,12 +1,20 @@
 import type { Permission } from "./permissions";
 
 /**
- * All administrator roles, ordered from most to least privileged.
+ * The names of every administrator role, ordered from most to least privileged.
  *
  * The four values are the ones the `administrator_role_valid` CHECK constraint
  * on `users.administrator_role` permits.
  */
-export type AdministratorRoleName = "full" | "settings" | "users" | "base";
+export const ADMINISTRATOR_ROLE_NAMES = [
+	"full",
+	"settings",
+	"users",
+	"base",
+] as const;
+
+/** A role that grants a user administrative access to the instance. */
+export type AdministratorRoleName = (typeof ADMINISTRATOR_ROLE_NAMES)[number];
 
 /**
  * The permissions level of each administrator role.

--- a/packages/data/src/db/schema/users.ts
+++ b/packages/data/src/db/schema/users.ts
@@ -4,6 +4,7 @@
 // `last_password_change`) in sync with
 // `../../../../../../virtool/virtool/users/pg.py`.
 
+import type { AdministratorRoleName } from "@virtool/contracts";
 import { type SQL, sql } from "drizzle-orm";
 import {
 	type AnyPgColumn,
@@ -11,7 +12,6 @@ import {
 	customType,
 	integer,
 	jsonb,
-	pgEnum,
 	pgTable,
 	text,
 	timestamp,
@@ -28,14 +28,6 @@ function lower(column: AnyPgColumn): SQL {
 	return sql`lower(${column})`;
 }
 
-export const administratorRole = pgEnum("administratorrole", [
-	"full",
-	"settings",
-	"spaces",
-	"users",
-	"base",
-]);
-
 export const users = pgTable(
 	"users",
 	{
@@ -43,7 +35,12 @@ export const users = pgTable(
 		active: boolean("active")
 			.$defaultFn(() => true)
 			.notNull(),
-		administratorRole: administratorRole("administrator_role"),
+		// `text`, closed by the `administrator_role_valid` CHECK constraint.
+		// `$type` asserts rather than validates, which is what that constraint
+		// makes safe: a value outside the union cannot reach the column without a
+		// Python-side migration.
+		administratorRole:
+			text("administrator_role").$type<AdministratorRoleName>(),
 		email: text("email")
 			.$defaultFn(() => "")
 			.notNull(),

--- a/packages/data/src/users/data.test.ts
+++ b/packages/data/src/users/data.test.ts
@@ -654,7 +654,6 @@ describe("listAdministratorRoles", () => {
 		expect(roles.map((role) => role.id)).toEqual([
 			"full",
 			"settings",
-			"spaces",
 			"users",
 			"base",
 		]);

--- a/packages/data/src/users/data.ts
+++ b/packages/data/src/users/data.ts
@@ -164,8 +164,8 @@ const DEFAULT_USER_SETTINGS: AccountSettings = {
 	quickAnalyzeWorkflow: "pathoscope",
 };
 
-// Mirrors AVAILABLE_ROLES in virtool/administrators/api.py: every member of the
-// AdministratorRole enum, with its capitalized name and docstring description.
+// Mirrors virtool/models/roles.py::AdministratorRole: every member of that
+// enum, with its capitalized name and docstring description.
 const ADMINISTRATOR_ROLES: AdministratorRole[] = [
 	{
 		id: "full",
@@ -178,11 +178,6 @@ const ADMINISTRATOR_ROLES: AdministratorRole[] = [
 		description: "Manage instance settings.",
 	},
 	{
-		id: "spaces",
-		name: "Spaces",
-		description: "Manage users in any space. Delete any space.",
-	},
-	{
 		id: "users",
 		name: "Users",
 		description: "Create user accounts. Control activation of user accounts.",
@@ -191,7 +186,7 @@ const ADMINISTRATOR_ROLES: AdministratorRole[] = [
 		id: "base",
 		name: "Base",
 		description:
-			"Provides ability to:\n    - Create new spaces even if the `Free Spaces` setting is not enabled.\n    - Manage HMMs and common references.\n    - View all running jobs.\n    - Cancel any job.",
+			"Provides ability to:\n    - Manage HMMs and common references.\n    - View all running jobs.\n    - Cancel any job.",
 	},
 ];
 


### PR DESCRIPTION
## Summary
- The role picker offered `spaces`, but assigning it 500s: Python's migration `997cf9a66f10` remapped those rows to `base` and added an `administrator_role_valid` CHECK permitting only `full`, `settings`, `users` and `base`. Dropped it from `AdministratorRoleName`, the level map, `ADMINISTRATOR_ROLES` and the request validator.
- That same migration dropped the `administratorrole` type, so the Drizzle mirror was describing a type Postgres no longer has. `users.administrator_role` is now `text().$type<AdministratorRoleName>()`, matching `jobs.state`.
- Fixed two comments citing deleted Python code, and dropped the `Free Spaces` line from the `base` role description to match Python's current docstring.