### PR TITLE
fix: identify Virtool to NCBI and GitHub to avoid blocked requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1593,6 +1593,27 @@ See [docs/storage.md](docs/storage.md) for the interface, the key
 layout, the backend configuration and its both-or-neither credential
 rule, the three S3 quirks, and the testing setup.
 
+### Every outbound request identifies itself with a `User-Agent`
+
+Anything reaching a third party — NCBI BLAST and GenBank, the virtool.ca
+HMM manifest, the GitHub-hosted release archive — sends
+`User-Agent: virtool`, from the one `USER_AGENT` constant in
+`@virtool/data/userAgent`. NCBI throttles or blocks anonymous traffic and
+BLAST polling is the highest-volume outbound path here; GitHub refuses a
+request carrying no `User-Agent` at all.
+
+**There is no shared HTTP client to hang it off, and adding one is out of
+scope by decision.** Python built a single `aiohttp.ClientSession` at
+startup; here each call site takes its own `AbortSignal.timeout`, which
+works, and a singleton client would be exactly the module-scope
+construction `packages/data` avoids everywhere else.
+
+**The token carries no version**, deliberately: `packages/data` has no
+build-time global to read one from — `apps/web` has `__APP_VERSION__` and
+`apps/tasks` a JSON import of its own manifest, neither visible from
+there — and one token every call site agrees on beats a version on the
+subset that could reach one.
+
 ### Server → client push runs over SSE with id-only frames
 
 Server-pushed cache invalidations are delivered over a single SSE

--- a/apps/tasks/src/download.ts
+++ b/apps/tasks/src/download.ts
@@ -3,6 +3,7 @@
 import { createWriteStream } from "node:fs";
 import { pipeline } from "node:stream/promises";
 import { setTimeout as delay } from "node:timers/promises";
+import { USER_AGENT } from "@virtool/data/userAgent";
 import type { Logger } from "@virtool/logger";
 
 /**
@@ -76,7 +77,12 @@ async function attemptDownload(
 	arm();
 
 	try {
-		const response = await fetch(url, { signal: composed });
+		const response = await fetch(url, {
+			// The release archive is served from GitHub, which refuses a request
+			// carrying no `User-Agent` at all.
+			headers: { "User-Agent": USER_AGENT },
+			signal: composed,
+		});
 
 		// Before a byte is read, as Python does. An error page fed to gunzip fails
 		// two steps later complaining about compression, not about the 404.

--- a/apps/tasks/src/tasks/install-hmms.test.ts
+++ b/apps/tasks/src/tasks/install-hmms.test.ts
@@ -141,15 +141,16 @@ function releaseArchive(
 }
 
 /** Serve `body` from `fetch`, or fail `failures` times first. */
-function stubFetch(body: Buffer, options: { status?: number } = {}): void {
-	vi.stubGlobal(
-		"fetch",
-		vi.fn(async () => {
-			return new Response(new Uint8Array(body), {
-				status: options.status ?? 200,
-			});
-		}),
-	);
+function stubFetch(body: Buffer, options: { status?: number } = {}) {
+	const fetchMock = vi.fn(async () => {
+		return new Response(new Uint8Array(body), {
+			status: options.status ?? 200,
+		});
+	});
+
+	vi.stubGlobal("fetch", fetchMock);
+
+	return fetchMock;
 }
 
 async function seedPendingStatus(releaseId: number | string = RELEASE_ID) {
@@ -236,6 +237,21 @@ describe("installHmmsTask", () => {
 		expect(row.complete).toBe(true);
 		expect(row.error).toBeNull();
 		expect(row.progress).toBe(100);
+	});
+
+	it("identifies itself to GitHub with a User-Agent", async () => {
+		await seedPendingStatus();
+
+		const fetchMock = stubFetch(await releaseArchive([createAnnotation(1)]));
+
+		await run(await claimInstall());
+
+		const [, init] = fetchMock.mock.calls[0] as unknown as [
+			string,
+			RequestInit,
+		];
+
+		expect(init.headers).toEqual({ "User-Agent": "virtool" });
 	});
 
 	it("leaves no install in progress afterwards", async () => {

--- a/packages/data/src/blast/ncbi.test.ts
+++ b/packages/data/src/blast/ncbi.test.ts
@@ -83,6 +83,16 @@ describe("submitBlast", () => {
 		expect(String(init.body)).toBe("QUERY=ATGCATGC");
 	});
 
+	it("identifies itself to NCBI with a User-Agent", async () => {
+		const fetchMock = stubFetch(textResponse(SUBMISSION_HTML));
+
+		await submitBlast("ATGCATGC");
+
+		const [, init] = fetchMock.mock.calls[0] as unknown as [URL, RequestInit];
+
+		expect(init.headers).toEqual({ "User-Agent": "virtool" });
+	});
+
 	it("throws when NCBI refuses the submission", async () => {
 		stubFetch(textResponse("too many searches", 429));
 
@@ -146,6 +156,16 @@ describe("checkBlastStatus", () => {
 			FORMAT_OBJECT: "SearchInfo",
 			RID: "ZZ7DFGH1013",
 		});
+	});
+
+	it("identifies itself to NCBI with a User-Agent", async () => {
+		const fetchMock = stubFetch(textResponse("Status=READY"));
+
+		await checkBlastStatus("ZZ7DFGH1013");
+
+		const [, init] = fetchMock.mock.calls[0] as unknown as [URL, RequestInit];
+
+		expect(init.headers).toEqual({ "User-Agent": "virtool" });
 	});
 
 	it("throws when NCBI refuses the check", async () => {

--- a/packages/data/src/blast/ncbi.ts
+++ b/packages/data/src/blast/ncbi.ts
@@ -18,6 +18,7 @@
 import { readZipMember } from "@virtool/archive/zip";
 import type { JsonObject, JsonValue } from "@virtool/contracts";
 import { AppError } from "../errors";
+import { USER_AGENT } from "../userAgent";
 
 /** The one CGI endpoint every BLAST exchange goes through. */
 const BLAST_URL = "https://blast.ncbi.nlm.nih.gov/Blast.cgi";
@@ -85,16 +86,25 @@ function signalWithTimeout(signal?: AbortSignal): AbortSignal {
 	return signal ? AbortSignal.any([signal, deadline]) : deadline;
 }
 
+/**
+ * `init` cannot carry headers or a signal: both are this function's, and a
+ * caller supplying either would silently drop the `User-Agent` NCBI wants or
+ * the deadline it must not run without.
+ */
 async function request(
 	url: URL,
-	init: RequestInit,
+	init: Omit<RequestInit, "headers" | "signal">,
 	signal: AbortSignal | undefined,
 	description: string,
 ): Promise<Response> {
 	let response: Response;
 
 	try {
-		response = await fetch(url, { ...init, signal: signalWithTimeout(signal) });
+		response = await fetch(url, {
+			...init,
+			headers: { "User-Agent": USER_AGENT },
+			signal: signalWithTimeout(signal),
+		});
 	} catch (err) {
 		// The caller's signal is a drain or a fence, not a fault of NCBI's. It
 		// escapes untranslated so the sweep leaves the row alone rather than

--- a/packages/data/src/genbank/data.test.ts
+++ b/packages/data/src/genbank/data.test.ts
@@ -223,6 +223,16 @@ describe("getGenbank", () => {
 			});
 		});
 
+		it("identifies itself to NCBI with a User-Agent", async () => {
+			const fetchMock = mockFetch(HOST_RECORD);
+
+			await getGenbank(logger, "NC_045512");
+
+			const [, init] = firstCall(fetchMock.mock.calls) as [URL, RequestInit];
+
+			expect(init.headers).toEqual({ "User-Agent": "virtool" });
+		});
+
 		it("encodes an accession that needs escaping", async () => {
 			const fetchMock = mockFetch(HOST_RECORD);
 

--- a/packages/data/src/genbank/data.ts
+++ b/packages/data/src/genbank/data.ts
@@ -1,6 +1,7 @@
 import type { Genbank } from "@virtool/contracts";
 import type { Logger } from "@virtool/logger";
 import { AppError } from "../errors";
+import { USER_AGENT } from "../userAgent";
 
 const FETCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";
 
@@ -283,7 +284,10 @@ export async function getGenbank(
 	let response: Response;
 
 	try {
-		response = await fetch(url, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+		response = await fetch(url, {
+			headers: { "User-Agent": USER_AGENT },
+			signal: AbortSignal.timeout(TIMEOUT_MS),
+		});
 	} catch (err) {
 		// A timeout arrives here too, and means the same thing to the caller as a
 		// refused connection: NCBI did not answer.

--- a/packages/data/src/hmm/data.test.ts
+++ b/packages/data/src/hmm/data.test.ts
@@ -227,11 +227,14 @@ describe("fetchAndUpdateRelease", () => {
 	};
 
 	/** Answer the manifest fetch with `body` under `status`. */
-	function stubFetch(status: number, body: unknown): void {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(async () => new Response(JSON.stringify(body), { status })),
+	function stubFetch(status: number, body: unknown) {
+		const fetchMock = vi.fn(
+			async () => new Response(JSON.stringify(body), { status }),
 		);
+
+		vi.stubGlobal("fetch", fetchMock);
+
+		return fetchMock;
 	}
 
 	/**
@@ -279,6 +282,19 @@ describe("fetchAndUpdateRelease", () => {
 
 		expect(row?.release).toEqual(release);
 		expect(row?.errors).toEqual([]);
+	});
+
+	it("identifies itself to virtool.ca with a User-Agent", async () => {
+		const fetchMock = stubFetch(200, { "virtool-hmm": [manifestRelease] });
+
+		await fetchAndUpdateRelease(db);
+
+		const [, init] = fetchMock.mock.calls[0] as unknown as [
+			string,
+			RequestInit,
+		];
+
+		expect(init.headers).toEqual({ "User-Agent": "virtool" });
 	});
 
 	it("creates the status row when there is none", async () => {

--- a/packages/data/src/hmm/data.ts
+++ b/packages/data/src/hmm/data.ts
@@ -30,6 +30,7 @@ import {
 import { tasks } from "../db/schema/tasks";
 import { users } from "../db/schema/users";
 import { AppError } from "../errors";
+import { USER_AGENT } from "../userAgent";
 
 /** The task type the runner matches to run an HMM install. */
 export const HMM_INSTALL_TASK_TYPE = "install_hmms";
@@ -301,6 +302,7 @@ async function fetchManifestRelease(
 	let response: Response;
 	try {
 		response = await fetch(MANIFEST_URL, {
+			headers: { "User-Agent": USER_AGENT },
 			signal: signal
 				? AbortSignal.any([signal, AbortSignal.timeout(MANIFEST_TIMEOUT_MS)])
 				: AbortSignal.timeout(MANIFEST_TIMEOUT_MS),

--- a/packages/data/src/userAgent.ts
+++ b/packages/data/src/userAgent.ts
@@ -1,0 +1,19 @@
+/**
+ * How Virtool identifies itself to the third parties it calls.
+ *
+ * NCBI asks that automated callers say who they are and throttles or blocks
+ * anonymous traffic; GitHub refuses a request carrying no `User-Agent` at all.
+ * Python sent one on every outbound request from a single shared
+ * `aiohttp.ClientSession`. There is no shared client here — each call site takes
+ * its own deadline, which works — so the header travels as this constant
+ * instead.
+ *
+ * **It carries no version.** Python's was `virtool/{version}`, and matching that
+ * would mean threading a string through every function between an app's
+ * entrypoint and its `fetch`: `packages/data` has no build-time global to read
+ * one from, `apps/web` having `__APP_VERSION__` and `apps/tasks` a JSON import
+ * of its own manifest, neither of which is visible here. A bare product token is
+ * what NCBI and GitHub ask for, and one token every outbound request agrees on
+ * is worth more than a version on the subset of call sites that could reach one.
+ */
+export const USER_AGENT = "virtool";


### PR DESCRIPTION
## Summary

- Every outbound request went out anonymous. NCBI throttles or blocks unidentified callers and BLAST polling is our highest-volume outbound path; GitHub refuses a request carrying no `User-Agent` at all. A single `USER_AGENT` constant in `@virtool/data/userAgent` now travels with all four third-party call sites — NCBI BLAST (submit, poll, result fetch), the GenBank efetch call, the virtool.ca HMM manifest, and the GitHub-hosted release archive `apps/tasks` downloads.
- **No shared HTTP client**, per VIR-2971. Each call site already takes its own `AbortSignal.timeout`, and a singleton would be exactly the module-scope construction `packages/data` avoids everywhere else. `request()` in `blast/ncbi.ts` narrows its `init` to `Omit<RequestInit, "headers" | "signal">` so a caller cannot silently drop either.
- **The token carries no version**, which was the one open call the issue left. Python sent `virtool/{version}` from one shared aiohttp session, but `packages/data` has no build-time global to read one from — `apps/web` has `__APP_VERSION__` and `apps/tasks` a JSON import of its own manifest, neither visible from there — so matching it meant threading a string through nine signatures and ~45 test call sites. Stamping only the sites that *can* reach a version would leave `install_hmms` sending `virtool/1.2.3` while `sweep_blast` sends `virtool`, which reads as a bug in a log. Easy to reverse if you'd rather have it.

`apps/site`'s build-time `api.github.com` fetch is deliberately untouched — separate deploy, separate gates, and not in the issue's scope.

Closes VIR-2971.