### PR TITLE
chore: baseline drizzle migrations against production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1486,6 +1486,15 @@ what `apps/jobs-api/src/metrics/registry.ts`'s `other` folding and
 the database leaves open, and never widen one it closes. The union itself
 lives in `@virtool/contracts` — one definition, imported by the mirror.
 
+**Declare a foreign key table-level, with an explicit name.** Use
+`foreignKey({ columns, foreignColumns, name })`, never an inline
+`.references()`, and name it `{table}_{column}_fkey` — the name Postgres
+assigned, because Alembic never named these itself. `.references()`
+auto-names a constraint production does not have, and because migration
+`0000` is stamped rather than run, the wrong name is caught by nothing
+until a much later migration emits SQL against a constraint that does not
+exist. `schema/foreignKeys.test.ts` pins all 54.
+
 Three `pgEnum` declarations (`messagecolor`, `indextype`,
 `session_type_enum`) describe a Postgres enum where the real column is
 `text` plus a CHECK. Each carries a comment saying so. They are inert —

--- a/biome.json
+++ b/biome.json
@@ -13,6 +13,7 @@
 			"!apps/site/**",
 			"!dev/**",
 			"!packages/sqlite/src/fixtures/**",
+			"!packages/data/drizzle/**",
 			"!**/routeTree.gen.ts",
 			"!**/node_modules",
 			"!**/dist",

--- a/docs/database.md
+++ b/docs/database.md
@@ -46,6 +46,26 @@ injects the value client-side at insert time (the true analog of
 SQLAlchemy's `default=`) and stays out of the DDL. Reserve `.default()`
 for a column that genuinely has a `server_default` in Python.
 
+### Foreign keys: declare them table-level, with an explicit name
+
+Every foreign key uses the table-level `foreignKey({ columns,
+foreignColumns, name })`, never an inline `.references()`. The name is
+always `{table}_{column}_fkey`, which is the default name Postgres
+assigned because Alembic never named these constraints itself.
+
+Inline `.references()` agrees with production on the columns, the
+referenced table and the referential actions — and disagrees on the
+name, auto-generating `{table}_{column}_{reftable}_{refcolumn}_fk`.
+Nothing catches that at apply time. Migration `0000` is stamped as
+already-applied rather than run, so a wrong name never reaches a
+database; it reaches `meta/0000_snapshot.json`, which every later
+`drizzle-kit generate` diffs against. The first migration to touch a
+foreign key would then emit SQL naming a constraint production does not
+have, and fail long after anything connects it to the cause.
+
+`schema/foreignKeys.test.ts` pins all 54 against that rule, so a new
+table declared with `.references()` fails the suite by name.
+
 ### Column constraints: mirror them, and only them
 
 The mirror's one job is fidelity, so a column's TypeScript type has to
@@ -231,14 +251,17 @@ ownership. Notes for that day:
 
 - **Baseline against production.** The first `drizzle-kit generate`
   against an empty database will not be byte-identical to what Alembic
-  produced. Index naming, default expressions, and enum value
-  ordering all drift. Capture the live shape with `pg_dump
-  --schema-only`, hand-check the generated migration against it, and
-  stamp the live DB as already-applied rather than running the
-  generated migration cold.
-- **`casing: 'snake_case'`** in `drizzle.config.ts`. Our schema files
-  use snake_case columns with camelCase TS identifiers; without this
-  flag the generated migrations will rename every column.
+  produced. Capture the live shape with `pg_dump --schema-only` and
+  hand-check the generated migration against it, then stamp the live DB
+  as already-applied rather than running the generated migration cold.
+  Checked against production, index naming, default expressions and enum
+  value ordering all came out identical; **foreign key names** were the
+  drift, on all 54 of them — see "Foreign keys" above.
+- **`casing: 'snake_case'`** in `drizzle.config.ts`. It is set, but it
+  decides nothing today: every column in the mirror passes its name
+  explicitly, so there is nothing for the flag to infer. It is a
+  guardrail for a column added without one, not a fix for an existing
+  problem.
 - **Pair `drizzle-orm` and `drizzle-kit` versions.** They share
   internals and ship breaking changes together. Bumping one without
   the other has shipped silent schema-generation regressions in the

--- a/packages/data/drizzle.config.ts
+++ b/packages/data/drizzle.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from "drizzle-kit";
+
+/*
+ `generate` reads the schema and never connects, so an unset URL is not an
+ error here. Only `migrate`, `push`, `pull` and `studio` connect, and they fail
+ on the empty string with a connection error that names it.
+*/
+const url = process.env.VT_POSTGRES_URL ?? "";
+
+export default defineConfig({
+	dialect: "postgresql",
+	/*
+	 The barrel rather than a glob, so what a migration describes is exactly what
+	 `createDb` types the runtime handle against. A glob would also pick up
+	 `sql.ts`, which is deliberately absent from the barrel.
+	*/
+	schema: "./src/db/schema/index.ts",
+	out: "./drizzle",
+	/*
+	 Every column in the mirror names itself explicitly, so this decides nothing
+	 today. It is set so that a column added without an explicit name is emitted
+	 as snake_case rather than under its camelCase TS identifier, which would
+	 describe a column production does not have.
+	*/
+	casing: "snake_case",
+	/*
+	 Kit's own defaults, pinned. Production's bookkeeping row is inserted by hand
+	 against this table and schema; if a later default moved either, kit would
+	 find no stamp and run `0000` against a database that already has every
+	 table in it.
+	*/
+	migrations: {
+		table: "__drizzle_migrations",
+		schema: "drizzle",
+	},
+	dbCredentials: { url },
+});

--- a/packages/data/drizzle/0000_baseline.sql
+++ b/packages/data/drizzle/0000_baseline.sql
@@ -1,0 +1,573 @@
+CREATE TYPE "public"."analysisformat" AS ENUM('sam', 'bam', 'fasta', 'fastq', 'csv', 'tsv', 'json');--> statement-breakpoint
+CREATE TYPE "public"."subtractiontype" AS ENUM('fasta', 'bowtie2');--> statement-breakpoint
+CREATE TYPE "public"."action" AS ENUM('create', 'update', 'delete', 'modify', 'remove');--> statement-breakpoint
+CREATE TYPE "public"."resourcetype" AS ENUM('app', 'group');--> statement-breakpoint
+CREATE TABLE "analyses" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "analyses_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"legacy_id" text,
+	"created_at" timestamp NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"workflow" text NOT NULL,
+	"ready" boolean NOT NULL,
+	"results" jsonb,
+	"sample" text NOT NULL,
+	"sample_id" bigint,
+	"reference" text,
+	"reference_id" bigint,
+	"index" text,
+	"index_id" bigint NOT NULL,
+	"user_id" integer NOT NULL,
+	"job_id" integer,
+	CONSTRAINT "analyses_legacy_id_key" UNIQUE("legacy_id"),
+	CONSTRAINT "ck_analyses_reference_present" CHECK (num_nonnulls("analyses"."reference", "analyses"."reference_id") >= 1)
+);
+--> statement-breakpoint
+CREATE TABLE "analysis_files" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"analysis_id" bigint NOT NULL,
+	"description" text,
+	"format" "analysisformat",
+	"name" text,
+	"name_on_disk" text,
+	"size" bigint,
+	"storage_key" text,
+	"uploaded_at" timestamp,
+	CONSTRAINT "analysis_files_name_on_disk_key" UNIQUE("name_on_disk"),
+	CONSTRAINT "uq_analysis_files_storage_key" UNIQUE("storage_key")
+);
+--> statement-breakpoint
+CREATE TABLE "analysis_subtractions" (
+	"analysis_id" bigint NOT NULL,
+	"subtraction_id" bigint NOT NULL,
+	CONSTRAINT "analysis_subtractions_pkey" PRIMARY KEY("analysis_id","subtraction_id")
+);
+--> statement-breakpoint
+CREATE TABLE "nuvs_blast" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"analysis_id" bigint NOT NULL,
+	"sequence_index" integer NOT NULL,
+	"created_at" timestamp NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"last_checked_at" timestamp NOT NULL,
+	"error" text,
+	"interval" integer,
+	"rid" varchar(24),
+	"ready" boolean NOT NULL,
+	"result" json,
+	"task_id" integer,
+	CONSTRAINT "nuvs_blast_analysis_id_sequence_index_key" UNIQUE("analysis_id","sequence_index")
+);
+--> statement-breakpoint
+CREATE TABLE "api_keys" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"hashed" text NOT NULL,
+	"name" text NOT NULL,
+	"created_at" timestamp NOT NULL,
+	"user_id" integer NOT NULL,
+	"permissions" jsonb NOT NULL,
+	CONSTRAINT "api_keys_hashed_key" UNIQUE("hashed")
+);
+--> statement-breakpoint
+CREATE TABLE "caches" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"key" text NOT NULL,
+	"storage_key" text NOT NULL,
+	"params" jsonb NOT NULL,
+	"size" bigint NOT NULL,
+	"created_at" timestamp NOT NULL,
+	"last_accessed_at" timestamp NOT NULL,
+	CONSTRAINT "cache_key" UNIQUE("key"),
+	CONSTRAINT "caches_storage_key_key" UNIQUE("storage_key")
+);
+--> statement-breakpoint
+CREATE TABLE "groups" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"legacy_id" text,
+	"name" varchar(255) NOT NULL,
+	"permissions" jsonb NOT NULL,
+	CONSTRAINT "groups_name_unique" UNIQUE("name"),
+	CONSTRAINT "groups_legacy_id_key" UNIQUE("legacy_id")
+);
+--> statement-breakpoint
+CREATE TABLE "user_groups" (
+	"group_id" integer NOT NULL,
+	"user_id" integer NOT NULL,
+	"primary" boolean NOT NULL,
+	CONSTRAINT "user_groups_pkey" PRIMARY KEY("group_id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "legacy_history" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "legacy_history_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"legacy_id" text,
+	"created_at" timestamp NOT NULL,
+	"description" text NOT NULL,
+	"method_name" text NOT NULL,
+	"user_id" integer NOT NULL,
+	"otu" text NOT NULL,
+	"otu_name" text NOT NULL,
+	"otu_version" text,
+	"reference" text,
+	"reference_id" bigint,
+	"index" text,
+	"index_id" bigint,
+	CONSTRAINT "legacy_history_legacy_id_key" UNIQUE("legacy_id")
+);
+--> statement-breakpoint
+CREATE TABLE "legacy_history_diff" (
+	"id" serial NOT NULL,
+	"change_id" text NOT NULL,
+	"history_id" bigint,
+	"diff" jsonb NOT NULL,
+	CONSTRAINT "history_diffs_pkey" PRIMARY KEY("id"),
+	CONSTRAINT "history_diffs_change_id_key" UNIQUE("change_id"),
+	CONSTRAINT "legacy_history_diff_history_id_key" UNIQUE("history_id")
+);
+--> statement-breakpoint
+CREATE TABLE "hmms" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "hmms_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"legacy_id" text,
+	"cluster" integer NOT NULL,
+	"count" integer NOT NULL,
+	"length" integer NOT NULL,
+	"mean_entropy" double precision NOT NULL,
+	"total_entropy" double precision NOT NULL,
+	"hidden" boolean NOT NULL,
+	"names" jsonb NOT NULL,
+	"families" jsonb NOT NULL,
+	"genera" jsonb NOT NULL,
+	"entries" jsonb NOT NULL,
+	CONSTRAINT "hmms_legacy_id_key" UNIQUE("legacy_id")
+);
+--> statement-breakpoint
+CREATE TABLE "legacy_hmm_status" (
+	"id" integer PRIMARY KEY NOT NULL,
+	"errors" jsonb NOT NULL,
+	"release" jsonb,
+	"installed" jsonb,
+	"task_id" integer,
+	"updates" jsonb NOT NULL,
+	CONSTRAINT "ck_legacy_hmm_status_singleton" CHECK ("legacy_hmm_status"."id" = 1)
+);
+--> statement-breakpoint
+CREATE TABLE "index_files" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"index" text,
+	"index_id" bigint NOT NULL,
+	"type" text,
+	"size" bigint,
+	"storage_key" text NOT NULL,
+	CONSTRAINT "uq_index_files_storage_key" UNIQUE("storage_key"),
+	CONSTRAINT "index_files_index_id_name_key" UNIQUE("index_id","name"),
+	CONSTRAINT "ck_index_files_type" CHECK ("index_files"."type" in ('json', 'fasta', 'bowtie2', 'sqlite'))
+);
+--> statement-breakpoint
+CREATE TABLE "indexes" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "indexes_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"legacy_id" text,
+	"version" integer NOT NULL,
+	"created_at" timestamp NOT NULL,
+	"manifest" jsonb NOT NULL,
+	"ready" boolean NOT NULL,
+	"storage_key" text NOT NULL,
+	"otus_json_storage_key" text,
+	"reference_id" bigint NOT NULL,
+	"user_id" integer NOT NULL,
+	"job_id" integer,
+	"task_id" integer,
+	CONSTRAINT "indexes_legacy_id_key" UNIQUE("legacy_id"),
+	CONSTRAINT "indexes_storage_key_key" UNIQUE("storage_key"),
+	CONSTRAINT "uq_indexes_otus_json_storage_key" UNIQUE("otus_json_storage_key"),
+	CONSTRAINT "uq_indexes_reference_id_version" UNIQUE("reference_id","version"),
+	CONSTRAINT "ck_indexes_job_or_task" CHECK (num_nonnulls("indexes"."job_id", "indexes"."task_id") <= 1)
+);
+--> statement-breakpoint
+CREATE TABLE "jobs" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"acquired" boolean DEFAULT false NOT NULL,
+	"claim" jsonb,
+	"claimed_at" timestamp,
+	"created_at" timestamp NOT NULL,
+	"finished_at" timestamp,
+	"key" text,
+	"legacy_id" text,
+	"pinged_at" timestamp,
+	"state" text NOT NULL,
+	"steps" jsonb,
+	"user_id" integer NOT NULL,
+	"workflow" text NOT NULL,
+	CONSTRAINT "jobs_legacy_id_key" UNIQUE("legacy_id"),
+	CONSTRAINT "ck_jobs_state" CHECK ("jobs"."state" in ('pending', 'running', 'cancelled', 'failed', 'succeeded'))
+);
+--> statement-breakpoint
+CREATE TABLE "labels" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"color" varchar(7),
+	"description" text,
+	"name" text,
+	CONSTRAINT "labels_name_key" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE "instance_messages" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"active" boolean,
+	"color" text NOT NULL,
+	"message" text,
+	"created_at" timestamp,
+	"updated_at" timestamp,
+	"user" text,
+	"user_id" integer,
+	CONSTRAINT "ck_instance_messages_color" CHECK ("instance_messages"."color" in ('red', 'yellow', 'blue', 'purple', 'orange', 'grey'))
+);
+--> statement-breakpoint
+CREATE TABLE "alembic_version" (
+	"version_num" varchar(32) NOT NULL,
+	CONSTRAINT "alembic_version_pkc" PRIMARY KEY("version_num")
+);
+--> statement-breakpoint
+CREATE TABLE "revisions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"revision" text,
+	"created_at" timestamp NOT NULL,
+	"applied_at" timestamp NOT NULL,
+	CONSTRAINT "revisions_revision_key" UNIQUE("revision")
+);
+--> statement-breakpoint
+CREATE TABLE "legacy_otus" (
+	"id" text PRIMARY KEY NOT NULL,
+	"data" jsonb NOT NULL,
+	"name" text NOT NULL,
+	"abbreviation" text NOT NULL,
+	"last_indexed_version" integer,
+	"reference_id" bigint NOT NULL,
+	"verified" boolean NOT NULL,
+	"version" integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "legacy_sequences" (
+	"id" text PRIMARY KEY NOT NULL,
+	"data" jsonb NOT NULL,
+	"otu_id" text NOT NULL,
+	"isolate_id" text NOT NULL,
+	"segment" text,
+	"position" bigint
+);
+--> statement-breakpoint
+CREATE TABLE "legacy_reference_groups" (
+	"reference_id" bigint NOT NULL,
+	"group_id" integer NOT NULL,
+	"build" boolean NOT NULL,
+	"modify" boolean NOT NULL,
+	"modify_otu" boolean NOT NULL,
+	CONSTRAINT "legacy_reference_groups_pkey" PRIMARY KEY("reference_id","group_id")
+);
+--> statement-breakpoint
+CREATE TABLE "legacy_reference_users" (
+	"reference_id" bigint NOT NULL,
+	"user_id" integer NOT NULL,
+	"build" boolean NOT NULL,
+	"modify" boolean NOT NULL,
+	"modify_otu" boolean NOT NULL,
+	CONSTRAINT "legacy_reference_users_pkey" PRIMARY KEY("reference_id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "legacy_references" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "legacy_references_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"legacy_id" text,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"organism" text NOT NULL,
+	"created_at" timestamp NOT NULL,
+	"archived" boolean NOT NULL,
+	"restrict_source_types" boolean NOT NULL,
+	"source_types" jsonb NOT NULL,
+	"user_id" integer NOT NULL,
+	"upload_id" integer,
+	"cloned_from_id" bigint,
+	"task_id" integer,
+	CONSTRAINT "legacy_references_legacy_id_key" UNIQUE("legacy_id")
+);
+--> statement-breakpoint
+CREATE TABLE "legacy_sample_labels" (
+	"sample_id" bigint NOT NULL,
+	"label_id" integer NOT NULL,
+	CONSTRAINT "legacy_sample_labels_pkey" PRIMARY KEY("sample_id","label_id")
+);
+--> statement-breakpoint
+CREATE TABLE "legacy_sample_subtractions" (
+	"sample_id" bigint NOT NULL,
+	"subtraction_id" bigint NOT NULL,
+	CONSTRAINT "legacy_sample_subtractions_pkey" PRIMARY KEY("sample_id","subtraction_id")
+);
+--> statement-breakpoint
+CREATE TABLE "legacy_samples" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "legacy_samples_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"legacy_id" text,
+	"name" text NOT NULL,
+	"host" text NOT NULL,
+	"isolate" text NOT NULL,
+	"locale" text NOT NULL,
+	"notes" text NOT NULL,
+	"library_type" text NOT NULL,
+	"format" text NOT NULL,
+	"group_id" integer,
+	"quality" jsonb,
+	"created_at" timestamp NOT NULL,
+	"paired" boolean NOT NULL,
+	"ready" boolean NOT NULL,
+	"hold" boolean NOT NULL,
+	"is_legacy" boolean NOT NULL,
+	"all_read" boolean NOT NULL,
+	"all_write" boolean NOT NULL,
+	"group_read" boolean NOT NULL,
+	"group_write" boolean NOT NULL,
+	"user_id" integer,
+	"job_id" integer,
+	CONSTRAINT "legacy_samples_legacy_id_key" UNIQUE("legacy_id"),
+	CONSTRAINT "legacy_samples_job_id_key" UNIQUE("job_id")
+);
+--> statement-breakpoint
+CREATE TABLE "sample_reads" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"sample" text NOT NULL,
+	"sample_id" bigint,
+	"name" varchar(13) NOT NULL,
+	"name_on_disk" text NOT NULL,
+	"size" bigint,
+	"storage_key" text NOT NULL,
+	"upload" integer,
+	"uploaded_at" timestamp,
+	CONSTRAINT "uq_sample_reads_storage_key" UNIQUE("storage_key"),
+	CONSTRAINT "sample_reads_sample_id_name_key" UNIQUE("sample_id","name"),
+	CONSTRAINT "sample_reads_sample_name_key" UNIQUE("sample","name")
+);
+--> statement-breakpoint
+CREATE TABLE "sample_uploads" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "sample_uploads_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"sample" text NOT NULL,
+	"sample_id" bigint,
+	"upload_id" integer NOT NULL,
+	"index" integer NOT NULL,
+	CONSTRAINT "sample_uploads_upload_id_key" UNIQUE("upload_id")
+);
+--> statement-breakpoint
+CREATE TABLE "sessions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"session_id" text NOT NULL,
+	"user_id" integer,
+	"ip" text NOT NULL,
+	"created_at" timestamp NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"token_hash" text,
+	"reset_code" text,
+	"reset_remember" boolean,
+	"session_type" text NOT NULL,
+	CONSTRAINT "sessions_session_id_key" UNIQUE("session_id"),
+	CONSTRAINT "session_type_valid" CHECK ("sessions"."session_type" in ('anonymous', 'authenticated', 'reset'))
+);
+--> statement-breakpoint
+CREATE TABLE "settings" (
+	"id" integer PRIMARY KEY NOT NULL,
+	"default_source_types" jsonb NOT NULL,
+	"enable_api" boolean NOT NULL,
+	"enable_sentry" boolean NOT NULL,
+	"minimum_password_length" integer NOT NULL,
+	"sample_all_read" boolean NOT NULL,
+	"sample_all_write" boolean NOT NULL,
+	"sample_group" text NOT NULL,
+	"sample_group_read" boolean NOT NULL,
+	"sample_group_write" boolean NOT NULL,
+	CONSTRAINT "ck_settings_singleton" CHECK ("settings"."id" = 1),
+	CONSTRAINT "ck_settings_sample_group" CHECK ("settings"."sample_group" in ('none', 'force_choice', 'users_primary_group'))
+);
+--> statement-breakpoint
+CREATE TABLE "subtraction_files" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text,
+	"subtraction_id" bigint NOT NULL,
+	"type" "subtractiontype",
+	"size" bigint,
+	"storage_key" text,
+	CONSTRAINT "uq_subtraction_files_storage_key" UNIQUE("storage_key"),
+	CONSTRAINT "subtraction_files_subtraction_id_name_key" UNIQUE("subtraction_id","name")
+);
+--> statement-breakpoint
+CREATE TABLE "subtractions" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "subtractions_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"legacy_id" text,
+	"name" text NOT NULL,
+	"nickname" text NOT NULL,
+	"count" integer,
+	"gc" jsonb,
+	"created_at" timestamp NOT NULL,
+	"deleted" boolean NOT NULL,
+	"ready" boolean NOT NULL,
+	"user_id" integer,
+	"job_id" integer,
+	"upload_id" integer,
+	CONSTRAINT "subtractions_legacy_id_key" UNIQUE("legacy_id"),
+	CONSTRAINT "subtractions_job_id_key" UNIQUE("job_id")
+);
+--> statement-breakpoint
+CREATE TABLE "tasks" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"acquired_at" timestamp,
+	"complete" boolean,
+	"context" jsonb,
+	"count" integer,
+	"created_at" timestamp NOT NULL,
+	"error" text,
+	"file_size" bigint,
+	"progress" integer,
+	"runner_id" varchar(255),
+	"step" text,
+	"type" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "uploads" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"created_at" timestamp,
+	"name" text,
+	"name_on_disk" text,
+	"ready" boolean NOT NULL,
+	"removed" boolean NOT NULL,
+	"removed_at" timestamp,
+	"reserved" boolean NOT NULL,
+	"size" bigint,
+	"storage_key" text,
+	"type" text,
+	"uploaded_at" timestamp,
+	"user_id" integer NOT NULL,
+	CONSTRAINT "uploads_name_on_disk_key" UNIQUE("name_on_disk"),
+	CONSTRAINT "uq_uploads_storage_key" UNIQUE("storage_key"),
+	CONSTRAINT "ck_uploads_type" CHECK ("uploads"."type" in ('reference', 'reads', 'subtraction'))
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"active" boolean NOT NULL,
+	"administrator_role" text,
+	"email" text NOT NULL,
+	"force_reset" boolean NOT NULL,
+	"handle" text NOT NULL,
+	"last_password_change" timestamp NOT NULL,
+	"legacy_id" text,
+	"password" "bytea" NOT NULL,
+	"settings" jsonb NOT NULL,
+	CONSTRAINT "users_legacy_id_key" UNIQUE("legacy_id"),
+	CONSTRAINT "administrator_role_valid" CHECK ("users"."administrator_role" in ('full', 'settings', 'users', 'base'))
+);
+--> statement-breakpoint
+CREATE TABLE "analysis_results" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"analysis_id" text NOT NULL,
+	"results" jsonb NOT NULL,
+	CONSTRAINT "analysis_results_analysis_id_key" UNIQUE("analysis_id")
+);
+--> statement-breakpoint
+CREATE TABLE "job_analyses" (
+	"job_id" integer NOT NULL,
+	"analysis_id" text NOT NULL,
+	CONSTRAINT "job_analyses_pkey" PRIMARY KEY("job_id")
+);
+--> statement-breakpoint
+CREATE TABLE "job_indexes" (
+	"job_id" integer NOT NULL,
+	"index_id" text NOT NULL,
+	CONSTRAINT "job_indexes_pkey" PRIMARY KEY("job_id")
+);
+--> statement-breakpoint
+CREATE TABLE "permissions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text,
+	"description" text,
+	"resource_type" "resourcetype",
+	"action" "action"
+);
+--> statement-breakpoint
+ALTER TABLE "analyses" ADD CONSTRAINT "analyses_sample_id_fkey" FOREIGN KEY ("sample_id") REFERENCES "public"."legacy_samples"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "analyses" ADD CONSTRAINT "analyses_reference_id_fkey" FOREIGN KEY ("reference_id") REFERENCES "public"."legacy_references"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "analyses" ADD CONSTRAINT "analyses_index_id_fkey" FOREIGN KEY ("index_id") REFERENCES "public"."indexes"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "analyses" ADD CONSTRAINT "analyses_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "analyses" ADD CONSTRAINT "analyses_job_id_fkey" FOREIGN KEY ("job_id") REFERENCES "public"."jobs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "analysis_files" ADD CONSTRAINT "analysis_files_analysis_id_fkey" FOREIGN KEY ("analysis_id") REFERENCES "public"."analyses"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "analysis_subtractions" ADD CONSTRAINT "analysis_subtractions_analysis_id_fkey" FOREIGN KEY ("analysis_id") REFERENCES "public"."analyses"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "analysis_subtractions" ADD CONSTRAINT "analysis_subtractions_subtraction_id_fkey" FOREIGN KEY ("subtraction_id") REFERENCES "public"."subtractions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "nuvs_blast" ADD CONSTRAINT "nuvs_blast_analysis_id_fkey" FOREIGN KEY ("analysis_id") REFERENCES "public"."analyses"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "nuvs_blast" ADD CONSTRAINT "nuvs_blast_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "public"."tasks"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_groups" ADD CONSTRAINT "user_groups_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_groups" ADD CONSTRAINT "user_groups_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_history" ADD CONSTRAINT "legacy_history_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_history" ADD CONSTRAINT "legacy_history_reference_id_fkey" FOREIGN KEY ("reference_id") REFERENCES "public"."legacy_references"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_history" ADD CONSTRAINT "legacy_history_index_id_fkey" FOREIGN KEY ("index_id") REFERENCES "public"."indexes"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_history_diff" ADD CONSTRAINT "legacy_history_diff_history_id_fkey" FOREIGN KEY ("history_id") REFERENCES "public"."legacy_history"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_hmm_status" ADD CONSTRAINT "legacy_hmm_status_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "public"."tasks"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "index_files" ADD CONSTRAINT "index_files_index_id_fkey" FOREIGN KEY ("index_id") REFERENCES "public"."indexes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "indexes" ADD CONSTRAINT "indexes_reference_id_fkey" FOREIGN KEY ("reference_id") REFERENCES "public"."legacy_references"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "indexes" ADD CONSTRAINT "indexes_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "indexes" ADD CONSTRAINT "indexes_job_id_fkey" FOREIGN KEY ("job_id") REFERENCES "public"."jobs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "indexes" ADD CONSTRAINT "indexes_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "public"."tasks"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "instance_messages" ADD CONSTRAINT "instance_messages_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_otus" ADD CONSTRAINT "legacy_otus_reference_id_fkey" FOREIGN KEY ("reference_id") REFERENCES "public"."legacy_references"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_sequences" ADD CONSTRAINT "legacy_sequences_otu_id_fkey" FOREIGN KEY ("otu_id") REFERENCES "public"."legacy_otus"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_reference_groups" ADD CONSTRAINT "legacy_reference_groups_reference_id_fkey" FOREIGN KEY ("reference_id") REFERENCES "public"."legacy_references"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_reference_groups" ADD CONSTRAINT "legacy_reference_groups_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_reference_users" ADD CONSTRAINT "legacy_reference_users_reference_id_fkey" FOREIGN KEY ("reference_id") REFERENCES "public"."legacy_references"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_reference_users" ADD CONSTRAINT "legacy_reference_users_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_references" ADD CONSTRAINT "legacy_references_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_references" ADD CONSTRAINT "legacy_references_upload_id_fkey" FOREIGN KEY ("upload_id") REFERENCES "public"."uploads"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_references" ADD CONSTRAINT "legacy_references_cloned_from_id_fkey" FOREIGN KEY ("cloned_from_id") REFERENCES "public"."legacy_references"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_references" ADD CONSTRAINT "legacy_references_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "public"."tasks"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_sample_labels" ADD CONSTRAINT "legacy_sample_labels_sample_id_fkey" FOREIGN KEY ("sample_id") REFERENCES "public"."legacy_samples"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_sample_labels" ADD CONSTRAINT "legacy_sample_labels_label_id_fkey" FOREIGN KEY ("label_id") REFERENCES "public"."labels"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_sample_subtractions" ADD CONSTRAINT "legacy_sample_subtractions_sample_id_fkey" FOREIGN KEY ("sample_id") REFERENCES "public"."legacy_samples"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_sample_subtractions" ADD CONSTRAINT "legacy_sample_subtractions_subtraction_id_fkey" FOREIGN KEY ("subtraction_id") REFERENCES "public"."subtractions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_samples" ADD CONSTRAINT "legacy_samples_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "public"."groups"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_samples" ADD CONSTRAINT "legacy_samples_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legacy_samples" ADD CONSTRAINT "legacy_samples_job_id_fkey" FOREIGN KEY ("job_id") REFERENCES "public"."jobs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sample_reads" ADD CONSTRAINT "sample_reads_sample_id_fkey" FOREIGN KEY ("sample_id") REFERENCES "public"."legacy_samples"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sample_reads" ADD CONSTRAINT "sample_reads_upload_fkey" FOREIGN KEY ("upload") REFERENCES "public"."uploads"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sample_uploads" ADD CONSTRAINT "sample_uploads_sample_id_fkey" FOREIGN KEY ("sample_id") REFERENCES "public"."legacy_samples"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sample_uploads" ADD CONSTRAINT "sample_uploads_upload_id_fkey" FOREIGN KEY ("upload_id") REFERENCES "public"."uploads"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subtraction_files" ADD CONSTRAINT "subtraction_files_subtraction_id_fkey" FOREIGN KEY ("subtraction_id") REFERENCES "public"."subtractions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subtractions" ADD CONSTRAINT "subtractions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subtractions" ADD CONSTRAINT "subtractions_job_id_fkey" FOREIGN KEY ("job_id") REFERENCES "public"."jobs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subtractions" ADD CONSTRAINT "subtractions_upload_id_fkey" FOREIGN KEY ("upload_id") REFERENCES "public"."uploads"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "uploads" ADD CONSTRAINT "uploads_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "job_analyses" ADD CONSTRAINT "job_analyses_job_id_fkey" FOREIGN KEY ("job_id") REFERENCES "public"."jobs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "job_indexes" ADD CONSTRAINT "job_indexes_job_id_fkey" FOREIGN KEY ("job_id") REFERENCES "public"."jobs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "ix_analyses_sample" ON "analyses" USING btree ("sample");--> statement-breakpoint
+CREATE INDEX "ix_analyses_sample_id_workflow" ON "analyses" USING btree ("sample_id","workflow");--> statement-breakpoint
+CREATE INDEX "ix_analysis_subtractions_subtraction_id" ON "analysis_subtractions" USING btree ("subtraction_id");--> statement-breakpoint
+CREATE INDEX "idx_api_keys_user_id" ON "api_keys" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "ix_caches_last_accessed_at_id" ON "caches" USING btree ("last_accessed_at","id");--> statement-breakpoint
+CREATE UNIQUE INDEX "primary_group_unique" ON "user_groups" USING btree ("primary","user_id") WHERE false;--> statement-breakpoint
+CREATE INDEX "ix_legacy_history_index" ON "legacy_history" USING btree ("index");--> statement-breakpoint
+CREATE INDEX "ix_legacy_history_index_id" ON "legacy_history" USING btree ("index_id");--> statement-breakpoint
+CREATE INDEX "ix_legacy_history_otu_otu_version" ON "legacy_history" USING btree ("otu","otu_version" DESC NULLS FIRST);--> statement-breakpoint
+CREATE INDEX "ix_legacy_history_reference" ON "legacy_history" USING btree ("reference");--> statement-breakpoint
+CREATE INDEX "ix_legacy_history_reference_id" ON "legacy_history" USING btree ("reference_id");--> statement-breakpoint
+CREATE INDEX "ix_legacy_history_user_id" ON "legacy_history" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "ix_jobs_state_created_at" ON "jobs" USING btree ("state","created_at");--> statement-breakpoint
+CREATE INDEX "ix_jobs_user_id_state" ON "jobs" USING btree ("user_id","state");--> statement-breakpoint
+CREATE INDEX "ix_jobs_workflow_state" ON "jobs" USING btree ("workflow","state");--> statement-breakpoint
+CREATE UNIQUE INDEX "instance_messages_one_active" ON "instance_messages" USING btree ("active") WHERE "instance_messages"."active" = true;--> statement-breakpoint
+CREATE INDEX "ix_legacy_otus_reference_id" ON "legacy_otus" USING btree ("reference_id");--> statement-breakpoint
+CREATE INDEX "legacy_otus_name_lower" ON "legacy_otus" USING btree (lower("name"),"id");--> statement-breakpoint
+CREATE INDEX "ix_legacy_sequences_otu_id" ON "legacy_sequences" USING btree ("otu_id");--> statement-breakpoint
+CREATE INDEX "ix_legacy_sequences_otu_id_position" ON "legacy_sequences" USING btree ("otu_id","position");--> statement-breakpoint
+CREATE INDEX "ix_legacy_samples_all_read" ON "legacy_samples" USING btree ("all_read") WHERE "legacy_samples"."all_read" = true;--> statement-breakpoint
+CREATE INDEX "ix_legacy_samples_group_id" ON "legacy_samples" USING btree ("group_id");--> statement-breakpoint
+CREATE INDEX "ix_legacy_samples_group_read" ON "legacy_samples" USING btree ("group_read") WHERE "legacy_samples"."group_read" = true;--> statement-breakpoint
+CREATE INDEX "ix_legacy_samples_user_id_created_at" ON "legacy_samples" USING btree ("user_id","created_at" DESC NULLS FIRST);--> statement-breakpoint
+CREATE INDEX "idx_sessions_expires_at" ON "sessions" USING btree ("expires_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_sessions_session_id" ON "sessions" USING btree ("session_id");--> statement-breakpoint
+CREATE INDEX "idx_sessions_type" ON "sessions" USING btree ("session_type");--> statement-breakpoint
+CREATE INDEX "idx_sessions_user_id" ON "sessions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_tasks_active" ON "tasks" USING btree ("acquired_at") WHERE "tasks"."complete" = false and "tasks"."error" is null;--> statement-breakpoint
+CREATE INDEX "idx_tasks_unacquired" ON "tasks" USING btree ("acquired_at") WHERE "tasks"."acquired_at" is null;--> statement-breakpoint
+CREATE UNIQUE INDEX "users_handle_lower_unique" ON "users" USING btree (lower("handle"));

--- a/packages/data/drizzle/meta/0000_snapshot.json
+++ b/packages/data/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,4205 @@
+{
+  "id": "28766de7-8cc8-4b4e-86a1-153ec865501b",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analyses": {
+      "name": "analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analyses_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sample": {
+          "name": "sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index": {
+          "name": "index",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_analyses_sample": {
+          "name": "ix_analyses_sample",
+          "columns": [
+            {
+              "expression": "sample",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_analyses_sample_id_workflow": {
+          "name": "ix_analyses_sample_id_workflow",
+          "columns": [
+            {
+              "expression": "sample_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analyses_sample_id_fkey": {
+          "name": "analyses_sample_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analyses_reference_id_fkey": {
+          "name": "analyses_reference_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analyses_index_id_fkey": {
+          "name": "analyses_index_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analyses_user_id_fkey": {
+          "name": "analyses_user_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analyses_job_id_fkey": {
+          "name": "analyses_job_id_fkey",
+          "tableFrom": "analyses",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analyses_legacy_id_key": {
+          "name": "analyses_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_analyses_reference_present": {
+          "name": "ck_analyses_reference_present",
+          "value": "num_nonnulls(\"analyses\".\"reference\", \"analyses\".\"reference_id\") >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.analysis_files": {
+      "name": "analysis_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "analysisformat",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_on_disk": {
+          "name": "name_on_disk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "analysis_files_analysis_id_fkey": {
+          "name": "analysis_files_analysis_id_fkey",
+          "tableFrom": "analysis_files",
+          "tableTo": "analyses",
+          "columnsFrom": [
+            "analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analysis_files_name_on_disk_key": {
+          "name": "analysis_files_name_on_disk_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name_on_disk"
+          ]
+        },
+        "uq_analysis_files_storage_key": {
+          "name": "uq_analysis_files_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_subtractions": {
+      "name": "analysis_subtractions",
+      "schema": "",
+      "columns": {
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtraction_id": {
+          "name": "subtraction_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_analysis_subtractions_subtraction_id": {
+          "name": "ix_analysis_subtractions_subtraction_id",
+          "columns": [
+            {
+              "expression": "subtraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_subtractions_analysis_id_fkey": {
+          "name": "analysis_subtractions_analysis_id_fkey",
+          "tableFrom": "analysis_subtractions",
+          "tableTo": "analyses",
+          "columnsFrom": [
+            "analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "analysis_subtractions_subtraction_id_fkey": {
+          "name": "analysis_subtractions_subtraction_id_fkey",
+          "tableFrom": "analysis_subtractions",
+          "tableTo": "subtractions",
+          "columnsFrom": [
+            "subtraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "analysis_subtractions_pkey": {
+          "name": "analysis_subtractions_pkey",
+          "columns": [
+            "analysis_id",
+            "subtraction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nuvs_blast": {
+      "name": "nuvs_blast",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_index": {
+          "name": "sequence_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rid": {
+          "name": "rid",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nuvs_blast_analysis_id_fkey": {
+          "name": "nuvs_blast_analysis_id_fkey",
+          "tableFrom": "nuvs_blast",
+          "tableTo": "analyses",
+          "columnsFrom": [
+            "analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nuvs_blast_task_id_fkey": {
+          "name": "nuvs_blast_task_id_fkey",
+          "tableFrom": "nuvs_blast",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nuvs_blast_analysis_id_sequence_index_key": {
+          "name": "nuvs_blast_analysis_id_sequence_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "analysis_id",
+            "sequence_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hashed": {
+          "name": "hashed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_api_keys_user_id": {
+          "name": "idx_api_keys_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_fkey": {
+          "name": "api_keys_user_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key": {
+          "name": "api_keys_hashed_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caches": {
+      "name": "caches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_caches_last_accessed_at_id": {
+          "name": "ix_caches_last_accessed_at_id",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cache_key": {
+          "name": "cache_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        },
+        "caches_storage_key_key": {
+          "name": "caches_storage_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_name_unique": {
+          "name": "groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "groups_legacy_id_key": {
+          "name": "groups_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary": {
+          "name": "primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "primary_group_unique": {
+          "name": "primary_group_unique",
+          "columns": [
+            {
+              "expression": "primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_group_id_fkey": {
+          "name": "user_groups_group_id_fkey",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_user_id_fkey": {
+          "name": "user_groups_user_id_fkey",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_pkey": {
+          "name": "user_groups_pkey",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_history": {
+      "name": "legacy_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "legacy_history_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method_name": {
+          "name": "method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu": {
+          "name": "otu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu_name": {
+          "name": "otu_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu_version": {
+          "name": "otu_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index": {
+          "name": "index",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_legacy_history_index": {
+          "name": "ix_legacy_history_index",
+          "columns": [
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_index_id": {
+          "name": "ix_legacy_history_index_id",
+          "columns": [
+            {
+              "expression": "index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_otu_otu_version": {
+          "name": "ix_legacy_history_otu_otu_version",
+          "columns": [
+            {
+              "expression": "otu",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "otu_version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_reference": {
+          "name": "ix_legacy_history_reference",
+          "columns": [
+            {
+              "expression": "reference",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_reference_id": {
+          "name": "ix_legacy_history_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_history_user_id": {
+          "name": "ix_legacy_history_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_history_user_id_fkey": {
+          "name": "legacy_history_user_id_fkey",
+          "tableFrom": "legacy_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_history_reference_id_fkey": {
+          "name": "legacy_history_reference_id_fkey",
+          "tableFrom": "legacy_history",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_history_index_id_fkey": {
+          "name": "legacy_history_index_id_fkey",
+          "tableFrom": "legacy_history",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legacy_history_legacy_id_key": {
+          "name": "legacy_history_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_history_diff": {
+      "name": "legacy_history_diff",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_id": {
+          "name": "history_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff": {
+          "name": "diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_history_diff_history_id_fkey": {
+          "name": "legacy_history_diff_history_id_fkey",
+          "tableFrom": "legacy_history_diff",
+          "tableTo": "legacy_history",
+          "columnsFrom": [
+            "history_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "history_diffs_pkey": {
+          "name": "history_diffs_pkey",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "history_diffs_change_id_key": {
+          "name": "history_diffs_change_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "change_id"
+          ]
+        },
+        "legacy_history_diff_history_id_key": {
+          "name": "legacy_history_diff_history_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "history_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hmms": {
+      "name": "hmms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "hmms_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster": {
+          "name": "cluster",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "length": {
+          "name": "length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mean_entropy": {
+          "name": "mean_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_entropy": {
+          "name": "total_entropy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "names": {
+          "name": "names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "families": {
+          "name": "families",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genera": {
+          "name": "genera",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hmms_legacy_id_key": {
+          "name": "hmms_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_hmm_status": {
+      "name": "legacy_hmm_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release": {
+          "name": "release",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed": {
+          "name": "installed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updates": {
+          "name": "updates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_hmm_status_task_id_fkey": {
+          "name": "legacy_hmm_status_task_id_fkey",
+          "tableFrom": "legacy_hmm_status",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_legacy_hmm_status_singleton": {
+          "name": "ck_legacy_hmm_status_singleton",
+          "value": "\"legacy_hmm_status\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.index_files": {
+      "name": "index_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "index_files_index_id_fkey": {
+          "name": "index_files_index_id_fkey",
+          "tableFrom": "index_files",
+          "tableTo": "indexes",
+          "columnsFrom": [
+            "index_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_index_files_storage_key": {
+          "name": "uq_index_files_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        },
+        "index_files_index_id_name_key": {
+          "name": "index_files_index_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "index_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_index_files_type": {
+          "name": "ck_index_files_type",
+          "value": "\"index_files\".\"type\" in ('json', 'fasta', 'bowtie2', 'sqlite')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.indexes": {
+      "name": "indexes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "indexes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otus_json_storage_key": {
+          "name": "otus_json_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "indexes_reference_id_fkey": {
+          "name": "indexes_reference_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "indexes_user_id_fkey": {
+          "name": "indexes_user_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "indexes_job_id_fkey": {
+          "name": "indexes_job_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "indexes_task_id_fkey": {
+          "name": "indexes_task_id_fkey",
+          "tableFrom": "indexes",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "indexes_legacy_id_key": {
+          "name": "indexes_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        },
+        "indexes_storage_key_key": {
+          "name": "indexes_storage_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        },
+        "uq_indexes_otus_json_storage_key": {
+          "name": "uq_indexes_otus_json_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "otus_json_storage_key"
+          ]
+        },
+        "uq_indexes_reference_id_version": {
+          "name": "uq_indexes_reference_id_version",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reference_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_indexes_job_or_task": {
+          "name": "ck_indexes_job_or_task",
+          "value": "num_nonnulls(\"indexes\".\"job_id\", \"indexes\".\"task_id\") <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "acquired": {
+          "name": "acquired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "claim": {
+          "name": "claim",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinged_at": {
+          "name": "pinged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_jobs_state_created_at": {
+          "name": "ix_jobs_state_created_at",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_jobs_user_id_state": {
+          "name": "ix_jobs_user_id_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_jobs_workflow_state": {
+          "name": "ix_jobs_workflow_state",
+          "columns": [
+            {
+              "expression": "workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_user_id_fkey": {
+          "name": "jobs_user_id_fkey",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "jobs_legacy_id_key": {
+          "name": "jobs_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_jobs_state": {
+          "name": "ck_jobs_state",
+          "value": "\"jobs\".\"state\" in ('pending', 'running', 'cancelled', 'failed', 'succeeded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_name_key": {
+          "name": "labels_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_messages": {
+      "name": "instance_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user": {
+          "name": "user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "instance_messages_one_active": {
+          "name": "instance_messages_one_active",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"instance_messages\".\"active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instance_messages_user_id_fkey": {
+          "name": "instance_messages_user_id_fkey",
+          "tableFrom": "instance_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_instance_messages_color": {
+          "name": "ck_instance_messages_color",
+          "value": "\"instance_messages\".\"color\" in ('red', 'yellow', 'blue', 'purple', 'orange', 'grey')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.alembic_version": {
+      "name": "alembic_version",
+      "schema": "",
+      "columns": {
+        "version_num": {
+          "name": "version_num",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "alembic_version_pkc": {
+          "name": "alembic_version_pkc",
+          "columns": [
+            "version_num"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.revisions": {
+      "name": "revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "revisions_revision_key": {
+          "name": "revisions_revision_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "revision"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_otus": {
+      "name": "legacy_otus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_indexed_version": {
+          "name": "last_indexed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_legacy_otus_reference_id": {
+          "name": "ix_legacy_otus_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_otus_name_lower": {
+          "name": "legacy_otus_name_lower",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_otus_reference_id_fkey": {
+          "name": "legacy_otus_reference_id_fkey",
+          "tableFrom": "legacy_otus",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_sequences": {
+      "name": "legacy_sequences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otu_id": {
+          "name": "otu_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isolate_id": {
+          "name": "isolate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment": {
+          "name": "segment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_legacy_sequences_otu_id": {
+          "name": "ix_legacy_sequences_otu_id",
+          "columns": [
+            {
+              "expression": "otu_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_sequences_otu_id_position": {
+          "name": "ix_legacy_sequences_otu_id_position",
+          "columns": [
+            {
+              "expression": "otu_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_sequences_otu_id_fkey": {
+          "name": "legacy_sequences_otu_id_fkey",
+          "tableFrom": "legacy_sequences",
+          "tableTo": "legacy_otus",
+          "columnsFrom": [
+            "otu_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_reference_groups": {
+      "name": "legacy_reference_groups",
+      "schema": "",
+      "columns": {
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build": {
+          "name": "build",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify": {
+          "name": "modify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify_otu": {
+          "name": "modify_otu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_reference_groups_reference_id_fkey": {
+          "name": "legacy_reference_groups_reference_id_fkey",
+          "tableFrom": "legacy_reference_groups",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_reference_groups_group_id_fkey": {
+          "name": "legacy_reference_groups_group_id_fkey",
+          "tableFrom": "legacy_reference_groups",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_reference_groups_pkey": {
+          "name": "legacy_reference_groups_pkey",
+          "columns": [
+            "reference_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_reference_users": {
+      "name": "legacy_reference_users",
+      "schema": "",
+      "columns": {
+        "reference_id": {
+          "name": "reference_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build": {
+          "name": "build",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify": {
+          "name": "modify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify_otu": {
+          "name": "modify_otu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_reference_users_reference_id_fkey": {
+          "name": "legacy_reference_users_reference_id_fkey",
+          "tableFrom": "legacy_reference_users",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_reference_users_user_id_fkey": {
+          "name": "legacy_reference_users_user_id_fkey",
+          "tableFrom": "legacy_reference_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_reference_users_pkey": {
+          "name": "legacy_reference_users_pkey",
+          "columns": [
+            "reference_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_references": {
+      "name": "legacy_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "legacy_references_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organism": {
+          "name": "organism",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restrict_source_types": {
+          "name": "restrict_source_types",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_types": {
+          "name": "source_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloned_from_id": {
+          "name": "cloned_from_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_references_user_id_fkey": {
+          "name": "legacy_references_user_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_references_upload_id_fkey": {
+          "name": "legacy_references_upload_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_references_cloned_from_id_fkey": {
+          "name": "legacy_references_cloned_from_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "legacy_references",
+          "columnsFrom": [
+            "cloned_from_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_references_task_id_fkey": {
+          "name": "legacy_references_task_id_fkey",
+          "tableFrom": "legacy_references",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legacy_references_legacy_id_key": {
+          "name": "legacy_references_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_sample_labels": {
+      "name": "legacy_sample_labels",
+      "schema": "",
+      "columns": {
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_sample_labels_sample_id_fkey": {
+          "name": "legacy_sample_labels_sample_id_fkey",
+          "tableFrom": "legacy_sample_labels",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "legacy_sample_labels_label_id_fkey": {
+          "name": "legacy_sample_labels_label_id_fkey",
+          "tableFrom": "legacy_sample_labels",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_sample_labels_pkey": {
+          "name": "legacy_sample_labels_pkey",
+          "columns": [
+            "sample_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_sample_subtractions": {
+      "name": "legacy_sample_subtractions",
+      "schema": "",
+      "columns": {
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtraction_id": {
+          "name": "subtraction_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "legacy_sample_subtractions_sample_id_fkey": {
+          "name": "legacy_sample_subtractions_sample_id_fkey",
+          "tableFrom": "legacy_sample_subtractions",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "legacy_sample_subtractions_subtraction_id_fkey": {
+          "name": "legacy_sample_subtractions_subtraction_id_fkey",
+          "tableFrom": "legacy_sample_subtractions",
+          "tableTo": "subtractions",
+          "columnsFrom": [
+            "subtraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "legacy_sample_subtractions_pkey": {
+          "name": "legacy_sample_subtractions_pkey",
+          "columns": [
+            "sample_id",
+            "subtraction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_samples": {
+      "name": "legacy_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "legacy_samples_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isolate": {
+          "name": "isolate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_type": {
+          "name": "library_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paired": {
+          "name": "paired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold": {
+          "name": "hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_legacy": {
+          "name": "is_legacy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_read": {
+          "name": "all_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_write": {
+          "name": "all_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_read": {
+          "name": "group_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_write": {
+          "name": "group_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_legacy_samples_all_read": {
+          "name": "ix_legacy_samples_all_read",
+          "columns": [
+            {
+              "expression": "all_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"legacy_samples\".\"all_read\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_samples_group_id": {
+          "name": "ix_legacy_samples_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_samples_group_read": {
+          "name": "ix_legacy_samples_group_read",
+          "columns": [
+            {
+              "expression": "group_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"legacy_samples\".\"group_read\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_legacy_samples_user_id_created_at": {
+          "name": "ix_legacy_samples_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_samples_group_id_fkey": {
+          "name": "legacy_samples_group_id_fkey",
+          "tableFrom": "legacy_samples",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_samples_user_id_fkey": {
+          "name": "legacy_samples_user_id_fkey",
+          "tableFrom": "legacy_samples",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_samples_job_id_fkey": {
+          "name": "legacy_samples_job_id_fkey",
+          "tableFrom": "legacy_samples",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legacy_samples_legacy_id_key": {
+          "name": "legacy_samples_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        },
+        "legacy_samples_job_id_key": {
+          "name": "legacy_samples_job_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sample_reads": {
+      "name": "sample_reads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sample": {
+          "name": "sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(13)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_on_disk": {
+          "name": "name_on_disk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload": {
+          "name": "upload",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sample_reads_sample_id_fkey": {
+          "name": "sample_reads_sample_id_fkey",
+          "tableFrom": "sample_reads",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sample_reads_upload_fkey": {
+          "name": "sample_reads_upload_fkey",
+          "tableFrom": "sample_reads",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_sample_reads_storage_key": {
+          "name": "uq_sample_reads_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        },
+        "sample_reads_sample_id_name_key": {
+          "name": "sample_reads_sample_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sample_id",
+            "name"
+          ]
+        },
+        "sample_reads_sample_name_key": {
+          "name": "sample_reads_sample_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sample",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sample_uploads": {
+      "name": "sample_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "sample_uploads_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "sample": {
+          "name": "sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_id": {
+          "name": "sample_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sample_uploads_sample_id_fkey": {
+          "name": "sample_uploads_sample_id_fkey",
+          "tableFrom": "sample_uploads",
+          "tableTo": "legacy_samples",
+          "columnsFrom": [
+            "sample_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sample_uploads_upload_id_fkey": {
+          "name": "sample_uploads_upload_id_fkey",
+          "tableFrom": "sample_uploads",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sample_uploads_upload_id_key": {
+          "name": "sample_uploads_upload_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "upload_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_code": {
+          "name": "reset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_remember": {
+          "name": "reset_remember",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_session_id": {
+          "name": "idx_sessions_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_type": {
+          "name": "idx_sessions_type",
+          "columns": [
+            {
+              "expression": "session_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_fkey": {
+          "name": "sessions_user_id_fkey",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_id_key": {
+          "name": "sessions_session_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_type_valid": {
+          "name": "session_type_valid",
+          "value": "\"sessions\".\"session_type\" in ('anonymous', 'authenticated', 'reset')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "default_source_types": {
+          "name": "default_source_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enable_api": {
+          "name": "enable_api",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enable_sentry": {
+          "name": "enable_sentry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minimum_password_length": {
+          "name": "minimum_password_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_all_read": {
+          "name": "sample_all_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_all_write": {
+          "name": "sample_all_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_group": {
+          "name": "sample_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_group_read": {
+          "name": "sample_group_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_group_write": {
+          "name": "sample_group_write",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_settings_singleton": {
+          "name": "ck_settings_singleton",
+          "value": "\"settings\".\"id\" = 1"
+        },
+        "ck_settings_sample_group": {
+          "name": "ck_settings_sample_group",
+          "value": "\"settings\".\"sample_group\" in ('none', 'force_choice', 'users_primary_group')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subtraction_files": {
+      "name": "subtraction_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtraction_id": {
+          "name": "subtraction_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subtractiontype",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subtraction_files_subtraction_id_fkey": {
+          "name": "subtraction_files_subtraction_id_fkey",
+          "tableFrom": "subtraction_files",
+          "tableTo": "subtractions",
+          "columnsFrom": [
+            "subtraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_subtraction_files_storage_key": {
+          "name": "uq_subtraction_files_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        },
+        "subtraction_files_subtraction_id_name_key": {
+          "name": "subtraction_files_subtraction_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subtraction_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtractions": {
+      "name": "subtractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "subtractions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gc": {
+          "name": "gc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subtractions_user_id_fkey": {
+          "name": "subtractions_user_id_fkey",
+          "tableFrom": "subtractions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subtractions_job_id_fkey": {
+          "name": "subtractions_job_id_fkey",
+          "tableFrom": "subtractions",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subtractions_upload_id_fkey": {
+          "name": "subtractions_upload_id_fkey",
+          "tableFrom": "subtractions",
+          "tableTo": "uploads",
+          "columnsFrom": [
+            "upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subtractions_legacy_id_key": {
+          "name": "subtractions_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        },
+        "subtractions_job_id_key": {
+          "name": "subtractions_job_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_id": {
+          "name": "runner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step": {
+          "name": "step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tasks_active": {
+          "name": "idx_tasks_active",
+          "columns": [
+            {
+              "expression": "acquired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"complete\" = false and \"tasks\".\"error\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tasks_unacquired": {
+          "name": "idx_tasks_unacquired",
+          "columns": [
+            {
+              "expression": "acquired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"acquired_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploads": {
+      "name": "uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_on_disk": {
+          "name": "name_on_disk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed": {
+          "name": "removed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserved": {
+          "name": "reserved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "uploads_user_id_fkey": {
+          "name": "uploads_user_id_fkey",
+          "tableFrom": "uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uploads_name_on_disk_key": {
+          "name": "uploads_name_on_disk_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name_on_disk"
+          ]
+        },
+        "uq_uploads_storage_key": {
+          "name": "uq_uploads_storage_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_uploads_type": {
+          "name": "ck_uploads_type",
+          "value": "\"uploads\".\"type\" in ('reference', 'reads', 'subtraction')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "administrator_role": {
+          "name": "administrator_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_reset": {
+          "name": "force_reset",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_password_change": {
+          "name": "last_password_change",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_handle_lower_unique": {
+          "name": "users_handle_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"handle\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_legacy_id_key": {
+          "name": "users_legacy_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "administrator_role_valid": {
+          "name": "administrator_role_valid",
+          "value": "\"users\".\"administrator_role\" in ('full', 'settings', 'users', 'base')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.analysis_results": {
+      "name": "analysis_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analysis_results_analysis_id_key": {
+          "name": "analysis_results_analysis_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "analysis_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_analyses": {
+      "name": "job_analyses",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_analyses_job_id_fkey": {
+          "name": "job_analyses_job_id_fkey",
+          "tableFrom": "job_analyses",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "job_analyses_pkey": {
+          "name": "job_analyses_pkey",
+          "columns": [
+            "job_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_indexes": {
+      "name": "job_indexes",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_indexes_job_id_fkey": {
+          "name": "job_indexes_job_id_fkey",
+          "tableFrom": "job_indexes",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "job_indexes_pkey": {
+          "name": "job_indexes_pkey",
+          "columns": [
+            "job_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "resourcetype",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.analysisformat": {
+      "name": "analysisformat",
+      "schema": "public",
+      "values": [
+        "sam",
+        "bam",
+        "fasta",
+        "fastq",
+        "csv",
+        "tsv",
+        "json"
+      ]
+    },
+    "public.subtractiontype": {
+      "name": "subtractiontype",
+      "schema": "public",
+      "values": [
+        "fasta",
+        "bowtie2"
+      ]
+    },
+    "public.action": {
+      "name": "action",
+      "schema": "public",
+      "values": [
+        "create",
+        "update",
+        "delete",
+        "modify",
+        "remove"
+      ]
+    },
+    "public.resourcetype": {
+      "name": "resourcetype",
+      "schema": "public",
+      "values": [
+        "app",
+        "group"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/data/drizzle/meta/_journal.json
+++ b/packages/data/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1786744254751,
+      "tag": "0000_baseline",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -8,6 +8,8 @@
 		"./*": "./src/*.ts"
 	},
 	"scripts": {
+		"db:generate": "drizzle-kit generate",
+		"db:migrate": "drizzle-kit migrate",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"typecheck": "tsc --noEmit"

--- a/packages/data/src/db/schema/analyses.ts
+++ b/packages/data/src/db/schema/analyses.ts
@@ -19,6 +19,7 @@ import {
 	bigint,
 	boolean,
 	check,
+	foreignKey,
 	index,
 	integer,
 	json,
@@ -64,23 +65,40 @@ export const analyses = pgTable(
 		// The legacy `sample` string column is still written by Python and is needed
 		// to locate a migrated analysis's slug-prefixed objects in storage.
 		sample: text("sample").notNull(),
-		sample_id: bigint("sample_id", { mode: "number" }).references(
-			() => legacySamples.id,
-		),
+		sample_id: bigint("sample_id", { mode: "number" }),
 		reference: text("reference"),
-		reference_id: bigint("reference_id", { mode: "number" }).references(
-			() => legacyReferences.id,
-		),
+		reference_id: bigint("reference_id", { mode: "number" }),
 		index: text("index"),
-		index_id: bigint("index_id", { mode: "number" })
-			.notNull()
-			.references(() => indexes.id),
-		user_id: integer("user_id")
-			.notNull()
-			.references(() => users.id),
-		job_id: integer("job_id").references(() => jobs.id),
+		index_id: bigint("index_id", { mode: "number" }).notNull(),
+		user_id: integer("user_id").notNull(),
+		job_id: integer("job_id"),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.sample_id],
+			foreignColumns: [legacySamples.id],
+			name: "analyses_sample_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.reference_id],
+			foreignColumns: [legacyReferences.id],
+			name: "analyses_reference_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.index_id],
+			foreignColumns: [indexes.id],
+			name: "analyses_index_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.user_id],
+			foreignColumns: [users.id],
+			name: "analyses_user_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.job_id],
+			foreignColumns: [jobs.id],
+			name: "analyses_job_id_fkey",
+		}),
 		unique("analyses_legacy_id_key").on(table.legacy_id),
 		index("ix_analyses_sample").on(table.sample),
 		index("ix_analyses_sample_id_workflow").on(table.sample_id, table.workflow),
@@ -94,14 +112,20 @@ export const analyses = pgTable(
 export const analysisSubtractions = pgTable(
 	"analysis_subtractions",
 	{
-		analysis_id: bigint("analysis_id", { mode: "number" })
-			.notNull()
-			.references(() => analyses.id, { onDelete: "cascade" }),
-		subtraction_id: bigint("subtraction_id", { mode: "number" })
-			.notNull()
-			.references(() => subtractions.id),
+		analysis_id: bigint("analysis_id", { mode: "number" }).notNull(),
+		subtraction_id: bigint("subtraction_id", { mode: "number" }).notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.analysis_id],
+			foreignColumns: [analyses.id],
+			name: "analysis_subtractions_analysis_id_fkey",
+		}).onDelete("cascade"),
+		foreignKey({
+			columns: [table.subtraction_id],
+			foreignColumns: [subtractions.id],
+			name: "analysis_subtractions_subtraction_id_fkey",
+		}),
 		primaryKey({
 			name: "analysis_subtractions_pkey",
 			columns: [table.analysis_id, table.subtraction_id],
@@ -116,9 +140,7 @@ export const analysisFiles = pgTable(
 	"analysis_files",
 	{
 		id: serial("id").primaryKey(),
-		analysis_id: bigint("analysis_id", { mode: "number" })
-			.notNull()
-			.references(() => analyses.id, { onDelete: "cascade" }),
+		analysis_id: bigint("analysis_id", { mode: "number" }).notNull(),
 		description: text("description"),
 		format: analysisFormat("format"),
 		name: text("name"),
@@ -131,6 +153,11 @@ export const analysisFiles = pgTable(
 		uploaded_at: timestamp("uploaded_at"),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.analysis_id],
+			foreignColumns: [analyses.id],
+			name: "analysis_files_analysis_id_fkey",
+		}).onDelete("cascade"),
 		unique("analysis_files_name_on_disk_key").on(table.name_on_disk),
 		unique("uq_analysis_files_storage_key").on(table.storage_key),
 	],
@@ -143,9 +170,7 @@ export const nuvsBlast = pgTable(
 	"nuvs_blast",
 	{
 		id: serial("id").primaryKey(),
-		analysis_id: bigint("analysis_id", { mode: "number" })
-			.notNull()
-			.references(() => analyses.id, { onDelete: "cascade" }),
+		analysis_id: bigint("analysis_id", { mode: "number" }).notNull(),
 		sequence_index: integer("sequence_index").notNull(),
 		created_at: timestamp("created_at").notNull(),
 		updated_at: timestamp("updated_at").notNull(),
@@ -156,9 +181,19 @@ export const nuvsBlast = pgTable(
 		ready: boolean("ready").notNull(),
 		// `json`, not `jsonb` — the upstream column is `JSON`.
 		result: json("result").$type<Record<string, unknown>>(),
-		task_id: integer("task_id").references(() => tasks.id),
+		task_id: integer("task_id"),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.analysis_id],
+			foreignColumns: [analyses.id],
+			name: "nuvs_blast_analysis_id_fkey",
+		}).onDelete("cascade"),
+		foreignKey({
+			columns: [table.task_id],
+			foreignColumns: [tasks.id],
+			name: "nuvs_blast_task_id_fkey",
+		}),
 		unique("nuvs_blast_analysis_id_sequence_index_key").on(
 			table.analysis_id,
 			table.sequence_index,

--- a/packages/data/src/db/schema/apiKeys.ts
+++ b/packages/data/src/db/schema/apiKeys.ts
@@ -4,6 +4,7 @@
 
 import type { Permissions } from "@virtool/contracts";
 import {
+	foreignKey,
 	index,
 	integer,
 	jsonb,
@@ -22,12 +23,15 @@ export const apiKeys = pgTable(
 		hashed: text("hashed").notNull(),
 		name: text("name").notNull(),
 		createdAt: timestamp("created_at").notNull(),
-		userId: integer("user_id")
-			.notNull()
-			.references(() => users.id, { onDelete: "cascade" }),
+		userId: integer("user_id").notNull(),
 		permissions: jsonb("permissions").$type<Permissions>().notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.userId],
+			foreignColumns: [users.id],
+			name: "api_keys_user_id_fkey",
+		}).onDelete("cascade"),
 		unique("api_keys_hashed_key").on(table.hashed),
 		index("idx_api_keys_user_id").on(table.userId),
 	],

--- a/packages/data/src/db/schema/foreignKeys.test.ts
+++ b/packages/data/src/db/schema/foreignKeys.test.ts
@@ -1,0 +1,50 @@
+import { is } from "drizzle-orm";
+import { getTableConfig, PgTable } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+import * as schema from "./index";
+
+/*
+ Production's foreign keys carry Postgres's default constraint name,
+ `{table}_{column}_fkey`, because Alembic never named them itself. Drizzle's
+ inline `.references()` auto-names a constraint `{table}_{col}_{ref}_{refcol}_fk`
+ instead, which agrees with production on everything but the name.
+
+ Nothing catches that at apply time: migration `0000` is stamped as
+ already-applied rather than run, so the wrong name reaches no database — it
+ reaches `meta/0000_snapshot.json`, which every later `generate` diffs against.
+ The first migration to touch a foreign key would then emit SQL naming a
+ constraint production does not have, and fail long after the cause.
+
+ So every foreign key is declared with a table-level `foreignKey({ name })`.
+ This pins that.
+*/
+
+/* The barrel's exports are each typed with their own literal table name, and
+   that union is not assignable to the general `PgTable`. Widen to `unknown`
+   and let `is()` do the narrowing. */
+function tables(): PgTable[] {
+	return (Object.values(schema) as unknown[]).filter(
+		(value): value is PgTable => is(value, PgTable),
+	);
+}
+
+describe("foreign key constraint names", () => {
+	const found = tables().flatMap((table) => {
+		const config = getTableConfig(table);
+		return config.foreignKeys.map((fk) => {
+			const reference = fk.reference();
+			return {
+				actual: fk.getName(),
+				expected: `${config.name}_${reference.columns.map((c) => c.name).join("_")}_fkey`,
+			};
+		});
+	});
+
+	it("covers every foreign key in the mirror", () => {
+		expect(found).toHaveLength(54);
+	});
+
+	it.each(found)("names $expected", ({ actual, expected }) => {
+		expect(actual).toBe(expected);
+	});
+});

--- a/packages/data/src/db/schema/groups.ts
+++ b/packages/data/src/db/schema/groups.ts
@@ -8,6 +8,7 @@ import type { Permissions } from "@virtool/contracts";
 import { sql } from "drizzle-orm";
 import {
 	boolean,
+	foreignKey,
 	integer,
 	jsonb,
 	pgTable,
@@ -37,17 +38,23 @@ export type GroupRow = typeof groups.$inferSelect;
 export const userGroups = pgTable(
 	"user_groups",
 	{
-		groupId: integer("group_id")
-			.notNull()
-			.references(() => groups.id, { onDelete: "cascade" }),
-		userId: integer("user_id")
-			.notNull()
-			.references(() => users.id, { onDelete: "cascade" }),
+		groupId: integer("group_id").notNull(),
+		userId: integer("user_id").notNull(),
 		primary: boolean("primary")
 			.$defaultFn(() => false)
 			.notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.groupId],
+			foreignColumns: [groups.id],
+			name: "user_groups_group_id_fkey",
+		}).onDelete("cascade"),
+		foreignKey({
+			columns: [table.userId],
+			foreignColumns: [users.id],
+			name: "user_groups_user_id_fkey",
+		}).onDelete("cascade"),
 		primaryKey({
 			name: "user_groups_pkey",
 			columns: [table.groupId, table.userId],

--- a/packages/data/src/db/schema/history.ts
+++ b/packages/data/src/db/schema/history.ts
@@ -13,6 +13,7 @@
 
 import {
 	bigint,
+	foreignKey,
 	index,
 	integer,
 	jsonb,
@@ -37,9 +38,7 @@ export const legacyHistory = pgTable(
 		created_at: timestamp("created_at").notNull(),
 		description: text("description").notNull(),
 		method_name: text("method_name").notNull(),
-		user_id: integer("user_id")
-			.notNull()
-			.references(() => users.id),
+		user_id: integer("user_id").notNull(),
 		// A bare string column with no foreign key by design: `legacy_otus` keys on
 		// the 8-character Mongo id and has no `legacy_id`, so this already holds the
 		// OTU's primary key.
@@ -49,15 +48,26 @@ export const legacyHistory = pgTable(
 		// write upstream — the column never stores the sentinel itself.
 		otu_version: text("otu_version"),
 		reference: text("reference"),
-		reference_id: bigint("reference_id", { mode: "number" }).references(
-			() => legacyReferences.id,
-		),
+		reference_id: bigint("reference_id", { mode: "number" }),
 		index: text("index"),
-		index_id: bigint("index_id", { mode: "number" }).references(
-			() => indexes.id,
-		),
+		index_id: bigint("index_id", { mode: "number" }),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.user_id],
+			foreignColumns: [users.id],
+			name: "legacy_history_user_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.reference_id],
+			foreignColumns: [legacyReferences.id],
+			name: "legacy_history_reference_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.index_id],
+			foreignColumns: [indexes.id],
+			name: "legacy_history_index_id_fkey",
+		}),
 		unique("legacy_history_legacy_id_key").on(table.legacy_id),
 		index("ix_legacy_history_index").on(table.index),
 		index("ix_legacy_history_index_id").on(table.index_id),
@@ -81,14 +91,17 @@ export const legacyHistoryDiff = pgTable(
 		// `history_id` and Python still writes it, so an insert from here must too —
 		// the column is NOT NULL upstream.
 		change_id: text("change_id").notNull(),
-		history_id: bigint("history_id", { mode: "number" }).references(
-			() => legacyHistory.id,
-		),
+		history_id: bigint("history_id", { mode: "number" }),
 		// A dictdiffer diff: an array of `[action, path, changes]` triples, shaped by
 		// `@server/history/dictdiffer` and opaque to the database.
 		diff: jsonb("diff").$type<unknown>().notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.history_id],
+			foreignColumns: [legacyHistory.id],
+			name: "legacy_history_diff_history_id_fkey",
+		}),
 		/* `history_diffs_*` rather than `legacy_history_diff_*`: the constraint
 		   predates the table's rename and production never renamed it. The primary
 		   key is named for the same reason — an inferred one would be

--- a/packages/data/src/db/schema/hmms.ts
+++ b/packages/data/src/db/schema/hmms.ts
@@ -15,6 +15,7 @@ import {
 	boolean,
 	check,
 	doublePrecision,
+	foreignKey,
 	integer,
 	jsonb,
 	pgTable,
@@ -92,10 +93,17 @@ export const legacyHmmStatus = pgTable(
 		errors: jsonb("errors").$type<string[]>().notNull(),
 		release: jsonb("release").$type<HmmRelease>(),
 		installed: jsonb("installed").$type<HmmUpdate>(),
-		task_id: integer("task_id").references(() => tasks.id),
+		task_id: integer("task_id"),
 		updates: jsonb("updates").$type<HmmUpdate[]>().notNull(),
 	},
-	(table) => [check("ck_legacy_hmm_status_singleton", sql`${table.id} = 1`)],
+	(table) => [
+		foreignKey({
+			columns: [table.task_id],
+			foreignColumns: [tasks.id],
+			name: "legacy_hmm_status_task_id_fkey",
+		}),
+		check("ck_legacy_hmm_status_singleton", sql`${table.id} = 1`),
+	],
 );
 
 /** A row from the `legacy_hmm_status` singleton table. */

--- a/packages/data/src/db/schema/indexes.ts
+++ b/packages/data/src/db/schema/indexes.ts
@@ -13,6 +13,7 @@ import {
 	bigint,
 	boolean,
 	check,
+	foreignKey,
 	integer,
 	jsonb,
 	pgTable,
@@ -52,18 +53,34 @@ export const indexes = pgTable(
 		// that has never been asked for its OTU JSON has not written one, and the key
 		// is minted on first write.
 		otus_json_storage_key: text("otus_json_storage_key"),
-		reference_id: bigint("reference_id", { mode: "number" })
-			.notNull()
-			.references(() => legacyReferences.id),
-		user_id: integer("user_id")
-			.notNull()
-			.references(() => users.id),
+		reference_id: bigint("reference_id", { mode: "number" }).notNull(),
+		user_id: integer("user_id").notNull(),
 		// A build is backed by at most one of these: `job_id` for a legacy
 		// workflow-run build, `task_id` for one started from either service today.
-		job_id: integer("job_id").references(() => jobs.id),
-		task_id: integer("task_id").references(() => tasks.id),
+		job_id: integer("job_id"),
+		task_id: integer("task_id"),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.reference_id],
+			foreignColumns: [legacyReferences.id],
+			name: "indexes_reference_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.user_id],
+			foreignColumns: [users.id],
+			name: "indexes_user_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.job_id],
+			foreignColumns: [jobs.id],
+			name: "indexes_job_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.task_id],
+			foreignColumns: [tasks.id],
+			name: "indexes_task_id_fkey",
+		}),
 		unique("indexes_legacy_id_key").on(table.legacy_id),
 		unique("indexes_storage_key_key").on(table.storage_key),
 		unique("uq_indexes_otus_json_storage_key").on(table.otus_json_storage_key),
@@ -88,9 +105,7 @@ export const indexFiles = pgTable(
 		// writes `str(index_id)` and this side writes the same — a row is then
 		// identical whichever runner built it.
 		index: text("index"),
-		index_id: bigint("index_id", { mode: "number" })
-			.notNull()
-			.references(() => indexes.id, { onDelete: "cascade" }),
+		index_id: bigint("index_id", { mode: "number" }).notNull(),
 		type: text("type").$type<IndexFileType>(),
 		size: bigint("size", { mode: "number" }),
 		// The file's complete object-storage key, superseding the per-index
@@ -98,6 +113,11 @@ export const indexFiles = pgTable(
 		storage_key: text("storage_key").notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.index_id],
+			foreignColumns: [indexes.id],
+			name: "index_files_index_id_fkey",
+		}).onDelete("cascade"),
 		unique("uq_index_files_storage_key").on(table.storage_key),
 		// `index_files_index_id_name_key`. Declared because a build's registration
 		// of its artifact upserts on it, and an `ON CONFLICT` naming columns no

--- a/packages/data/src/db/schema/jobs.ts
+++ b/packages/data/src/db/schema/jobs.ts
@@ -23,6 +23,7 @@ import { sql } from "drizzle-orm";
 import {
 	boolean,
 	check,
+	foreignKey,
 	index,
 	integer,
 	jsonb,
@@ -51,15 +52,18 @@ export const jobs = pgTable(
 		pinged_at: timestamp("pinged_at"),
 		state: text("state").$type<JobState>().notNull(),
 		steps: jsonb("steps").$type<StoredJobStep[]>(),
-		user_id: integer("user_id")
-			.notNull()
-			.references(() => users.id),
+		user_id: integer("user_id").notNull(),
 		// Deliberately left open. Python's `Workflow` is an application-level enum
 		// with no CHECK constraint behind it, so a row can hold a workflow this
 		// build has never heard of.
 		workflow: text("workflow").notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.user_id],
+			foreignColumns: [users.id],
+			name: "jobs_user_id_fkey",
+		}),
 		unique("jobs_legacy_id_key").on(table.legacy_id),
 		index("ix_jobs_state_created_at").on(table.state, table.created_at),
 		index("ix_jobs_user_id_state").on(table.user_id, table.state),

--- a/packages/data/src/db/schema/messages.ts
+++ b/packages/data/src/db/schema/messages.ts
@@ -7,6 +7,7 @@ import { sql } from "drizzle-orm";
 import {
 	boolean,
 	check,
+	foreignKey,
 	integer,
 	pgTable,
 	serial,
@@ -29,9 +30,14 @@ export const instanceMessages = pgTable(
 		// Nullable upstream: a row migrated from Mongo carries its author in the
 		// legacy `user` column, and a trigger resolves `user_id` from it. Every
 		// read joins on it, so a row that predates the backfill is simply invisible.
-		userId: integer("user_id").references(() => users.id),
+		userId: integer("user_id"),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.userId],
+			foreignColumns: [users.id],
+			name: "instance_messages_user_id_fkey",
+		}),
 		uniqueIndex("instance_messages_one_active")
 			.on(table.active)
 			.where(sql`${table.active} = true`),

--- a/packages/data/src/db/schema/otus.ts
+++ b/packages/data/src/db/schema/otus.ts
@@ -19,6 +19,7 @@
 import {
 	bigint,
 	boolean,
+	foreignKey,
 	index,
 	integer,
 	jsonb,
@@ -40,13 +41,16 @@ export const legacyOtus = pgTable(
 			.$defaultFn(() => "")
 			.notNull(),
 		last_indexed_version: integer("last_indexed_version"),
-		reference_id: bigint("reference_id", { mode: "number" })
-			.notNull()
-			.references(() => legacyReferences.id),
+		reference_id: bigint("reference_id", { mode: "number" }).notNull(),
 		verified: boolean("verified").notNull(),
 		version: integer("version").notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.reference_id],
+			foreignColumns: [legacyReferences.id],
+			name: "legacy_otus_reference_id_fkey",
+		}),
 		index("ix_legacy_otus_reference_id").on(table.reference_id),
 		index("legacy_otus_name_lower").on(lower(table.name), table.id),
 	],
@@ -66,14 +70,17 @@ export const legacySequences = pgTable(
 	{
 		id: text("id").primaryKey(),
 		data: jsonb("data").$type<Record<string, unknown>>().notNull(),
-		otu_id: text("otu_id")
-			.notNull()
-			.references(() => legacyOtus.id, { onDelete: "cascade" }),
+		otu_id: text("otu_id").notNull(),
 		isolate_id: text("isolate_id").notNull(),
 		segment: text("segment"),
 		position: bigint("position", { mode: "number" }),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.otu_id],
+			foreignColumns: [legacyOtus.id],
+			name: "legacy_sequences_otu_id_fkey",
+		}).onDelete("cascade"),
 		index("ix_legacy_sequences_otu_id").on(table.otu_id),
 		index("ix_legacy_sequences_otu_id_position").on(
 			table.otu_id,

--- a/packages/data/src/db/schema/references.ts
+++ b/packages/data/src/db/schema/references.ts
@@ -4,9 +4,9 @@
 // in sync with `../../../../../../virtool/virtool/references/sql.py`.
 
 import {
-	type AnyPgColumn,
 	bigint,
 	boolean,
+	foreignKey,
 	integer,
 	jsonb,
 	pgTable,
@@ -47,27 +47,41 @@ export const legacyReferences = pgTable(
 			.$type<string[]>()
 			.$defaultFn(() => [])
 			.notNull(),
-		user_id: integer("user_id")
-			.notNull()
-			.references(() => users.id),
-		upload_id: integer("upload_id").references(() => uploads.id),
-		cloned_from_id: bigint("cloned_from_id", { mode: "number" }).references(
-			(): AnyPgColumn => legacyReferences.id,
-		),
-		task_id: integer("task_id").references(() => tasks.id),
+		user_id: integer("user_id").notNull(),
+		upload_id: integer("upload_id"),
+		cloned_from_id: bigint("cloned_from_id", { mode: "number" }),
+		task_id: integer("task_id"),
 	},
-	(table) => [unique("legacy_references_legacy_id_key").on(table.legacy_id)],
+	(table) => [
+		foreignKey({
+			columns: [table.user_id],
+			foreignColumns: [users.id],
+			name: "legacy_references_user_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.upload_id],
+			foreignColumns: [uploads.id],
+			name: "legacy_references_upload_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.cloned_from_id],
+			foreignColumns: [table.id],
+			name: "legacy_references_cloned_from_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.task_id],
+			foreignColumns: [tasks.id],
+			name: "legacy_references_task_id_fkey",
+		}),
+		unique("legacy_references_legacy_id_key").on(table.legacy_id),
+	],
 );
 
 export const legacyReferenceUsers = pgTable(
 	"legacy_reference_users",
 	{
-		reference_id: bigint("reference_id", { mode: "number" })
-			.notNull()
-			.references(() => legacyReferences.id),
-		user_id: integer("user_id")
-			.notNull()
-			.references(() => users.id),
+		reference_id: bigint("reference_id", { mode: "number" }).notNull(),
+		user_id: integer("user_id").notNull(),
 		build: boolean("build")
 			.$defaultFn(() => false)
 			.notNull(),
@@ -79,6 +93,16 @@ export const legacyReferenceUsers = pgTable(
 			.notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.reference_id],
+			foreignColumns: [legacyReferences.id],
+			name: "legacy_reference_users_reference_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.user_id],
+			foreignColumns: [users.id],
+			name: "legacy_reference_users_user_id_fkey",
+		}),
 		primaryKey({
 			name: "legacy_reference_users_pkey",
 			columns: [table.reference_id, table.user_id],
@@ -89,12 +113,8 @@ export const legacyReferenceUsers = pgTable(
 export const legacyReferenceGroups = pgTable(
 	"legacy_reference_groups",
 	{
-		reference_id: bigint("reference_id", { mode: "number" })
-			.notNull()
-			.references(() => legacyReferences.id),
-		group_id: integer("group_id")
-			.notNull()
-			.references(() => groups.id),
+		reference_id: bigint("reference_id", { mode: "number" }).notNull(),
+		group_id: integer("group_id").notNull(),
 		build: boolean("build")
 			.$defaultFn(() => false)
 			.notNull(),
@@ -106,6 +126,16 @@ export const legacyReferenceGroups = pgTable(
 			.notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.reference_id],
+			foreignColumns: [legacyReferences.id],
+			name: "legacy_reference_groups_reference_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.group_id],
+			foreignColumns: [groups.id],
+			name: "legacy_reference_groups_group_id_fkey",
+		}),
 		primaryKey({
 			name: "legacy_reference_groups_pkey",
 			columns: [table.reference_id, table.group_id],

--- a/packages/data/src/db/schema/samples.ts
+++ b/packages/data/src/db/schema/samples.ts
@@ -7,6 +7,7 @@ import { sql } from "drizzle-orm";
 import {
 	bigint,
 	boolean,
+	foreignKey,
 	index,
 	integer,
 	jsonb,
@@ -64,7 +65,7 @@ export const legacySamples = pgTable(
 		format: text("format")
 			.$defaultFn(() => "fastq")
 			.notNull(),
-		group_id: integer("group_id").references(() => groups.id),
+		group_id: integer("group_id"),
 		quality: jsonb("quality").$type<SampleQuality>(),
 		created_at: timestamp("created_at").notNull(),
 		paired: boolean("paired")
@@ -91,10 +92,25 @@ export const legacySamples = pgTable(
 		group_write: boolean("group_write")
 			.$defaultFn(() => false)
 			.notNull(),
-		user_id: integer("user_id").references(() => users.id),
-		job_id: integer("job_id").references(() => jobs.id),
+		user_id: integer("user_id"),
+		job_id: integer("job_id"),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.group_id],
+			foreignColumns: [groups.id],
+			name: "legacy_samples_group_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.user_id],
+			foreignColumns: [users.id],
+			name: "legacy_samples_user_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.job_id],
+			foreignColumns: [jobs.id],
+			name: "legacy_samples_job_id_fkey",
+		}),
 		unique("legacy_samples_legacy_id_key").on(table.legacy_id),
 		unique("legacy_samples_job_id_key").on(table.job_id),
 		index("ix_legacy_samples_all_read")
@@ -115,14 +131,20 @@ export const legacySamples = pgTable(
 export const legacySampleLabels = pgTable(
 	"legacy_sample_labels",
 	{
-		sample_id: bigint("sample_id", { mode: "number" })
-			.notNull()
-			.references(() => legacySamples.id, { onDelete: "cascade" }),
-		label_id: integer("label_id")
-			.notNull()
-			.references(() => labels.id),
+		sample_id: bigint("sample_id", { mode: "number" }).notNull(),
+		label_id: integer("label_id").notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.sample_id],
+			foreignColumns: [legacySamples.id],
+			name: "legacy_sample_labels_sample_id_fkey",
+		}).onDelete("cascade"),
+		foreignKey({
+			columns: [table.label_id],
+			foreignColumns: [labels.id],
+			name: "legacy_sample_labels_label_id_fkey",
+		}),
 		primaryKey({
 			name: "legacy_sample_labels_pkey",
 			columns: [table.sample_id, table.label_id],
@@ -135,14 +157,20 @@ export const legacySampleLabels = pgTable(
 export const legacySampleSubtractions = pgTable(
 	"legacy_sample_subtractions",
 	{
-		sample_id: bigint("sample_id", { mode: "number" })
-			.notNull()
-			.references(() => legacySamples.id, { onDelete: "cascade" }),
-		subtraction_id: bigint("subtraction_id", { mode: "number" })
-			.notNull()
-			.references(() => subtractions.id),
+		sample_id: bigint("sample_id", { mode: "number" }).notNull(),
+		subtraction_id: bigint("subtraction_id", { mode: "number" }).notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.sample_id],
+			foreignColumns: [legacySamples.id],
+			name: "legacy_sample_subtractions_sample_id_fkey",
+		}).onDelete("cascade"),
+		foreignKey({
+			columns: [table.subtraction_id],
+			foreignColumns: [subtractions.id],
+			name: "legacy_sample_subtractions_subtraction_id_fkey",
+		}),
 		primaryKey({
 			name: "legacy_sample_subtractions_pkey",
 			columns: [table.sample_id, table.subtraction_id],
@@ -156,18 +184,28 @@ export const sampleReads = pgTable(
 	{
 		id: serial("id").primaryKey(),
 		sample: text("sample").notNull(),
-		sample_id: bigint("sample_id", { mode: "number" }).references(
-			() => legacySamples.id,
-		),
+		sample_id: bigint("sample_id", { mode: "number" }),
 		name: varchar("name", { length: 13 }).notNull(),
 		name_on_disk: text("name_on_disk").notNull(),
 		size: bigint("size", { mode: "number" }),
 		// The reads file's complete object-storage key.
 		storage_key: text("storage_key").notNull(),
-		upload: integer("upload").references(() => uploads.id),
+		upload: integer("upload"),
 		uploaded_at: timestamp("uploaded_at"),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.sample_id],
+			foreignColumns: [legacySamples.id],
+			name: "sample_reads_sample_id_fkey",
+		}),
+		/* `sample_reads_upload_fkey`, not `..._upload_id_fkey`: the column really is
+		   named `upload`, and Postgres named the constraint after it. */
+		foreignKey({
+			columns: [table.upload],
+			foreignColumns: [uploads.id],
+			name: "sample_reads_upload_fkey",
+		}),
 		unique("uq_sample_reads_storage_key").on(table.storage_key),
 		unique("sample_reads_sample_id_name_key").on(table.sample_id, table.name),
 		unique("sample_reads_sample_name_key").on(table.sample, table.name),
@@ -182,15 +220,23 @@ export const sampleUploads = pgTable(
 			.primaryKey()
 			.generatedAlwaysAsIdentity(),
 		sample: text("sample").notNull(),
-		sample_id: bigint("sample_id", { mode: "number" }).references(
-			() => legacySamples.id,
-		),
-		upload_id: integer("upload_id")
-			.notNull()
-			.references(() => uploads.id),
+		sample_id: bigint("sample_id", { mode: "number" }),
+		upload_id: integer("upload_id").notNull(),
 		index: integer("index").notNull(),
 	},
-	(table) => [unique("sample_uploads_upload_id_key").on(table.upload_id)],
+	(table) => [
+		foreignKey({
+			columns: [table.sample_id],
+			foreignColumns: [legacySamples.id],
+			name: "sample_uploads_sample_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.upload_id],
+			foreignColumns: [uploads.id],
+			name: "sample_uploads_upload_id_fkey",
+		}),
+		unique("sample_uploads_upload_id_key").on(table.upload_id),
+	],
 );
 
 /** A row from the `legacy_samples` table. */

--- a/packages/data/src/db/schema/sessions.ts
+++ b/packages/data/src/db/schema/sessions.ts
@@ -7,6 +7,7 @@ import { sql } from "drizzle-orm";
 import {
 	boolean,
 	check,
+	foreignKey,
 	index,
 	integer,
 	pgTable,
@@ -24,9 +25,7 @@ export const sessions = pgTable(
 	{
 		id: serial("id").primaryKey(),
 		sessionId: text("session_id").notNull(),
-		userId: integer("user_id").references(() => users.id, {
-			onDelete: "cascade",
-		}),
+		userId: integer("user_id"),
 		ip: text("ip").notNull(),
 		createdAt: timestamp("created_at").notNull(),
 		expiresAt: timestamp("expires_at").notNull(),
@@ -36,6 +35,11 @@ export const sessions = pgTable(
 		sessionType: text("session_type").$type<SessionType>().notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.userId],
+			foreignColumns: [users.id],
+			name: "sessions_user_id_fkey",
+		}).onDelete("cascade"),
 		unique("sessions_session_id_key").on(table.sessionId),
 		index("idx_sessions_expires_at").on(table.expiresAt),
 		uniqueIndex("idx_sessions_session_id").on(table.sessionId),

--- a/packages/data/src/db/schema/subtractions.ts
+++ b/packages/data/src/db/schema/subtractions.ts
@@ -11,6 +11,7 @@ import { SubtractionFileType } from "@virtool/contracts";
 import {
 	bigint,
 	boolean,
+	foreignKey,
 	integer,
 	jsonb,
 	pgEnum,
@@ -65,11 +66,26 @@ export const subtractions = pgTable(
 		ready: boolean("ready")
 			.$defaultFn(() => false)
 			.notNull(),
-		user_id: integer("user_id").references(() => users.id),
-		job_id: integer("job_id").references(() => jobs.id),
-		upload_id: integer("upload_id").references(() => uploads.id),
+		user_id: integer("user_id"),
+		job_id: integer("job_id"),
+		upload_id: integer("upload_id"),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.user_id],
+			foreignColumns: [users.id],
+			name: "subtractions_user_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.job_id],
+			foreignColumns: [jobs.id],
+			name: "subtractions_job_id_fkey",
+		}),
+		foreignKey({
+			columns: [table.upload_id],
+			foreignColumns: [uploads.id],
+			name: "subtractions_upload_id_fkey",
+		}),
 		unique("subtractions_legacy_id_key").on(table.legacy_id),
 		unique("subtractions_job_id_key").on(table.job_id),
 	],
@@ -80,9 +96,7 @@ export const subtractionFiles = pgTable(
 	{
 		id: serial("id").primaryKey(),
 		name: text("name"),
-		subtraction_id: bigint("subtraction_id", { mode: "number" })
-			.notNull()
-			.references(() => subtractions.id),
+		subtraction_id: bigint("subtraction_id", { mode: "number" }).notNull(),
 		type: subtractionType("type"),
 		// Files routinely exceed 2 GiB, past the range of a 32-bit integer, so this
 		// mirrors Python's BigInteger. `mode: "number"` is safe up to 2^53.
@@ -93,6 +107,11 @@ export const subtractionFiles = pgTable(
 		storage_key: text("storage_key"),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.subtraction_id],
+			foreignColumns: [subtractions.id],
+			name: "subtraction_files_subtraction_id_fkey",
+		}),
 		unique("uq_subtraction_files_storage_key").on(table.storage_key),
 		unique("subtraction_files_subtraction_id_name_key").on(
 			table.subtraction_id,

--- a/packages/data/src/db/schema/uploads.ts
+++ b/packages/data/src/db/schema/uploads.ts
@@ -8,6 +8,7 @@ import {
 	bigint,
 	boolean,
 	check,
+	foreignKey,
 	integer,
 	pgTable,
 	serial,
@@ -45,11 +46,14 @@ export const uploads = pgTable(
 		// that replaced the enum deleted those rows.
 		type: text("type").$type<UploadType>(),
 		uploadedAt: timestamp("uploaded_at"),
-		userId: integer("user_id")
-			.notNull()
-			.references(() => users.id),
+		userId: integer("user_id").notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.userId],
+			foreignColumns: [users.id],
+			name: "uploads_user_id_fkey",
+		}),
 		unique("uploads_name_on_disk_key").on(table.nameOnDisk),
 		unique("uq_uploads_storage_key").on(table.storageKey),
 		check(

--- a/packages/data/src/db/schema/vestigial.ts
+++ b/packages/data/src/db/schema/vestigial.ts
@@ -15,6 +15,7 @@
 // consumer to share one with.
 
 import {
+	foreignKey,
 	integer,
 	jsonb,
 	pgEnum,
@@ -74,12 +75,15 @@ export const analysisResults = pgTable(
 export const jobAnalyses = pgTable(
 	"job_analyses",
 	{
-		job_id: integer("job_id")
-			.notNull()
-			.references(() => jobs.id),
+		job_id: integer("job_id").notNull(),
 		analysis_id: text("analysis_id").notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.job_id],
+			foreignColumns: [jobs.id],
+			name: "job_analyses_job_id_fkey",
+		}),
 		primaryKey({ name: "job_analyses_pkey", columns: [table.job_id] }),
 	],
 );
@@ -88,12 +92,15 @@ export const jobAnalyses = pgTable(
 export const jobIndexes = pgTable(
 	"job_indexes",
 	{
-		job_id: integer("job_id")
-			.notNull()
-			.references(() => jobs.id),
+		job_id: integer("job_id").notNull(),
 		index_id: text("index_id").notNull(),
 	},
 	(table) => [
+		foreignKey({
+			columns: [table.job_id],
+			foreignColumns: [jobs.id],
+			name: "job_indexes_job_id_fkey",
+		}),
 		primaryKey({ name: "job_indexes_pkey", columns: [table.job_id] }),
 	],
 );

--- a/packages/data/tsconfig.json
+++ b/packages/data/tsconfig.json
@@ -3,5 +3,5 @@
 	"compilerOptions": {
 		"types": ["node"]
 	},
-	"include": ["src"]
+	"include": ["src", "drizzle.config.ts"]
 }


### PR DESCRIPTION
## Summary

- Adds `packages/data/drizzle.config.ts` and the generated baseline migration `0000_baseline.sql`, the first steps of taking Postgres migrations over from Alembic. Alembic still owns the schema — nothing here applies a migration, and no behaviour changes.
- Pins all 54 foreign key constraint names in the schema mirror. Production carries Postgres's default `{table}_{column}_fkey`, because Alembic never named these itself; inline `.references()` auto-names them `{table}_{col}_{ref}_{refcol}_fk`, agreeing with production on columns, referenced table and both referential actions, and disagreeing on every name. `foreignKeys.test.ts` pins the rule so a table declared with `.references()` fails by name.
- The baseline was hand-checked object by object against a schema-only dump of production. Foreign key names were the only real drift; enum member order (4/4), indexes (31/31), primary/unique constraints (78/78), CHECK constraints (11/11), identity sequence names (8/8), column nullability and server defaults all matched.

Why the naming matters: `0000` is stamped as already-applied rather than run, so a wrong name reaches no database. It reaches `meta/0000_snapshot.json`, which every later `generate` diffs against — and the first migration to touch a foreign key would emit SQL naming a constraint production does not have.

Two divergences are known and tracked rather than fixed here: 89 unbounded `varchar` columns are `text` in the mirror and `legacy_history_diff`'s sequence keeps its pre-rename name (VIR-2986), and the `instance_messages` trigger has no Drizzle representation (VIR-2987). All three are inert while `0000` is stamped rather than run.